### PR TITLE
feat(standards): SPEC-REGULA-STANDARDS-001 조화 표준 적용성 추적기 (#62)

### DIFF
--- a/__tests__/lib/standards/applicability-engine.test.ts
+++ b/__tests__/lib/standards/applicability-engine.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { getApplicableStandards } from '@/lib/standards/applicability-engine';
+
+describe('getApplicableStandards', () => {
+  it('returns ISO 14971 for any device type', () => {
+    const result = getApplicableStandards({
+      deviceTypeKey: 'general_device',
+      regulatoryPathway: 'fda_510k',
+      hasSoftware: false,
+      isElectrical: false,
+      isSterile: false,
+      usesAnimalTissue: false,
+    });
+    expect(result.some((s) => s.standardNumber === 'ISO 14971:2019')).toBe(true);
+  });
+
+  it('includes IEC 62304 when device has software', () => {
+    const result = getApplicableStandards({
+      deviceTypeKey: 'general_device',
+      regulatoryPathway: 'fda_510k',
+      hasSoftware: true,
+      isElectrical: false,
+      isSterile: false,
+      usesAnimalTissue: false,
+    });
+    expect(result.some((s) => s.standardNumber === 'IEC 62304:2006/AMD1:2015')).toBe(true);
+  });
+
+  it('includes IEC 60601-1 for electrical_medical_device', () => {
+    const result = getApplicableStandards({
+      deviceTypeKey: 'electrical_medical_device',
+      regulatoryPathway: 'fda_510k',
+      hasSoftware: false,
+      isElectrical: true,
+      isSterile: false,
+      usesAnimalTissue: false,
+    });
+    expect(result.some((s) => s.standardNumber.startsWith('IEC 60601-1:'))).toBe(true);
+  });
+
+  it('includes ISO 11135 for sterile_device', () => {
+    const result = getApplicableStandards({
+      deviceTypeKey: 'sterile_device',
+      regulatoryPathway: 'fda_510k',
+      hasSoftware: false,
+      isElectrical: false,
+      isSterile: true,
+      usesAnimalTissue: false,
+    });
+    expect(result.some((s) => s.standardNumber === 'ISO 11135:2014')).toBe(true);
+  });
+
+  it('includes ISO 10993-1 for device using animal tissue', () => {
+    const result = getApplicableStandards({
+      deviceTypeKey: 'general_device',
+      regulatoryPathway: 'eu_mdr_class_ii',
+      hasSoftware: false,
+      isElectrical: false,
+      isSterile: false,
+      usesAnimalTissue: true,
+    });
+    expect(result.some((s) => s.standardNumber === 'ISO 10993-1:2018')).toBe(true);
+  });
+
+  it('returns software_only with IEC 62304 and IEC 62366 as mandatory', () => {
+    const result = getApplicableStandards({
+      deviceTypeKey: 'software_only',
+      regulatoryPathway: 'fda_510k',
+      hasSoftware: true,
+      isElectrical: false,
+      isSterile: false,
+      usesAnimalTissue: false,
+    });
+    const mandatory = result.filter((s) => s.isMandatory).map((s) => s.standardNumber);
+    expect(mandatory).toContain('IEC 62304:2006/AMD1:2015');
+    expect(mandatory).toContain('IEC 62366-1:2015');
+  });
+
+  it('returns fdaRecognized=true for FDA-recognized standards', () => {
+    const result = getApplicableStandards({
+      deviceTypeKey: 'general_device',
+      regulatoryPathway: 'fda_510k',
+      hasSoftware: false,
+      isElectrical: false,
+      isSterile: false,
+      usesAnimalTissue: false,
+    });
+    const iso14971 = result.find((s) => s.standardNumber === 'ISO 14971:2019');
+    expect(iso14971?.fdaRecognized).toBe(true);
+  });
+
+  it('deduplicates standards when multiple rules apply same standard', () => {
+    const result = getApplicableStandards({
+      deviceTypeKey: 'electrical_medical_device',
+      regulatoryPathway: 'fda_510k',
+      hasSoftware: true,
+      isElectrical: true,
+      isSterile: false,
+      usesAnimalTissue: false,
+    });
+    const nums = result.map((s) => s.standardNumber);
+    const unique = new Set(nums);
+    expect(nums.length).toBe(unique.size);
+  });
+});

--- a/app/(app)/workflows/standards/_components/StandardsForm.tsx
+++ b/app/(app)/workflows/standards/_components/StandardsForm.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState } from 'react';
+import type { ApplicableStandard } from '@/lib/standards/applicability-engine';
+
+interface StandardsResult {
+  standards: ApplicableStandard[];
+  totalCount: number;
+}
+
+interface CheckboxFieldProps {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}
+
+function CheckboxField({ id, label, checked, onChange }: CheckboxFieldProps) {
+  return (
+    <label htmlFor={id} className="flex cursor-pointer items-center gap-2 text-sm">
+      <input
+        type="checkbox"
+        id={id}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-4 w-4 rounded border-border accent-brand-700"
+      />
+      {label}
+    </label>
+  );
+}
+
+export function StandardsForm() {
+  const [deviceTypeKey, setDeviceTypeKey] = useState('general_device');
+  const [regulatoryPathway, setRegulatoryPathway] = useState('fda_510k');
+  const [hasSoftware, setHasSoftware] = useState(false);
+  const [isElectrical, setIsElectrical] = useState(false);
+  const [isSterile, setIsSterile] = useState(false);
+  const [usesAnimalTissue, setUsesAnimalTissue] = useState(false);
+  const [result, setResult] = useState<StandardsResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/ra/standards', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceTypeKey,
+          regulatoryPathway,
+          hasSoftware,
+          isElectrical,
+          isSterile,
+          usesAnimalTissue,
+        }),
+      });
+      if (!res.ok) throw new Error('Standards lookup failed');
+      setResult(await res.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-4 rounded-lg border border-border bg-surface p-5"
+      >
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-1">
+            <label htmlFor="deviceTypeKey" className="text-sm font-medium text-ink-700">
+              Device Type
+            </label>
+            <select
+              id="deviceTypeKey"
+              value={deviceTypeKey}
+              onChange={(e) => setDeviceTypeKey(e.target.value)}
+              className="rounded border border-border bg-white px-3 py-2 text-sm text-ink-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            >
+              <option value="general_device">General Device</option>
+              <option value="electrical_medical_device">Electrical Medical Device</option>
+              <option value="software_only">Software Only (SaMD)</option>
+              <option value="sterile_device">Sterile Device</option>
+              <option value="in_vitro_diagnostic">In Vitro Diagnostic (IVD)</option>
+              <option value="active_implantable">Active Implantable</option>
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="regulatoryPathway" className="text-sm font-medium text-ink-700">
+              Regulatory Pathway
+            </label>
+            <select
+              id="regulatoryPathway"
+              value={regulatoryPathway}
+              onChange={(e) => setRegulatoryPathway(e.target.value)}
+              className="rounded border border-border bg-white px-3 py-2 text-sm text-ink-900 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            >
+              <option value="fda_510k">FDA 510(k)</option>
+              <option value="fda_pma">FDA PMA</option>
+              <option value="eu_mdr_class_i">EU MDR Class I</option>
+              <option value="eu_mdr_class_ii">EU MDR Class II</option>
+              <option value="eu_mdr_class_iii">EU MDR Class III</option>
+              <option value="all">All Pathways</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-5">
+          <CheckboxField
+            id="hasSoftware"
+            label="Contains Software"
+            checked={hasSoftware}
+            onChange={setHasSoftware}
+          />
+          <CheckboxField
+            id="isElectrical"
+            label="Electrical Device"
+            checked={isElectrical}
+            onChange={setIsElectrical}
+          />
+          <CheckboxField
+            id="isSterile"
+            label="Sterile Device"
+            checked={isSterile}
+            onChange={setIsSterile}
+          />
+          <CheckboxField
+            id="usesAnimalTissue"
+            label="Uses Animal Tissue"
+            checked={usesAnimalTissue}
+            onChange={setUsesAnimalTissue}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-fit rounded bg-brand-700 px-4 py-2 text-sm font-medium text-white hover:bg-brand-800 disabled:opacity-60"
+        >
+          {loading ? 'Analyzing...' : 'Find Applicable Standards'}
+        </button>
+      </form>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {result && (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-ink-500">{result.totalCount} applicable standards found</p>
+          {result.standards.map((s) => (
+            <div
+              key={s.standardNumber}
+              className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-sm font-semibold text-ink-900">{s.standardNumber}</p>
+                  <p className="mt-0.5 text-sm text-ink-600">{s.title}</p>
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  {s.fdaRecognized && (
+                    <span className="rounded border border-border px-1.5 py-0.5 text-xs font-medium text-ink-700">
+                      FDA
+                    </span>
+                  )}
+                  {s.euHarmonized && (
+                    <span className="rounded border border-border px-1.5 py-0.5 text-xs font-medium text-ink-700">
+                      EU
+                    </span>
+                  )}
+                  <span
+                    className={`rounded px-1.5 py-0.5 text-xs font-medium ${
+                      s.isMandatory
+                        ? 'bg-brand-100 text-brand-800'
+                        : 'bg-ink-100 text-ink-600'
+                    }`}
+                  >
+                    {s.isMandatory ? 'Mandatory' : 'Recommended'}
+                  </span>
+                </div>
+              </div>
+              <p className="text-xs text-ink-500">{s.applicabilityReason}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/workflows/standards/page.tsx
+++ b/app/(app)/workflows/standards/page.tsx
@@ -1,0 +1,16 @@
+import { StandardsForm } from './_components/StandardsForm';
+
+export const metadata = { title: 'Standards Tracker — Regula' };
+
+export default function StandardsPage() {
+  return (
+    <main className="container mx-auto max-w-4xl py-8 px-4">
+      <h1 className="text-2xl font-bold mb-2">Harmonized Standards Tracker</h1>
+      <p className="text-muted-foreground mb-6">
+        Map applicable standards for your device and identify FDA-recognized / EU-harmonized
+        requirements.
+      </p>
+      <StandardsForm />
+    </main>
+  );
+}

--- a/app/api/ra/standards/route.ts
+++ b/app/api/ra/standards/route.ts
@@ -1,0 +1,59 @@
+// POST /api/ra/standards — deterministic standards applicability lookup.
+// @MX:SPEC SPEC-REGULA-STANDARDS-001
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import {
+  type DeviceProfile,
+  getApplicableStandards,
+} from '@/lib/standards/applicability-engine';
+
+const RequestSchema = z.object({
+  deviceTypeKey: z.enum([
+    'general_device',
+    'electrical_medical_device',
+    'software_only',
+    'sterile_device',
+    'in_vitro_diagnostic',
+    'active_implantable',
+  ]),
+  regulatoryPathway: z.enum([
+    'fda_510k',
+    'fda_pma',
+    'eu_mdr_class_i',
+    'eu_mdr_class_ii',
+    'eu_mdr_class_iii',
+    'all',
+  ]),
+  hasSoftware: z.boolean().default(false),
+  isElectrical: z.boolean().default(false),
+  isSterile: z.boolean().default(false),
+  usesAnimalTissue: z.boolean().default(false),
+});
+
+export const POST = withPermission('dashboard.view', async (req, _ctx, session) => {
+  const body = await req.json();
+  const parsed = RequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const profile: DeviceProfile = parsed.data;
+  const standards = getApplicableStandards(profile);
+
+  await writeAudit({
+    action: 'standards_searched',
+    actor_id: session.user.id,
+    resource_type: 'standards_catalog',
+    resource_id: profile.deviceTypeKey,
+    meta_json: {
+      deviceTypeKey: profile.deviceTypeKey,
+      regulatoryPathway: profile.regulatoryPathway,
+      count: standards.length,
+    },
+  });
+
+  return NextResponse.json({ standards, totalCount: standards.length });
+});

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -134,7 +134,11 @@ export type AuditAction =
   | 'vigilance_event_created'
   | 'vigilance_reportability_assessed'
   | 'vigilance_report_drafted'
-  | 'vigilance_report_exported';
+  | 'vigilance_report_exported'
+  // SPEC-REGULA-STANDARDS-001 — standards tracker audit actions via 0048_standards_applicability.sql:
+  | 'standards_searched'
+  | 'standards_gap_analyzed'
+  | 'standards_compliance_updated';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -861,3 +861,43 @@ export const orgNotificationSettings = pgTable('org_notification_settings', {
   createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 });
+
+// SPEC-REGULA-STANDARDS-001 — standards catalog.
+// Migration: 0047_standards_catalog.sql
+export const standardsCatalog = pgTable('standards_catalog', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  standardNumber: text('standard_number').notNull().unique(),
+  title: text('title').notNull(),
+  body: text('body').notNull(),
+  version: text('version').notNull(),
+  publicationYear: integer('publication_year').notNull(),
+  // status CHECK: 'current'|'withdrawn'|'under_revision'
+  status: text('status').notNull().default('current'),
+  supersedes: text('supersedes'),
+  scopeKeywords: text('scope_keywords').array().notNull().default(['']),
+  fdaRecognized: boolean('fda_recognized').notNull().default(false),
+  euHarmonized: boolean('eu_harmonized').notNull().default(false),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});
+
+// SPEC-REGULA-STANDARDS-001 — standards applicability mapping.
+// Migration: 0048_standards_applicability.sql
+export const standardsApplicability = pgTable(
+  'standards_applicability',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    deviceTypeKey: text('device_type_key').notNull(),
+    standardId: uuid('standard_id')
+      .notNull()
+      .references(() => standardsCatalog.id, { onDelete: 'cascade' }),
+    applicabilityReason: text('applicability_reason').notNull(),
+    // regulatoryPathway CHECK: 'fda_510k'|'fda_pma'|'eu_mdr_class_i'|'eu_mdr_class_ii'|'eu_mdr_class_iii'|'all'
+    regulatoryPathway: text('regulatory_pathway').notNull(),
+    isMandatory: boolean('is_mandatory').notNull().default(true),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniqueMapping: unique().on(t.deviceTypeKey, t.standardId, t.regulatoryPathway),
+  }),
+);

--- a/lib/standards/applicability-engine.ts
+++ b/lib/standards/applicability-engine.ts
@@ -1,0 +1,350 @@
+// @MX:ANCHOR: [AUTO] Standards applicability mapping — called by API route and UI
+// @MX:REASON: Public API boundary; fan_in >= 3 (route, tests, UI)
+// @MX:SPEC: SPEC-REGULA-STANDARDS-001 REQ-STANDARDS-001~006
+
+export interface DeviceProfile {
+  deviceTypeKey: string; // 'electrical_medical_device'|'active_implantable'|'software_only'|'in_vitro_diagnostic'|'sterile_device'|'general_device'
+  regulatoryPathway: string; // 'fda_510k'|'fda_pma'|'eu_mdr_class_i'|'eu_mdr_class_ii'|'eu_mdr_class_iii'|'all'
+  hasSoftware: boolean;
+  isElectrical: boolean;
+  isSterile: boolean;
+  usesAnimalTissue: boolean;
+}
+
+export interface ApplicableStandard {
+  standardNumber: string;
+  title: string;
+  body: string;
+  isMandatory: boolean;
+  applicabilityReason: string;
+  fdaRecognized: boolean;
+  euHarmonized: boolean;
+}
+
+// Static catalog of key medical device standards (seed data — no external API needed)
+export const STANDARDS_SEED_DATA = [
+  {
+    standardNumber: 'ISO 14971:2019',
+    title: 'Medical devices — Application of risk management to medical devices',
+    body: 'ISO',
+    version: '2019',
+    publicationYear: 2019,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['risk', 'risk management', 'hazard'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'IEC 62304:2006/AMD1:2015',
+    title: 'Medical device software — Software life cycle processes',
+    body: 'IEC',
+    version: '2015',
+    publicationYear: 2015,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['software', 'SLC', 'lifecycle'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'IEC 62366-1:2015',
+    title: 'Medical devices — Usability engineering',
+    body: 'IEC',
+    version: '2015',
+    publicationYear: 2015,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['usability', 'human factors', 'UE'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'IEC 60601-1:2005/AMD2:2020',
+    title:
+      'Medical electrical equipment — General requirements for basic safety and essential performance',
+    body: 'IEC',
+    version: '2020',
+    publicationYear: 2020,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['electrical', 'safety', 'EMC', 'electrical medical device'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'IEC 60601-1-2:2014/AMD1:2020',
+    title: 'Medical electrical equipment — Electromagnetic disturbances',
+    body: 'IEC',
+    version: '2020',
+    publicationYear: 2020,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['EMC', 'electromagnetic', 'electrical medical device'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'ISO 10993-1:2018',
+    title:
+      'Biological evaluation of medical devices — Part 1: Evaluation and testing within a risk management process',
+    body: 'ISO',
+    version: '2018',
+    publicationYear: 2018,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['biocompatibility', 'biological', 'materials'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'ISO 13485:2016',
+    title: 'Medical devices — Quality management systems',
+    body: 'ISO',
+    version: '2016',
+    publicationYear: 2016,
+    fdaRecognized: false,
+    euHarmonized: true,
+    scopeKeywords: ['QMS', 'quality', 'management system'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'ISO 11135:2014',
+    title: 'Sterilization of health-care products — Ethylene oxide',
+    body: 'ISO',
+    version: '2014',
+    publicationYear: 2014,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['sterile', 'sterilization', 'EO'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'ISO 11607-1:2019',
+    title: 'Packaging for terminally sterilized medical devices — Part 1: Requirements for materials',
+    body: 'ISO',
+    version: '2019',
+    publicationYear: 2019,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['packaging', 'sterile', 'sterilization'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'ASTM F2132',
+    title: 'Standard Specification for Accelerated Aging of Sterile Medical Device Packages',
+    body: 'ASTM',
+    version: 'latest',
+    publicationYear: 2021,
+    fdaRecognized: true,
+    euHarmonized: false,
+    scopeKeywords: ['packaging', 'sterile', 'aging'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'IEC 60601-1-6:2010/AMD1:2013',
+    title: 'Medical electrical equipment — Usability',
+    body: 'IEC',
+    version: '2013',
+    publicationYear: 2013,
+    fdaRecognized: true,
+    euHarmonized: true,
+    scopeKeywords: ['usability', 'electrical medical device', 'HFE'],
+    status: 'current' as const,
+  },
+  {
+    standardNumber: 'ISO/IEC 27001:2022',
+    title: 'Information security management systems',
+    body: 'ISO',
+    version: '2022',
+    publicationYear: 2022,
+    fdaRecognized: false,
+    euHarmonized: false,
+    scopeKeywords: ['cybersecurity', 'information security', 'ISMS'],
+    status: 'current' as const,
+  },
+] as const;
+
+type ApplicabilityRule = {
+  standardNumber: string;
+  isMandatory: boolean;
+  reason: string;
+  pathway: string;
+};
+
+// Mapping rules: deviceTypeKey → applicable standards with reason
+const APPLICABILITY_RULES: Record<string, ApplicabilityRule[]> = {
+  general_device: [
+    {
+      standardNumber: 'ISO 14971:2019',
+      isMandatory: true,
+      reason: 'Risk management required for all medical devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'ISO 13485:2016',
+      isMandatory: true,
+      reason: 'QMS required under EU MDR Annex IX',
+      pathway: 'eu_mdr_class_i',
+    },
+  ],
+  electrical_medical_device: [
+    {
+      standardNumber: 'ISO 14971:2019',
+      isMandatory: true,
+      reason: 'Risk management required for all medical devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'IEC 60601-1:2005/AMD2:2020',
+      isMandatory: true,
+      reason: 'General safety and performance for electrical medical equipment',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'IEC 60601-1-2:2014/AMD1:2020',
+      isMandatory: true,
+      reason: 'EMC requirements for electrical medical equipment',
+      pathway: 'all',
+    },
+  ],
+  software_only: [
+    {
+      standardNumber: 'ISO 14971:2019',
+      isMandatory: true,
+      reason: 'Risk management required for all medical devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'IEC 62304:2006/AMD1:2015',
+      isMandatory: true,
+      reason: 'Software lifecycle required for standalone software medical devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'IEC 62366-1:2015',
+      isMandatory: true,
+      reason: 'Usability engineering required for software with user interface',
+      pathway: 'all',
+    },
+  ],
+  sterile_device: [
+    {
+      standardNumber: 'ISO 14971:2019',
+      isMandatory: true,
+      reason: 'Risk management required for all medical devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'ISO 11135:2014',
+      isMandatory: true,
+      reason: 'Sterilization validation for EO sterilized devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'ISO 11607-1:2019',
+      isMandatory: true,
+      reason: 'Packaging validation for sterile medical devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'ASTM F2132',
+      isMandatory: false,
+      reason: 'Accelerated aging protocol for sterile packaging validation',
+      pathway: 'fda_510k',
+    },
+  ],
+  in_vitro_diagnostic: [
+    {
+      standardNumber: 'ISO 14971:2019',
+      isMandatory: true,
+      reason: 'Risk management required for all medical devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'ISO 13485:2016',
+      isMandatory: true,
+      reason: 'QMS required for IVD devices',
+      pathway: 'all',
+    },
+  ],
+  active_implantable: [
+    {
+      standardNumber: 'ISO 14971:2019',
+      isMandatory: true,
+      reason: 'Risk management required for all medical devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'IEC 60601-1:2005/AMD2:2020',
+      isMandatory: true,
+      reason: 'Electrical safety for active implantable devices',
+      pathway: 'all',
+    },
+    {
+      standardNumber: 'ISO 10993-1:2018',
+      isMandatory: true,
+      reason: 'Biocompatibility evaluation for implantable materials',
+      pathway: 'all',
+    },
+  ],
+};
+
+export function getApplicableStandards(profile: DeviceProfile): ApplicableStandard[] {
+  const catalogMap: Map<string, (typeof STANDARDS_SEED_DATA)[number]> = new Map(
+    STANDARDS_SEED_DATA.map((s) => [s.standardNumber as string, s]),
+  );
+  const rules: ApplicabilityRule[] =
+    APPLICABILITY_RULES[profile.deviceTypeKey] ?? APPLICABILITY_RULES['general_device'] ?? [];
+  const additionalRules: ApplicabilityRule[] = [];
+
+  if (profile.hasSoftware) {
+    additionalRules.push(
+      {
+        standardNumber: 'IEC 62304:2006/AMD1:2015',
+        isMandatory: true,
+        reason: 'Software lifecycle process required when device contains software',
+        pathway: 'all',
+      },
+      {
+        standardNumber: 'IEC 62366-1:2015',
+        isMandatory: true,
+        reason: 'Usability engineering for devices with software interface',
+        pathway: 'all',
+      },
+    );
+  }
+  if (profile.isElectrical && !rules.some((r) => r.standardNumber.startsWith('IEC 60601-1:'))) {
+    additionalRules.push({
+      standardNumber: 'IEC 60601-1:2005/AMD2:2020',
+      isMandatory: true,
+      reason: 'General safety for electrical medical equipment',
+      pathway: 'all',
+    });
+  }
+  if (profile.usesAnimalTissue) {
+    additionalRules.push({
+      standardNumber: 'ISO 10993-1:2018',
+      isMandatory: true,
+      reason: 'Biocompatibility required for devices using animal tissue',
+      pathway: 'all',
+    });
+  }
+
+  const allRules = [...rules, ...additionalRules];
+  const seen = new Set<string>();
+  const result: ApplicableStandard[] = [];
+
+  for (const rule of allRules) {
+    const key = `${rule.standardNumber}:${rule.pathway}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const catalog = catalogMap.get(rule.standardNumber);
+    if (!catalog) continue;
+    result.push({
+      standardNumber: rule.standardNumber,
+      title: catalog.title,
+      body: catalog.body,
+      isMandatory: rule.isMandatory,
+      applicabilityReason: rule.reason,
+      fdaRecognized: catalog.fdaRecognized,
+      euHarmonized: catalog.euHarmonized,
+    });
+  }
+
+  return result;
+}

--- a/migrations/0047_standards_catalog.sql
+++ b/migrations/0047_standards_catalog.sql
@@ -1,0 +1,19 @@
+-- SPEC-REGULA-STANDARDS-001: Standards catalog
+CREATE TABLE standards_catalog (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  standard_number TEXT NOT NULL UNIQUE,  -- e.g. "ISO 14971:2019"
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,                    -- 'ISO'|'IEC'|'EN'|'ASTM'|'CEN'
+  version TEXT NOT NULL,
+  publication_year INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'current', -- 'current'|'withdrawn'|'under_revision'
+  supersedes TEXT,                        -- previous standard number
+  scope_keywords TEXT[] NOT NULL DEFAULT '{}',
+  fda_recognized BOOLEAN NOT NULL DEFAULT FALSE,
+  eu_harmonized BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_standards_catalog_body ON standards_catalog(body);
+CREATE INDEX idx_standards_catalog_fda ON standards_catalog(fda_recognized);
+CREATE INDEX idx_standards_catalog_eu ON standards_catalog(eu_harmonized);

--- a/migrations/0048_standards_applicability.sql
+++ b/migrations/0048_standards_applicability.sql
@@ -1,0 +1,16 @@
+-- SPEC-REGULA-STANDARDS-001: Standards applicability mapping
+CREATE TABLE standards_applicability (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  device_type_key TEXT NOT NULL,          -- 'electrical_medical_device'|'active_implantable'|'software_only'|...
+  standard_id UUID NOT NULL REFERENCES standards_catalog(id) ON DELETE CASCADE,
+  applicability_reason TEXT NOT NULL,
+  regulatory_pathway TEXT NOT NULL,       -- 'fda_510k'|'fda_pma'|'eu_mdr_class_i'|'eu_mdr_class_ii'|'eu_mdr_class_iii'|'all'
+  is_mandatory BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(device_type_key, standard_id, regulatory_pathway)
+);
+
+-- Standards audit_actions enum update
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'standards_searched';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'standards_gap_analyzed';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'standards_compliance_updated';

--- a/migrations/0049_standards_workflow.sql
+++ b/migrations/0049_standards_workflow.sql
@@ -1,0 +1,2 @@
+-- SPEC-REGULA-STANDARDS-001: Standards workflow type
+ALTER TYPE workflow_type ADD VALUE IF NOT EXISTS 'standards';


### PR DESCRIPTION
## Summary

- 결정론적 규칙 기반 `applicability-engine`으로 장치 유형 + 경로별 적용 표준 매핑 (AI 불필요)
- 3개 마이그레이션(0047~0049): standards_catalog/applicability 테이블, audit_action 3개 추가, workflow_type 'standards' 추가
- POST `/api/ra/standards` API, StandardsForm UI 컴포넌트, 8개 vitest 단위 테스트 통과

## Test plan

- [x] `npm run typecheck` — 오류 없음
- [x] `npm test -- __tests__/lib/standards/applicability-engine.test.ts --run` — 8/8 통과
- [ ] 브라우저에서 `/workflows/standards` 접속 후 장치 유형 선택 → 표준 목록 확인
- [ ] FDA 510(k) + Electrical Medical Device 선택 시 IEC 60601-1 포함 확인
- [ ] Software Only + hasSoftware 선택 시 IEC 62304 + IEC 62366 Mandatory 확인

🗿 MoAI <email@mo.ai.kr>