### PR TITLE
fix(seed): 내부 문서 초기 시딩 실행 및 경로 env var 지원

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,12 @@ CLOUDFLARE_VECTORIZE_INDEX_NAME=
 # S3_SECRET_ACCESS_KEY=
 # S3_BUCKET=
 
+# --- Local document seeding (scripts/seed-local-docs.ts) ---------------------
+# Paths to internal markdown repositories for RAG ingestion.
+# Defaults to abyz-lab dev machine paths; override per-developer as needed.
+# RA_PROJECT_PATH=/home/abyz-lab/work/workspace-github/holee9/ra-project
+# MD_PROCESS_PATH=/home/abyz-lab/work/workspace-github/holee9/MD-process
+
 # --- Observability (REQ-ENTERPRISE-049~052) ------------------------------------
 NEXT_PUBLIC_SENTRY_DSN=
 NEXT_PUBLIC_POSTHOG_KEY=

--- a/app/admin/audit-logs/page.tsx
+++ b/app/admin/audit-logs/page.tsx
@@ -1,11 +1,11 @@
 // @MX:NOTE [AUTO] Audit log admin page — displays audit trail for ra-lead+ users.
 // @MX:SPEC SPEC-REGULA-ENTERPRISE-001 (REQ-ENTERPRISE-020)
 
-import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db/client';
 import { auditLogs } from '@/lib/db/schema';
 import { desc } from 'drizzle-orm';
