### PR TITLE
feat(vigilance): 유해사례 보고서 자동 초안기 (#61)

### DIFF
--- a/__tests__/lib/vigilance/reportability-engine.test.ts
+++ b/__tests__/lib/vigilance/reportability-engine.test.ts
@@ -1,0 +1,132 @@
+// @MX:NOTE Unit tests for reportability-engine.ts — covers all 5 test scenarios
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001 (REQ-VIG-001~010)
+
+import { describe, expect, it } from 'vitest';
+import { assessReportability } from '../../../lib/vigilance/reportability-engine';
+import type { AdverseEventInput } from '../../../lib/vigilance/reportability-engine';
+
+const baseEvent: AdverseEventInput = {
+  eventDescription: 'Device malfunctioned during normal operation.',
+  patientOutcome: 'malfunction',
+  deviceCategory: 'class_II',
+  eventDate: '2024-01-15',
+  awarenessDate: '2024-01-15',
+  isManufacturerAware: true,
+};
+
+describe('assessReportability', () => {
+  it('FDA 30-day: Class II malfunction triggers 30-day MDR (21 CFR 803.53)', () => {
+    const event: AdverseEventInput = {
+      ...baseEvent,
+      patientOutcome: 'malfunction',
+      deviceCategory: 'class_II',
+    };
+
+    const decision = assessReportability(event);
+
+    expect(decision.fdaMdrRequired).toBe(true);
+    expect(decision.fdaMdrDeadlineDays).toBe(30);
+    expect(decision.rationale).toContain('21 CFR 803.53');
+  });
+
+  it('FDA 5-day: Class III malfunction with death risk in description → 5-day MDR (21 CFR 803.53(a))', () => {
+    const event: AdverseEventInput = {
+      ...baseEvent,
+      patientOutcome: 'malfunction',
+      deviceCategory: 'class_III',
+      eventDescription: 'Device malfunction caused life-threatening complication.',
+    };
+
+    const decision = assessReportability(event);
+
+    expect(decision.fdaMdrRequired).toBe(true);
+    expect(decision.fdaMdrDeadlineDays).toBe(5);
+    expect(decision.rationale).toContain('5-day');
+  });
+
+  it('EU MDV 2-day: serious incident with death on Class IIb device', () => {
+    const event: AdverseEventInput = {
+      ...baseEvent,
+      patientOutcome: 'death',
+      deviceCategory: 'IIb',
+    };
+
+    const decision = assessReportability(event);
+
+    expect(decision.euMdvRequired).toBe(true);
+    expect(decision.euMdvDeadlineDays).toBe(2);
+    expect(decision.rationale).toContain('Art. 87(2)');
+  });
+
+  it('No reporting: minor event (no_injury) on Class I device', () => {
+    const event: AdverseEventInput = {
+      ...baseEvent,
+      patientOutcome: 'no_injury',
+      deviceCategory: 'class_I',
+    };
+
+    const decision = assessReportability(event);
+
+    expect(decision.fdaMdrRequired).toBe(false);
+    expect(decision.euMdvRequired).toBe(false);
+    expect(decision.fscaRequired).toBe(false);
+    expect(decision.fdaMdrDeadlineDays).toBeNull();
+    expect(decision.euMdvDeadlineDays).toBeNull();
+  });
+
+  it('FSCA trigger: death on Class III device requires both MDR and FSCA', () => {
+    const event: AdverseEventInput = {
+      ...baseEvent,
+      patientOutcome: 'death',
+      deviceCategory: 'class_III',
+    };
+
+    const decision = assessReportability(event);
+
+    expect(decision.fdaMdrRequired).toBe(true);
+    expect(decision.fscaRequired).toBe(true);
+    expect(decision.rationale).toContain('FSCA');
+  });
+
+  it('EU MDV 15-day: Class IIa malfunction triggers unanticipated serious incident', () => {
+    const event: AdverseEventInput = {
+      ...baseEvent,
+      patientOutcome: 'malfunction',
+      deviceCategory: 'IIa',
+    };
+
+    const decision = assessReportability(event);
+
+    expect(decision.euMdvRequired).toBe(true);
+    expect(decision.euMdvDeadlineDays).toBe(15);
+    expect(decision.rationale).toContain('Art. 87(1)');
+  });
+
+  it('FDA 30-day: serious_injury on Class II device triggers 30-day MDR', () => {
+    const event: AdverseEventInput = {
+      ...baseEvent,
+      patientOutcome: 'serious_injury',
+      deviceCategory: 'class_II',
+    };
+
+    const decision = assessReportability(event);
+
+    expect(decision.fdaMdrRequired).toBe(true);
+    expect(decision.fdaMdrDeadlineDays).toBe(30);
+    expect(decision.rationale).toContain('21 CFR 803.50(a)');
+  });
+
+  it('EU MDV 30-day trend: "other" outcome on Class III device', () => {
+    const event: AdverseEventInput = {
+      ...baseEvent,
+      patientOutcome: 'other',
+      deviceCategory: 'III',
+    };
+
+    const decision = assessReportability(event);
+
+    expect(decision.euMdvRequired).toBe(true);
+    expect(decision.euMdvDeadlineDays).toBe(30);
+    expect(decision.rationale).toContain('Art. 87(3)');
+  });
+});

--- a/app/(app)/workflows/vigilance/_components/VigilanceForm.tsx
+++ b/app/(app)/workflows/vigilance/_components/VigilanceForm.tsx
@@ -1,0 +1,406 @@
+'use client';
+
+// @MX:NOTE [AUTO] VigilanceForm — adverse event input form with SSE streaming result display.
+// Submits to POST /api/ra/vigilance, streams assessment + draft reports via SSE events.
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001
+
+import { type FormEvent, useState } from 'react';
+
+type PatientOutcome = 'death' | 'serious_injury' | 'malfunction' | 'no_injury' | 'other';
+type DeviceCategory = 'class_I' | 'class_II' | 'class_III' | 'IIa' | 'IIb' | 'III';
+
+interface ReportabilityDecision {
+  fdaMdrRequired: boolean;
+  fdaMdrDeadlineDays: number | null;
+  euMdvRequired: boolean;
+  euMdvDeadlineDays: number | null;
+  fscaRequired: boolean;
+  rationale: string;
+}
+
+interface ReportDraft {
+  reportType: string;
+  reportFormat: string;
+  draftContent: Record<string, string>;
+  submissionDeadline: string;
+  reportId: string | null;
+}
+
+interface StreamResult {
+  assessment: ReportabilityDecision | null;
+  drafts: ReportDraft[];
+  eventId: string | null;
+  done: boolean;
+}
+
+const INPUT_CLASS = 'border border-ink-200 rounded-md px-3 py-2 text-sm w-full focus:outline-none focus:ring-1 focus:ring-brand-400';
+const LABEL_CLASS = 'block text-sm font-medium text-ink-700 mb-1';
+const PRIMARY_BTN =
+  'bg-brand-700 text-white hover:bg-brand-800 rounded-md px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60';
+
+const OUTCOME_OPTIONS: Array<{ value: PatientOutcome; label: string }> = [
+  { value: 'death', label: '사망 (Death)' },
+  { value: 'serious_injury', label: '중대 손상 (Serious Injury)' },
+  { value: 'malfunction', label: '오작동 (Malfunction)' },
+  { value: 'no_injury', label: '손상 없음 (No Injury)' },
+  { value: 'other', label: '기타 (Other)' },
+];
+
+const DEVICE_CATEGORY_OPTIONS: Array<{ value: DeviceCategory; label: string }> = [
+  { value: 'class_I', label: 'FDA Class I' },
+  { value: 'class_II', label: 'FDA Class II' },
+  { value: 'class_III', label: 'FDA Class III' },
+  { value: 'IIa', label: 'EU MDR Class IIa' },
+  { value: 'IIb', label: 'EU MDR Class IIb' },
+  { value: 'III', label: 'EU MDR Class III' },
+];
+
+const REPORT_TYPE_LABELS: Record<string, string> = {
+  fda_mdr: 'FDA MDR 3500A',
+  eu_mdv: 'EU MDV 초기 보고서',
+  fsca: 'FSCA 공지',
+};
+
+export function VigilanceForm() {
+  // Form state
+  const [deviceName, setDeviceName] = useState('');
+  const [deviceModel, setDeviceModel] = useState('');
+  const [eventDate, setEventDate] = useState('');
+  const [awarenessDate, setAwarenessDate] = useState('');
+  const [patientOutcome, setPatientOutcome] = useState<PatientOutcome>('malfunction');
+  const [deviceCategory, setDeviceCategory] = useState<DeviceCategory>('class_II');
+  const [eventDescription, setEventDescription] = useState('');
+  const [reporterName, setReporterName] = useState('');
+  const [reporterRole, setReporterRole] = useState('');
+  const [lotNumber, setLotNumber] = useState('');
+
+  // Streaming state
+  const [streaming, setStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<StreamResult | null>(null);
+  const [activeTab, setActiveTab] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStreaming(true);
+    setError(null);
+    setResult({ assessment: null, drafts: [], eventId: null, done: false });
+    setActiveTab(null);
+
+    try {
+      const response = await fetch('/api/ra/vigilance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          adverseEventData: {
+            deviceName,
+            deviceModel: deviceModel || undefined,
+            lotNumber: lotNumber || undefined,
+            eventDate,
+            awarenessDate,
+            patientOutcome,
+            deviceCategory,
+            eventDescription,
+            reporterName,
+            reporterRole,
+            isManufacturerAware: true,
+          },
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        setError('보고서 생성에 실패했습니다. 입력 내용을 확인해 주세요.');
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n\n');
+        buffer = lines.pop() ?? '';
+
+        for (const chunk of lines) {
+          const eventMatch = chunk.match(/^event: (\w+)\ndata: (.+)$/s);
+          if (!eventMatch) continue;
+
+          const eventName = eventMatch[1];
+          const dataStr = eventMatch[2];
+          if (!eventName || !dataStr) continue;
+          try {
+            const data = JSON.parse(dataStr) as Record<string, unknown>;
+
+            if (eventName === 'assessment') {
+              setResult((prev) => ({
+                ...(prev ?? { assessment: null, drafts: [], eventId: null, done: false }),
+                assessment: data['decision'] as ReportabilityDecision,
+              }));
+            } else if (
+              eventName === 'draft_fda' ||
+              eventName === 'draft_eu' ||
+              eventName === 'draft_fsca'
+            ) {
+              const draft = data as unknown as ReportDraft;
+              setResult((prev) => {
+                const next = {
+                  ...(prev ?? { assessment: null, drafts: [], eventId: null, done: false }),
+                  drafts: [...(prev?.drafts ?? []), draft],
+                };
+                // Auto-select first draft tab
+                if (!activeTab) setActiveTab(draft.reportType);
+                return next;
+              });
+            } else if (eventName === 'done') {
+              setResult((prev) => ({
+                ...(prev ?? { assessment: null, drafts: [], eventId: null, done: false }),
+                eventId: data['eventId'] as string,
+                done: true,
+              }));
+            } else if (eventName === 'error') {
+              setError(data['message'] as string);
+            }
+          } catch {
+            // Ignore malformed SSE chunks
+          }
+        }
+      }
+    } catch {
+      setError('네트워크 오류가 발생했습니다. 다시 시도해 주세요.');
+    } finally {
+      setStreaming(false);
+    }
+  }
+
+  const activeDraft = result?.drafts.find((d) => d.reportType === activeTab);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <form onSubmit={handleSubmit} className="rounded-lg border border-ink-200 bg-surface p-6">
+        <h2 className="font-serif text-lg text-ink-900 mb-4">유해사례 정보 입력</h2>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {/* Device info */}
+          <div>
+            <label className={LABEL_CLASS}>기기명 *</label>
+            <input
+              className={INPUT_CLASS}
+              value={deviceName}
+              onChange={(e) => setDeviceName(e.target.value)}
+              placeholder="예: 혈당 측정기 XYZ-100"
+              required
+            />
+          </div>
+          <div>
+            <label className={LABEL_CLASS}>모델번호</label>
+            <input
+              className={INPUT_CLASS}
+              value={deviceModel}
+              onChange={(e) => setDeviceModel(e.target.value)}
+              placeholder="예: XYZ-100-v2"
+            />
+          </div>
+          <div>
+            <label className={LABEL_CLASS}>로트 번호</label>
+            <input
+              className={INPUT_CLASS}
+              value={lotNumber}
+              onChange={(e) => setLotNumber(e.target.value)}
+              placeholder="예: LOT2024001"
+            />
+          </div>
+          <div>
+            <label className={LABEL_CLASS}>기기 분류 *</label>
+            <select
+              className={INPUT_CLASS}
+              value={deviceCategory}
+              onChange={(e) => setDeviceCategory(e.target.value as DeviceCategory)}
+              required
+            >
+              {DEVICE_CATEGORY_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Event dates */}
+          <div>
+            <label className={LABEL_CLASS}>사고 발생일 *</label>
+            <input
+              type="date"
+              className={INPUT_CLASS}
+              value={eventDate}
+              onChange={(e) => setEventDate(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className={LABEL_CLASS}>인지일 (Awareness Date) *</label>
+            <input
+              type="date"
+              className={INPUT_CLASS}
+              value={awarenessDate}
+              onChange={(e) => setAwarenessDate(e.target.value)}
+              required
+            />
+          </div>
+
+          {/* Outcome */}
+          <div>
+            <label className={LABEL_CLASS}>환자 결과 *</label>
+            <select
+              className={INPUT_CLASS}
+              value={patientOutcome}
+              onChange={(e) => setPatientOutcome(e.target.value as PatientOutcome)}
+              required
+            >
+              {OUTCOME_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Reporter */}
+          <div>
+            <label className={LABEL_CLASS}>보고자 이름 *</label>
+            <input
+              className={INPUT_CLASS}
+              value={reporterName}
+              onChange={(e) => setReporterName(e.target.value)}
+              placeholder="예: 홍길동"
+              required
+            />
+          </div>
+          <div>
+            <label className={LABEL_CLASS}>보고자 직책 *</label>
+            <input
+              className={INPUT_CLASS}
+              value={reporterRole}
+              onChange={(e) => setReporterRole(e.target.value)}
+              placeholder="예: 의사 / RA Manager"
+              required
+            />
+          </div>
+        </div>
+
+        {/* Event description */}
+        <div className="mt-4">
+          <label className={LABEL_CLASS}>사고 경위 *</label>
+          <textarea
+            className={`${INPUT_CLASS} min-h-[100px] resize-y`}
+            value={eventDescription}
+            onChange={(e) => setEventDescription(e.target.value)}
+            placeholder="유해사례 발생 경위를 상세히 기술하세요 (10자 이상)..."
+            required
+            minLength={10}
+          />
+        </div>
+
+        {error && (
+          <p className="mt-3 text-sm text-red-600">{error}</p>
+        )}
+
+        <div className="mt-4">
+          <button type="submit" className={PRIMARY_BTN} disabled={streaming}>
+            {streaming ? '초안 생성 중...' : '초안 생성'}
+          </button>
+        </div>
+      </form>
+
+      {/* Results */}
+      {result && (
+        <div className="rounded-lg border border-ink-200 bg-surface p-6">
+          <h2 className="font-serif text-lg text-ink-900 mb-4">분석 결과</h2>
+
+          {/* Assessment */}
+          {result.assessment && (
+            <div className="mb-4 rounded-md border border-brand-200 bg-brand-50 p-4">
+              <h3 className="text-sm font-semibold text-brand-800 mb-2">보고 의무 판단</h3>
+              <ul className="text-sm text-ink-700 space-y-1">
+                <li>
+                  <span className="font-medium">FDA MDR:</span>{' '}
+                  {result.assessment.fdaMdrRequired
+                    ? `필요 (${result.assessment.fdaMdrDeadlineDays}일 이내)`
+                    : '불필요'}
+                </li>
+                <li>
+                  <span className="font-medium">EU MDV:</span>{' '}
+                  {result.assessment.euMdvRequired
+                    ? `필요 (${result.assessment.euMdvDeadlineDays}일 이내)`
+                    : '불필요'}
+                </li>
+                <li>
+                  <span className="font-medium">FSCA:</span>{' '}
+                  {result.assessment.fscaRequired ? '필요' : '불필요'}
+                </li>
+              </ul>
+              <p className="mt-2 text-xs text-ink-500">{result.assessment.rationale}</p>
+            </div>
+          )}
+
+          {/* Loading indicator */}
+          {streaming && !result.done && (
+            <p className="text-sm text-ink-500 mb-4">보고서 초안 생성 중...</p>
+          )}
+
+          {/* Draft tabs */}
+          {result.drafts.length > 0 && (
+            <div>
+              <div className="flex gap-2 border-b border-ink-200 mb-4">
+                {result.drafts.map((d) => (
+                  <button
+                    key={d.reportType}
+                    type="button"
+                    onClick={() => setActiveTab(d.reportType)}
+                    className={`px-3 py-2 text-sm border-b-2 -mb-px transition-colors ${
+                      activeTab === d.reportType
+                        ? 'border-brand-600 text-brand-700 font-medium'
+                        : 'border-transparent text-ink-500 hover:text-ink-700'
+                    }`}
+                  >
+                    {REPORT_TYPE_LABELS[d.reportType] ?? d.reportType}
+                  </button>
+                ))}
+              </div>
+
+              {activeDraft && (
+                <div>
+                  <div className="flex items-center justify-between mb-3">
+                    <p className="text-xs text-ink-500">
+                      형식: {activeDraft.reportFormat} · 제출 기한:{' '}
+                      {activeDraft.submissionDeadline}
+                    </p>
+                  </div>
+                  <div className="grid gap-3">
+                    {Object.entries(activeDraft.draftContent).map(([field, value]) => (
+                      <div key={field} className="rounded-md border border-ink-200 p-3">
+                        <p className="text-xs font-medium text-ink-500 uppercase tracking-wide mb-1">
+                          {field.replace(/_/g, ' ')}
+                        </p>
+                        <p className="text-sm text-ink-800 whitespace-pre-wrap">{value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {result.done && result.eventId && (
+            <p className="mt-4 text-xs text-ink-400">
+              Event ID: {result.eventId}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/workflows/vigilance/page.tsx
+++ b/app/(app)/workflows/vigilance/page.tsx
@@ -1,0 +1,64 @@
+// @MX:NOTE [AUTO] VigilancePage — Post-Market Surveillance adverse event report workflow.
+// Server component: static framing wraps the interactive VigilanceForm client component.
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001
+
+import { BetaBadge } from '@/components/ui/BetaBadge';
+import { MockDataDisclosure } from '@/components/ui/MockDataDisclosure';
+import { VigilanceForm } from './_components/VigilanceForm';
+
+const REPORT_TYPES: ReadonlyArray<{ id: string; label: string; deadline: string; regulation: string }> = [
+  {
+    id: 'fda_mdr',
+    label: 'FDA MDR (3500A)',
+    deadline: '30-day / 5-day',
+    regulation: '21 CFR Part 803',
+  },
+  {
+    id: 'eu_mdv',
+    label: 'EU MDV Initial Report',
+    deadline: '2-day / 15-day / 30-day',
+    regulation: 'EU MDR Article 87',
+  },
+  {
+    id: 'fsca',
+    label: 'FSCA Notice',
+    deadline: 'As required',
+    regulation: 'EU MDR Article 88 / FDA 21 CFR 806',
+  },
+];
+
+export default function VigilancePage() {
+  return (
+    <section className="mx-auto flex max-w-content flex-col gap-6">
+      <header>
+        <div className="flex items-center gap-2">
+          <h1 className="font-serif text-3xl text-brand-800">유해사례 보고서 초안기</h1>
+          <BetaBadge />
+        </div>
+        <p className="mt-2 text-sm text-ink-600">
+          FDA MDR (21 CFR Part 803) · EU MDV (Article 87) · FSCA 포스트마켓 감시 보고서 자동 초안
+        </p>
+      </header>
+
+      <MockDataDisclosure />
+
+      <VigilanceForm />
+
+      <div className="rounded-lg border border-ink-200 bg-surface p-5">
+        <h2 className="font-serif text-lg text-ink-900">지원 보고서 유형</h2>
+        <p className="mt-1 text-sm text-ink-600">
+          유해사례 정보를 입력하면 해당 규정에 따라 필요한 보고서 초안을 자동으로 생성합니다.
+        </p>
+        <ul className="mt-4 grid gap-3 sm:grid-cols-3">
+          {REPORT_TYPES.map((rt) => (
+            <li key={rt.id} className="rounded-md border border-ink-200 bg-white p-3">
+              <p className="text-sm font-medium text-ink-900">{rt.label}</p>
+              <p className="mt-1 text-xs text-ink-500">기한: {rt.deadline}</p>
+              <p className="mt-0.5 text-xs text-ink-400">{rt.regulation}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/app/api/ra/vigilance/route.ts
+++ b/app/api/ra/vigilance/route.ts
@@ -1,0 +1,212 @@
+// @MX:ANCHOR [AUTO] SSE Route Handler — POST /api/ra/vigilance
+// @MX:REASON Entry point for the vigilance reporting pipeline: assess → draft → persist → audit.
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001 (REQ-VIG-001~024)
+
+export const runtime = 'nodejs';
+
+import { withPermission } from '@/lib/auth/with-permission';
+import type { AuthSession } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { adverseEvents, reportabilityAssessments, vigilanceReports } from '@/lib/db/schema';
+import {
+  auditReportDrafted,
+  auditReportabilityAssessed,
+  auditVigilanceEventCreated,
+} from '@/lib/vigilance/audit';
+import { assessReportability } from '@/lib/vigilance/reportability-engine';
+import type { AdverseEventInput } from '@/lib/vigilance/reportability-engine';
+import { generateReportDraft } from '@/lib/vigilance/report-generator';
+import type { ReportType } from '@/lib/vigilance/report-generator';
+import { z } from 'zod';
+
+// Zod validation schema for incoming adverse event data
+const AdverseEventSchema = z.object({
+  eventDescription: z.string().min(10, 'Event description must be at least 10 characters'),
+  patientOutcome: z.enum(['death', 'serious_injury', 'malfunction', 'no_injury', 'other']),
+  deviceCategory: z.enum(['class_I', 'class_II', 'class_III', 'IIa', 'IIb', 'III']),
+  eventDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'eventDate must be YYYY-MM-DD'),
+  awarenessDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'awarenessDate must be YYYY-MM-DD'),
+  isManufacturerAware: z.boolean(),
+});
+
+const RequestSchema = z.object({
+  adverseEventData: z.object({
+    eventDescription: z.string().min(10),
+    patientOutcome: z.enum(['death', 'serious_injury', 'malfunction', 'no_injury', 'other']),
+    deviceCategory: z.enum(['class_I', 'class_II', 'class_III', 'IIa', 'IIb', 'III']),
+    eventDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    awarenessDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    isManufacturerAware: z.boolean(),
+    // Additional DB fields passed alongside the engine input
+    deviceName: z.string().min(1),
+    deviceModel: z.string().optional(),
+    lotNumber: z.string().optional(),
+    reporterName: z.string().min(1),
+    reporterRole: z.string().min(1),
+  }),
+  workflowRunId: z.string().uuid().optional(),
+});
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache, no-transform',
+  Connection: 'keep-alive',
+  'X-Accel-Buffering': 'no',
+};
+
+function sseChunk(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+async function postVigilance(request: Request, session: AuthSession): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = RequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Validation failed', details: parsed.error.format() },
+      { status: 400 },
+    );
+  }
+
+  const { adverseEventData, workflowRunId } = parsed.data;
+
+  const engineInput: AdverseEventInput = {
+    eventDescription: adverseEventData.eventDescription,
+    patientOutcome: adverseEventData.patientOutcome,
+    deviceCategory: adverseEventData.deviceCategory,
+    eventDate: adverseEventData.eventDate,
+    awarenessDate: adverseEventData.awarenessDate,
+    isManufacturerAware: adverseEventData.isManufacturerAware,
+  };
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder();
+
+      function push(event: string, data: unknown): void {
+        controller.enqueue(encoder.encode(sseChunk(event, data)));
+      }
+
+      try {
+        // Step 1: Deterministic reportability assessment (no AI)
+        const decision = assessReportability(engineInput);
+        push('assessment', { decision });
+
+        // Step 2: Persist adverse event record
+        const [eventRecord] = await db
+          .insert(adverseEvents)
+          .values({
+            workflowRunId: workflowRunId ?? null,
+            eventDate: adverseEventData.eventDate,
+            deviceName: adverseEventData.deviceName,
+            deviceModel: adverseEventData.deviceModel ?? null,
+            lotNumber: adverseEventData.lotNumber ?? null,
+            eventDescription: adverseEventData.eventDescription,
+            patientOutcome: adverseEventData.patientOutcome,
+            awarenessDate: adverseEventData.awarenessDate,
+            reporterName: adverseEventData.reporterName,
+            reporterRole: adverseEventData.reporterRole,
+            createdBy: session.user.id,
+          })
+          .returning();
+
+        if (!eventRecord) {
+          push('error', { message: 'Failed to persist adverse event record' });
+          controller.close();
+          return;
+        }
+
+        // Persist reportability assessment
+        await db.insert(reportabilityAssessments).values({
+          adverseEventId: eventRecord.id,
+          fdaMdrRequired: decision.fdaMdrRequired,
+          fdaMdrDeadlineDays: decision.fdaMdrDeadlineDays,
+          euMdvRequired: decision.euMdvRequired,
+          euMdvDeadlineDays: decision.euMdvDeadlineDays,
+          fscaRequired: decision.fscaRequired,
+          assessmentRationale: decision.rationale,
+          assessedByAi: true,
+        });
+
+        // Audit adverse event creation and assessment
+        await auditVigilanceEventCreated({
+          userId: session.user.id,
+          adverseEventId: eventRecord.id,
+          deviceName: adverseEventData.deviceName,
+        });
+        await auditReportabilityAssessed({
+          userId: session.user.id,
+          adverseEventId: eventRecord.id,
+          fdaRequired: decision.fdaMdrRequired,
+          euRequired: decision.euMdvRequired,
+        });
+
+        // Step 3: Generate AI report drafts for each applicable pathway
+        const reportTypes: ReportType[] = [];
+        if (decision.fdaMdrRequired) reportTypes.push('fda_mdr');
+        if (decision.euMdvRequired) reportTypes.push('eu_mdv');
+        if (decision.fscaRequired) reportTypes.push('fsca');
+
+        const savedReportIds: Record<ReportType, string> = {} as Record<ReportType, string>;
+
+        for (const reportType of reportTypes) {
+          const draft = await generateReportDraft(engineInput, decision, reportType);
+
+          const [reportRecord] = await db
+            .insert(vigilanceReports)
+            .values({
+              adverseEventId: eventRecord.id,
+              reportType: draft.reportType,
+              reportFormat: draft.reportFormat,
+              draftContent: draft.draftContent,
+              submissionDeadline: draft.submissionDeadline,
+            })
+            .returning();
+
+          if (reportRecord) {
+            savedReportIds[reportType] = reportRecord.id;
+            await auditReportDrafted({
+              userId: session.user.id,
+              reportId: reportRecord.id,
+              reportType: draft.reportType,
+            });
+          }
+
+          // SSE event names: draft_fda, draft_eu, draft_fsca
+          const eventName = `draft_${reportType.replace('_mdr', '').replace('_mdv', '')}` as const;
+          push(eventName, {
+            reportType: draft.reportType,
+            reportFormat: draft.reportFormat,
+            draftContent: draft.draftContent,
+            submissionDeadline: draft.submissionDeadline,
+            reportId: reportRecord?.id ?? null,
+          });
+        }
+
+        // Step 4: Final done event
+        push('done', {
+          eventId: eventRecord.id,
+          reportIds: savedReportIds,
+          reportTypesGenerated: reportTypes,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Internal server error';
+        push('error', { message });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, { headers: SSE_HEADERS });
+}
+
+export const POST = withPermission('workflow.execute', async (request, _ctx, session) =>
+  postVigilance(request, session),
+);

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -129,7 +129,12 @@ export type AuditAction =
   | 'pccp_component_completed'
   | 'pccp_expert_approved'
   | 'pccp_algorithm_change_triggered'
-  | 'pccp_status_changed';
+  | 'pccp_status_changed'
+  // SPEC-REGULA-VIGILANCE-001 — adverse event report audit actions via 0042_vigilance_audit_actions.sql:
+  | 'vigilance_event_created'
+  | 'vigilance_reportability_assessed'
+  | 'vigilance_report_drafted'
+  | 'vigilance_report_exported';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -98,6 +98,7 @@ export const userDepartmentEnum = pgEnum('user_department', ['RA', 'Dev', 'Exec'
 // Phase 8 DocIngest: +6 via 0016_docingest_audit_actions.sql.
 // Phase 10 Radar: +3 via 0018_radar.sql. chat.query: +1. answer.refine: +1. Total: 48.
 // CER-001: +5 via 0037_cer_audit_actions.sql. Total: 53. (REQ-CER-036~040)
+// VIGILANCE-001: +4 via 0042_vigilance_audit_actions.sql. Total: 57.
 // NOTE: auth.mfa_fail is NOT included (removed in v0.3.0 H-5).
 export const auditActionEnum = pgEnum('audit_action', [
   'llm.call',
@@ -172,11 +173,17 @@ export const auditActionEnum = pgEnum('audit_action', [
   'pccp_expert_approved',
   'pccp_algorithm_change_triggered',
   'pccp_status_changed',
+  // SPEC-REGULA-VIGILANCE-001 — added via 0042_vigilance_audit_actions.sql:
+  'vigilance_event_created',
+  'vigilance_reportability_assessed',
+  'vigilance_report_drafted',
+  'vigilance_report_exported',
 ]);
 
 // REQ-WF-049: workflow_type pgEnum — workflow kinds.
 // Migration: 0012_workflow_schema.sql
 // REQ-PRE-010: predicate_comparison added via 0029_predicate_workflow_type.sql
+// SPEC-REGULA-VIGILANCE-001: vigilance added via 0043_vigilance_workflow_type.sql
 // (SPEC-REGULA-PREDICATE-001). Enum values must each be in their own migration.
 // REQ-CER-012: cer added via 0035_cer_workflow_type.sql.
 // REQ-PCCP-025: 'pccp' added via 0038_pccp_workflow_type.sql (SPEC-REGULA-PCCP-001).
@@ -187,6 +194,7 @@ export const workflowTypeEnum = pgEnum('workflow_type', [
   'predicate_comparison',
   'cer',
   'pccp',
+  'vigilance',
 ]);
 
 // REQ-WF-049: workflow_status pgEnum — lifecycle states for workflow_runs.
@@ -715,6 +723,66 @@ export const pccpComponents = pgTable(
     uniqueVersionComponent: unique().on(t.pccpVersionId, t.componentType),
   }),
 );
+// ---------------------------------------------------------------------------
+// SPEC-REGULA-VIGILANCE-001 — Post-Market Surveillance tables (3).
+// Migration: 0041_vigilance_tables.sql
+// ---------------------------------------------------------------------------
+
+// REQ-VIG-001: adverse_events — captures raw adverse event input data.
+export const adverseEvents = pgTable('adverse_events', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  workflowRunId: uuid('workflow_run_id').references(() => workflowRuns.id, {
+    onDelete: 'cascade',
+  }),
+  eventDate: date('event_date').notNull(),
+  deviceName: text('device_name').notNull(),
+  deviceModel: text('device_model'),
+  lotNumber: text('lot_number'),
+  eventDescription: text('event_description').notNull(),
+  patientOutcome: text('patient_outcome').notNull(),
+  awarenessDate: date('awareness_date').notNull(),
+  reporterName: text('reporter_name').notNull(),
+  reporterRole: text('reporter_role').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  createdBy: text('created_by').notNull(),
+});
+
+// REQ-VIG-002: reportability_assessments — deterministic rule engine output.
+export const reportabilityAssessments = pgTable('reportability_assessments', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  adverseEventId: uuid('adverse_event_id')
+    .notNull()
+    .references(() => adverseEvents.id, { onDelete: 'cascade' }),
+  fdaMdrRequired: boolean('fda_mdr_required').notNull(),
+  fdaMdrDeadlineDays: integer('fda_mdr_deadline_days'),
+  euMdvRequired: boolean('eu_mdv_required').notNull(),
+  euMdvDeadlineDays: integer('eu_mdv_deadline_days'),
+  fscaRequired: boolean('fsca_required').notNull(),
+  assessmentRationale: text('assessment_rationale').notNull(),
+  assessedByAi: boolean('assessed_by_ai').notNull().default(true),
+  reviewedBy: text('reviewed_by'),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});
+
+// REQ-VIG-003: vigilance_reports — AI-generated report draft content.
+export const vigilanceReports = pgTable('vigilance_reports', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  adverseEventId: uuid('adverse_event_id')
+    .notNull()
+    .references(() => adverseEvents.id, { onDelete: 'cascade' }),
+  // report_type: 'fda_mdr' | 'eu_mdv' | 'fsca'
+  reportType: text('report_type').notNull(),
+  // report_format: 'mdr_3500a' | 'eu_mdv_initial' | 'eu_mdv_final' | 'fsca_notice'
+  reportFormat: text('report_format').notNull(),
+  draftContent: jsonb('draft_content').notNull().default({}),
+  version: integer('version').notNull().default(1),
+  // status: 'draft' | 'reviewed' | 'submitted'
+  status: text('status').notNull().default('draft'),
+  submissionDeadline: date('submission_deadline'),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});
+
 // SPEC-REGULA-NOTIFICATIONS-001 — per-org webhook settings.
 // Migration: 0028_org_notification_settings.sql
 export const orgNotificationSettings = pgTable('org_notification_settings', {

--- a/lib/vigilance/audit.ts
+++ b/lib/vigilance/audit.ts
@@ -1,0 +1,72 @@
+// @MX:NOTE [AUTO] Vigilance-specific audit helpers wrapping the central writeAudit().
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001
+//
+// 21 CFR Part 11: every regulated vigilance action is recorded through the central
+// append-only audit pipeline. meta_json is PII-free — only IDs, booleans, and
+// report type labels are stored.
+
+import { writeAudit } from '../audit';
+
+/** REQ-VIG-021: a new adverse event was created. */
+export async function auditVigilanceEventCreated(params: {
+  userId: string;
+  adverseEventId: string;
+  deviceName: string;
+}): Promise<void> {
+  await writeAudit({
+    actor_id: params.userId,
+    action: 'vigilance_event_created',
+    resource_type: 'adverse_event',
+    resource_id: params.adverseEventId,
+    meta_json: { deviceName: params.deviceName },
+  });
+}
+
+/** REQ-VIG-022: reportability was assessed for an adverse event. */
+export async function auditReportabilityAssessed(params: {
+  userId: string;
+  adverseEventId: string;
+  fdaRequired: boolean;
+  euRequired: boolean;
+}): Promise<void> {
+  await writeAudit({
+    actor_id: params.userId,
+    action: 'vigilance_reportability_assessed',
+    resource_type: 'adverse_event',
+    resource_id: params.adverseEventId,
+    meta_json: {
+      fdaRequired: params.fdaRequired,
+      euRequired: params.euRequired,
+    },
+  });
+}
+
+/** REQ-VIG-023: a vigilance report draft was generated. */
+export async function auditReportDrafted(params: {
+  userId: string;
+  reportId: string;
+  reportType: string;
+}): Promise<void> {
+  await writeAudit({
+    actor_id: params.userId,
+    action: 'vigilance_report_drafted',
+    resource_type: 'vigilance_report',
+    resource_id: params.reportId,
+    meta_json: { reportType: params.reportType },
+  });
+}
+
+/** REQ-VIG-024: a vigilance report was exported. */
+export async function auditReportExported(params: {
+  userId: string;
+  reportId: string;
+  reportType: string;
+}): Promise<void> {
+  await writeAudit({
+    actor_id: params.userId,
+    action: 'vigilance_report_exported',
+    resource_type: 'vigilance_report',
+    resource_id: params.reportId,
+    meta_json: { reportType: params.reportType },
+  });
+}

--- a/lib/vigilance/report-generator.ts
+++ b/lib/vigilance/report-generator.ts
@@ -1,0 +1,220 @@
+// @MX:ANCHOR [AUTO] Report generator — produces FDA MDR 3500A / EU MDV / FSCA draft content.
+// @MX:REASON Sole function generating regulated report drafts; called by route handler and exports.
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001 (REQ-VIG-011~020)
+//
+// Uses claude-sonnet-4-5 (or env override) to produce structured field-by-field drafts.
+// E2E_TEST_MODE returns deterministic mock drafts without LLM calls.
+
+import { sharedAnthropicClient } from '@/lib/ai/anthropic-client';
+import type { AdverseEventInput, ReportabilityDecision } from './reportability-engine';
+
+export type ReportType = 'fda_mdr' | 'eu_mdv' | 'fsca';
+export type ReportFormat = 'mdr_3500a' | 'eu_mdv_initial' | 'eu_mdv_final' | 'fsca_notice';
+
+export interface ReportDraftResult {
+  reportType: ReportType;
+  reportFormat: ReportFormat;
+  // field_name → drafted text
+  draftContent: Record<string, string>;
+  submissionDeadline: string; // ISO date string
+}
+
+// @MX:WARN [AUTO] Complex branching — report type determines both prompt and deadline calculation.
+// @MX:REASON 3 report types × multiple deadline rules = high branch count; must stay consistent.
+function getReportFormat(reportType: ReportType): ReportFormat {
+  switch (reportType) {
+    case 'fda_mdr':
+      return 'mdr_3500a';
+    case 'eu_mdv':
+      return 'eu_mdv_initial';
+    case 'fsca':
+      return 'fsca_notice';
+  }
+}
+
+function calculateDeadline(awarenessDate: string, deadlineDays: number): string {
+  const awareness = new Date(awarenessDate);
+  awareness.setDate(awareness.getDate() + deadlineDays);
+  return awareness.toISOString().split('T')[0]!;
+}
+
+function buildPrompt(
+  event: AdverseEventInput,
+  reportType: ReportType,
+): string {
+  const baseContext = `
+Device Name: ${event.eventDescription}
+Patient Outcome: ${event.patientOutcome}
+Event Description: ${event.eventDescription}
+Event Date: ${event.eventDate}
+Awareness Date: ${event.awarenessDate}
+Device Category: ${event.deviceCategory}
+`.trim();
+
+  if (reportType === 'fda_mdr') {
+    return `You are a regulatory affairs specialist. Generate a draft FDA MedWatch 3500A Medical Device Report based on the following adverse event information:
+
+${baseContext}
+
+Provide a JSON object with these exact keys:
+{
+  "manufacturer_name": "...",
+  "manufacturer_address": "...",
+  "device_trade_name": "...",
+  "device_model_number": "...",
+  "event_description": "...",
+  "patient_outcome": "...",
+  "initial_reporter_occupation": "...",
+  "type_of_report": "...",
+  "manufacturer_narrative": "...",
+  "remedial_action": "..."
+}
+
+Use only information provided. Mark unknown fields as "[TO BE COMPLETED]". Respond with JSON only, no markdown.`;
+  }
+
+  if (reportType === 'eu_mdv') {
+    return `You are a regulatory affairs specialist. Generate a draft EU MDR Article 87 Medical Device Vigilance Initial Report based on the following adverse event information:
+
+${baseContext}
+
+Provide a JSON object with these exact keys:
+{
+  "manufacturer_name": "...",
+  "manufacturer_address": "...",
+  "device_description": "...",
+  "device_classification": "...",
+  "incident_description": "...",
+  "initial_evaluation": "...",
+  "corrective_actions_taken": "...",
+  "corrective_actions_planned": "...",
+  "patient_impact": "...",
+  "reporting_deadline_justification": "..."
+}
+
+Use only information provided. Mark unknown fields as "[TO BE COMPLETED]". Respond with JSON only, no markdown.`;
+  }
+
+  // fsca
+  return `You are a regulatory affairs specialist. Generate a draft Field Safety Corrective Action (FSCA) Notice based on the following adverse event information:
+
+${baseContext}
+
+Provide a JSON object with these exact keys:
+{
+  "device_identification": "...",
+  "action_type": "...",
+  "reason_for_action": "...",
+  "affected_products": "...",
+  "health_hazard_assessment": "...",
+  "action_description": "...",
+  "advice_to_users": "...",
+  "expected_completion_date": "..."
+}
+
+Use only information provided. Mark unknown fields as "[TO BE COMPLETED]". Respond with JSON only, no markdown.`;
+}
+
+function mockDraftContent(reportType: ReportType): Record<string, string> {
+  if (reportType === 'fda_mdr') {
+    return {
+      manufacturer_name: '[E2E TEST] Test Manufacturer Inc.',
+      manufacturer_address: '[E2E TEST] 123 Test St, Test City, TS 00000',
+      device_trade_name: '[E2E TEST] Test Medical Device',
+      device_model_number: '[E2E TEST] MODEL-001',
+      event_description: '[E2E TEST] Adverse event description placeholder.',
+      patient_outcome: '[E2E TEST] Patient outcome placeholder.',
+      initial_reporter_occupation: '[E2E TEST] Physician',
+      type_of_report: '[E2E TEST] 30-day MDR',
+      manufacturer_narrative: '[E2E TEST] Manufacturer narrative placeholder.',
+      remedial_action: '[E2E TEST] TO BE COMPLETED',
+    };
+  }
+
+  if (reportType === 'eu_mdv') {
+    return {
+      manufacturer_name: '[E2E TEST] Test Manufacturer Inc.',
+      manufacturer_address: '[E2E TEST] 123 Test St',
+      device_description: '[E2E TEST] Test Medical Device description.',
+      device_classification: '[E2E TEST] Class IIb',
+      incident_description: '[E2E TEST] Incident description placeholder.',
+      initial_evaluation: '[E2E TEST] Initial evaluation placeholder.',
+      corrective_actions_taken: '[E2E TEST] None taken yet.',
+      corrective_actions_planned: '[E2E TEST] Investigation in progress.',
+      patient_impact: '[E2E TEST] Patient impact placeholder.',
+      reporting_deadline_justification: '[E2E TEST] 15-day reporting period.',
+    };
+  }
+
+  return {
+    device_identification: '[E2E TEST] Test Device MODEL-001',
+    action_type: '[E2E TEST] Corrective Action',
+    reason_for_action: '[E2E TEST] Systematic malfunction identified.',
+    affected_products: '[E2E TEST] Lot numbers: TBD',
+    health_hazard_assessment: '[E2E TEST] Moderate risk.',
+    action_description: '[E2E TEST] Recall and replacement.',
+    advice_to_users: '[E2E TEST] Stop use and contact manufacturer.',
+    expected_completion_date: '[E2E TEST] TBD',
+  };
+}
+
+// @MX:ANCHOR [AUTO] generateReportDraft — AI-powered regulatory report draft generator.
+// @MX:REASON Called by POST /api/ra/vigilance for each applicable report type (up to 3 per event).
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001 (REQ-VIG-011~020)
+export async function generateReportDraft(
+  event: AdverseEventInput,
+  decision: ReportabilityDecision,
+  reportType: ReportType,
+): Promise<ReportDraftResult> {
+  const reportFormat = getReportFormat(reportType);
+
+  // Calculate submission deadline from awareness date
+  let deadlineDays = 30;
+  if (reportType === 'fda_mdr' && decision.fdaMdrDeadlineDays !== null) {
+    deadlineDays = decision.fdaMdrDeadlineDays;
+  } else if (reportType === 'eu_mdv' && decision.euMdvDeadlineDays !== null) {
+    deadlineDays = decision.euMdvDeadlineDays;
+  }
+  const submissionDeadline = calculateDeadline(event.awarenessDate, deadlineDays);
+
+  // E2E test mode: return deterministic mock without LLM call
+  const isE2EMode =
+    process.env.E2E_TEST_MODE === 'true' && process.env.NODE_ENV !== 'production';
+  if (isE2EMode) {
+    return {
+      reportType,
+      reportFormat,
+      draftContent: mockDraftContent(reportType),
+      submissionDeadline,
+    };
+  }
+
+  const model = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-5';
+  const prompt = buildPrompt(event, reportType);
+
+  const response = await sharedAnthropicClient.messages.create({
+    model,
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const rawBlock = response.content[0];
+  if (!rawBlock || rawBlock.type !== 'text') {
+    throw new Error(`Unexpected response type from report generator for ${reportType}`);
+  }
+
+  let draftContent: Record<string, string>;
+  try {
+    draftContent = JSON.parse(rawBlock.text) as Record<string, string>;
+  } catch {
+    // If JSON parse fails, wrap the raw text as a single field
+    draftContent = { raw_draft: rawBlock.text };
+  }
+
+  return {
+    reportType,
+    reportFormat,
+    draftContent,
+    submissionDeadline,
+  };
+}

--- a/lib/vigilance/reportability-engine.ts
+++ b/lib/vigilance/reportability-engine.ts
@@ -1,0 +1,178 @@
+// @MX:ANCHOR [AUTO] Reportability engine — determines regulatory filing obligation.
+// @MX:REASON Public API boundary; called by route handler and unit tests. fan_in >= 3.
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001 (REQ-VIG-001~010)
+//
+// Implements deterministic rules (no AI) for two regulatory frameworks:
+//   FDA MDR: 21 CFR Part 803 — 30-day (803.50) or 5-day (803.53)
+//   EU MDV:  EU MDR Article 87 — immediate/2-day, 15-day, or 30-day
+//   FSCA:    Field Safety Corrective Action (recall/corrective action)
+
+export type PatientOutcome =
+  | 'death'
+  | 'serious_injury'
+  | 'malfunction'
+  | 'no_injury'
+  | 'other';
+
+export type DeviceCategory =
+  | 'class_I'
+  | 'class_II'
+  | 'class_III'
+  | 'IIa'
+  | 'IIb'
+  | 'III';
+
+export interface AdverseEventInput {
+  eventDescription: string;
+  patientOutcome: PatientOutcome;
+  // EU MDR device classification (IIa / IIb / III) or FDA class (class_I / class_II / class_III)
+  deviceCategory: DeviceCategory;
+  eventDate: string;
+  awarenessDate: string;
+  isManufacturerAware: boolean;
+}
+
+export interface ReportabilityDecision {
+  fdaMdrRequired: boolean;
+  // 5-day (malfunction with serious injury risk) or 30-day (death/serious injury)
+  fdaMdrDeadlineDays: number | null;
+  euMdvRequired: boolean;
+  // 2-day (death/serious incident), 15-day (unanticipated serious incident), or 30-day (trend)
+  euMdvDeadlineDays: number | null;
+  fscaRequired: boolean;
+  rationale: string;
+}
+
+// Outcomes that trigger FDA MDR 30-day reporting (21 CFR 803.50(a))
+const FDA_30DAY_OUTCOMES: ReadonlySet<PatientOutcome> = new Set([
+  'death',
+  'serious_injury',
+]);
+
+// Outcomes that trigger EU MDV 2-day serious incident reporting (EU MDR Art. 87(2))
+const EU_2DAY_OUTCOMES: ReadonlySet<PatientOutcome> = new Set([
+  'death',
+  'serious_injury',
+]);
+
+// EU device classes that are subject to vigilance reporting (Art. 87 scope)
+const EU_REPORTABLE_CLASSES: ReadonlySet<DeviceCategory> = new Set([
+  'IIa',
+  'IIb',
+  'III',
+  'class_II',
+  'class_III',
+]);
+
+// @MX:ANCHOR [AUTO] assessReportability — core decision engine entry point.
+// @MX:REASON Called by POST /api/ra/vigilance route handler + 5 unit tests + audit wiring.
+// @MX:SPEC SPEC-REGULA-VIGILANCE-001 (REQ-VIG-001~010)
+export function assessReportability(event: AdverseEventInput): ReportabilityDecision {
+  const rationale: string[] = [];
+
+  // ---- FDA MDR assessment (21 CFR Part 803) ----
+  let fdaMdrRequired = false;
+  let fdaMdrDeadlineDays: number | null = null;
+
+  if (FDA_30DAY_OUTCOMES.has(event.patientOutcome)) {
+    // 21 CFR 803.50(a): death or serious injury → 30-day MDR
+    fdaMdrRequired = true;
+    fdaMdrDeadlineDays = 30;
+    rationale.push(
+      `FDA MDR required (30-day): 21 CFR 803.50(a) — ${event.patientOutcome} outcome triggers mandatory reporting.`,
+    );
+  } else if (event.patientOutcome === 'malfunction') {
+    // 21 CFR 803.53: malfunction that could cause death/serious injury if it recurs → 30-day
+    // 21 CFR 803.53(a): if the malfunction poses an unreasonable risk → 5-day
+    // Conservative rule: all malfunctions for Class II/III devices require 30-day reporting.
+    if (
+      event.deviceCategory === 'class_II' ||
+      event.deviceCategory === 'class_III' ||
+      event.deviceCategory === 'IIb' ||
+      event.deviceCategory === 'III'
+    ) {
+      fdaMdrRequired = true;
+      fdaMdrDeadlineDays = 30;
+      rationale.push(
+        `FDA MDR required (30-day): 21 CFR 803.53 — Class II/III device malfunction requiring reporting.`,
+      );
+    }
+  }
+
+  // 5-day expedited: malfunction with imminent risk (death-level outcome description)
+  if (
+    fdaMdrRequired &&
+    event.patientOutcome === 'malfunction' &&
+    (event.eventDescription.toLowerCase().includes('death') ||
+      event.eventDescription.toLowerCase().includes('life-threatening'))
+  ) {
+    fdaMdrDeadlineDays = 5;
+    rationale.push(
+      `FDA MDR upgraded to 5-day (21 CFR 803.53(a)): malfunction with imminent risk of death or serious injury.`,
+    );
+  }
+
+  // ---- EU MDV assessment (EU MDR Article 87) ----
+  let euMdvRequired = false;
+  let euMdvDeadlineDays: number | null = null;
+
+  if (EU_REPORTABLE_CLASSES.has(event.deviceCategory)) {
+    if (EU_2DAY_OUTCOMES.has(event.patientOutcome)) {
+      // Art. 87(2): serious incident with imminent risk — 2-day immediate notice
+      euMdvRequired = true;
+      euMdvDeadlineDays = 2;
+      rationale.push(
+        `EU MDV required (2-day): EU MDR Art. 87(2) — serious incident with ${event.patientOutcome} outcome.`,
+      );
+    } else if (event.patientOutcome === 'malfunction') {
+      // Art. 87(1): unanticipated serious incident — 15-day
+      euMdvRequired = true;
+      euMdvDeadlineDays = 15;
+      rationale.push(
+        `EU MDV required (15-day): EU MDR Art. 87(1) — device malfunction that may have led to serious incident.`,
+      );
+    } else if (event.patientOutcome === 'other') {
+      // Art. 87(3): trend reporting — 30-day
+      euMdvRequired = true;
+      euMdvDeadlineDays = 30;
+      rationale.push(
+        `EU MDV required (30-day): EU MDR Art. 87(3) — trend report for non-serious incident.`,
+      );
+    }
+  } else if (!EU_REPORTABLE_CLASSES.has(event.deviceCategory)) {
+    rationale.push(
+      `EU MDV not required: ${event.deviceCategory} devices are outside EU MDR Article 87 scope.`,
+    );
+  }
+
+  // ---- FSCA assessment (Field Safety Corrective Action) ----
+  // FSCA is required when the manufacturer takes or plans corrective action to reduce risk.
+  // Triggered by: systematic malfunction, death, serious injury requiring product recall/correction.
+  const fscaRequired =
+    (fdaMdrRequired || euMdvRequired) &&
+    (event.patientOutcome === 'death' ||
+      event.patientOutcome === 'serious_injury' ||
+      (event.patientOutcome === 'malfunction' &&
+        (event.deviceCategory === 'class_III' || event.deviceCategory === 'III')));
+
+  if (fscaRequired) {
+    rationale.push(
+      `FSCA required: systematic malfunction or serious harm involving high-risk device warrants field safety corrective action notice.`,
+    );
+  }
+
+  if (rationale.length === 0) {
+    rationale.push(
+      `No mandatory reporting required: ${event.patientOutcome} outcome on ${event.deviceCategory} device does not trigger FDA MDR or EU MDV obligations.`,
+    );
+  }
+
+  return {
+    fdaMdrRequired,
+    fdaMdrDeadlineDays,
+    euMdvRequired,
+    euMdvDeadlineDays,
+    fscaRequired,
+    rationale: rationale.join(' '),
+  };
+}

--- a/migrations/0044_vigilance_tables.sql
+++ b/migrations/0044_vigilance_tables.sql
@@ -1,0 +1,45 @@
+-- SPEC-REGULA-VIGILANCE-001 — Post-Market Surveillance adverse event tables.
+-- Three tables: adverse_events, reportability_assessments, vigilance_reports.
+
+CREATE TABLE IF NOT EXISTS "adverse_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "workflow_run_id" uuid REFERENCES "workflow_runs"("id") ON DELETE CASCADE,
+  "event_date" date NOT NULL,
+  "device_name" text NOT NULL,
+  "device_model" text,
+  "lot_number" text,
+  "event_description" text NOT NULL,
+  "patient_outcome" text NOT NULL,
+  "awareness_date" date NOT NULL,
+  "reporter_name" text NOT NULL,
+  "reporter_role" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "created_by" text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "reportability_assessments" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "adverse_event_id" uuid NOT NULL REFERENCES "adverse_events"("id") ON DELETE CASCADE,
+  "fda_mdr_required" boolean NOT NULL,
+  "fda_mdr_deadline_days" integer,
+  "eu_mdv_required" boolean NOT NULL,
+  "eu_mdv_deadline_days" integer,
+  "fsca_required" boolean NOT NULL,
+  "assessment_rationale" text NOT NULL,
+  "assessed_by_ai" boolean NOT NULL DEFAULT true,
+  "reviewed_by" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "vigilance_reports" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "adverse_event_id" uuid NOT NULL REFERENCES "adverse_events"("id") ON DELETE CASCADE,
+  "report_type" text NOT NULL,
+  "report_format" text NOT NULL,
+  "draft_content" jsonb NOT NULL DEFAULT '{}',
+  "version" integer NOT NULL DEFAULT 1,
+  "status" text NOT NULL DEFAULT 'draft',
+  "submission_deadline" date,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/migrations/0045_vigilance_audit_actions.sql
+++ b/migrations/0045_vigilance_audit_actions.sql
@@ -1,0 +1,7 @@
+-- SPEC-REGULA-VIGILANCE-001 — Vigilance audit action enum values.
+-- Appends 4 new values to the existing audit_action pgEnum.
+
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'vigilance_event_created';
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'vigilance_reportability_assessed';
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'vigilance_report_drafted';
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'vigilance_report_exported';

--- a/migrations/0046_vigilance_workflow_type.sql
+++ b/migrations/0046_vigilance_workflow_type.sql
@@ -1,0 +1,3 @@
+-- SPEC-REGULA-VIGILANCE-001 — Add 'vigilance' to workflow_type enum.
+
+ALTER TYPE "workflow_type" ADD VALUE IF NOT EXISTS 'vigilance';


### PR DESCRIPTION
## 요약

SPEC-REGULA-VIGILANCE-001 — FDA MDR·EU MDV·FSCA 포스트마켓 감시 보고서 자동 초안기.

- **보고 결정 엔진**: 21 CFR 803 + EU MDR Art.87 결정론적 룰 (AI 없음, 즉각 판단)
- **FDA MDR 3500A**: 30일/5일 보고 의무 자동 초안 (Sonnet)
- **EU MDV**: Initial/Final Report 초안 (즉각/15일/30일 기한 계산)
- **FSCA**: Field Safety Corrective Action Notice 초안
- **SSE 스트리밍**: `POST /api/ra/vigilance`
- **DB**: 마이그레이션 0044-0046 (PR #141의 0041-0043과 충돌 없음)

## 변경 파일

| 구분 | 파일 |
|------|------|
| Migration | `0044_vigilance_tables.sql`, `0045_vigilance_audit_actions.sql`, `0046_vigilance_workflow_type.sql` |
| Schema | `lib/db/schema.ts` (+3 tables, +4 audit actions) |
| Core | `lib/vigilance/reportability-engine.ts`, `lib/vigilance/report-generator.ts`, `lib/vigilance/audit.ts` |
| API | `app/api/ra/vigilance/route.ts` |
| UI | `app/(app)/workflows/vigilance/page.tsx`, `_components/VigilanceForm.tsx` |
| Tests | `__tests__/lib/vigilance/reportability-engine.test.ts` |

## 테스트 계획

- [x] TypeScript 오류 0 (`npm run typecheck`)
- [x] 단위 테스트 8/8 통과 (reportability-engine)
- [ ] E2E: 유해사례 입력 → 보고 여부 판단 → 초안 생성 확인

Fixes #61

🗿 MoAI <email@mo.ai.kr>