### PR TITLE
feat(clinical-lit): 임상 문헌 검색 & 근거 합성기 구현 (#60)

### DIFF
--- a/__tests__/lib/cer/evidence-synthesis.test.ts
+++ b/__tests__/lib/cer/evidence-synthesis.test.ts
@@ -1,0 +1,155 @@
+// @MX:SPEC REQ-CLINLIT-021~025
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('ai', () => ({
+  generateObject: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/llm-provider', () => ({
+  getLlmModel: vi.fn(() => 'mock-model'),
+}));
+
+import { generateObject } from 'ai';
+import type { AppraiserArticle } from '../../../lib/cer/evidence-synthesis';
+import { synthesizeEvidence } from '../../../lib/cer/evidence-synthesis';
+import type { PicoFramework } from '../../../lib/cer/pico-generator';
+
+const MOCK_PICO: PicoFramework = {
+  patient: 'adult patients requiring cardiac monitoring',
+  intervention: 'implantable cardiac monitor',
+  comparator: null,
+  outcome: 'arrhythmia detection accuracy and safety',
+  meshTerms: ['Cardiac Monitor', 'Arrhythmias, Cardiac'],
+  searchQuery: '"cardiac monitor"[MeSH] AND "arrhythmia"[MeSH]',
+};
+
+const makeArticle = (pmid: string, gradeQuality: string): AppraiserArticle => ({
+  pmid,
+  title: `Study ${pmid}`,
+  abstract: 'This study evaluated the device in clinical setting.',
+  authors: ['Smith J', 'Doe A'],
+  journal: 'J Med Dev',
+  year: 2022,
+  sign50Level: gradeQuality === 'high' ? '1++' : '2+',
+  gradeQuality,
+  citation: `Smith J, Doe A. Study ${pmid}. J Med Dev. 2022.`,
+});
+
+const MOCK_SYNTHESIS_RESPONSE = {
+  object: {
+    gradeSummary: 'The overall body of evidence is of moderate quality.',
+    narrativeSynthesis: 'Studies demonstrate acceptable safety and efficacy.',
+    cerSection6Draft: '## 6. Clinical Background\n\nContent here.',
+    cerSection7Draft: '## 7. Clinical Data\n\n| Study | GRADE |\n|-------|-------|\n| Study 1 | High |',
+    cerSection8Draft: '## 8. Appraisal\n\nOverall the evidence supports the device.',
+  },
+};
+
+describe('synthesizeEvidence', () => {
+  it('returns all required draft sections non-empty', async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce(MOCK_SYNTHESIS_RESPONSE as never);
+
+    const articles = [makeArticle('11111111', 'high'), makeArticle('22222222', 'moderate')];
+    const result = await synthesizeEvidence(articles, 'cardiac monitor device', MOCK_PICO);
+
+    expect(result.gradeSummary.length).toBeGreaterThan(0);
+    expect(result.narrativeSynthesis.length).toBeGreaterThan(0);
+    expect(result.cerSection6Draft.length).toBeGreaterThan(0);
+    expect(result.cerSection7Draft.length).toBeGreaterThan(0);
+    expect(result.cerSection8Draft.length).toBeGreaterThan(0);
+  });
+
+  it('correctly counts GRADE distribution', async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce(MOCK_SYNTHESIS_RESPONSE as never);
+
+    const articles = [
+      makeArticle('1', 'high'),
+      makeArticle('2', 'high'),
+      makeArticle('3', 'moderate'),
+      makeArticle('4', 'low'),
+      makeArticle('5', 'very_low'),
+    ];
+    const result = await synthesizeEvidence(articles, 'device', MOCK_PICO);
+
+    expect(result.gradeCounts.high).toBe(2);
+    expect(result.gradeCounts.moderate).toBe(1);
+    expect(result.gradeCounts.low).toBe(1);
+    expect(result.gradeCounts.veryLow).toBe(1);
+  });
+
+  it('handles empty article list gracefully without additional LLM calls', async () => {
+    const callsBefore = vi.mocked(generateObject).mock.calls.length;
+
+    const result = await synthesizeEvidence([], 'device', MOCK_PICO);
+
+    const callsAfter = vi.mocked(generateObject).mock.calls.length;
+    expect(callsAfter).toBe(callsBefore); // no new calls for empty list
+
+    expect(result.cerSection6Draft.length).toBeGreaterThan(0);
+    expect(result.gradeCounts).toEqual({ high: 0, moderate: 0, low: 0, veryLow: 0 });
+  });
+
+  it('returns mock data in E2E_TEST_MODE without additional generateObject calls', async () => {
+    const callsBefore = vi.mocked(generateObject).mock.calls.length;
+
+    process.env.E2E_TEST_MODE = 'true';
+
+    const articles = [makeArticle('9999', 'moderate')];
+    const result = await synthesizeEvidence(articles, 'device', MOCK_PICO);
+
+    const callsAfter = vi.mocked(generateObject).mock.calls.length;
+    expect(callsAfter).toBe(callsBefore); // no new calls
+
+    expect(result.cerSection6Draft.length).toBeGreaterThan(0);
+    expect(result.cerSection7Draft.length).toBeGreaterThan(0);
+    expect(result.cerSection8Draft.length).toBeGreaterThan(0);
+
+    process.env.E2E_TEST_MODE = '';
+  });
+});
+
+describe('screenArticles (via screening-pipeline)', () => {
+  it('maps decisions correctly for each article', async () => {
+    vi.mock('ai', () => ({
+      generateObject: vi.fn(),
+    }));
+
+    // Import inline to pick up fresh mock.
+    const { screenArticles } = await import('../../../lib/cer/screening-pipeline');
+
+    vi.mocked(generateObject).mockResolvedValueOnce({
+      object: {
+        decisions: [
+          { pmid: '11111111', decision: 'include', reason: 'Relevant to PICO' },
+          { pmid: '22222222', decision: 'exclude', reason: 'Different patient population' },
+        ],
+      },
+    } as never);
+
+    const articles = [
+      {
+        pmid: '11111111',
+        title: 'Cardiac monitor study',
+        abstract: 'RCT in cardiac patients.',
+        authors: ['Smith J'],
+        journal: 'J Card',
+        year: 2022,
+      },
+      {
+        pmid: '22222222',
+        title: 'Pediatric study',
+        abstract: 'Study in children.',
+        authors: ['Doe A'],
+        journal: 'J Ped',
+        year: 2021,
+      },
+    ];
+
+    const results = await screenArticles(articles, MOCK_PICO, 'cardiac monitor');
+
+    expect(results).toHaveLength(2);
+    expect(results.find((r) => r.pmid === '11111111')?.decision).toBe('include');
+    expect(results.find((r) => r.pmid === '22222222')?.decision).toBe('exclude');
+  });
+});

