### PR TITLE
feat(impact): SPEC-REGULA-IMPACT-001 규제 변경 영향 추적기

### DIFF
--- a/app/api/admin/radar/impact/route.ts
+++ b/app/api/admin/radar/impact/route.ts
@@ -1,0 +1,53 @@
+// POST /api/admin/radar/impact — trigger impact analysis for a regulatory update (admin only).
+// @MX:SPEC SPEC-REGULA-IMPACT-001
+
+import { z } from 'zod';
+import { withPermission } from '../../../../../lib/auth/with-permission';
+import { db } from '../../../../../lib/db/client';
+import { analyzeImpact } from '../../../../../lib/impact/analyzer';
+
+const TriggerSchema = z.object({
+  regulatory_update_id: z.string().uuid(),
+});
+
+export const POST = withPermission('dashboard.view', async (req, _ctx, session) => {
+  if (session.user.role !== 'admin') {
+    return Response.json({ error: 'Admin access required' }, { status: 403 });
+  }
+
+  const orgId = session.user.organizationId;
+  if (!orgId) {
+    return Response.json({ error: 'Organization context required' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = TriggerSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 422 });
+  }
+
+  let result: Awaited<ReturnType<typeof analyzeImpact>>;
+  try {
+    result = await analyzeImpact(
+      {
+        regulatory_update_id: parsed.data.regulatory_update_id,
+        org_id: orgId,
+        actor_id: session.user.id,
+      },
+      db,
+    );
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('not found')) {
+      return Response.json({ error: err.message }, { status: 404 });
+    }
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+
+  return Response.json(result);
+});

--- a/app/api/ra/impact/[assessmentId]/route.ts
+++ b/app/api/ra/impact/[assessmentId]/route.ts
@@ -11,62 +11,59 @@ import {
   regulatoryUpdates,
 } from '../../../../../lib/db/schema';
 
-export const GET = withPermission(
-  'dashboard.view',
-  async (_req, ctx, session) => {
-    const params = ctx.params ? await ctx.params : {};
-    const assessmentId = (params as { assessmentId?: string }).assessmentId ?? '';
-    const orgId = session.user.organizationId;
-    if (!orgId) {
-      return Response.json({ error: 'Organization context required' }, { status: 400 });
-    }
+export const GET = withPermission('dashboard.view', async (_req, ctx, session) => {
+  const params = ctx.params ? await ctx.params : {};
+  const assessmentId = (params as { assessmentId?: string }).assessmentId ?? '';
+  const orgId = session.user.organizationId;
+  if (!orgId) {
+    return Response.json({ error: 'Organization context required' }, { status: 400 });
+  }
 
-    const [row] = await db
-      .select({
-        id: regulatoryImpactAssessments.id,
-        regulatory_update_id: regulatoryImpactAssessments.regulatoryUpdateId,
-        update_title: regulatoryUpdates.title,
-        update_region: regulatoryUpdates.region,
-        project_id: regulatoryImpactAssessments.projectId,
-        project_name: projects.name,
-        impact_level: regulatoryImpactAssessments.impactLevel,
-        affected_sections: regulatoryImpactAssessments.affectedSections,
-        analysis_summary: regulatoryImpactAssessments.analysisSummary,
-        confidence: regulatoryImpactAssessments.confidence,
-        created_by: regulatoryImpactAssessments.createdBy,
-        created_at: regulatoryImpactAssessments.createdAt,
-      })
-      .from(regulatoryImpactAssessments)
-      .innerJoin(projects, eq(projects.id, regulatoryImpactAssessments.projectId))
-      .innerJoin(
-        regulatoryUpdates,
-        eq(regulatoryUpdates.id, regulatoryImpactAssessments.regulatoryUpdateId),
-      )
-      .where(
-        and(eq(regulatoryImpactAssessments.id, assessmentId), eq(projects.organizationId, orgId)),
-      )
-      .limit(1);
+  const [row] = await db
+    .select({
+      id: regulatoryImpactAssessments.id,
+      regulatory_update_id: regulatoryImpactAssessments.regulatoryUpdateId,
+      update_title: regulatoryUpdates.title,
+      update_region: regulatoryUpdates.region,
+      project_id: regulatoryImpactAssessments.projectId,
+      project_name: projects.name,
+      impact_level: regulatoryImpactAssessments.impactLevel,
+      affected_sections: regulatoryImpactAssessments.affectedSections,
+      analysis_summary: regulatoryImpactAssessments.analysisSummary,
+      confidence: regulatoryImpactAssessments.confidence,
+      created_by: regulatoryImpactAssessments.createdBy,
+      created_at: regulatoryImpactAssessments.createdAt,
+    })
+    .from(regulatoryImpactAssessments)
+    .innerJoin(projects, eq(projects.id, regulatoryImpactAssessments.projectId))
+    .innerJoin(
+      regulatoryUpdates,
+      eq(regulatoryUpdates.id, regulatoryImpactAssessments.regulatoryUpdateId),
+    )
+    .where(
+      and(eq(regulatoryImpactAssessments.id, assessmentId), eq(projects.organizationId, orgId)),
+    )
+    .limit(1);
 
-    if (!row) {
-      return Response.json({ error: 'Assessment not found' }, { status: 404 });
-    }
+  if (!row) {
+    return Response.json({ error: 'Assessment not found' }, { status: 404 });
+  }
 
-    const actionItems = await db
-      .select({
-        id: impactActionItems.id,
-        priority: impactActionItems.priority,
-        document_type: impactActionItems.documentType,
-        section_reference: impactActionItems.sectionReference,
-        description: impactActionItems.description,
-        status: impactActionItems.status,
-        assigned_to: impactActionItems.assignedTo,
-        created_at: impactActionItems.createdAt,
-        resolved_at: impactActionItems.resolvedAt,
-      })
-      .from(impactActionItems)
-      .where(eq(impactActionItems.assessmentId, assessmentId))
-      .orderBy(impactActionItems.createdAt);
+  const actionItems = await db
+    .select({
+      id: impactActionItems.id,
+      priority: impactActionItems.priority,
+      document_type: impactActionItems.documentType,
+      section_reference: impactActionItems.sectionReference,
+      description: impactActionItems.description,
+      status: impactActionItems.status,
+      assigned_to: impactActionItems.assignedTo,
+      created_at: impactActionItems.createdAt,
+      resolved_at: impactActionItems.resolvedAt,
+    })
+    .from(impactActionItems)
+    .where(eq(impactActionItems.assessmentId, assessmentId))
+    .orderBy(impactActionItems.createdAt);
 
-    return Response.json({ assessment: { ...row, action_items: actionItems } });
-  },
-);
+  return Response.json({ assessment: { ...row, action_items: actionItems } });
+});

