### PR TITLE
fix(e2e): citation-click DocViewer + expert-review resolve — 54/54 E2E pass

### DIFF
--- a/app/(app)/expert-review/page.tsx
+++ b/app/(app)/expert-review/page.tsx
@@ -1,25 +1,27 @@
 // @MX:NOTE [AUTO] Expert Review Queue Page — T-007 (REQ-ENTERPRISE-024).
 // Server component with RBAC check. Only ra-lead and above can access.
-// Fetches pending reviews from API and passes to QueueList.
+// Queries DB directly (RSC pattern) for fresh pending reviews.
 // @MX:SPEC SPEC-REGULA-ENTERPRISE-001 (REQ-ENTERPRISE-024)
 
 import { QueueList } from '@/components/expert-review/QueueList';
 import { auth } from '@/lib/auth';
 import { hasRole } from '@/lib/auth/rbac';
 import type { Role } from '@/lib/auth/rbac';
+import { db } from '@/lib/db/client';
+import { expertReviews } from '@/lib/db/schema';
 import type { ExpertReview } from '@/types/expert-review';
+import { desc, eq } from 'drizzle-orm';
 import { redirect } from 'next/navigation';
 
-// Server-side fetch with no-store cache (always fresh data).
+// Direct DB query — avoids unauthenticated server-side API fetch.
 async function fetchPendingReviews(): Promise<ExpertReview[]> {
   try {
-    const res = await fetch(
-      `${process.env.NEXTAUTH_URL ?? 'http://localhost:3000'}/api/ra/expert-review?status=pending`,
-      { cache: 'no-store' },
-    );
-    if (!res.ok) return [];
-    const data = (await res.json()) as { data: ExpertReview[] };
-    return data.data ?? [];
+    const rows = await db
+      .select()
+      .from(expertReviews)
+      .where(eq(expertReviews.status, 'pending'))
+      .orderBy(desc(expertReviews.createdAt));
+    return rows as unknown as ExpertReview[];
   } catch {
     return [];
   }

--- a/app/api/ra/consult/route.ts
+++ b/app/api/ra/consult/route.ts
@@ -14,16 +14,22 @@ import { consult, ensureConversation } from '../../../../lib/ai/consult';
 import { encodeSSE } from '../../../../lib/ai/streaming';
 import { writeAudit } from '../../../../lib/audit';
 import { withPermission } from '../../../../lib/auth/with-permission';
+import { db } from '../../../../lib/db/client';
+import { messages } from '../../../../lib/db/schema';
 import { ConsultRequestSchema } from '../../../../types/consult';
 import type { StreamEvent } from '../../../../types/streaming';
 
-// E2E_TEST_MODE: deterministic fake SSE stream — no LLM calls, no DB writes.
-// Active only when process.env.E2E_TEST_MODE === 'true'.
-async function* e2eTestEvents(query: string): AsyncGenerator<StreamEvent, void, unknown> {
+// E2E_TEST_MODE: deterministic fake SSE stream — no LLM calls.
+// Yields real conversationId/messageId so expert-review FK constraints are satisfied.
+async function* e2eTestEvents(
+  query: string,
+  conversationId: string,
+  messageId: string,
+): AsyncGenerator<StreamEvent, void, unknown> {
   const isLowConf = query.trim() === '__test:low_confidence__';
   const isCitationTest = query.trim() === '__test:citation_response__';
 
-  yield { type: 'meta', conversationId: 'e2e-test-conv-id', messageId: 'e2e-test-msg-id' };
+  yield { type: 'meta', conversationId, messageId };
   const text = isLowConf
     ? 'Test response with low confidence score for expert review.'
     : 'This is a test regulatory response. EU MDR Article 10 requires establishing a quality management system.';
@@ -168,8 +174,19 @@ export const POST = withPermission('consult.create', async (req, _ctx, session) 
 
       const isE2EMode =
         process.env.E2E_TEST_MODE === 'true' && process.env.NODE_ENV !== 'production';
+
+      if (isE2EMode) {
+        // Create a real message row so expert-review FK constraints pass.
+        await db.insert(messages).values({
+          id: messageId,
+          conversationId,
+          role: 'assistant',
+          contentProse: 'E2E test response.',
+        }).onConflictDoNothing();
+      }
+
       const eventSource = isE2EMode
-        ? e2eTestEvents(input.question)
+        ? e2eTestEvents(input.question, conversationId, messageId)
         : consult(input, authJsSession, messageId, conversationId, signal);
 
       try {

--- a/app/api/ra/sources/[id]/route.ts
+++ b/app/api/ra/sources/[id]/route.ts
@@ -6,6 +6,54 @@ import { withPermission } from '../../../../../lib/auth/with-permission';
 import { db } from '../../../../../lib/db/client';
 import { sourceSections, sources } from '../../../../../lib/db/schema';
 
+// E2E_TEST_MODE: deterministic mock sources for non-UUID test IDs.
+// Prevents PostgreSQL UUID parse error when citation tests use 'test-src-N' IDs.
+const E2E_MOCK_SOURCES: Record<
+  string,
+  {
+    id: string;
+    orgLabel: string;
+    title: string;
+    year: number;
+    type: string;
+    url: null;
+    sections: { id: string; anchor: string; heading: string; text: string }[];
+  }
+> = {
+  'test-src-1': {
+    id: 'test-src-1',
+    orgLabel: 'EU MDR',
+    title: 'Regulation (EU) 2017/745',
+    year: 2017,
+    type: 'Regulation',
+    url: null,
+    sections: [
+      {
+        id: 'ts1-s1',
+        anchor: 'Article 10',
+        heading: 'General obligations of manufacturers',
+        text: 'Manufacturers of devices shall establish, document, implement, maintain, keep up to date and continually improve a quality management system.',
+      },
+    ],
+  },
+  'test-src-2': {
+    id: 'test-src-2',
+    orgLabel: 'FDA 21 CFR',
+    title: '21 CFR Part 820',
+    year: 2022,
+    type: 'Regulation',
+    url: null,
+    sections: [
+      {
+        id: 'ts2-s1',
+        anchor: '820.30',
+        heading: 'Design Controls',
+        text: 'Each manufacturer of any class III or class II device shall establish and maintain procedures to control the design of the device.',
+      },
+    ],
+  },
+};
+
 export const GET = withPermission('conversation.view', async (_req, ctx) => {
   // Next.js 15 passes params as a Promise. Resolve it safely.
   const rawParams = (ctx as { params: Promise<{ id: string }> | { id: string } }).params;
@@ -14,6 +62,12 @@ export const GET = withPermission('conversation.view', async (_req, ctx) => {
 
   if (!id) {
     return new Response('Missing source id', { status: 400 });
+  }
+
+  // E2E_TEST_MODE: return mock source for known test IDs to avoid UUID parse errors.
+  if (process.env.E2E_TEST_MODE === 'true' && process.env.NODE_ENV !== 'production') {
+    const mock = E2E_MOCK_SOURCES[id];
+    if (mock) return Response.json(mock);
   }
 
   const [source] = await db.select().from(sources).where(eq(sources.id, id)).limit(1);

--- a/components/chat/ChatShell.tsx
+++ b/components/chat/ChatShell.tsx
@@ -98,7 +98,7 @@ export function ChatShell() {
             expertReviewRequired={structured.expertReviewRequired}
             expertReviewReason={structured.expertReviewReason}
             conversationId={meta?.conversationId}
-            messageId={meta?.conversationId}
+            messageId={meta?.messageId}
           />
         </div>
       )}

--- a/components/expert-review/QueueList.tsx
+++ b/components/expert-review/QueueList.tsx
@@ -2,17 +2,34 @@
 
 // @MX:NOTE [AUTO] QueueList — T-007 (REQ-ENTERPRISE-025).
 // Renders a list of ExpertReview items as ReviewCard components.
-// Shows empty state when no items.
+// Manages status transitions via PATCH /api/ra/expert-review/[id].
 // @MX:SPEC SPEC-REGULA-ENTERPRISE-001 (REQ-ENTERPRISE-025)
 
 import type { ExpertReview } from '@/types/expert-review';
+import { useState } from 'react';
 import { ReviewCard } from './ReviewCard';
 
 interface QueueListProps {
   items: ExpertReview[];
 }
 
-export function QueueList({ items }: QueueListProps) {
+export function QueueList({ items: initialItems }: QueueListProps) {
+  const [items, setItems] = useState<ExpertReview[]>(initialItems);
+
+  async function handleStatusChange(id: string, status: string) {
+    const res = await fetch(`/api/ra/expert-review/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    if (!res.ok) return;
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, status: status as ExpertReview['status'] } : item,
+      ),
+    );
+  }
+
   if (items.length === 0) {
     return (
       <div data-testid="queue-list" className="py-8 text-center text-sm text-ink-400">
@@ -25,7 +42,7 @@ export function QueueList({ items }: QueueListProps) {
     <ul data-testid="queue-list" className="flex flex-col gap-3">
       {items.map((item) => (
         <li key={item.id}>
-          <ReviewCard item={item} />
+          <ReviewCard item={item} onStatusChange={handleStatusChange} />
         </li>
       ))}
     </ul>

--- a/lib/ai/consult.ts
+++ b/lib/ai/consult.ts
@@ -198,15 +198,6 @@ export async function* consult(
   try {
     const result = await streamText({
       model: getLlmModel(),
-      messages: [
-        {
-          role: 'user',
-          content: [
-            // Pass system content as first user block via prefilled approach.
-            // Actually use system param directly.
-          ],
-        },
-      ],
       system: systemMessages.map((m) => m.text).join('\n\n'),
       prompt: rewrittenQuery,
       maxTokens: 2048,

--- a/tests/e2e/audit-log.spec.ts
+++ b/tests/e2e/audit-log.spec.ts
@@ -60,13 +60,21 @@ test.describe('Audit log — 21 CFR Part 11 (REQ-LAUNCH-020)', () => {
     expect(entry).not.toHaveProperty('updatedAt');
   });
 
-  test('audit log is accessible to admin role only', async ({ page, request }) => {
+  test('audit log is accessible to admin role only', async ({ playwright, baseURL }) => {
     const server = requiresLiveServer();
     test.skip(server.skip, server.reason);
 
-    // Unauthenticated request must return 401.
-    const res = await request.get('/api/audit-logs');
-    expect([401, 403]).toContain(res.status());
+    // Explicitly empty storageState forces a truly unauthenticated request.
+    const ctx = await playwright.request.newContext({
+      baseURL: baseURL ?? 'http://localhost:3000',
+      storageState: { cookies: [], origins: [] },
+    });
+    try {
+      const res = await ctx.get('/api/audit-logs');
+      expect([401, 403]).toContain(res.status());
+    } finally {
+      await ctx.dispose();
+    }
   });
 
   test('audit log admin UI shows entries table', async ({ page }) => {

--- a/tests/e2e/citation-click.spec.ts
+++ b/tests/e2e/citation-click.spec.ts
@@ -2,50 +2,73 @@
 // @MX:SPEC: REQ-LAUNCH-019
 
 import { expect, test } from '@playwright/test';
+import { requiresAuthState } from './fixtures/env-guard';
 
 const NEEDS_SERVER =
   process.env.CI !== 'true' && !process.env.PLAYWRIGHT_BASE_URL
     ? 'Requires running Next.js server (set PLAYWRIGHT_BASE_URL or run in CI)'
     : undefined;
 
-// TODO: SPEC-REGULA-RELEASE-HARDENING-001
-// All four tests below require:
-//   1. A valid authenticated session injected via storageState or cookie.
-//   2. A test-mode API route that intercepts '__test:citation_response__' and
-//      returns a seeded streaming response with citation blocks.
-//
-// data-testid attributes (REQ-QUALITY-E2E-001 through REQ-QUALITY-E2E-004) have
-// been added to Citation, DocViewer, Composer, and ChatShell (TASK-006b).
-// Remaining blockers: authenticated session fixture + test API route.
-// Tests remain as test.fail() until those are implemented.
-
 test.describe('Citation click → DocViewer (REQ-LAUNCH-019)', () => {
-  test('clicking a citation block opens the DocViewer panel', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     test.skip(!!NEEDS_SERVER, NEEDS_SERVER ?? '');
-    // TODO: SPEC-REGULA-RELEASE-HARDENING-001 REQ-QUALITY-E2E-001
-    // data-testid attrs are now present (TASK-006b).
-    // Remaining blockers: authenticated session fixture + '__test:citation_response__' API route.
-    test.skip(true, 'Blocked: no auth session fixture and no test API route for citation response');
+    const auth = requiresAuthState();
+    test.skip(auth.skip, auth.reason);
+
+    // Submit citation_response trigger and wait for streaming to finish.
+    await page.goto('/chat');
+    const composer = page.locator('[data-testid="chat-composer"]');
+    await composer.fill('__test:citation_response__');
+    await page.keyboard.press('Enter');
+
+    // Wait for at least one citation block to appear.
+    await expect(page.locator('[data-testid="citation-block"]').first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('clicking a citation block opens the DocViewer panel', async ({ page }) => {
+    await page.locator('[data-testid="citation-block"]').first().click();
+
+    const docViewer = page.locator('[data-testid="doc-viewer"]');
+    await expect(docViewer).toBeVisible({ timeout: 5_000 });
   });
 
   test('DocViewer displays the cited document title', async ({ page }) => {
-    test.skip(!!NEEDS_SERVER, NEEDS_SERVER ?? '');
-    // TODO: SPEC-REGULA-RELEASE-HARDENING-001 REQ-QUALITY-E2E-002
-    // Remaining blockers: authenticated session fixture + test API route.
-    test.skip(true, 'Blocked: no auth session fixture and no test API route for citation response');
+    await page.locator('[data-testid="citation-block"]').first().click();
+
+    const docViewer = page.locator('[data-testid="doc-viewer"]');
+    await expect(docViewer).toBeVisible({ timeout: 5_000 });
+
+    // Title must be visible with actual document content (not loading placeholder).
+    const title = docViewer.locator('[data-testid="doc-viewer-title"]');
+    await expect(title).toBeVisible();
+    // Wait up to 10s for the source fetch to resolve (mock API in E2E mode).
+    await expect(title).not.toHaveText('불러오는 중...', { timeout: 10_000 });
+    await expect(title).not.toBeEmpty();
   });
 
   test('DocViewer deep links to the correct page/section', async ({ page }) => {
-    test.skip(!!NEEDS_SERVER, NEEDS_SERVER ?? '');
-    // TODO: SPEC-REGULA-RELEASE-HARDENING-001 REQ-QUALITY-E2E-003
-    // Remaining blockers: authenticated session fixture + test API route.
-    test.skip(true, 'Blocked: no auth session fixture and no test API route for citation response');
+    await page.locator('[data-testid="citation-block"]').first().click();
+
+    const docViewer = page.locator('[data-testid="doc-viewer"]');
+    await expect(docViewer).toBeVisible({ timeout: 5_000 });
+
+    // URL hash must encode the source index.
+    await expect(page).toHaveURL(/#source=/, { timeout: 5_000 });
   });
 
   test('DocViewer can be closed and chat remains intact', async ({ page }) => {
-    test.skip(!!NEEDS_SERVER, NEEDS_SERVER ?? '');
-    // TODO: SPEC-REGULA-RELEASE-HARDENING-001 REQ-QUALITY-E2E-004
-    // Remaining blockers: authenticated session fixture + test API route.
-    test.skip(true, 'Blocked: no auth session fixture and no test API route for citation response');
+    await page.locator('[data-testid="citation-block"]').first().click();
+
+    const docViewer = page.locator('[data-testid="doc-viewer"]');
+    await expect(docViewer).toBeVisible({ timeout: 5_000 });
+
+    // Close via the close button.
+    await docViewer.locator('[data-testid="doc-viewer-close"]').click();
+    await expect(docViewer).not.toBeVisible({ timeout: 3_000 });
+
+    // Chat content must still be intact.
+    await expect(page.locator('[data-testid="citation-block"]').first()).toBeVisible();
   });
 });

--- a/tests/e2e/expert-review.spec.ts
+++ b/tests/e2e/expert-review.spec.ts
@@ -64,16 +64,29 @@ test.describe('Expert review flow (REQ-LAUNCH-017)', () => {
     const a = requiresAuthState();
     test.skip(a.skip, a.reason);
 
+    // First: enqueue a review item via the low-confidence flow.
+    await page.goto('/chat');
+    const composer = page.locator('[data-testid="chat-composer"]');
+    await composer.fill('__test:low_confidence__');
+    await page.keyboard.press('Enter');
+
+    const callout = page.locator('[data-testid="expert-review-callout"]');
+    await expect(callout).toBeVisible({ timeout: 15_000 });
+
+    const sendBtn = callout.locator('[data-testid="send-review-btn"]');
+    await expect(sendBtn).toBeVisible();
+    await sendBtn.click();
+    await expect(sendBtn).toBeDisabled({ timeout: 5_000 });
+
+    // Navigate to the review queue — item should now be present.
     await page.goto('/expert-review');
     await expect(page.locator('[data-testid="review-queue-table"]')).toBeVisible();
 
-    // If no items are present, skip gracefully — seeded data required.
     const cards = page.locator('[data-testid="review-card"]');
-    const count = await cards.count();
-    test.skip(count === 0, 'No review items in queue — seed data required');
+    await expect(cards.first()).toBeVisible({ timeout: 5_000 });
 
     // Advance first pending card to in_progress to expose resolve button.
-    const startBtn = page.locator('[data-testid="review-card"]').first().locator('button').first();
+    const startBtn = cards.first().locator('button').first();
     if (await startBtn.isVisible()) {
       await startBtn.click();
     }


### PR DESCRIPTION
## Summary

- **#118 Fixes**: citation-click 4개 + expert-review resolve 1개 (5개 skip → 0 skip)
- **54/54 E2E 전체 통과** (workers=6, 1.3m)

## 변경 내용

| 파일 | 변경 |
|---|---|
| `app/api/ra/sources/[id]/route.ts` | E2E_TEST_MODE mock 소스 반환 (UUID 파싱 오류 방지) |
| `app/api/ra/consult/route.ts` | e2eTestEvents에 실제 IDs 전달, messages row 생성 |
| `components/chat/ChatShell.tsx` | messageId prop 버그 수정 (conversationId→messageId) |
| `app/(app)/expert-review/page.tsx` | API fetch → Drizzle 직접 쿼리 |
| `components/expert-review/QueueList.tsx` | PATCH API + 낙관적 UI 상태 전환 |
| `tests/e2e/citation-click.spec.ts` | test.skip 제거, 실제 테스트 구현 |
| `tests/e2e/expert-review.spec.ts` | resolve 테스트 큐 아이템 생성 로직 추가 |

## E2E 결과
```
Before: 49 pass / 5 skip
After:  54 pass / 0 skip / 0 fail
```

## 테스트 계획
- [x] citation-click.spec.ts 4/4 pass
- [x] expert-review.spec.ts 4/4 pass (including resolve)
- [x] 전체 54/54 pass 확인 (workers=6)

Fixes #118

🗿 MoAI <email@mo.ai.kr>