--- a/__tests__/lib/cer/pico-generator.test.ts
+++ b/__tests__/lib/cer/pico-generator.test.ts
@@ -1,0 +1,79 @@
+// @MX:SPEC REQ-CLINLIT-001~005
+
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the AI SDK before importing module under test.
+vi.mock('ai', () => ({
+  generateObject: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/llm-provider', () => ({
+  getLlmFastModel: vi.fn(() => 'mock-model'),
+}));
+
+import { generateObject } from 'ai';
+import { generatePicoQuery } from '../../../lib/cer/pico-generator';
+
+const MOCK_PICO_RESPONSE = {
+  object: {
+    patient: 'adult patients with type 2 diabetes mellitus requiring glucose monitoring',
+    intervention: 'continuous glucose monitoring (CGM) device',
+    comparator: 'self-monitoring blood glucose (SMBG)',
+    outcome: 'glycemic control (HbA1c reduction) and safety events',
+    meshTerms: ['Blood Glucose Self-Monitoring', 'Diabetes Mellitus, Type 2', 'HbA1c Proteins'],
+    searchQuery:
+      '"continuous glucose monitoring"[MeSH] AND "diabetes mellitus, type 2"[MeSH] AND (safety OR efficacy)',
+  },
+};
+
+describe('generatePicoQuery', () => {
+  it('returns a valid PicoFramework shape', async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce(MOCK_PICO_RESPONSE as never);
+
+    const result = await generatePicoQuery(
+      'Continuous glucose monitoring system for type 2 diabetes patients',
+    );
+
+    expect(result.patient).toBeTruthy();
+    expect(result.intervention).toBeTruthy();
+    expect(result.outcome).toBeTruthy();
+    expect(result.searchQuery).toBeTruthy();
+    expect(Array.isArray(result.meshTerms)).toBe(true);
+  });
+
+  it('returns non-empty searchQuery', async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce(MOCK_PICO_RESPONSE as never);
+
+    const result = await generatePicoQuery('orthopedic implant device');
+
+    expect(result.searchQuery.length).toBeGreaterThan(0);
+  });
+
+  it('returns mock data in E2E_TEST_MODE without calling generateObject for PICO', async () => {
+    const callsBefore = vi.mocked(generateObject).mock.calls.length;
+
+    process.env.E2E_TEST_MODE = 'true';
+    // NODE_ENV is 'test' in vitest — satisfies the !== 'production' guard.
+
+    const result = await generatePicoQuery('test device description');
+
+    const callsAfter = vi.mocked(generateObject).mock.calls.length;
+    expect(callsAfter).toBe(callsBefore); // no new calls
+
+    expect(result.searchQuery).toBeTruthy();
+    expect(result.patient).toBeTruthy();
+
+    process.env.E2E_TEST_MODE = '';
+  });
+
+  it('passes device description to intervention in E2E mode', async () => {
+    process.env.E2E_TEST_MODE = 'true';
+
+    const description = 'spinal cord stimulation device for chronic pain management';
+    const result = await generatePicoQuery(description);
+
+    expect(result.intervention).toContain(description.slice(0, 50));
+
+    process.env.E2E_TEST_MODE = '';
+  });
+});