--- a/app/api/ra/impact/[assessmentId]/route.ts
+++ b/app/api/ra/impact/[assessmentId]/route.ts
@@ -13,8 +13,9 @@ import {
 
 export const GET = withPermission(
   'dashboard.view',
-  async (_req, ctx: { params: Promise<{ assessmentId: string }> }, session) => {
-    const { assessmentId } = await ctx.params;
+  async (_req, ctx, session) => {
+    const params = ctx.params ? await ctx.params : {};
+    const assessmentId = (params as { assessmentId?: string }).assessmentId ?? '';
     const orgId = session.user.organizationId;
     if (!orgId) {
       return Response.json({ error: 'Organization context required' }, { status: 400 });

--- a/app/api/ra/impact/[assessmentId]/route.ts
+++ b/app/api/ra/impact/[assessmentId]/route.ts
@@ -1,0 +1,71 @@
+// GET /api/ra/impact/[assessmentId] — single assessment with action items.
+// @MX:SPEC SPEC-REGULA-IMPACT-001
+
+import { and, eq } from 'drizzle-orm';
+import { withPermission } from '../../../../../lib/auth/with-permission';
+import { db } from '../../../../../lib/db/client';
+import {
+  impactActionItems,
+  projects,
+  regulatoryImpactAssessments,
+  regulatoryUpdates,
+} from '../../../../../lib/db/schema';
+
+export const GET = withPermission(
+  'dashboard.view',
+  async (_req, ctx: { params: Promise<{ assessmentId: string }> }, session) => {
+    const { assessmentId } = await ctx.params;
+    const orgId = session.user.organizationId;
+    if (!orgId) {
+      return Response.json({ error: 'Organization context required' }, { status: 400 });
+    }
+
+    const [row] = await db
+      .select({
+        id: regulatoryImpactAssessments.id,
+        regulatory_update_id: regulatoryImpactAssessments.regulatoryUpdateId,
+        update_title: regulatoryUpdates.title,
+        update_region: regulatoryUpdates.region,
+        project_id: regulatoryImpactAssessments.projectId,
+        project_name: projects.name,
+        impact_level: regulatoryImpactAssessments.impactLevel,
+        affected_sections: regulatoryImpactAssessments.affectedSections,
+        analysis_summary: regulatoryImpactAssessments.analysisSummary,
+        confidence: regulatoryImpactAssessments.confidence,
+        created_by: regulatoryImpactAssessments.createdBy,
+        created_at: regulatoryImpactAssessments.createdAt,
+      })
+      .from(regulatoryImpactAssessments)
+      .innerJoin(projects, eq(projects.id, regulatoryImpactAssessments.projectId))
+      .innerJoin(
+        regulatoryUpdates,
+        eq(regulatoryUpdates.id, regulatoryImpactAssessments.regulatoryUpdateId),
+      )
+      .where(
+        and(eq(regulatoryImpactAssessments.id, assessmentId), eq(projects.organizationId, orgId)),
+      )
+      .limit(1);
+
+    if (!row) {
+      return Response.json({ error: 'Assessment not found' }, { status: 404 });
+    }
+
+    const actionItems = await db
+      .select({
+        id: impactActionItems.id,
+        priority: impactActionItems.priority,
+        document_type: impactActionItems.documentType,
+        section_reference: impactActionItems.sectionReference,
+        description: impactActionItems.description,
+        status: impactActionItems.status,
+        assigned_to: impactActionItems.assignedTo,
+        created_at: impactActionItems.createdAt,
+        resolved_at: impactActionItems.resolvedAt,
+      })
+      .from(impactActionItems)
+      .where(eq(impactActionItems.assessmentId, assessmentId))
+      .orderBy(impactActionItems.createdAt);
+
+    return Response.json({ assessment: { ...row, action_items: actionItems } });
+  },
+);

--- a/app/api/ra/impact/route.ts
+++ b/app/api/ra/impact/route.ts
@@ -1,0 +1,59 @@
+// GET /api/ra/impact — list regulatory impact assessments for the org.
+// @MX:SPEC SPEC-REGULA-IMPACT-001
+
+import { eq } from 'drizzle-orm';
+import { withPermission } from '../../../../lib/auth/with-permission';
+import { db } from '../../../../lib/db/client';
+import {
+  impactActionItems,
+  projects,
+  regulatoryImpactAssessments,
+  regulatoryUpdates,
+} from '../../../../lib/db/schema';
+
+export const GET = withPermission('dashboard.view', async (_req, _ctx, session) => {
+  const orgId = session.user.organizationId;
+  if (!orgId) {
+    return Response.json({ error: 'Organization context required' }, { status: 400 });
+  }
+
+  const assessments = await db
+    .select({
+      id: regulatoryImpactAssessments.id,
+      regulatory_update_id: regulatoryImpactAssessments.regulatoryUpdateId,
+      update_title: regulatoryUpdates.title,
+      update_region: regulatoryUpdates.region,
+      project_id: regulatoryImpactAssessments.projectId,
+      project_name: projects.name,
+      impact_level: regulatoryImpactAssessments.impactLevel,
+      analysis_summary: regulatoryImpactAssessments.analysisSummary,
+      confidence: regulatoryImpactAssessments.confidence,
+      created_at: regulatoryImpactAssessments.createdAt,
+    })
+    .from(regulatoryImpactAssessments)
+    .innerJoin(projects, eq(projects.id, regulatoryImpactAssessments.projectId))
+    .innerJoin(
+      regulatoryUpdates,
+      eq(regulatoryUpdates.id, regulatoryImpactAssessments.regulatoryUpdateId),
+    )
+    .where(eq(projects.organizationId, orgId))
+    .orderBy(regulatoryImpactAssessments.createdAt)
+    .limit(200);
+
+  // Attach open action item counts
+  const withCounts = await Promise.all(
+    assessments.map(async (a) => {
+      const items = await db
+        .select({ id: impactActionItems.id, status: impactActionItems.status })
+        .from(impactActionItems)
+        .where(eq(impactActionItems.assessmentId, a.id));
+      return {
+        ...a,
+        action_items_total: items.length,
+        action_items_open: items.filter((i) => i.status === 'open').length,
+      };
+    }),
+  );
+
+  return Response.json({ assessments: withCounts });
+});

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -50,7 +50,9 @@ import { auditLogs } from './db/schema';
 //
 // SPEC-REGULA-PREDICATE-001 values added via 0031_predicate_audit_actions.sql (2):
 //   predicate_search, predicate_comparison_generated
-// Total: 50 values.
+// SPEC-REGULA-IMPACT-001 values added via 0034_impact_audit_actions.sql (3):
+//   impact.assessment_created, impact.critical_detected, impact.action_item_created
+// Total: 54 values.
 export type AuditAction =
   | 'llm.call'
   | 'source.access'
@@ -108,7 +110,11 @@ export type AuditAction =
   | 'predicate_search'
   | 'predicate_comparison_generated'
   // Predicate export (PDF/DOCX) — REQ-PRE-015, audited for traceability:
-  | 'predicate_comparison_exported';
+  | 'predicate_comparison_exported'
+  // SPEC-REGULA-IMPACT-001 — impact analysis events via 0034_impact_audit_actions.sql:
+  | 'impact.assessment_created'
+  | 'impact.critical_detected'
+  | 'impact.action_item_created';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -5,10 +5,11 @@
 //          SPEC-REGULA-ENTERPRISE-001 (REQ-ENTERPRISE-016, 027, 028),
 //          SPEC-REGULA-WORKFLOWS-001 (REQ-WF-049, REQ-WF-051)
 //
-// Table inventory (16):
+// Table inventory (18):
 //   users, organizations, projects, conversations, messages, message_sources,
 //   message_blocks, sources, source_sections, templates, regulatory_updates,
-//   expert_reviews, audit_logs, org_members, project_members, workflow_runs
+//   expert_reviews, audit_logs, org_members, project_members, workflow_runs,
+//   regulatory_impact_assessments, impact_action_items
 //
 // pgEnum inventory (11):
 //   locale, theme_pref, message_role, confidence_level, block_type,
@@ -154,6 +155,10 @@ export const auditActionEnum = pgEnum('audit_action', [
   'predicate_comparison_generated',
   // Predicate export (PDF/DOCX) — added via 0032_predicate_export_audit_action.sql (REQ-PRE-015):
   'predicate_comparison_exported',
+  // SPEC-REGULA-IMPACT-001 — added via 0034_impact_audit_actions.sql (3):
+  'impact.assessment_created',
+  'impact.critical_detected',
+  'impact.action_item_created',
 ]);
 
 // REQ-WF-049: workflow_type pgEnum — three Phase 9 workflow kinds.
@@ -588,6 +593,51 @@ export const verificationTokens = pgTable(
     pk: primaryKey({ columns: [t.identifier, t.token] }),
   }),
 );
+
+// SPEC-REGULA-IMPACT-001 — regulatory change impact assessment.
+// Migrations: 0033_impact_tables.sql, 0034_impact_audit_actions.sql
+// @MX:SPEC SPEC-REGULA-IMPACT-001
+export const regulatoryImpactAssessments = pgTable(
+  'regulatory_impact_assessments',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    regulatoryUpdateId: uuid('regulatory_update_id')
+      .notNull()
+      .references(() => regulatoryUpdates.id, { onDelete: 'cascade' }),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    impactLevel: text('impact_level').notNull(),
+    affectedSections: jsonb('affected_sections').notNull().default([]),
+    analysisSummary: text('analysis_summary'),
+    confidence: numeric('confidence', { precision: 3, scale: 2 }),
+    createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    riaUpdateProjectKey: unique('ria_update_project_key').on(t.regulatoryUpdateId, t.projectId),
+    riaProjectImpactIdx: index('idx_ria_project_impact').on(t.projectId, t.impactLevel),
+    riaUpdateIdx: index('idx_ria_update').on(t.regulatoryUpdateId),
+  }),
+);
+
+export const impactActionItems = pgTable('impact_action_items', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  assessmentId: uuid('assessment_id')
+    .notNull()
+    .references(() => regulatoryImpactAssessments.id, { onDelete: 'cascade' }),
+  projectId: uuid('project_id')
+    .notNull()
+    .references(() => projects.id, { onDelete: 'cascade' }),
+  priority: text('priority').notNull(),
+  documentType: text('document_type'),
+  sectionReference: text('section_reference'),
+  description: text('description').notNull(),
+  status: text('status').notNull().default('open'),
+  assignedTo: uuid('assigned_to').references(() => users.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  resolvedAt: timestamp('resolved_at', { withTimezone: true, mode: 'date' }),
+});
 
 // SPEC-REGULA-NOTIFICATIONS-001 — per-org webhook settings.
 // Migration: 0028_org_notification_settings.sql

--- a/lib/impact/action-queue.ts
+++ b/lib/impact/action-queue.ts
@@ -1,0 +1,45 @@
+// SPEC-REGULA-IMPACT-001 — persist impact action items from scan results.
+
+import type { Database } from '@/lib/db/client';
+import { impactActionItems } from '@/lib/db/schema';
+import type { AffectedSection, ImpactLevel } from './types';
+
+interface ActionItemInput {
+  assessment_id: string;
+  project_id: string;
+  priority: ImpactLevel;
+  sections: AffectedSection[];
+  summary: string;
+}
+
+/**
+ * Persists action items for a completed impact assessment.
+ * One action item is created per affected section; a fallback generic item
+ * is created when no sections were identified.
+ */
+export async function enqueueActionItems(input: ActionItemInput, db: Database): Promise<void> {
+  if (input.sections.length === 0) {
+    await db.insert(impactActionItems).values({
+      assessmentId: input.assessment_id,
+      projectId: input.project_id,
+      priority: input.priority,
+      documentType: null,
+      sectionReference: null,
+      description: input.summary || 'Review regulatory update for potential impact.',
+      status: 'open',
+    });
+    return;
+  }
+
+  const rows = input.sections.map((s) => ({
+    assessmentId: input.assessment_id,
+    projectId: input.project_id,
+    priority: input.priority,
+    documentType: s.document_type,
+    sectionReference: s.section_reference,
+    description: s.rationale,
+    status: 'open' as const,
+  }));
+
+  await db.insert(impactActionItems).values(rows);
+}

--- a/lib/impact/analyzer.ts
+++ b/lib/impact/analyzer.ts
@@ -1,0 +1,159 @@
+// SPEC-REGULA-IMPACT-001 — orchestrates portfolio scan → DB persist → audit.
+// @MX:ANCHOR [AUTO] Top-level impact analysis orchestrator.
+// @MX:REASON Called by admin API route and (future) radar notifier webhook. fan_in >= 2.
+// @MX:SPEC SPEC-REGULA-IMPACT-001
+
+import type { Database } from '@/lib/db/client';
+import {
+  impactActionItems,
+  projects,
+  regulatoryImpactAssessments,
+  regulatoryUpdates,
+} from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { enqueueActionItems } from './action-queue';
+import {
+  auditActionItemCreated,
+  auditAssessmentCreated,
+  auditCriticalDetected,
+} from './audit-wiring';
+import { scanPortfolio } from './portfolio-scanner';
+import type { ImpactAssessment } from './types';
+
+export interface AnalysisRequest {
+  regulatory_update_id: string;
+  org_id: string;
+  actor_id: string;
+}
+
+export interface AnalysisResult {
+  assessments_created: number;
+  action_items_created: number;
+  critical_count: number;
+}
+
+/**
+ * Run full impact analysis for one regulatory update against an org's portfolio.
+ * Idempotent: UNIQUE(regulatory_update_id, project_id) prevents duplicates.
+ */
+export async function analyzeImpact(req: AnalysisRequest, db: Database): Promise<AnalysisResult> {
+  const [update] = await db
+    .select({
+      id: regulatoryUpdates.id,
+      title: regulatoryUpdates.title,
+      region: regulatoryUpdates.region,
+      severity: regulatoryUpdates.severity,
+      affectedProductTypes: regulatoryUpdates.affectedProductTypes,
+      impactTypeHint: regulatoryUpdates.impactTypeHint,
+      impactAnalysisText: regulatoryUpdates.impactAnalysisText,
+    })
+    .from(regulatoryUpdates)
+    .where(eq(regulatoryUpdates.id, req.regulatory_update_id))
+    .limit(1);
+
+  if (!update) throw new Error(`Regulatory update ${req.regulatory_update_id} not found`);
+
+  const scanResults = await scanPortfolio(update, req.org_id, db);
+
+  let assessmentsCreated = 0;
+  let actionItemsCreated = 0;
+  let criticalCount = 0;
+
+  for (const result of scanResults) {
+    const [inserted] = await db
+      .insert(regulatoryImpactAssessments)
+      .values({
+        regulatoryUpdateId: req.regulatory_update_id,
+        projectId: result.project_id,
+        impactLevel: result.impact_level,
+        affectedSections: result.affected_sections,
+        analysisSummary: result.analysis_summary,
+        confidence: String(result.confidence),
+        createdBy: req.actor_id,
+      })
+      .onConflictDoNothing()
+      .returning({ id: regulatoryImpactAssessments.id });
+
+    if (!inserted) continue; // already existed — skip
+
+    assessmentsCreated++;
+
+    await auditAssessmentCreated({
+      actor_id: req.actor_id,
+      assessment_id: inserted.id,
+      project_id: result.project_id,
+      regulatory_update_id: req.regulatory_update_id,
+      impact_level: result.impact_level,
+    });
+
+    if (result.impact_level === 'critical') {
+      criticalCount++;
+      await auditCriticalDetected({
+        actor_id: req.actor_id,
+        assessment_id: inserted.id,
+        project_id: result.project_id,
+        regulatory_update_id: req.regulatory_update_id,
+      });
+    }
+
+    await enqueueActionItems(
+      {
+        assessment_id: inserted.id,
+        project_id: result.project_id,
+        priority: result.impact_level,
+        sections: result.affected_sections,
+        summary: result.analysis_summary,
+      },
+      db,
+    );
+
+    // Count created action items for reporting
+    const items = await db
+      .select({ id: impactActionItems.id })
+      .from(impactActionItems)
+      .where(eq(impactActionItems.assessmentId, inserted.id));
+
+    for (const item of items) {
+      actionItemsCreated++;
+      await auditActionItemCreated({
+        actor_id: req.actor_id,
+        action_item_id: item.id,
+        assessment_id: inserted.id,
+        project_id: result.project_id,
+      });
+    }
+  }
+
+  return {
+    assessments_created: assessmentsCreated,
+    action_items_created: actionItemsCreated,
+    critical_count: criticalCount,
+  };
+}
+
+/** List all assessments for a given org (via project membership). */
+export async function listAssessmentsForOrg(
+  orgId: string,
+  db: Database,
+): Promise<ImpactAssessment[]> {
+  const rows = await db
+    .select({
+      id: regulatoryImpactAssessments.id,
+      regulatory_update_id: regulatoryImpactAssessments.regulatoryUpdateId,
+      project_id: regulatoryImpactAssessments.projectId,
+      project_name: projects.name,
+      impact_level: regulatoryImpactAssessments.impactLevel,
+      affected_sections: regulatoryImpactAssessments.affectedSections,
+      analysis_summary: regulatoryImpactAssessments.analysisSummary,
+      confidence: regulatoryImpactAssessments.confidence,
+      created_by: regulatoryImpactAssessments.createdBy,
+      created_at: regulatoryImpactAssessments.createdAt,
+    })
+    .from(regulatoryImpactAssessments)
+    .innerJoin(projects, eq(projects.id, regulatoryImpactAssessments.projectId))
+    .where(eq(projects.organizationId, orgId))
+    .orderBy(regulatoryImpactAssessments.createdAt)
+    .limit(200);
+
+  return rows as unknown as ImpactAssessment[];
+}

--- a/lib/impact/audit-wiring.ts
+++ b/lib/impact/audit-wiring.ts
@@ -1,0 +1,60 @@
+// SPEC-REGULA-IMPACT-001 — audit logging helpers for impact analysis events.
+
+import { writeAudit } from '@/lib/audit';
+import type { ImpactLevel } from './types';
+
+export async function auditAssessmentCreated(params: {
+  actor_id: string;
+  assessment_id: string;
+  project_id: string;
+  regulatory_update_id: string;
+  impact_level: ImpactLevel;
+}): Promise<void> {
+  await writeAudit({
+    actor_id: params.actor_id,
+    action: 'impact.assessment_created',
+    resource_type: 'impact_assessment',
+    resource_id: params.assessment_id,
+    meta_json: {
+      project_id: params.project_id,
+      regulatory_update_id: params.regulatory_update_id,
+      impact_level: params.impact_level,
+    },
+  });
+}
+
+export async function auditCriticalDetected(params: {
+  actor_id: string;
+  assessment_id: string;
+  project_id: string;
+  regulatory_update_id: string;
+}): Promise<void> {
+  await writeAudit({
+    actor_id: params.actor_id,
+    action: 'impact.critical_detected',
+    resource_type: 'impact_assessment',
+    resource_id: params.assessment_id,
+    meta_json: {
+      project_id: params.project_id,
+      regulatory_update_id: params.regulatory_update_id,
+    },
+  });
+}
+
+export async function auditActionItemCreated(params: {
+  actor_id: string;
+  action_item_id: string;
+  assessment_id: string;
+  project_id: string;
+}): Promise<void> {
+  await writeAudit({
+    actor_id: params.actor_id,
+    action: 'impact.action_item_created',
+    resource_type: 'impact_action_item',
+    resource_id: params.action_item_id,
+    meta_json: {
+      assessment_id: params.assessment_id,
+      project_id: params.project_id,
+    },
+  });
+}

--- a/lib/impact/portfolio-scanner.ts
+++ b/lib/impact/portfolio-scanner.ts
@@ -1,0 +1,88 @@
+// SPEC-REGULA-IMPACT-001 — scan org portfolio projects for a regulatory update.
+// @MX:ANCHOR [AUTO] Entry point for impact analysis pipeline.
+// @MX:REASON Called by analyzer.ts and admin API route. fan_in >= 2, grows to 3+ with UI.
+// @MX:SPEC SPEC-REGULA-IMPACT-001
+
+import type { Database } from '@/lib/db/client';
+import { projects } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { mapSections } from './section-mapper';
+import type { ImpactLevel, ScanResult } from './types';
+
+interface RegUpdateForScan {
+  id: string;
+  region: string;
+  severity: string;
+  affectedProductTypes: string[];
+  impactTypeHint: string | null;
+  impactAnalysisText: string | null;
+  title: string;
+}
+
+// Normalize severity → ImpactLevel
+function severityToLevel(severity: string, confidence: number): ImpactLevel {
+  if (severity === 'critical' || (severity === 'high' && confidence >= 0.8)) return 'critical';
+  if (severity === 'high') return 'high';
+  if (severity === 'medium') return 'medium';
+  return 'info';
+}
+
+function hasRegionOverlap(updateRegion: string, targetMarkets: string[]): boolean {
+  if (!targetMarkets.length) return true;
+  const norm = updateRegion.toUpperCase();
+  return targetMarkets.some((m) => {
+    const mn = m.toUpperCase();
+    return mn.includes(norm) || norm.includes(mn);
+  });
+}
+
+function hasCategoryOverlap(affectedTypes: string[], deviceClass: string | null): boolean {
+  if (!affectedTypes.length) return true; // broad update — affects all
+  if (!deviceClass) return false;
+  const dc = deviceClass.toLowerCase();
+  return affectedTypes.some((t) => dc.includes(t.toLowerCase()) || t.toLowerCase().includes(dc));
+}
+
+/**
+ * Scans all active projects in the org for relevance to a regulatory update.
+ * Returns only projects with at least 'info'-level impact.
+ */
+export async function scanPortfolio(
+  update: RegUpdateForScan,
+  orgId: string,
+  db: Database,
+): Promise<ScanResult[]> {
+  const rows = await db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      deviceClass: projects.deviceClass,
+      targetMarkets: projects.targetMarkets,
+    })
+    .from(projects)
+    .where(eq(projects.organizationId, orgId));
+
+  const results: ScanResult[] = [];
+
+  for (const project of rows) {
+    const regionMatch = hasRegionOverlap(update.region, project.targetMarkets ?? []);
+    const categoryMatch = hasCategoryOverlap(update.affectedProductTypes, project.deviceClass);
+
+    if (!regionMatch && !categoryMatch) continue;
+
+    const confidence = regionMatch && categoryMatch ? 0.85 : 0.5;
+    const sections = await mapSections(update, project.deviceClass);
+    const level = severityToLevel(update.severity, confidence);
+
+    results.push({
+      project_id: project.id,
+      project_name: project.name,
+      impact_level: level,
+      affected_sections: sections,
+      analysis_summary: `${update.title} — region: ${update.region}, severity: ${update.severity}.${sections.length > 0 ? ` ${sections.length} section(s) require attention.` : ''}`,
+      confidence,
+    });
+  }
+
+  return results;
+}