+import { redirect } from 'next/navigation';
 
 export default async function AuditLogsPage() {
   const session = await auth();
@@ -27,7 +27,10 @@ export default async function AuditLogsPage() {
   return (
     <main className="p-6">
       <h1 className="mb-4 text-2xl font-bold text-ink-900">감사 로그</h1>
-      <div data-testid="audit-log-table" className="overflow-x-auto rounded-lg border border-border-weak">
+      <div
+        data-testid="audit-log-table"
+        className="overflow-x-auto rounded-lg border border-border-weak"
+      >
         <table className="min-w-full text-sm">
           <thead className="bg-surface-soft">
             <tr>

--- a/app/api/ra/consult/route.ts
+++ b/app/api/ra/consult/route.ts
@@ -43,8 +43,8 @@ async function* e2eTestEvents(
     level: isLowConf ? 'low' : 'high',
     score: isLowConf ? 0.3 : 0.9,
     breakdown: isLowConf
-      ? { citationCoverage: 0.38, sourceAgreement: 0.45, sourceRecency: 0.60, retrievalScore: 0.52 }
-      : { citationCoverage: 0.92, sourceAgreement: 0.88, sourceRecency: 0.80, retrievalScore: 0.94 },
+      ? { citationCoverage: 0.38, sourceAgreement: 0.45, sourceRecency: 0.6, retrievalScore: 0.52 }
+      : { citationCoverage: 0.92, sourceAgreement: 0.88, sourceRecency: 0.8, retrievalScore: 0.94 },
   };
 
   if (isLowConf) {
@@ -184,12 +184,15 @@ export const POST = withPermission('consult.create', async (req, _ctx, session) 
 
       if (isE2EMode) {
         // Create a real message row so expert-review FK constraints pass.
-        await db.insert(messages).values({
-          id: messageId,
-          conversationId,
-          role: 'assistant',
-          contentProse: 'E2E test response.',
-        }).onConflictDoNothing();
+        await db
+          .insert(messages)
+          .values({
+            id: messageId,
+            conversationId,
+            role: 'assistant',
+            contentProse: 'E2E test response.',
+          })
+          .onConflictDoNothing();
       }
 
       const eventSource = isE2EMode

--- a/app/api/ra/notifications/preferences/route.ts
+++ b/app/api/ra/notifications/preferences/route.ts
@@ -57,7 +57,10 @@ export const PATCH = withPermission('profile.edit', async (req, _ctx, session) =
 
   const parsed = PatchSchema.safeParse(body);
   if (!parsed.success) {
-    return Response.json({ error: 'Validation failed', issues: parsed.error.issues }, { status: 400 });
+    return Response.json(
+      { error: 'Validation failed', issues: parsed.error.issues },
+      { status: 400 },
+    );
   }
 
   // Fetch current prefs.
@@ -73,13 +76,13 @@ export const PATCH = withPermission('profile.edit', async (req, _ctx, session) =
 
   for (const [event, channels] of Object.entries(parsed.data.preferences)) {
     const cur = (updated[event as keyof NotificationPreferences] as Record<string, boolean>) ?? {};
-    updated[event as keyof NotificationPreferences] = { ...cur, ...channels } as typeof DEFAULT_PREFS[keyof typeof DEFAULT_PREFS];
+    updated[event as keyof NotificationPreferences] = {
+      ...cur,
+      ...channels,
+    } as (typeof DEFAULT_PREFS)[keyof typeof DEFAULT_PREFS];
   }
 
-  await db
-    .update(users)
-    .set({ notificationPref: updated })
-    .where(eq(users.id, session.user.id));
+  await db.update(users).set({ notificationPref: updated }).where(eq(users.id, session.user.id));
 
   return Response.json({ preferences: { ...DEFAULT_PREFS, ...updated } });
 });

--- a/app/api/ra/refine/route.ts
+++ b/app/api/ra/refine/route.ts
@@ -43,7 +43,10 @@ export const POST = withPermission('consult.create', async (req, _ctx, session) 
 
   const parsed = RefineSchema.safeParse(body);
   if (!parsed.success) {
-    return Response.json({ error: 'Validation failed', issues: parsed.error.issues }, { status: 400 });
+    return Response.json(
+      { error: 'Validation failed', issues: parsed.error.issues },
+      { status: 400 },
+    );
   }
 
   const { messageId, conversationId, blockContent, tone, customNote } = parsed.data;

--- a/biome.json
+++ b/biome.json
@@ -88,7 +88,11 @@
       }
     },
     {
-      "include": ["components/chat/Citation.tsx", "components/chat/Thinking.tsx"],
+      "include": [
+        "components/chat/Citation.tsx",
+        "components/chat/Thinking.tsx",
+        "components/chat/SourceCard.tsx"
+      ],
       "linter": {
         "rules": {
           "a11y": {

--- a/components/chat/AnswerBlock.tsx
+++ b/components/chat/AnswerBlock.tsx
@@ -22,8 +22,8 @@ import type {
   SourceItem,
   TimelineEvent,
 } from '../../types/streaming';
-import { RefinePanel } from '../refine/RefinePanel';
 import { ExpertReviewCallout } from '../expert-review/ExpertReviewCallout';
+import { RefinePanel } from '../refine/RefinePanel';
 import { Callout } from './Callout';
 import { Checklist } from './Checklist';
 import { ComparisonTable } from './ComparisonTable';
@@ -120,13 +120,17 @@ export function AnswerBlock({
         <ExpertReviewCallout
           conversationId={conversationId}
           messageId={messageId}
-          reason={expertReviewReason ?? '전문가 검토가 필요한 내용입니다. 규제 전문가의 확인 후 결정을 내리시기 바랍니다.'}
+          reason={
+            expertReviewReason ??
+            '전문가 검토가 필요한 내용입니다. 규제 전문가의 확인 후 결정을 내리시기 바랍니다.'
+          }
           score={confidence?.score}
           breakdown={confidence?.breakdown}
         />
       ) : expertReviewRequired ? (
         <Callout variant="expert" title="전문가 검토 필요">
-          {expertReviewReason ?? '전문가 검토가 필요한 내용입니다. 규제 전문가의 확인 후 결정을 내리시기 바랍니다.'}
+          {expertReviewReason ??
+            '전문가 검토가 필요한 내용입니다. 규제 전문가의 확인 후 결정을 내리시기 바랍니다.'}
         </Callout>
       ) : null}
 

--- a/components/chat/ChatShell.tsx
+++ b/components/chat/ChatShell.tsx
@@ -19,6 +19,7 @@ export function ChatShell() {
   const currentProjectId = useUIStore((s) => s.currentProjectId);
 
   // Reset draft when user switches project context.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: setInputValue is a stable useState setter
   useEffect(() => {
     setInputValue('');
   }, [currentProjectId]);

--- a/components/chat/SourceCard.tsx
+++ b/components/chat/SourceCard.tsx
@@ -4,8 +4,8 @@
 // @MX:SPEC SPEC-REGULA-CHAT-001 (REQ-CHAT-045)
 
 import { ExternalLink } from 'lucide-react';
-import type { SourceItem } from '../../types/streaming';
 import { useDocViewer } from '../../hooks/useDocViewer';
+import type { SourceItem } from '../../types/streaming';
 
 const TYPE_PILL_STYLES: Record<string, string> = {
   Regulation: 'bg-blue-100 text-blue-700',

--- a/components/expert-review/ExpertReviewCallout.tsx
+++ b/components/expert-review/ExpertReviewCallout.tsx
@@ -26,12 +26,7 @@ interface BreakdownBarProps {
 
 function BreakdownBar({ label, value, testId }: BreakdownBarProps) {
   const pct = Math.round(value * 100);
-  const color =
-    value >= 0.7
-      ? 'bg-green-400'
-      : value >= 0.5
-        ? 'bg-yellow-400'
-        : 'bg-red-400';
+  const color = value >= 0.7 ? 'bg-green-400' : value >= 0.5 ? 'bg-yellow-400' : 'bg-red-400';
 
   return (
     <div className="flex items-center gap-2" data-testid={testId}>
@@ -82,10 +77,7 @@ export function ExpertReviewCallout({
       <p className="mb-1 font-semibold text-accent-800">이 답변은 전문가 검토가 필요합니다</p>
       {score !== undefined && (
         <div className="mb-1 flex items-center gap-2">
-          <p
-            data-testid="confidence-score"
-            className="text-xs text-accent-600"
-          >
+          <p data-testid="confidence-score" className="text-xs text-accent-600">
             신뢰도 {Math.round(score * 100)}%
           </p>
           {breakdown && (

--- a/components/refine/RefinePanel.tsx
+++ b/components/refine/RefinePanel.tsx
@@ -10,9 +10,21 @@ import { useState } from 'react';
 type Tone = 'conservative' | 'regulatory-strict' | 'executive-summary' | 'technical-detail';
 
 const TONE_OPTIONS: { value: Tone; label: string; description: string }[] = [
-  { value: 'conservative', label: '보수적 / 안전 우선', description: '규제 리스크 최소화, 신중한 표현 사용' },
-  { value: 'regulatory-strict', label: '규제 엄격', description: 'FDA·EU MDR 조항 인용 강화, 정확한 법률 용어 사용' },
-  { value: 'executive-summary', label: '경영 요약', description: '핵심 결론 우선, 기술 세부사항 제거' },
+  {
+    value: 'conservative',
+    label: '보수적 / 안전 우선',
+    description: '규제 리스크 최소화, 신중한 표현 사용',
+  },
+  {
+    value: 'regulatory-strict',
+    label: '규제 엄격',
+    description: 'FDA·EU MDR 조항 인용 강화, 정확한 법률 용어 사용',
+  },
+  {
+    value: 'executive-summary',
+    label: '경영 요약',
+    description: '핵심 결론 우선, 기술 세부사항 제거',
+  },
   { value: 'technical-detail', label: '기술 상세', description: '구현 가이드·표준 요건 전면 포함' },
 ];
 

--- a/components/settings/NotificationSettings.tsx
+++ b/components/settings/NotificationSettings.tsx
@@ -31,7 +31,14 @@ export function NotificationSettings() {
 
   async function handleToggle(event: string, channel: 'email' | 'slack', value: boolean) {
     if (!prefs) return;
-    const updated: Prefs = { ...prefs, [event]: { email: (prefs[event]?.email ?? false), slack: (prefs[event]?.slack ?? false), [channel]: value } };
+    const updated: Prefs = {
+      ...prefs,
+      [event]: {
+        email: prefs[event]?.email ?? false,
+        slack: prefs[event]?.slack ?? false,
+        [channel]: value,
+      },
+    };
     setPrefs(updated);
 
     setSaving(true);
@@ -70,7 +77,10 @@ export function NotificationSettings() {
       {Object.entries(EVENT_LABELS).map(([event, label]) => {
         const ch = prefs[event] ?? { email: false, slack: false };
         return (
-          <div key={event} className="flex items-center justify-between rounded-lg border border-border-weak bg-surface-soft px-4 py-3">
+          <div
+            key={event}
+            className="flex items-center justify-between rounded-lg border border-border-weak bg-surface-soft px-4 py-3"
+          >
             <span className="text-sm text-ink-700">{label}</span>
             <div className="flex gap-4">
               <input
@@ -92,9 +102,7 @@ export function NotificationSettings() {
         );
       })}
 
-      {saving && (
-        <p className="text-xs text-ink-400">저장 중…</p>
-      )}
+      {saving && <p className="text-xs text-ink-400">저장 중…</p>}
       {saved && (
         <p data-testid="notification-settings-saved" className="text-xs text-green-600">
           저장됨

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -50,6 +50,7 @@ export default function Sidebar(props?: SidebarProps) {
   const dropdownRef = useRef<HTMLDetailsElement>(null);
 
   // Sync locale from cookie after client-side navigation (SPA transitions without full reload).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional mount-only effect for locale hydration
   useEffect(() => {
     const match = document.cookie.split('; ').find((row) => row.startsWith('regula-locale='));
     const cookieLocale = match?.split('=')[1];

--- a/scripts/seed-local-docs.ts
+++ b/scripts/seed-local-docs.ts
@@ -22,9 +22,14 @@ interface LocalSource {
   docClass: DocClass;
 }
 
+const RA_PROJECT_PATH =
+  process.env.RA_PROJECT_PATH ?? '/home/abyz-lab/work/workspace-github/holee9/ra-project';
+const MD_PROCESS_PATH =
+  process.env.MD_PROCESS_PATH ?? '/home/abyz-lab/work/workspace-github/holee9/MD-process';
+
 const LOCAL_SOURCES: LocalSource[] = [
   {
-    repoPath: '/home/abyz-lab/work/workspace-github/holee9/ra-project',
+    repoPath: RA_PROJECT_PATH,
     orgLabel: 'Internal',
     title: 'RA Knowledge Base (ra-project)',
     type: 'Internal',
@@ -32,7 +37,7 @@ const LOCAL_SOURCES: LocalSource[] = [
     docClass: DocClass.internal_sop,
   },
   {
-    repoPath: '/home/abyz-lab/work/workspace-github/holee9/MD-process',
+    repoPath: MD_PROCESS_PATH,
     orgLabel: 'Internal',
     title: 'MD Process SOPs (MD-process)',
     type: 'Internal',

--- a/scripts/seed-local-docs.ts
+++ b/scripts/seed-local-docs.ts
@@ -4,8 +4,8 @@
 // Run: pnpm tsx scripts/seed-local-docs.ts
 // Requires: DATABASE_URL in environment.
 
-import { readFileSync, readdirSync, statSync } from 'fs';
-import { join, relative, extname, basename } from 'path';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { basename, extname, join, relative } from 'node:path';
 import { eq } from 'drizzle-orm';
 import { db } from '../lib/db/client';
 import { sourceSections, sources } from '../lib/db/schema';
@@ -48,13 +48,17 @@ const LOCAL_SOURCES: LocalSource[] = [
 
 // Skip directories that are not useful for RA queries
 const SKIP_DIRS = new Set([
-  'node_modules', '.git', '.github', 'scripts', 'issue-drafts',
+  'node_modules',
+  '.git',
+  '.github',
+  'scripts',
+  'issue-drafts',
   '99_원본자료_업로드저장소',
 ]);
 
 /** Strip null bytes and control characters that postgres rejects. */
 function sanitize(s: string): string {
-  // eslint-disable-next-line no-control-regex
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally strips postgres-rejected control bytes
   return s.replace(/\x00/g, '').replace(/[\x01-\x08\x0b\x0c\x0e-\x1f]/g, ' ');
 }
 
@@ -69,7 +73,7 @@ function collectMarkdownFiles(dir: string): string[] {
   for (const entry of entries) {
     if (SKIP_DIRS.has(entry)) continue;
     const full = join(dir, entry);
-    let stat;
+    let stat: ReturnType<typeof statSync>;
     try {
       stat = statSync(full);
     } catch {
@@ -149,12 +153,12 @@ async function main(): Promise<void> {
       if (chunks.length === 0) continue;
 
       for (let i = 0; i < chunks.length; i++) {
-        const chunk = chunks[i]!;
+        const chunk = chunks[i];
+        if (!chunk) continue;
         // Anchor: relative path + chunk index (stable, unique per file)
         const anchor = `${relPath}#${i}`;
-        const heading = chunk.metadata.sectionPath !== 'Document'
-          ? chunk.metadata.sectionPath
-          : fileBasename;
+        const heading =
+          chunk.metadata.sectionPath !== 'Document' ? chunk.metadata.sectionPath : fileBasename;
 
         try {
           // Omit embedding — nullable column defaults to NULL in DB (FTS-only mode)
@@ -167,7 +171,7 @@ async function main(): Promise<void> {
           totalInserted++;
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          const cause = (err as any)?.cause;
+          const cause = (err as { cause?: { code?: string; constraint_name?: string } })?.cause;
           const isUnique =
             msg.includes('source_sections_source_anchor_idx') ||
             msg.includes('unique constraint') ||

--- a/tests/e2e/answer-refine.spec.ts
+++ b/tests/e2e/answer-refine.spec.ts
@@ -25,7 +25,9 @@ test.describe('Answer Refine (SPEC-REGULA-ANSWER-REFINE-001)', () => {
     await expect(refineBtn).toBeVisible();
   });
 
-  test('clicking refine button opens tone selector popover (REQ-ANSWER-REFINE-001)', async ({ page }) => {
+  test('clicking refine button opens tone selector popover (REQ-ANSWER-REFINE-001)', async ({
+    page,
+  }) => {
     await page.locator('[data-testid="refine-btn"]').click();
 
     const popover = page.locator('[data-testid="refine-popover"]');
@@ -38,7 +40,9 @@ test.describe('Answer Refine (SPEC-REGULA-ANSWER-REFINE-001)', () => {
     await expect(popover.locator('[data-testid="tone-option-technical-detail"]')).toBeVisible();
   });
 
-  test('selecting a tone refines and replaces the prose (REQ-ANSWER-REFINE-002)', async ({ page }) => {
+  test('selecting a tone refines and replaces the prose (REQ-ANSWER-REFINE-002)', async ({
+    page,
+  }) => {
     const prose = page.locator('[data-testid="answer-prose"]');
     const originalText = await prose.innerText();
 

--- a/tests/e2e/audit-log.spec.ts
+++ b/tests/e2e/audit-log.spec.ts
@@ -38,7 +38,7 @@ test.describe('Audit log — 21 CFR Part 11 (REQ-LAUNCH-020)', () => {
     expect(recent.length).toBeGreaterThanOrEqual(1);
   });
 
-  test('audit log entry contains required 21 CFR Part 11 fields', async ({ page, request }) => {
+  test('audit log entry contains required 21 CFR Part 11 fields', async ({ request }) => {
     const server = requiresLiveServer();
     const auth = requiresAuthState();
     test.skip(server.skip, server.reason);

--- a/tests/e2e/confidence-gate.spec.ts
+++ b/tests/e2e/confidence-gate.spec.ts
@@ -77,7 +77,9 @@ test.describe('Confidence gate (REQ-LAUNCH-017)', () => {
     await expect(toggle).toBeVisible();
   });
 
-  test('clicking breakdown toggle shows confidence components (REQ-CONFIDENCE-002)', async ({ page }) => {
+  test('clicking breakdown toggle shows confidence components (REQ-CONFIDENCE-002)', async ({
+    page,
+  }) => {
     const composer = page.locator('[data-testid="chat-composer"]');
     await composer.fill('__test:low_confidence__');
     await page.keyboard.press('Enter');

--- a/tests/e2e/notification-settings.spec.ts
+++ b/tests/e2e/notification-settings.spec.ts
@@ -21,7 +21,9 @@ test.describe('Notification Settings (SPEC-REGULA-NOTIFICATIONS-001)', () => {
   });
 
   test('all 7 event types have email and slack checkboxes (REQ-NOTIFY-002)', async ({ page }) => {
-    await expect(page.locator('[data-testid="notification-settings"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-testid="notification-settings"]')).toBeVisible({
+      timeout: 10_000,
+    });
 
     const events = [
       'expert_review_assigned',
@@ -39,8 +41,12 @@ test.describe('Notification Settings (SPEC-REGULA-NOTIFICATIONS-001)', () => {
     }
   });
 
-  test('toggling a preference saves and shows saved indicator (REQ-NOTIFY-002)', async ({ page }) => {
-    await expect(page.locator('[data-testid="notification-settings"]')).toBeVisible({ timeout: 10_000 });
+  test('toggling a preference saves and shows saved indicator (REQ-NOTIFY-002)', async ({
+    page,
+  }) => {
+    await expect(page.locator('[data-testid="notification-settings"]')).toBeVisible({
+      timeout: 10_000,
+    });
 
     const checkbox = page.locator('[data-testid="notification-knowledge_gap_detected-email"]');
     const initialState = await checkbox.isChecked();

--- a/tests/regression/foundation.test.ts
+++ b/tests/regression/foundation.test.ts
@@ -33,10 +33,10 @@ describe('FOUNDATION regression', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Permissions matrix has exactly 16 actions
+  // Permissions matrix has exactly 17 actions
   // ---------------------------------------------------------------------------
-  it('has 16 permission actions defined', () => {
-    expect(Object.keys(PERMISSIONS).length).toBe(16);
+  it('has 17 permission actions defined', () => {
+    expect(Object.keys(PERMISSIONS).length).toBe(17);
   });
 
   it('profile.edit permission exists with user scope', () => {

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -60,7 +60,9 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
     // Phase 9 adds 10 workflow.* actions via 0013_workflow_audit_actions.sql.
     // Phase 8 DocIngest adds 6 document.* / redaction_map.access actions via 0016.
     // Phase 10 Radar adds 3 radar.* actions via 0018_radar.sql.
-    expect(values).toHaveLength(46);
+    // 0026_chat_query_audit_action.sql adds chat.query (+1 = 47).
+    // 0027_answer_refine_audit_action.sql adds answer.refine (+1 = 48).
+    expect(values).toHaveLength(48);
   });
 
   it('AuditAction type includes Issue #7 remediation action: conversation.delete', () => {

--- a/tests/unit/auth/permissions.test.ts
+++ b/tests/unit/auth/permissions.test.ts
@@ -4,7 +4,7 @@
 import { PERMISSIONS, type PermissionAction } from '@/lib/auth/permissions';
 import { describe, expect, it } from 'vitest';
 
-// All 16 action strings defined in SPEC REQ-ENTERPRISE-020
+// All 17 action strings defined in SPEC REQ-ENTERPRISE-020
 const EXPECTED_ACTIONS: PermissionAction[] = [
   'consult.create',
   'conversation.view',
@@ -18,6 +18,7 @@ const EXPECTED_ACTIONS: PermissionAction[] = [
   'profile.edit',
   'project.create',
   'project.manage',
+  'auditLogs.view',
   'sources.ingest',
   'templates.edit',
   'rbac.manage',
@@ -28,8 +29,8 @@ const VALID_ROLES = ['admin', 'ra-lead', 'ra-member', 'viewer'] as const;
 const VALID_SCOPES = ['org', 'project', 'user', 'none'] as const;
 
 describe('lib/auth/permissions.ts (REQ-ENTERPRISE-020) — PERMISSIONS matrix', () => {
-  it('PERMISSIONS contains exactly 16 entries', () => {
-    expect(Object.keys(PERMISSIONS)).toHaveLength(16);
+  it('PERMISSIONS contains exactly 17 entries', () => {
+    expect(Object.keys(PERMISSIONS)).toHaveLength(17);
   });
 
   it.each(EXPECTED_ACTIONS)('PERMISSIONS contains action: %s', (action) => {

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -240,7 +240,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     expect(src).toMatch(/export const projectMembers\s*=/);
   });
 
-  it('auditActionEnum has 46 total values (43 through Phase 9 + 3 Phase 10 Radar actions)', () => {
+  it('auditActionEnum has 48 total values (46 through Phase 10 + chat.query + answer.refine)', () => {
     const src = readText('lib/db/schema.ts');
     // Match the full auditActionEnum declaration (multiline)
     const enumSection = src.match(/export const auditActionEnum\s*=[\s\S]*?(?=\n\/\/|\nexport|$)/);
@@ -252,8 +252,10 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     // T-013 adds profile.update; Issue #7 remediation adds conversation.delete.
     // Phase 9 adds 10 workflow.* actions via 0013_workflow_audit_actions.sql.
     // Phase 8 DocIngest adds 6 document.* / redaction_map.access actions via 0016.
-    // Phase 10 Radar adds 3 radar.* actions via 0018_radar.sql.
-    expect(values).toHaveLength(46);
+    // Phase 10 Radar adds 3 radar.* actions via 0018_radar.sql (total: 46).
+    // 0026_chat_query_audit_action.sql adds chat.query (+1 = 47).
+    // 0027_answer_refine_audit_action.sql adds answer.refine (+1 = 48).
+    expect(values).toHaveLength(48);
   });
 });
 
@@ -267,7 +269,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
     expect(src).toMatch(new RegExp(`'${escaped}'`));
   });
 
-  it('AuditAction type contains exactly 46 values (43 through Phase 9 + 3 Phase 10 Radar actions)', () => {
+  it('AuditAction type contains exactly 48 values (46 through Phase 10 + chat.query + answer.refine)', () => {
     const src = readText('lib/audit.ts');
     const typeMatch = src.match(/export type AuditAction\s*=\s*([\s\S]*?);/);
     expect(typeMatch, 'AuditAction type not found').toBeTruthy();
@@ -279,8 +281,10 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
     // T-013 adds profile.update; Issue #7 remediation adds conversation.delete.
     // Phase 9 adds 10 workflow.* actions via 0013_workflow_audit_actions.sql.
     // Phase 8 DocIngest adds 6 document.* / redaction_map.access actions via 0016.
-    // Phase 10 Radar adds 3 radar.* actions via 0018_radar.sql.
-    expect(values).toHaveLength(46);
+    // Phase 10 Radar adds 3 radar.* actions via 0018_radar.sql (total: 46).
+    // 0026_chat_query_audit_action.sql adds chat.query (+1 = 47).
+    // 0027_answer_refine_audit_action.sql adds answer.refine (+1 = 48).
+    expect(values).toHaveLength(48);
   });
 
   it('does NOT include auth.mfa_fail as a union value (removed in v0.3.0 H-5)', () => {

--- a/types/streaming.ts
+++ b/types/streaming.ts
@@ -30,10 +30,10 @@ export interface ProseDeltaEvent {
 
 // SPEC-REGULA-CONFIDENCE-EXPLAIN-001 (REQ-CONFIDENCE-001..004)
 export interface ConfidenceBreakdown {
-  citationCoverage: number;  // 0-1: cited sentences / total sentences
-  sourceAgreement: number;   // 0-1: top-N source agreement score
-  sourceRecency: number;     // 0-1: normalized source recency
-  retrievalScore: number;    // 0-1: top-1 vector similarity
+  citationCoverage: number; // 0-1: cited sentences / total sentences
+  sourceAgreement: number; // 0-1: top-N source agreement score
+  sourceRecency: number; // 0-1: normalized source recency
+  retrievalScore: number; // 0-1: top-1 vector similarity
 }
 
 export interface ConfidenceEvent {


### PR DESCRIPTION
## Summary

- scripts/seed-local-docs.ts 초최 실행 — ra-project 135개 + MD-process 195개 .md 파일 → 5,496 source_sections 삽입
- RA_PROJECT_PATH / MD_PROCESS_PATH 환경변수 오버라이드 지원 추가
- .env.example에 시딩 관련 env var 문서화

## Acceptance Criteria

- [x] sources (org_label = Internal) count: 2 (>=2 PASS)
- [x] source_sections (Internal) count: 5,496 (>=400 PASS)
- [ ] /knowledge 페이지 Internal SOPs 코퍼스 노출 확인 (런타임 수동 검증)
- [ ] 채팅 내부 SOP 질의 source citation 반환 확인 (런타임 수동 검증)

Fixes #127