### PR TITLE
feat(refine): 답변 인라인 정제 — 톤 프리셋 UI + API (Wave 5 REQ-ANSWER-REFINE-001..004)

### DIFF
--- a/app/api/ra/refine/route.ts
+++ b/app/api/ra/refine/route.ts
@@ -1,0 +1,103 @@
+// @MX:ANCHOR [AUTO] Refine Route — POST /api/ra/refine
+// @MX:REASON Entry point for inline answer refinement with tone presets.
+// @MX:SPEC SPEC-REGULA-ANSWER-REFINE-001 (REQ-ANSWER-REFINE-001..004)
+export const runtime = 'nodejs';
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { z } from 'zod';
+
+export const TONE_LABELS: Record<string, string> = {
+  conservative: '보수적 / 안전 우선',
+  'regulatory-strict': '규제 엄격',
+  'executive-summary': '경영 요약',
+  'technical-detail': '기술 상세',
+};
+
+const RefineSchema = z.object({
+  messageId: z.string().min(1),
+  conversationId: z.string().min(1),
+  blockContent: z.string().min(1).max(20_000),
+  tone: z.enum(['conservative', 'regulatory-strict', 'executive-summary', 'technical-detail']),
+  customNote: z.string().max(500).optional(),
+});
+
+const TONE_INSTRUCTIONS: Record<string, string> = {
+  conservative:
+    'Rewrite the following regulatory answer using a conservative, safety-first tone. Emphasize risk mitigation, regulatory conservatism, and cautious language.',
+  'regulatory-strict':
+    'Rewrite using strict regulatory language aligned with FDA and EU MDR requirements. Use precise regulatory terminology and cite specific article numbers where applicable.',
+  'executive-summary':
+    'Rewrite as a concise executive summary. Lead with the key decision, omit technical detail, and close with the recommended action.',
+  'technical-detail':
+    'Rewrite with full technical depth. Include method rationale, specific standard requirements, and detailed implementation guidance.',
+};
+
+export const POST = withPermission('consult.create', async (req, _ctx, session) => {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = RefineSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: 'Validation failed', issues: parsed.error.issues }, { status: 400 });
+  }
+
+  const { messageId, conversationId, blockContent, tone, customNote } = parsed.data;
+
+  // E2E_TEST_MODE: return deterministic refined content without LLM call.
+  const isE2EMode = process.env.E2E_TEST_MODE === 'true' && process.env.NODE_ENV !== 'production';
+  if (isE2EMode) {
+    const toneLabel = TONE_LABELS[tone] ?? tone;
+    const refined = `[${toneLabel} 톤으로 정제됨] ${blockContent.slice(0, 200)}`;
+    return Response.json({
+      refined,
+      tone,
+      sourceMessageId: messageId,
+    });
+  }
+
+  // Production: delegate to LLM via configured provider.
+  const { getLlmModel } = await import('@/lib/ai/llm-provider');
+  const { generateText } = await import('ai');
+  const model = getLlmModel();
+
+  const instruction = TONE_INSTRUCTIONS[tone] ?? TONE_INSTRUCTIONS.conservative;
+  const noteClause = customNote ? `\n\nAdditional context: ${customNote}` : '';
+  const prompt = `${instruction}${noteClause}\n\nOriginal content:\n${blockContent}\n\nRefined version:`;
+
+  const result = await generateText({ model, prompt });
+  const refined = result.text ?? blockContent;
+
+  // Append immutable audit record.
+  try {
+    await writeAudit({
+      action: 'answer.refine',
+      actor_id: session.user.id,
+      resource_type: 'message',
+      resource_id: messageId,
+      conversation_id: conversationId,
+      meta_json: {
+        tone,
+        customNote,
+        originalLength: blockContent.length,
+        refinedLength: refined.length,
+      },
+    });
+  } catch {
+    // Audit failure does NOT block the response (fail-open for user experience).
+  }
+
+  return Response.json({
+    refined,
+    tone,
+    sourceMessageId: messageId,
+  });
+});
+
+export function GET(): Response {
+  return new Response('Method Not Allowed', { status: 405 });
+}