--- a/lib/impact/section-mapper.ts
+++ b/lib/impact/section-mapper.ts
@@ -1,0 +1,104 @@
+// SPEC-REGULA-IMPACT-001 — map regulatory update to affected document sections.
+// @MX:TODO [AUTO] LLM-based section identification stubbed; wire full prompt in Phase 2.
+// @MX:PRIORITY medium
+
+import type { AffectedSection } from './types';
+
+interface UpdateInfo {
+  region: string;
+  impactTypeHint: string | null;
+  impactAnalysisText: string | null;
+}
+
+// Heuristic mapping: impact type → typical document sections requiring update.
+const IMPACT_TYPE_SECTIONS: Record<string, AffectedSection[]> = {
+  labeling: [
+    {
+      document_type: 'IFU',
+      section_reference: '§5 Indications for Use',
+      rationale: 'Labeling change affects IFU',
+    },
+    {
+      document_type: '510(k)',
+      section_reference: 'Section 14: Proposed Labeling',
+      rationale: 'Labeling change affects 510(k) labeling section',
+    },
+  ],
+  software: [
+    {
+      document_type: 'SaMD Documentation',
+      section_reference: '§3 Software Description',
+      rationale: 'Software regulation impacts SaMD docs',
+    },
+    {
+      document_type: 'Risk Management File',
+      section_reference: 'Hazard Analysis',
+      rationale: 'Software change may introduce new hazards',
+    },
+  ],
+  clinical: [
+    {
+      document_type: 'Clinical Evaluation Report',
+      section_reference: '§6 Clinical Evidence',
+      rationale: 'Clinical data requirement change',
+    },
+    {
+      document_type: '510(k)',
+      section_reference: 'Section 12: Clinical Investigations',
+      rationale: 'Clinical requirement impacts submission',
+    },
+  ],
+  cybersecurity: [
+    {
+      document_type: 'Cybersecurity Documentation',
+      section_reference: 'Threat Model',
+      rationale: 'Cybersecurity guidance update',
+    },
+    {
+      document_type: 'SaMD Documentation',
+      section_reference: '§7 Security Controls',
+      rationale: 'Cybersecurity impacts SaMD security section',
+    },
+  ],
+  qms: [
+    {
+      document_type: 'Quality Management System',
+      section_reference: 'Design Controls',
+      rationale: 'QMS regulation change',
+    },
+    {
+      document_type: 'Design History File',
+      section_reference: 'Design Verification',
+      rationale: 'QMS change may affect DHF',
+    },
+  ],
+};
+
+/**
+ * Returns affected sections for a regulatory update given the device class.
+ * Uses heuristic mapping; LLM enrichment is deferred to Phase 2.
+ */
+export async function mapSections(
+  update: UpdateInfo,
+  deviceClass: string | null,
+): Promise<AffectedSection[]> {
+  if (!update.impactTypeHint) return [];
+
+  const hint = update.impactTypeHint.toLowerCase();
+  for (const [key, sections] of Object.entries(IMPACT_TYPE_SECTIONS)) {
+    if (hint.includes(key)) {
+      // Class III devices get extra scrutiny — mark clinical section regardless
+      if (deviceClass?.toUpperCase().includes('III') && key !== 'clinical') {
+        const extra: AffectedSection = {
+          document_type: 'PMA',
+          section_reference: '§3 Device Description',
+          rationale: 'Class III device — PMA section review recommended',
+        };
+        return [...sections, extra];
+      }
+      return sections;
+    }
+  }
+
+  return [];
+}

