### PR TITLE
fix(config): next.config.mjs 함수→객체 변환 — withNextIntl standalone output 손실 버그

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,37 +3,30 @@ import createNextIntlPlugin from 'next-intl/plugin';
 // REQ-FND-003: Next.js 15 pinned with React 18.
 // REQ-ENTERPRISE-037: next-intl without i18n routing (cookie-based locale).
 // Strict mode enabled across the app for early error surfacing.
-import { PHASE_PRODUCTION_BUILD } from 'next/constants.js';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
-/** @param {string} phase @returns {import('next').NextConfig} */
-function config(phase) {
-  // During `next build`, route modules are imported to collect page data before
-  // any real env vars are available. Inject SKIP_ENV_VALIDATION so lib/env.ts
-  // bypasses Zod validation for that phase only. Runtime modes (dev, start)
-  // never set this, so full validation is enforced there.
-  const isBuild = phase === PHASE_PRODUCTION_BUILD;
-  // Mutate parent-process env so child workers inherit it (belt-and-suspenders).
-  if (isBuild) process.env.SKIP_ENV_VALIDATION = '1';
+// SKIP_ENV_VALIDATION is injected by the build script (package.json) and the
+// Dockerfile ENV, so we do not need a phase-function wrapper here.
 
-  return {
-    reactStrictMode: true,
-    // Also pass via Next.js env table so page-data workers receive it.
-    env: isBuild ? { SKIP_ENV_VALIDATION: '1' } : {},
-    poweredByHeader: false,
-    // App Router is the default in Next.js 15; no `experimental.appDir` needed.
-    experimental: {
-      // Server Actions are GA in Next.js 15. Body size limit raised for
-      // potential document upload payloads on the consult endpoint.
-      serverActions: {
-        bodySizeLimit: '4mb',
-      },
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  poweredByHeader: false,
+  // Standalone output bundles only the minimal server runtime needed for
+  // Docker deployment. Dev mode (pnpm dev) is unaffected.
+  output: 'standalone',
+  // App Router is the default in Next.js 15; no `experimental.appDir` needed.
+  experimental: {
+    // Server Actions are GA in Next.js 15. Body size limit raised for
+    // potential document upload payloads on the consult endpoint.
+    serverActions: {
+      bodySizeLimit: '4mb',
     },
-    // The `ai` SDK and several Radix packages ship ESM; transpile if needed.
-    transpilePackages: [],
-    // Images are not used in Phase 1 scaffolding; defaults are fine.
-  };
-}
+  },
+  // The `ai` SDK and several Radix packages ship ESM; transpile if needed.
+  transpilePackages: [],
+  // Images are not used in Phase 1 scaffolding; defaults are fine.
+};
 
-export default withNextIntl(config);
+export default withNextIntl(nextConfig);


### PR DESCRIPTION
## 요약

- `withNextIntl(config)` 호출 시 `config`가 함수이면 `output: 'standalone'` 옵션이 손실되는 버그 수정
- `next.config.mjs`를 함수 형태 → 정적 객체 형태로 변환
- `SKIP_ENV_VALIDATION`은 `package.json build` 스크립트와 `Dockerfile ENV`에서 이미 처리되므로 phase-함수 불필요

## 변경 파일

- `next.config.mjs`: 함수→객체, `output: 'standalone'` 명시

## 테스트 계획

- [ ] `pnpm build` 성공 확인
- [ ] `.next/standalone` 폴더 생성 확인
- [ ] TypeScript 오류 0개 확인

Fixes #139

🗿 MoAI <email@mo.ai.kr>