--- a/components/chat/AnswerBlock.tsx
+++ b/components/chat/AnswerBlock.tsx
@@ -10,6 +10,7 @@
 
 import { Copy, RefreshCw } from 'lucide-react';
 import dynamic from 'next/dynamic';
+import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
@@ -21,6 +22,7 @@ import type {
   SourceItem,
   TimelineEvent,
 } from '../../types/streaming';
+import { RefinePanel } from '../refine/RefinePanel';
 import { ExpertReviewCallout } from '../expert-review/ExpertReviewCallout';
 import { Callout } from './Callout';
 import { Checklist } from './Checklist';
@@ -80,6 +82,8 @@ export function AnswerBlock({
   related,
   onSuggestionClick,
 }: AnswerBlockProps) {
+  const [refinedProse, setRefinedProse] = useState<string | null>(null);
+  const displayProse = refinedProse ?? prose;
   const sourceCount = sources?.length ?? 0;
   const durationSec = durationMs !== null ? (durationMs / 1000).toFixed(1) : null;
 
@@ -127,12 +131,31 @@ export function AnswerBlock({
 
       {/* Section 3: Prose (REQ-STRUCT-028 Step 3) */}
       <section>
-        <p className="section-label mb-2 font-serif text-[10px] uppercase tracking-widest text-ink-400">
-          요약 답변
-        </p>
-        <div className="prose-sm prose max-w-none text-[15px] leading-[1.65] text-ink-800">
+        <div className="mb-2 flex items-center justify-between">
+          <p className="section-label font-serif text-[10px] uppercase tracking-widest text-ink-400">
+            요약 답변
+          </p>
+          {/* REQ-ANSWER-REFINE-001: inline tone-based refinement */}
+          {conversationId && messageId && prose.length > 0 && (
+            <RefinePanel
+              messageId={messageId}
+              conversationId={conversationId}
+              prose={displayProse}
+              onRefined={(text) => setRefinedProse(text)}
+            />
+          )}
+        </div>
+        {refinedProse && (
+          <p className="mb-1 text-[10px] text-brand-500 font-medium" data-testid="refined-label">
+            답변이 정제되었습니다
+          </p>
+        )}
+        <div
+          className="prose-sm prose max-w-none text-[15px] leading-[1.65] text-ink-800"
+          data-testid="answer-prose"
+        >
           <ReactMarkdown rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}>
-            {prose}
+            {displayProse}
           </ReactMarkdown>
         </div>
       </section>

--- a/components/refine/RefinePanel.tsx
+++ b/components/refine/RefinePanel.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+// @MX:NOTE [AUTO] RefinePanel — inline answer refinement with tone presets.
+// Shown as an overlay on AnswerBlock prose when user clicks "Refine".
+// @MX:SPEC SPEC-REGULA-ANSWER-REFINE-001 (REQ-ANSWER-REFINE-001..002)
+
+import { Wand2 } from 'lucide-react';
+import { useState } from 'react';
+
+type Tone = 'conservative' | 'regulatory-strict' | 'executive-summary' | 'technical-detail';
+
+const TONE_OPTIONS: { value: Tone; label: string; description: string }[] = [
+  { value: 'conservative', label: '보수적 / 안전 우선', description: '규제 리스크 최소화, 신중한 표현 사용' },
+  { value: 'regulatory-strict', label: '규제 엄격', description: 'FDA·EU MDR 조항 인용 강화, 정확한 법률 용어 사용' },
+  { value: 'executive-summary', label: '경영 요약', description: '핵심 결론 우선, 기술 세부사항 제거' },
+  { value: 'technical-detail', label: '기술 상세', description: '구현 가이드·표준 요건 전면 포함' },
+];
+
+interface RefinePanelProps {
+  messageId: string;
+  conversationId: string;
+  prose: string;
+  onRefined: (refined: string, tone: Tone) => void;
+}
+
+export function RefinePanel({ messageId, conversationId, prose, onRefined }: RefinePanelProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [customNote, setCustomNote] = useState('');
+
+  async function handleRefine(tone: Tone) {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/ra/refine', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messageId, conversationId, blockContent: prose, tone, customNote }),
+      });
+      if (!res.ok) return;
+      const data = (await res.json()) as { refined: string; tone: string };
+      onRefined(data.refined, tone);
+      setOpen(false);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        data-testid="refine-btn"
+        onClick={() => setOpen((v) => !v)}
+        disabled={loading}
+        className="flex items-center gap-1.5 rounded-md border border-ink-200 px-2.5 py-1 text-xs text-ink-500 hover:border-brand-300 hover:text-brand-600 transition-colors disabled:opacity-50"
+      >
+        <Wand2 size={12} />
+        {loading ? '정제 중…' : '답변 정제'}
+      </button>
+
+      {open && !loading && (
+        <div
+          data-testid="refine-popover"
+          className="absolute left-0 top-full z-30 mt-1 w-72 rounded-xl border border-border-weak bg-white shadow-lg"
+        >
+          <p className="border-b border-border-weak px-4 py-2 text-xs font-semibold text-ink-700">
+            톤 프리셋 선택
+          </p>
+          <ul className="p-2">
+            {TONE_OPTIONS.map((opt) => (
+              <li key={opt.value}>
+                <button
+                  type="button"
+                  data-testid={`tone-option-${opt.value}`}
+                  className="w-full rounded-lg px-3 py-2 text-left text-xs hover:bg-brand-50 transition-colors"
+                  onClick={() => void handleRefine(opt.value)}
+                >
+                  <span className="block font-medium text-ink-800">{opt.label}</span>
+                  <span className="text-ink-400">{opt.description}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="border-t border-border-weak px-4 py-2">
+            <input
+              type="text"
+              data-testid="refine-custom-note"
+              value={customNote}
+              onChange={(e) => setCustomNote(e.target.value)}
+              placeholder="추가 지시사항 (선택)"
+              className="w-full rounded border border-border-weak px-2 py-1 text-xs placeholder:text-ink-400 focus:border-brand-300 focus:outline-none"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/ai/consult.ts
+++ b/lib/ai/consult.ts
@@ -198,15 +198,6 @@ export async function* consult(
   try {
     const result = await streamText({
       model: getLlmModel(),
-      messages: [
-        {
-          role: 'user',
-          content: [
-            // Pass system content as first user block via prefilled approach.
-            // Actually use system param directly.
-          ],
-        },
-      ],
       system: systemMessages.map((m) => m.text).join('\n\n'),
       prompt: rewrittenQuery,
       maxTokens: 2048,

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -96,7 +96,9 @@ export type AuditAction =
   | 'radar.notification'
   | 'radar.search'
   // E2E test mode audit action — added via 0026_chat_query_audit_action.sql:
-  | 'chat.query';
+  | 'chat.query'
+  // Wave 5 Answer Refine — added via 0027_answer_refine_audit_action.sql:
+  | 'answer.refine';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -147,6 +147,8 @@ export const auditActionEnum = pgEnum('audit_action', [
   'radar.search',
   // E2E test mode audit action — added via 0026_chat_query_audit_action.sql:
   'chat.query',
+  // Wave 5 Answer Refine — added via 0027_answer_refine_audit_action.sql:
+  'answer.refine',
 ]);
 
 // REQ-WF-049: workflow_type pgEnum — three Phase 9 workflow kinds.

--- a/migrations/0027_answer_refine_audit_action.sql
+++ b/migrations/0027_answer_refine_audit_action.sql
@@ -1,0 +1,3 @@
+-- Wave 5 Answer Refine: add answer.refine enum value to audit_action
+-- REQ-ANSWER-REFINE-003 (immutable revision audit trail)
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'answer.refine';

--- a/tests/e2e/answer-refine.spec.ts
+++ b/tests/e2e/answer-refine.spec.ts
@@ -1,0 +1,57 @@
+// @MX:NOTE: [AUTO] E2E spec: inline answer refinement with tone presets
+// @MX:SPEC: SPEC-REGULA-ANSWER-REFINE-001 (REQ-ANSWER-REFINE-001..002)
+
+import { expect, test } from '@playwright/test';
+import { requiresAuthState, requiresLiveServer } from './fixtures/env-guard';
+
+test.describe('Answer Refine (SPEC-REGULA-ANSWER-REFINE-001)', () => {
+  test.beforeEach(async ({ page }) => {
+    const server = requiresLiveServer();
+    const auth = requiresAuthState();
+    test.skip(server.skip, server.reason);
+    test.skip(auth.skip, auth.reason);
+
+    await page.goto('/chat');
+    const composer = page.locator('[data-testid="chat-composer"]');
+    await composer.fill('__test:citation_response__');
+    await page.keyboard.press('Enter');
+
+    // Wait for the answer prose to appear.
+    await expect(page.locator('[data-testid="answer-prose"]')).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('refine button is visible in the answer block (REQ-ANSWER-REFINE-001)', async ({ page }) => {
+    const refineBtn = page.locator('[data-testid="refine-btn"]');
+    await expect(refineBtn).toBeVisible();
+  });
+
+  test('clicking refine button opens tone selector popover (REQ-ANSWER-REFINE-001)', async ({ page }) => {
+    await page.locator('[data-testid="refine-btn"]').click();
+
+    const popover = page.locator('[data-testid="refine-popover"]');
+    await expect(popover).toBeVisible();
+
+    // All 4 tone options must be present.
+    await expect(popover.locator('[data-testid="tone-option-conservative"]')).toBeVisible();
+    await expect(popover.locator('[data-testid="tone-option-regulatory-strict"]')).toBeVisible();
+    await expect(popover.locator('[data-testid="tone-option-executive-summary"]')).toBeVisible();
+    await expect(popover.locator('[data-testid="tone-option-technical-detail"]')).toBeVisible();
+  });
+
+  test('selecting a tone refines and replaces the prose (REQ-ANSWER-REFINE-002)', async ({ page }) => {
+    const prose = page.locator('[data-testid="answer-prose"]');
+    const originalText = await prose.innerText();
+
+    // Open popover and select "executive-summary".
+    await page.locator('[data-testid="refine-btn"]').click();
+    await page.locator('[data-testid="tone-option-executive-summary"]').click();
+
+    // Wait for refined label to appear.
+    await expect(page.locator('[data-testid="refined-label"]')).toBeVisible({ timeout: 10_000 });
+
+    // Prose must be updated (E2E mock prepends "[경영 요약 톤으로 정제됨]").
+    const refinedText = await prose.innerText();
+    expect(refinedText).not.toBe(originalText);
+    expect(refinedText).toContain('정제됨');
+  });
+});

--- a/tests/e2e/audit-log.spec.ts
+++ b/tests/e2e/audit-log.spec.ts
@@ -60,13 +60,21 @@ test.describe('Audit log — 21 CFR Part 11 (REQ-LAUNCH-020)', () => {
     expect(entry).not.toHaveProperty('updatedAt');
   });
 
-  test('audit log is accessible to admin role only', async ({ page, request }) => {
+  test('audit log is accessible to admin role only', async ({ playwright, baseURL }) => {
     const server = requiresLiveServer();
     test.skip(server.skip, server.reason);
 
-    // Unauthenticated request must return 401.
-    const res = await request.get('/api/audit-logs');
-    expect([401, 403]).toContain(res.status());
+    // Explicitly empty storageState forces a truly unauthenticated request.
+    const ctx = await playwright.request.newContext({
+      baseURL: baseURL ?? 'http://localhost:3000',
+      storageState: { cookies: [], origins: [] },
+    });
+    try {
+      const res = await ctx.get('/api/audit-logs');
+      expect([401, 403]).toContain(res.status());
+    } finally {
+      await ctx.dispose();
+    }
   });
 
   test('audit log admin UI shows entries table', async ({ page }) => {


### PR DESCRIPTION
## Summary

- AnswerBlock prose 섹션에 '답변 정제' 버튼 추가
- 4종 톤 프리셋 팝오버 (conservative / regulatory-strict / executive-summary / technical-detail)
- POST /api/ra/refine 엔드포인트 (E2E mock + 프로덕션 LLM)
- audit_logs answer.refine 기록
- migrations/0027 DB 마이그레이션

## E2E 결과
- answer-refine.spec.ts: 3/3 pass

## 미구현 (향후 PR)
- Diff View (원본 vs 정제본 side-by-side)
- Citation 무결성 재검증
- Confidence 재계산
- 블록 잠금 (#71 e-signature 연계)

Fixes #84

🗿 MoAI <email@mo.ai.kr>