--- a/lib/impact/types.ts
+++ b/lib/impact/types.ts
@@ -1,0 +1,47 @@
+// SPEC-REGULA-IMPACT-001 — domain types for regulatory change impact tracking.
+
+export type ImpactLevel = 'critical' | 'high' | 'medium' | 'info';
+export type ActionItemStatus = 'open' | 'in_progress' | 'resolved';
+
+export interface AffectedSection {
+  document_type: string;
+  section_reference: string;
+  rationale: string;
+}
+
+export interface ImpactAssessment {
+  id: string;
+  regulatory_update_id: string;
+  project_id: string;
+  project_name: string;
+  impact_level: ImpactLevel;
+  affected_sections: AffectedSection[];
+  analysis_summary: string | null;
+  confidence: number | null;
+  created_by: string | null;
+  created_at: Date;
+  action_items?: ImpactActionItem[];
+}
+
+export interface ImpactActionItem {
+  id: string;
+  assessment_id: string;
+  project_id: string;
+  priority: ImpactLevel;
+  document_type: string | null;
+  section_reference: string | null;
+  description: string;
+  status: ActionItemStatus;
+  assigned_to: string | null;
+  created_at: Date;
+  resolved_at: Date | null;
+}
+
+export interface ScanResult {
+  project_id: string;
+  project_name: string;
+  impact_level: ImpactLevel;
+  affected_sections: AffectedSection[];
+  analysis_summary: string;
+  confidence: number;
+}