--- a/app/(app)/workflows/cer/_components/LiteratureSearchPanel.tsx
+++ b/app/(app)/workflows/cer/_components/LiteratureSearchPanel.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+// @MX:NOTE [AUTO] LiteratureSearchPanel — PICO-driven clinical literature search UI.
+// @MX:SPEC REQ-CLINLIT-001~025
+
+import { type FormEvent, useRef, useState } from 'react';
+
+interface PicoData {
+  patient: string;
+  intervention: string;
+  comparator: string | null;
+  outcome: string;
+  meshTerms: string[];
+  searchQuery: string;
+}
+
+interface GradeCounts {
+  high: number;
+  moderate: number;
+  low: number;
+  veryLow: number;
+}
+
+interface SearchResult {
+  searchId: string;
+  includedCount: number;
+  totalCount: number;
+  cerSection6Draft: string;
+  cerSection7Draft: string;
+  cerSection8Draft: string;
+}
+
+type PipelineStep = 'idle' | 'pico' | 'search' | 'screening' | 'synthesis' | 'done' | 'error';
+
+const STEP_LABELS: Record<PipelineStep, string> = {
+  idle: '대기 중',
+  pico: 'PICO 프레임워크 생성 중...',
+  search: 'PubMed 검색 중...',
+  screening: '제목/초록 스크리닝 중...',
+  synthesis: '근거 합성 중...',
+  done: '완료',
+  error: '오류 발생',
+};
+
+const INPUT_CLASS = 'border border-ink-200 rounded-md px-3 py-2 text-sm w-full';
+const PRIMARY_BTN =
+  'bg-brand-700 text-white hover:bg-brand-800 rounded-md px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60';
+
+interface Props {
+  cerRunId: string;
+  initialDeviceDescription?: string;
+}
+
+export function LiteratureSearchPanel({ cerRunId, initialDeviceDescription = '' }: Props) {
+  const [deviceDescription, setDeviceDescription] = useState(initialDeviceDescription);
+  const [step, setStep] = useState<PipelineStep>('idle');
+  const [pico, setPico] = useState<PicoData | null>(null);
+  const [searchCount, setSearchCount] = useState<number | null>(null);
+  const [screeningStats, setScreeningStats] = useState<{
+    total: number;
+    included: number;
+    excluded: number;
+    uncertain: number;
+  } | null>(null);
+  const [gradeCounts, setGradeCounts] = useState<GradeCounts | null>(null);
+  const [result, setResult] = useState<SearchResult | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [activeSection, setActiveSection] = useState<'6' | '7' | '8'>('6');
+  const abortRef = useRef<AbortController | null>(null);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!deviceDescription.trim()) return;
+
+    // Reset state.
+    setStep('pico');
+    setPico(null);
+    setSearchCount(null);
+    setScreeningStats(null);
+    setGradeCounts(null);
+    setResult(null);
+    setErrorMessage(null);
+
+    abortRef.current?.abort();
+    const abort = new AbortController();
+    abortRef.current = abort;
+
+    try {
+      const response = await fetch('/api/ra/workflows/cer/literature', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cerRunId, deviceDescription }),
+        signal: abort.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        const text = await response.text().catch(() => 'Unknown error');
+        setErrorMessage(`요청 실패: ${text}`);
+        setStep('error');
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const parsed = JSON.parse(line.slice(6)) as { event: string; data: unknown };
+            handleSSEEvent(parsed.event, parsed.data);
+          } catch {
+            // Ignore malformed SSE lines.
+          }
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setErrorMessage('네트워크 오류가 발생했습니다. 다시 시도해 주세요.');
+      setStep('error');
+    }
+  }
+
+  function handleSSEEvent(event: string, data: unknown) {
+    const d = data as Record<string, unknown>;
+    switch (event) {
+      case 'pico':
+        setPico(d.pico as PicoData);
+        setStep('search');
+        break;
+      case 'search':
+        setSearchCount(d.count as number);
+        setStep('screening');
+        break;
+      case 'screening':
+        setScreeningStats({
+          total: d.total as number,
+          included: d.included as number,
+          excluded: d.excluded as number,
+          uncertain: d.uncertain as number,
+        });
+        setStep('synthesis');
+        break;
+      case 'synthesis':
+        setGradeCounts(d.gradeCounts as GradeCounts);
+        break;
+      case 'done':
+        if (d.searchId) {
+          setResult(d as unknown as SearchResult);
+        }
+        setStep('done');
+        break;
+      case 'error':
+        setErrorMessage((d.message as string) ?? '알 수 없는 오류');
+        setStep('error');
+        break;
+    }
+  }
+
+  const isRunning = ['pico', 'search', 'screening', 'synthesis'].includes(step);
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="deviceDescription"
+            className="block text-sm font-medium text-ink-700 mb-1"
+          >
+            의료기기 설명 (Clinical Literature Search)
+          </label>
+          <textarea
+            id="deviceDescription"
+            className={`${INPUT_CLASS} h-28 resize-none`}
+            placeholder="의료기기의 종류, 적응증, 기술적 특성을 입력하세요. 예: 혈당 연속 모니터링 시스템 (CGM), 제2형 당뇨병 환자용, 효소 기반 전기화학 센서..."
+            value={deviceDescription}
+            onChange={(e) => setDeviceDescription(e.target.value)}
+            disabled={isRunning}
+          />
+        </div>
+        <button type="submit" className={PRIMARY_BTN} disabled={isRunning || !deviceDescription.trim()}>
+          {isRunning ? '검색 중...' : '검색 시작'}
+        </button>
+      </form>
+
+      {/* Pipeline progress indicator */}
+      {step !== 'idle' && (
+        <div className="space-y-3">
+          <PipelineProgress step={step} />
+
+          {pico && (
+            <div className="rounded-md border border-brand-200 bg-brand-50 p-3 text-sm space-y-1">
+              <p className="font-medium text-brand-800">PICO 프레임워크</p>
+              <p>
+                <span className="text-ink-500">P (환자군):</span> {pico.patient}
+              </p>
+              <p>
+                <span className="text-ink-500">I (중재):</span> {pico.intervention}
+              </p>
+              {pico.comparator && (
+                <p>
+                  <span className="text-ink-500">C (비교군):</span> {pico.comparator}
+                </p>
+              )}
+              <p>
+                <span className="text-ink-500">O (결과):</span> {pico.outcome}
+              </p>
+              <p className="text-xs text-ink-400 truncate">검색어: {pico.searchQuery}</p>
+            </div>
+          )}
+
+          {searchCount !== null && (
+            <p className="text-sm text-ink-600">
+              PubMed 검색 결과: <span className="font-medium">{searchCount}개</span> 논문
+            </p>
+          )}
+
+          {screeningStats && (
+            <div className="text-sm text-ink-600 space-y-1">
+              <p>스크리닝 결과:</p>
+              <div className="flex gap-4">
+                <span className="text-green-700">포함 {screeningStats.included}편</span>
+                <span className="text-red-600">제외 {screeningStats.excluded}편</span>
+                <span className="text-yellow-600">불확실 {screeningStats.uncertain}편</span>
+              </div>
+            </div>
+          )}
+
+          {gradeCounts && (
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-ink-700">GRADE 근거 수준</p>
+              <GradeBar counts={gradeCounts} />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* CER section drafts */}
+      {result && (
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-ink-700">
+            CER 섹션 초안 (포함 논문: {result.includedCount}편 / 전체 {result.totalCount}편)
+          </p>
+          <div className="flex gap-2 text-sm">
+            {(['6', '7', '8'] as const).map((sec) => (
+              <button
+                key={sec}
+                type="button"
+                onClick={() => setActiveSection(sec)}
+                className={`px-3 py-1 rounded-md border transition-colors ${
+                  activeSection === sec
+                    ? 'border-brand-500 bg-brand-50 text-brand-700 font-medium'
+                    : 'border-ink-200 text-ink-600 hover:bg-ink-50'
+                }`}
+              >
+                Section {sec}
+              </button>
+            ))}
+          </div>
+          <div className="rounded-md border border-ink-200 bg-white p-4 text-sm whitespace-pre-wrap font-mono text-ink-700 max-h-96 overflow-y-auto">
+            {activeSection === '6' && result.cerSection6Draft}
+            {activeSection === '7' && result.cerSection7Draft}
+            {activeSection === '8' && result.cerSection8Draft}
+          </div>
+        </div>
+      )}
+
+      {errorMessage && (
+        <p className="text-sm text-red-600 rounded-md border border-red-200 bg-red-50 px-3 py-2">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PipelineProgress({ step }: { step: PipelineStep }) {
+  const steps: PipelineStep[] = ['pico', 'search', 'screening', 'synthesis', 'done'];
+  const currentIndex = steps.indexOf(step);
+
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      {steps.map((s, i) => {
+        const isDone = i < currentIndex || step === 'done';
+        const isActive = s === step && step !== 'done';
+        return (
+          <div key={s} className="flex items-center gap-1">
+            <span
+              className={`w-5 h-5 rounded-full flex items-center justify-center text-xs font-medium ${
+                isDone
+                  ? 'bg-brand-600 text-white'
+                  : isActive
+                    ? 'bg-brand-200 text-brand-800 animate-pulse'
+                    : 'bg-ink-100 text-ink-400'
+              }`}
+            >
+              {isDone ? '✓' : i + 1}
+            </span>
+            {i < steps.length - 1 && (
+              <span className={`w-6 h-px ${i < currentIndex ? 'bg-brand-400' : 'bg-ink-200'}`} />
+            )}
+          </div>
+        );
+      })}
+      <span className="text-ink-500 ml-2">{STEP_LABELS[step]}</span>
+    </div>
+  );
+}
+
+function GradeBar({ counts }: { counts: GradeCounts }) {
+  const total = counts.high + counts.moderate + counts.low + counts.veryLow;
+  if (total === 0) return null;
+
+  const bars = [
+    { label: '고', count: counts.high, color: 'bg-green-500' },
+    { label: '중', count: counts.moderate, color: 'bg-blue-400' },
+    { label: '저', count: counts.low, color: 'bg-yellow-400' },
+    { label: '매우낮음', count: counts.veryLow, color: 'bg-red-400' },
+  ];
+
+  return (
+    <div className="space-y-1">
+      <div className="flex h-4 rounded overflow-hidden gap-px">
+        {bars.map(
+          (b) =>
+            b.count > 0 && (
+              <div
+                key={b.label}
+                className={`${b.color}`}
+                style={{ width: `${(b.count / total) * 100}%` }}
+                title={`${b.label}: ${b.count}편`}
+              />
+            ),
+        )}
+      </div>
+      <div className="flex gap-3 text-xs text-ink-500">
+        {bars.map(
+          (b) =>
+            b.count > 0 && (
+              <span key={b.label}>
+                <span className={`inline-block w-2 h-2 rounded-sm ${b.color} mr-1`} />
+                {b.label} {b.count}
+              </span>
+            ),
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/ra/workflows/cer/literature/route.ts
+++ b/app/api/ra/workflows/cer/literature/route.ts
@@ -1,0 +1,188 @@
+// @MX:ANCHOR [AUTO] Literature Search Route — POST /api/ra/workflows/cer/literature
+// @MX:REASON SSE streaming entry point for the PICO→search→screen→synthesize pipeline.
+// @MX:SPEC REQ-CLINLIT-001~025
+
+export const runtime = 'nodejs';
+
+import { withPermission } from '@/lib/auth/with-permission';
+import { formatVancouver } from '@/lib/cer/citation-formatter';
+import { synthesizeEvidence } from '@/lib/cer/evidence-synthesis';
+import { appraiseEvidence } from '@/lib/cer/literature-appraisal';
+import { generatePicoQuery } from '@/lib/cer/pico-generator';
+import { searchPubMed } from '@/lib/cer/pubmed-client';
+import { screenArticles } from '@/lib/cer/screening-pipeline';
+import { db } from '@/lib/db/client';
+import { evidenceSyntheses, literatureReferences, literatureSearches } from '@/lib/db/schema';
+import { z } from 'zod';
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache, no-transform',
+  Connection: 'keep-alive',
+  'X-Accel-Buffering': 'no',
+};
+
+const LiteratureSearchInputSchema = z.object({
+  cerRunId: z.string().uuid(),
+  deviceDescription: z.string().min(10).max(2000),
+});
+
+function sseEvent(event: string, data: unknown): string {
+  return `data: ${JSON.stringify({ event, data })}\n\n`;
+}
+
+export const POST = withPermission('consult.create', async (req, _ctx, _session) => {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = LiteratureSearchInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Validation failed', issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const { cerRunId, deviceDescription } = parsed.data;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder();
+      const push = (event: string, data: unknown) =>
+        controller.enqueue(encoder.encode(sseEvent(event, data)));
+
+      try {
+        // Step 1: Generate PICO framework.
+        const pico = await generatePicoQuery(deviceDescription);
+        push('pico', { pico });
+
+        // Step 2: Search PubMed.
+        const articles = await searchPubMed(pico.searchQuery, 50);
+        push('search', { count: articles.length, query: pico.searchQuery });
+
+        if (articles.length === 0) {
+          push('done', { searchId: null, message: 'No articles found for this query.' });
+          controller.close();
+          return;
+        }
+
+        // Step 3: Screen articles by title/abstract.
+        const screeningResults = await screenArticles(articles, pico, deviceDescription);
+        const includedPmids = new Set(
+          screeningResults.filter((r) => r.decision === 'include').map((r) => r.pmid),
+        );
+        push('screening', {
+          total: articles.length,
+          included: includedPmids.size,
+          excluded: screeningResults.filter((r) => r.decision === 'exclude').length,
+          uncertain: screeningResults.filter((r) => r.decision === 'uncertain').length,
+        });
+
+        // Step 4: Appraise included articles (deterministic SIGN 50 / GRADE).
+        const includedArticles = articles.filter((a) => includedPmids.has(a.pmid));
+        const appraisedArticles = includedArticles.map((article) => {
+          const appraisal = appraiseEvidence(article);
+          return {
+            ...article,
+            sign50Level: appraisal.sign50Level,
+            gradeQuality: appraisal.gradeQuality,
+            citation: formatVancouver(article),
+          };
+        });
+
+        // Step 5: Synthesize evidence into CER sections.
+        const synthesis = await synthesizeEvidence(appraisedArticles, deviceDescription, pico);
+        push('synthesis', {
+          gradeCounts: synthesis.gradeCounts,
+          gradeSummary: synthesis.gradeSummary.slice(0, 200),
+        });
+
+        // Step 6: Persist to database.
+        const screeningMap = new Map(screeningResults.map((r) => [r.pmid, r]));
+
+        const [searchRow] = await db
+          .insert(literatureSearches)
+          .values({
+            cerRunId,
+            deviceDescription,
+            picoPatient: pico.patient,
+            picoIntervention: pico.intervention,
+            picoComparator: pico.comparator,
+            picoOutcome: pico.outcome,
+            searchQuery: pico.searchQuery,
+            meshTerms: pico.meshTerms,
+            totalRecords: articles.length,
+            afterDedup: articles.length,
+            afterTitleAbstract: includedPmids.size,
+            afterFullText: includedPmids.size,
+            includedCount: includedPmids.size,
+          })
+          .returning({ id: literatureSearches.id });
+
+        const searchId = searchRow?.id;
+        if (!searchId) throw new Error('Failed to insert literature_searches row');
+
+        if (articles.length > 0) {
+          await db.insert(literatureReferences).values(
+            articles.map((article) => {
+              const screening = screeningMap.get(article.pmid);
+              const appraised = appraisedArticles.find((a) => a.pmid === article.pmid);
+              return {
+                searchId,
+                pmid: article.pmid,
+                title: article.title,
+                abstract: article.abstract ?? null,
+                authors: article.authors,
+                journal: article.journal,
+                year: article.year,
+                vancouverCitation: formatVancouver(article),
+                sign50Level: appraised?.sign50Level ?? null,
+                gradeQuality: appraised?.gradeQuality ?? null,
+                screeningDecision: screening?.decision ?? 'pending',
+                screeningReason: screening?.reason ?? null,
+                included: includedPmids.has(article.pmid),
+              };
+            }),
+          );
+        }
+
+        await db.insert(evidenceSyntheses).values({
+          searchId,
+          gradeSummary: synthesis.gradeSummary,
+          narrativeSynthesis: synthesis.narrativeSynthesis,
+          cerSection6Draft: synthesis.cerSection6Draft,
+          cerSection7Draft: synthesis.cerSection7Draft,
+          cerSection8Draft: synthesis.cerSection8Draft,
+          highCount: synthesis.gradeCounts.high,
+          moderateCount: synthesis.gradeCounts.moderate,
+          lowCount: synthesis.gradeCounts.low,
+          veryLowCount: synthesis.gradeCounts.veryLow,
+        });
+
+        push('done', {
+          searchId,
+          includedCount: includedPmids.size,
+          totalCount: articles.length,
+          cerSection6Draft: synthesis.cerSection6Draft,
+          cerSection7Draft: synthesis.cerSection7Draft,
+          cerSection8Draft: synthesis.cerSection8Draft,
+        });
+      } catch (err) {
+        console.error('[literature/route] pipeline error:', err);
+        push('error', { message: 'Literature search failed. Please try again.' });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, { headers: SSE_HEADERS });
+});
+
+export function GET(): Response {
+  return new Response('Method Not Allowed', { status: 405 });
+}

--- a/lib/cer/evidence-synthesis.ts
+++ b/lib/cer/evidence-synthesis.ts
@@ -1,0 +1,143 @@
+// @MX:ANCHOR [AUTO] Evidence synthesis — GRADE assessment and CER section draft generation.
+// @MX:REASON Sole function that produces regulated CER clinical evidence sections (6/7/8).
+// @MX:SPEC REQ-CLINLIT-021~025
+
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { getLlmModel } from '../ai/llm-provider';
+import type { PicoFramework } from './pico-generator';
+import type { PubMedArticle } from './pubmed-client';
+
+export interface SynthesisResult {
+  gradeSummary: string;
+  narrativeSynthesis: string;
+  cerSection6Draft: string; // Clinical Background (MEDDEV 2.7/1 Section 6)
+  cerSection7Draft: string; // Clinical Data table (MEDDEV 2.7/1 Section 7)
+  cerSection8Draft: string; // Appraisal of Clinical Data (MEDDEV 2.7/1 Section 8)
+  gradeCounts: { high: number; moderate: number; low: number; veryLow: number };
+}
+
+export type AppraiserArticle = PubMedArticle & {
+  sign50Level: string;
+  gradeQuality: string;
+  citation: string;
+};
+
+const SynthesisSchema = z.object({
+  gradeSummary: z.string().min(1),
+  narrativeSynthesis: z.string().min(1),
+  cerSection6Draft: z.string().min(1),
+  cerSection7Draft: z.string().min(1),
+  cerSection8Draft: z.string().min(1),
+});
+
+function countGrades(articles: AppraiserArticle[]): SynthesisResult['gradeCounts'] {
+  const counts = { high: 0, moderate: 0, low: 0, veryLow: 0 };
+  for (const a of articles) {
+    switch (a.gradeQuality) {
+      case 'high':
+        counts.high++;
+        break;
+      case 'moderate':
+        counts.moderate++;
+        break;
+      case 'low':
+        counts.low++;
+        break;
+      case 'very_low':
+        counts.veryLow++;
+        break;
+    }
+  }
+  return counts;
+}
+
+const MOCK_SYNTHESIS: Omit<SynthesisResult, 'gradeCounts'> = {
+  gradeSummary:
+    'GRADE evidence summary: moderate quality evidence from included studies supports device safety and performance.',
+  narrativeSynthesis:
+    'Narrative synthesis: included studies demonstrate acceptable safety and efficacy profile consistent with EU MDR requirements.',
+  cerSection6Draft:
+    '## 6. Clinical Background\n\nE2E mock CER Section 6 — Clinical Background content.',
+  cerSection7Draft:
+    '## 7. Clinical Data\n\n| Study | SIGN 50 | GRADE | Outcome |\n|-------|---------|-------|---------|\n| E2E Mock Study | 1+ | Moderate | Positive |',
+  cerSection8Draft:
+    '## 8. Appraisal of Clinical Data\n\nE2E mock CER Section 8 — Appraisal content.',
+};
+
+/**
+ * Synthesize evidence from included articles into GRADE summary and CER section drafts.
+ *
+ * Produces CER Sections 6 (Clinical Background), 7 (Clinical Data),
+ * and 8 (Appraisal of Clinical Data) per MEDDEV 2.7/1 Rev.4 structure.
+ * In E2E_TEST_MODE, returns deterministic mock content.
+ */
+export async function synthesizeEvidence(
+  includedArticles: AppraiserArticle[],
+  deviceDescription: string,
+  picoFramework: PicoFramework,
+): Promise<SynthesisResult> {
+  const gradeCounts = countGrades(includedArticles);
+
+  // E2E_TEST_MODE: return deterministic mock without LLM call.
+  const isE2EMode = process.env.E2E_TEST_MODE === 'true' && process.env.NODE_ENV !== 'production';
+  if (isE2EMode) {
+    return { ...MOCK_SYNTHESIS, gradeCounts };
+  }
+
+  if (includedArticles.length === 0) {
+    return {
+      gradeSummary: 'No articles were included after screening. No evidence synthesis possible.',
+      narrativeSynthesis: 'Insufficient evidence identified for narrative synthesis.',
+      cerSection6Draft:
+        '## 6. Clinical Background\n\nInsufficient literature identified for this device.',
+      cerSection7Draft: '## 7. Clinical Data\n\nNo included studies.',
+      cerSection8Draft:
+        '## 8. Appraisal of Clinical Data\n\nNo clinical data available for appraisal.',
+      gradeCounts,
+    };
+  }
+
+  const model = getLlmModel();
+
+  const articleSummaries = includedArticles
+    .slice(0, 30) // Cap at 30 to manage token budget
+    .map(
+      (a) =>
+        `- ${a.citation} [SIGN 50: ${a.sign50Level}, GRADE: ${a.gradeQuality}]\n  Title: ${a.title}\n  Abstract: ${a.abstract?.slice(0, 300) ?? 'N/A'}`,
+    )
+    .join('\n');
+
+  const gradeCountStr = `High: ${gradeCounts.high}, Moderate: ${gradeCounts.moderate}, Low: ${gradeCounts.low}, Very Low: ${gradeCounts.veryLow}`;
+
+  const prompt = `You are a clinical evaluation expert drafting an EU MDR Clinical Evaluation Report (CER) per MEDDEV 2.7/1 Rev.4.
+
+Device: ${deviceDescription}
+
+PICO:
+- Population: ${picoFramework.patient}
+- Intervention: ${picoFramework.intervention}
+- Outcome: ${picoFramework.outcome}
+
+Included studies (${includedArticles.length} total, showing up to 30):
+${articleSummaries}
+
+GRADE distribution: ${gradeCountStr}
+
+Generate:
+1. gradeSummary: A concise GRADE evidence quality summary paragraph
+2. narrativeSynthesis: A narrative synthesis paragraph describing safety and performance findings
+3. cerSection6Draft: EU MDR CER Section 6 — Clinical Background (markdown, ~300 words)
+4. cerSection7Draft: EU MDR CER Section 7 — Clinical Data as a markdown table with columns: Study, Year, Design, SIGN 50, GRADE, Key Finding
+5. cerSection8Draft: EU MDR CER Section 8 — Appraisal of Clinical Data including strengths, limitations, and conclusions (markdown, ~400 words)
+
+Return structured JSON.`;
+
+  const result = await generateObject({
+    model,
+    schema: SynthesisSchema,
+    prompt,
+  });
+
+  return { ...result.object, gradeCounts };
+}

--- a/lib/cer/pico-generator.ts
+++ b/lib/cer/pico-generator.ts
@@ -1,0 +1,78 @@
+// @MX:ANCHOR [AUTO] PICO query generator — entry point for clinical literature search.
+// @MX:REASON Called by literature route and CER workflow steps; fan_in >= 3 expected.
+// @MX:SPEC REQ-CLINLIT-001~005
+
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { getLlmFastModel } from '../ai/llm-provider';
+
+export interface PicoFramework {
+  patient: string; // Population/Patient
+  intervention: string; // Intervention (the device/treatment)
+  comparator: string | null; // Comparator (null if not applicable)
+  outcome: string; // Outcome measure
+  meshTerms: string[]; // MeSH terms derived
+  searchQuery: string; // Final PubMed query string
+}
+
+const PicoSchema = z.object({
+  patient: z.string().min(1),
+  intervention: z.string().min(1),
+  comparator: z.string().nullable(),
+  outcome: z.string().min(1),
+  meshTerms: z.array(z.string()),
+  searchQuery: z.string().min(1),
+});
+
+const MOCK_PICO: PicoFramework = {
+  patient: 'patients requiring medical device intervention',
+  intervention: 'test device',
+  comparator: null,
+  outcome: 'safety and efficacy outcomes',
+  meshTerms: ['Medical Devices', 'Patient Safety', 'Clinical Trials as Topic'],
+  searchQuery: '"medical device"[MeSH] AND "clinical trial"[pt] AND "safety"[MeSH]',
+};
+
+/**
+ * Generate a PICO framework and PubMed search query from a device description.
+ *
+ * Uses the fast (Haiku) model for cost efficiency. In E2E_TEST_MODE,
+ * returns deterministic mock data without making any LLM calls.
+ */
+// @MX:ANCHOR [AUTO] generatePicoQuery — public API called by literature search route.
+// @MX:REASON Single authoritative source for PICO generation; must remain stable across CER workflow.
+export async function generatePicoQuery(deviceDescription: string): Promise<PicoFramework> {
+  // E2E_TEST_MODE: return deterministic mock without LLM call.
+  const isE2EMode = process.env.E2E_TEST_MODE === 'true' && process.env.NODE_ENV !== 'production';
+  if (isE2EMode) {
+    return {
+      ...MOCK_PICO,
+      intervention: deviceDescription.slice(0, 100),
+    };
+  }
+
+  const model = getLlmFastModel();
+
+  const prompt = `You are an EU MDR clinical evaluation expert. Given the following medical device description, generate a PICO framework and an optimized PubMed search query for systematic literature review per MEDDEV 2.7/1 Rev.4.
+
+Device Description:
+${deviceDescription}
+
+Requirements:
+- Patient/Population: describe the target patient population for this device
+- Intervention: the device/procedure being evaluated
+- Comparator: standard of care or predicate device (null if not applicable)
+- Outcome: primary safety and performance outcomes
+- MeSH Terms: 3-8 relevant MeSH terms for PubMed
+- Search Query: a valid PubMed Boolean search query using MeSH terms and free text
+
+Return structured JSON matching the schema.`;
+
+  const result = await generateObject({
+    model,
+    schema: PicoSchema,
+    prompt,
+  });
+
+  return result.object;
+}

--- a/lib/cer/screening-pipeline.ts
+++ b/lib/cer/screening-pipeline.ts
@@ -1,0 +1,121 @@
+// @MX:ANCHOR [AUTO] Screening pipeline — LLM-based title/abstract relevance filter.
+// @MX:REASON Called per-batch in literature search; manages rate limits and token budgets.
+// @MX:SPEC REQ-CLINLIT-011~014
+
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { getLlmModel } from '../ai/llm-provider';
+import type { PicoFramework } from './pico-generator';
+import type { PubMedArticle } from './pubmed-client';
+
+export interface ScreeningResult {
+  pmid: string;
+  decision: 'include' | 'exclude' | 'uncertain';
+  reason: string;
+}
+
+const BATCH_SIZE = 10;
+
+const ScreeningBatchSchema = z.object({
+  decisions: z.array(
+    z.object({
+      pmid: z.string(),
+      decision: z.enum(['include', 'exclude', 'uncertain']),
+      reason: z.string(),
+    }),
+  ),
+});
+
+function buildBatchPrompt(
+  articles: PubMedArticle[],
+  pico: PicoFramework,
+  deviceDescription: string,
+): string {
+  const articleList = articles
+    .map(
+      (a, i) =>
+        `[${i + 1}] PMID: ${a.pmid}\nTitle: ${a.title}\nAbstract: ${a.abstract?.slice(0, 500) ?? 'N/A'}`,
+    )
+    .join('\n\n');
+
+  return `You are a systematic review screener for an EU MDR Clinical Evaluation Report (CER).
+
+Device: ${deviceDescription}
+
+PICO Framework:
+- Population: ${pico.patient}
+- Intervention: ${pico.intervention}
+- Comparator: ${pico.comparator ?? 'N/A'}
+- Outcome: ${pico.outcome}
+
+Screen the following articles based on their title and abstract. For each article, decide:
+- include: directly relevant to device safety/performance for the PICO population
+- exclude: clearly irrelevant (different device type, population, or outcome)
+- uncertain: insufficient information to decide; would need full-text review
+
+Articles:
+${articleList}
+
+Return a JSON object with a "decisions" array containing one entry per article with pmid, decision, and reason fields.`;
+}
+
+/**
+ * Screen articles in batches of 10 using the main LLM model.
+ *
+ * Returns include/exclude/uncertain decisions with brief reasoning.
+ * In E2E_TEST_MODE, returns deterministic mock decisions.
+ */
+export async function screenArticles(
+  articles: PubMedArticle[],
+  picoFramework: PicoFramework,
+  deviceDescription: string,
+): Promise<ScreeningResult[]> {
+  if (articles.length === 0) return [];
+
+  // E2E_TEST_MODE: return deterministic mock without LLM call.
+  const isE2EMode = process.env.E2E_TEST_MODE === 'true' && process.env.NODE_ENV !== 'production';
+  if (isE2EMode) {
+    return articles.map((a, i) => ({
+      pmid: a.pmid,
+      decision: i % 3 === 0 ? 'exclude' : ('include' as 'include' | 'exclude' | 'uncertain'),
+      reason: i % 3 === 0 ? 'E2E mock: excluded' : 'E2E mock: included as relevant',
+    }));
+  }
+
+  const model = getLlmModel();
+  const results: ScreeningResult[] = [];
+
+  // Process in batches of BATCH_SIZE to manage token limits.
+  for (let offset = 0; offset < articles.length; offset += BATCH_SIZE) {
+    const batch = articles.slice(offset, offset + BATCH_SIZE);
+    const prompt = buildBatchPrompt(batch, picoFramework, deviceDescription);
+
+    try {
+      const result = await generateObject({
+        model,
+        schema: ScreeningBatchSchema,
+        prompt,
+      });
+
+      for (const decision of result.object.decisions) {
+        results.push({
+          pmid: decision.pmid,
+          decision: decision.decision,
+          reason: decision.reason,
+        });
+      }
+    } catch (err) {
+      // On LLM failure for a batch, mark all articles as uncertain.
+      console.error('[screening-pipeline] batch screening failed:', err);
+      for (const article of batch) {
+        results.push({
+          pmid: article.pmid,
+          decision: 'uncertain',
+          reason: 'Screening error — manual review required.',
+        });
+      }
+    }
+  }
+
+  return results;
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -583,6 +583,70 @@ export const cerLiterature = pgTable('cer_literature', {
   createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 });
 
+// REQ-CLINLIT-001~005: literature_searches — PICO-based search protocol per CER run.
+// Migration: 0041_lit_searches.sql
+export const literatureSearches = pgTable('literature_searches', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  cerRunId: uuid('cer_run_id')
+    .notNull()
+    .references(() => workflowRuns.id, { onDelete: 'cascade' }),
+  protocolVersion: integer('protocol_version').notNull().default(1),
+  deviceDescription: text('device_description').notNull(),
+  picoPatient: text('pico_patient').notNull(),
+  picoIntervention: text('pico_intervention').notNull(),
+  picoComparator: text('pico_comparator'),
+  picoOutcome: text('pico_outcome').notNull(),
+  searchQuery: text('search_query').notNull(),
+  meshTerms: jsonb('mesh_terms').$type<string[]>().notNull().default([]),
+  totalRecords: integer('total_records').notNull().default(0),
+  afterDedup: integer('after_dedup').notNull().default(0),
+  afterTitleAbstract: integer('after_title_abstract').notNull().default(0),
+  afterFullText: integer('after_full_text').notNull().default(0),
+  includedCount: integer('included_count').notNull().default(0),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});
+
+// REQ-CLINLIT-011~014: literature_references — screened article records per search.
+// Migration: 0042_lit_references.sql
+export const literatureReferences = pgTable('literature_references', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  searchId: uuid('search_id')
+    .notNull()
+    .references(() => literatureSearches.id, { onDelete: 'cascade' }),
+  pmid: text('pmid').notNull(),
+  title: text('title').notNull(),
+  abstract: text('abstract'),
+  authors: jsonb('authors').$type<string[]>().notNull().default([]),
+  journal: text('journal').notNull(),
+  year: integer('year').notNull(),
+  vancouverCitation: text('vancouver_citation'),
+  sign50Level: text('sign50_level'),
+  gradeQuality: text('grade_quality'),
+  screeningDecision: text('screening_decision').notNull().default('pending'),
+  screeningReason: text('screening_reason'),
+  included: boolean('included').notNull().default(false),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});
+
+// REQ-CLINLIT-021~025: evidence_syntheses — GRADE synthesis + CER section drafts.
+// Migration: 0043_evidence_syntheses.sql
+export const evidenceSyntheses = pgTable('evidence_syntheses', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  searchId: uuid('search_id')
+    .notNull()
+    .references(() => literatureSearches.id, { onDelete: 'cascade' }),
+  gradeSummary: text('grade_summary').notNull(),
+  narrativeSynthesis: text('narrative_synthesis').notNull(),
+  cerSection6Draft: text('cer_section6_draft').notNull(),
+  cerSection7Draft: text('cer_section7_draft').notNull(),
+  cerSection8Draft: text('cer_section8_draft').notNull(),
+  highCount: integer('high_count').notNull().default(0),
+  moderateCount: integer('moderate_count').notNull().default(0),
+  lowCount: integer('low_count').notNull().default(0),
+  veryLowCount: integer('very_low_count').notNull().default(0),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});
+
 // ---------------------------------------------------------------------------
 // Auth.js v5 DrizzleAdapter tables — required for database session strategy.
 // Migration: 0023_auth_adapter_tables.sql

--- a/migrations/0041_lit_searches.sql
+++ b/migrations/0041_lit_searches.sql
@@ -1,0 +1,22 @@
+-- REQ-CLINLIT-001~005: literature_searches — PICO-based search protocol per CER run.
+-- Migration: 0041_lit_searches.sql
+-- @MX:SPEC Issue #60
+
+CREATE TABLE IF NOT EXISTS "literature_searches" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "cer_run_id" uuid NOT NULL REFERENCES "workflow_runs"("id") ON DELETE CASCADE,
+  "protocol_version" integer NOT NULL DEFAULT 1,
+  "device_description" text NOT NULL,
+  "pico_patient" text NOT NULL,
+  "pico_intervention" text NOT NULL,
+  "pico_comparator" text,
+  "pico_outcome" text NOT NULL,
+  "search_query" text NOT NULL,
+  "mesh_terms" jsonb NOT NULL DEFAULT '[]',
+  "total_records" integer NOT NULL DEFAULT 0,
+  "after_dedup" integer NOT NULL DEFAULT 0,
+  "after_title_abstract" integer NOT NULL DEFAULT 0,
+  "after_full_text" integer NOT NULL DEFAULT 0,
+  "included_count" integer NOT NULL DEFAULT 0,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/migrations/0042_lit_references.sql
+++ b/migrations/0042_lit_references.sql
@@ -1,0 +1,21 @@
+-- REQ-CLINLIT-011~014: literature_references — screened article records per search.
+-- Migration: 0042_lit_references.sql
+-- @MX:SPEC Issue #60
+
+CREATE TABLE IF NOT EXISTS "literature_references" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "search_id" uuid NOT NULL REFERENCES "literature_searches"("id") ON DELETE CASCADE,
+  "pmid" text NOT NULL,
+  "title" text NOT NULL,
+  "abstract" text,
+  "authors" jsonb NOT NULL DEFAULT '[]',
+  "journal" text NOT NULL,
+  "year" integer NOT NULL,
+  "vancouver_citation" text,
+  "sign50_level" text,
+  "grade_quality" text,
+  "screening_decision" text NOT NULL DEFAULT 'pending',
+  "screening_reason" text,
+  "included" boolean NOT NULL DEFAULT false,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/migrations/0043_evidence_syntheses.sql
+++ b/migrations/0043_evidence_syntheses.sql
@@ -1,0 +1,18 @@
+-- REQ-CLINLIT-021~025: evidence_syntheses — GRADE synthesis + CER section drafts.
+-- Migration: 0043_evidence_syntheses.sql
+-- @MX:SPEC Issue #60
+
+CREATE TABLE IF NOT EXISTS "evidence_syntheses" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "search_id" uuid NOT NULL REFERENCES "literature_searches"("id") ON DELETE CASCADE,
+  "grade_summary" text NOT NULL,
+  "narrative_synthesis" text NOT NULL,
+  "cer_section6_draft" text NOT NULL,
+  "cer_section7_draft" text NOT NULL,
+  "cer_section8_draft" text NOT NULL,
+  "high_count" integer NOT NULL DEFAULT 0,
+  "moderate_count" integer NOT NULL DEFAULT 0,
+  "low_count" integer NOT NULL DEFAULT 0,
+  "very_low_count" integer NOT NULL DEFAULT 0,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);


### PR DESCRIPTION
## 요약

SPEC-REGULA-CLINICAL-LIT-001 — EU MDR MEDDEV 2.7/1 Rev.4 준거 임상 문헌 검색 & 근거 합성 파이프라인 구현.

- **PICO 프레임워크**: Haiku 기반 장치 설명 → PubMed 검색어 자동 생성
- **PubMed 검색**: 기존 `searchPubMed()` 재사용, 초당 3 요청 제한 준수
- **스크리닝 파이프라인**: Sonnet으로 배치(10편) 제목/초록 관련성 필터링
- **근거 합성**: GRADE 수준 평가 + CER Section 6/7/8 초안 자동 생성
- **SSE 스트리밍**: `POST /api/ra/workflows/cer/literature` 엔드포인트
- **DB 마이그레이션**: 0041~0043 (literature_searches, literature_references, evidence_syntheses)
- **UI 컴포넌트**: LiteratureSearchPanel — 진행 표시 + GRADE 바 차트 + 섹션 탭

## 변경 파일

| 구분 | 파일 |
|------|------|
| Migration | `migrations/0041_lit_searches.sql`, `0042_lit_references.sql`, `0043_evidence_syntheses.sql` |
| Schema | `lib/db/schema.ts` (+3 tables) |
| Core modules | `lib/cer/pico-generator.ts`, `lib/cer/screening-pipeline.ts`, `lib/cer/evidence-synthesis.ts` |
| API | `app/api/ra/workflows/cer/literature/route.ts` |
| UI | `app/(app)/workflows/cer/_components/LiteratureSearchPanel.tsx` |
| Tests | `__tests__/lib/cer/pico-generator.test.ts`, `__tests__/lib/cer/evidence-synthesis.test.ts` |

## 테스트 계획

- [x] TypeScript 오류 0 (`pnpm tsc --noEmit`)
- [x] 단위 테스트 9/9 통과 (`pnpm vitest run __tests__/lib/cer/`)
- [ ] E2E: CER 워크플로우 → 문헌 검색 패널 접근 및 검색 실행
- [ ] DB 마이그레이션 적용 확인

Fixes #60

🗿 MoAI <email@mo.ai.kr>