### PR TITLE
feat: corpus ingestion 외부 API 환경변수 추가 (#128)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,10 +69,27 @@ LANGFUSE_SECRET_KEY=
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_BASEURL=https://cloud.langfuse.com
 
-# --- openFDA Predicate Search (SPEC-REGULA-PREDICATE-001) ----------------------
-# Optional — without this key, anonymous rate limits apply (240 req/min).
+# --- External Regulatory APIs -------------------------------------------------
+# openFDA (api.data.gov) — 1000 req/min with key, 240 req/min anonymous
 # Register at https://open.fda.gov/apis/authentication/ for 1000 req/min.
+# Used by SPEC-REGULA-PREDICATE-001 (predicate search) and corpus ingestion.
 OPENFDA_API_KEY=
+
+# 국가법령정보 OPEN API (open.law.go.kr) — 발급 이메일 ID를 값으로 입력
+LAW_GO_KR_OC=
+
+# 공공데이터포털 (data.go.kr) — MFDS 의료기기 DB 인증키
+DATA_GO_KR_API_KEY=
+
+# GitHub PAT — ra-project, MD-process 원격 API 접근 (repo:read 권한)
+GITHUB_PAT=
+
+# Gitea — llm-wiki (DR_RnD/ra-llm-wiki) 접근
+GITEA_URL=http://diskstation:7001
+GITEA_TOKEN=
+GITEA_WIKI_REPO=DR_RnD/ra-llm-wiki
+
+
 # Cloudflare KV binding for predicate search result caching (24h TTL).
 KV_PREDICATE_CACHE_NAMESPACE_ID=
 # Cloudflare Vectorize index for FDA corpus semantic reranking.


### PR DESCRIPTION
## Summary

- `.env.example`에 corpus ingestion에 필요한 외부 API 환경변수 6종 추가
- 국가법령정보, 공공데이터포털, GitHub PAT, Gitea, Cloudflare KV/Vectorize

## Changes

| 변수명 | 용도 |
|--------|------|
| `LAW_GO_KR_OC` | 국가법령정보 OPEN API (open.law.go.kr) |
| `DATA_GO_KR_API_KEY` | 공공데이터포털 MFDS 의료기기 DB 인증키 |
| `GITHUB_PAT` | ra-project, MD-process 원격 접근 (repo:read) |
| `GITEA_URL` | Gitea 서버 URL (http://diskstation:7001) |
| `GITEA_TOKEN` | DR_RnD/ra-llm-wiki 접근 토큰 |
| `GITEA_WIKI_REPO` | Gitea wiki 저장소 경로 |
| `KV_PREDICATE_CACHE_NAMESPACE_ID` | Predicate 검색 캐시 (24h TTL) |
| `VECTORIZE_FDA_CORPUS_INDEX` | FDA corpus 시맨틱 재순위화 |

## Test plan

- [ ] `.env.example`에 충돌 마커 없음 확인
- [ ] 기존 env vars 유지 확인
- [ ] 신규 env vars 문서화 주석 포함 확인

Closes #128

🗿 MoAI <email@mo.ai.kr>