--- a/migrations/0033_impact_tables.sql
+++ b/migrations/0033_impact_tables.sql
@@ -1,0 +1,42 @@
+-- SPEC-REGULA-IMPACT-001: regulatory_impact_assessments + impact_action_items tables.
+-- REQ-IMPACT-001 (per-project assessment), REQ-IMPACT-002 (action items).
+-- Branch: feat/issue-41-impact-tracker
+
+CREATE TABLE regulatory_impact_assessments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  regulatory_update_id UUID NOT NULL REFERENCES regulatory_updates(id) ON DELETE CASCADE,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  impact_level TEXT NOT NULL DEFAULT 'info',
+  affected_sections JSONB NOT NULL DEFAULT '[]',
+  analysis_summary TEXT,
+  confidence NUMERIC(3,2),
+  created_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT ria_update_project_key UNIQUE(regulatory_update_id, project_id),
+  CONSTRAINT ria_impact_level_check
+    CHECK (impact_level IN ('critical','high','medium','info'))
+);
+
+CREATE INDEX idx_ria_project_impact
+  ON regulatory_impact_assessments(project_id, impact_level);
+CREATE INDEX idx_ria_update
+  ON regulatory_impact_assessments(regulatory_update_id);
+
+CREATE TABLE impact_action_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assessment_id UUID NOT NULL
+    REFERENCES regulatory_impact_assessments(id) ON DELETE CASCADE,
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  priority TEXT NOT NULL DEFAULT 'medium',
+  document_type TEXT,
+  section_reference TEXT,
+  description TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open',
+  assigned_to UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at TIMESTAMPTZ,
+  CONSTRAINT iai_priority_check
+    CHECK (priority IN ('critical','high','medium','info')),
+  CONSTRAINT iai_status_check
+    CHECK (status IN ('open','in_progress','resolved'))
+);

--- a/migrations/0034_impact_audit_actions.sql
+++ b/migrations/0034_impact_audit_actions.sql
@@ -1,0 +1,6 @@
+-- SPEC-REGULA-IMPACT-001: 3 new audit_action enum values (REQ-IMPACT-003).
+-- Brings total from 51 to 54 on this branch.
+-- NOTE: Each ADD VALUE must be in its own transaction (Postgres restriction).
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'impact.assessment_created';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'impact.critical_detected';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'impact.action_item_created';

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -45,7 +45,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
     expect(src).toMatch(new RegExp(`'${escaped}'`));
   });
 
-  it('AuditAction type contains exactly 51 values (48 baseline + 3 Predicate actions)', () => {
+  it('AuditAction type contains exactly 54 values (48 baseline + 3 Predicate + 3 Impact)', () => {
     const src = readText('lib/audit.ts');
     // Extract the AuditAction type block
     const typeMatch = src.match(/export type AuditAction\s*=\s*([\s\S]*?);/);
@@ -62,8 +62,10 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
     // Phase 10 Radar adds 3 radar.* actions via 0018_radar.sql.
     // E2E chat.query (0026) + Wave 5 answer.refine (0027) bring the baseline to 48.
     // SPEC-REGULA-PREDICATE-001 adds predicate_search + predicate_comparison_generated (0031)
-    // + predicate_export_requested (0032 REQ-PRE-015), bringing the total to 51.
-    expect(values).toHaveLength(51);
+    // + predicate_comparison_exported (0032 REQ-PRE-015), bringing the total to 51.
+    // SPEC-REGULA-IMPACT-001 adds impact.assessment_created, impact.critical_detected,
+    // impact.action_item_created (0034), bringing the total to 54.
+    expect(values).toHaveLength(54);
   });
 
   it('AuditAction type includes Issue #7 remediation action: conversation.delete', () => {

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -240,7 +240,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     expect(src).toMatch(/export const projectMembers\s*=/);
   });
 
-  it('auditActionEnum has 51 total values (48 baseline + 3 Predicate actions)', () => {
+  it('auditActionEnum has 54 total values (51 baseline + 3 Impact actions)', () => {
     const src = readText('lib/db/schema.ts');
     // Match the full auditActionEnum declaration (multiline)
     const enumSection = src.match(/export const auditActionEnum\s*=[\s\S]*?(?=\n\/\/|\nexport|$)/);
@@ -252,8 +252,10 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     // Phase 9 (+10), Phase 8 DocIngest (+6), Phase 10 Radar (+3), chat.query (0026),
     // answer.refine (0027) bring the baseline to 48. SPEC-REGULA-PREDICATE-001 adds
     // predicate_search + predicate_comparison_generated (0031)
-    // + predicate_export_requested (0032), total 51.
-    expect(values).toHaveLength(51);
+    // + predicate_comparison_exported (0032), total 51.
+    // SPEC-REGULA-IMPACT-001 adds impact.assessment_created, impact.critical_detected,
+    // impact.action_item_created (0034), total 54.
+    expect(values).toHaveLength(54);
   });
 });
 
@@ -267,7 +269,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
     expect(src).toMatch(new RegExp(`'${escaped}'`));
   });
 
-  it('AuditAction type contains exactly 51 values (48 baseline + 3 Predicate actions)', () => {
+  it('AuditAction type contains exactly 54 values (51 baseline + 3 Impact actions)', () => {
     const src = readText('lib/audit.ts');
     const typeMatch = src.match(/export type AuditAction\s*=\s*([\s\S]*?);/);
     expect(typeMatch, 'AuditAction type not found').toBeTruthy();
@@ -279,8 +281,10 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
     // Phase 9 (+10), Phase 8 DocIngest (+6), Phase 10 Radar (+3), chat.query (0026),
     // answer.refine (0027) bring the baseline to 48. SPEC-REGULA-PREDICATE-001 adds
     // predicate_search + predicate_comparison_generated (0031)
-    // + predicate_export_requested (0032), total 51.
-    expect(values).toHaveLength(51);
+    // + predicate_comparison_exported (0032), total 51.
+    // SPEC-REGULA-IMPACT-001 adds impact.assessment_created, impact.critical_detected,
+    // impact.action_item_created (0034), total 54.
+    expect(values).toHaveLength(54);
   });
 
   it('does NOT include auth.mfa_fail as a union value (removed in v0.3.0 H-5)', () => {

--- a/tests/unit/impact-migrations.test.ts
+++ b/tests/unit/impact-migrations.test.ts
@@ -1,0 +1,182 @@
+// SPEC-REGULA-IMPACT-001 — static shape verification for impact tables and audit wiring.
+// These tests run without a database: they parse source/migration files and assert
+// structural contracts (column presence, audit action membership, schema exports).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(__dirname, '../..');
+
+function readText(rel: string): string {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+function readMigration(name: string): string {
+  return readText(`migrations/${name}`);
+}
+
+// ---------------------------------------------------------------------------
+// Migration 0033 — regulatory_impact_assessments + impact_action_items tables
+// ---------------------------------------------------------------------------
+describe('migration 0033_impact_tables.sql', () => {
+  const sql = readMigration('0033_impact_tables.sql');
+
+  it('creates regulatory_impact_assessments table', () => {
+    expect(sql).toMatch(/CREATE TABLE.*regulatory_impact_assessments/i);
+  });
+
+  it('creates impact_action_items table', () => {
+    expect(sql).toMatch(/CREATE TABLE.*impact_action_items/i);
+  });
+
+  it('regulatory_impact_assessments has required columns', () => {
+    for (const col of [
+      'id',
+      'regulatory_update_id',
+      'project_id',
+      'impact_level',
+      'affected_sections',
+      'analysis_summary',
+      'confidence',
+      'created_by',
+      'created_at',
+    ]) {
+      expect(sql, `column ${col} missing from regulatory_impact_assessments`).toContain(col);
+    }
+  });
+
+  it('impact_action_items has required columns', () => {
+    for (const col of [
+      'id',
+      'assessment_id',
+      'project_id',
+      'priority',
+      'description',
+      'status',
+      'created_at',
+    ]) {
+      expect(sql, `column ${col} missing from impact_action_items`).toContain(col);
+    }
+  });
+
+  it('regulatory_impact_assessments has UNIQUE(regulatory_update_id, project_id)', () => {
+    expect(sql).toMatch(/ria_update_project_key/i);
+  });
+
+  it('impact_level CHECK constraint covers expected values', () => {
+    expect(sql).toContain('critical');
+    expect(sql).toContain('high');
+    expect(sql).toContain('medium');
+    expect(sql).toContain('info');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration 0034 — audit action enum additions
+// ---------------------------------------------------------------------------
+describe('migration 0034_impact_audit_actions.sql', () => {
+  const sql = readMigration('0034_impact_audit_actions.sql');
+
+  const EXPECTED = [
+    'impact.assessment_created',
+    'impact.critical_detected',
+    'impact.action_item_created',
+  ];
+
+  it.each(EXPECTED)('adds audit action: %s', (action) => {
+    expect(sql).toContain(action);
+  });
+
+  it('uses ADD VALUE IF NOT EXISTS for idempotency', () => {
+    expect(sql).toMatch(/ADD VALUE IF NOT EXISTS/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lib/db/schema.ts — Drizzle table exports
+// ---------------------------------------------------------------------------
+describe('lib/db/schema.ts impact table exports', () => {
+  const src = readText('lib/db/schema.ts');
+
+  it('exports regulatoryImpactAssessments', () => {
+    expect(src).toContain('export const regulatoryImpactAssessments');
+  });
+
+  it('exports impactActionItems', () => {
+    expect(src).toContain('export const impactActionItems');
+  });
+
+  it('auditActionEnum includes all three impact actions', () => {
+    const enumSection = src.match(/export const auditActionEnum\s*=[\s\S]*?(?=\n\/\/|\nexport|$)/);
+    expect(enumSection, 'auditActionEnum not found').toBeTruthy();
+    const body = (enumSection as RegExpMatchArray)[0];
+    expect(body).toContain("'impact.assessment_created'");
+    expect(body).toContain("'impact.critical_detected'");
+    expect(body).toContain("'impact.action_item_created'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lib/audit.ts — AuditAction type sync
+// ---------------------------------------------------------------------------
+describe('lib/audit.ts impact AuditAction values', () => {
+  const src = readText('lib/audit.ts');
+
+  const IMPACT_ACTIONS = [
+    'impact.assessment_created',
+    'impact.critical_detected',
+    'impact.action_item_created',
+  ];
+
+  it.each(IMPACT_ACTIONS)('AuditAction type includes: %s', (action) => {
+    const escaped = action.replace(/\./g, '\\.');
+    expect(src).toMatch(new RegExp(`'${escaped}'`));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lib/impact/ — module exports
+// ---------------------------------------------------------------------------
+describe('lib/impact module exports', () => {
+  it('lib/impact/analyzer.ts exports analyzeImpact and listAssessmentsForOrg', () => {
+    const src = readText('lib/impact/analyzer.ts');
+    expect(src).toContain('export async function analyzeImpact');
+    expect(src).toContain('export async function listAssessmentsForOrg');
+  });
+
+  it('lib/impact/types.ts exports ImpactLevel and ImpactAssessment', () => {
+    const src = readText('lib/impact/types.ts');
+    expect(src).toContain('ImpactLevel');
+    expect(src).toContain('ImpactAssessment');
+  });
+
+  it('lib/impact/portfolio-scanner.ts exports scanPortfolio', () => {
+    const src = readText('lib/impact/portfolio-scanner.ts');
+    expect(src).toContain('export async function scanPortfolio');
+  });
+
+  it('lib/impact/audit-wiring.ts exports the three audit helpers', () => {
+    const src = readText('lib/impact/audit-wiring.ts');
+    expect(src).toContain('export async function auditAssessmentCreated');
+    expect(src).toContain('export async function auditCriticalDetected');
+    expect(src).toContain('export async function auditActionItemCreated');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route handler files exist
+// ---------------------------------------------------------------------------
+describe('impact route handlers exist', () => {
+  it('admin trigger route exists', () => {
+    expect(() => readText('app/api/admin/radar/impact/route.ts')).not.toThrow();
+  });
+
+  it('ra impact list route exists', () => {
+    expect(() => readText('app/api/ra/impact/route.ts')).not.toThrow();
+  });
+
+  it('ra impact detail route exists', () => {
+    expect(() => readText('app/api/ra/impact/[assessmentId]/route.ts')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 요약

- `regulatory_impact_assessments`, `impact_action_items` 테이블 추가 (마이그레이션 0033)
- `audit_action` 열거형에 `impact.assessment_created`, `impact.critical_detected`, `impact.action_item_created` 3개 값 추가 (마이그레이션 0034)
- `lib/impact/` 모듈: `portfolio-scanner`, `section-mapper`, `action-queue`, `audit-wiring`, `analyzer`
- API 라우트: `GET /api/ra/impact`, `GET /api/ra/impact/[assessmentId]`, `POST /api/admin/radar/impact`
- `lib/audit.ts`, `lib/db/schema.ts` audit 열거형 동기화 (51 → 54개 값)
- 정적 마이그레이션 검증 테스트 추가 — 79개 전부 통과

## 테스트 계획

- [x] `tests/unit/impact-migrations.test.ts` — 마이그레이션 파일 형태 및 모듈 export 검증
- [x] `tests/unit/enterprise-migrations.test.ts` — audit 열거형 54개 값 검증
- [x] biome lint 통과 (EXIT 0)

Closes #41