### PR TITLE
feat(classification): SPEC-REGULA-CLASSIFY-001 — 5개 관할권 의료기기 분류 마법사 (#59)

### DIFF
--- a/__tests__/lib/classification/classification-engine.test.ts
+++ b/__tests__/lib/classification/classification-engine.test.ts
@@ -1,0 +1,195 @@
+// SPEC-REGULA-CLASSIFY-001 — unit tests for the deterministic classification engine.
+// REQ-CLASSIFY-001~010: verify correct class assignment for each device type × jurisdiction.
+import { describe, expect, it } from 'vitest';
+import {
+  classifyDevice,
+  type DeviceInput,
+} from '../../../lib/classification/classification-engine';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const base: DeviceInput = {
+  deviceDescription: 'test device',
+  deviceType: 'non_active',
+  contactType: 'no_contact',
+  hasSoftware: false,
+  hasAiMl: false,
+  isSterile: false,
+};
+
+function input(overrides: Partial<DeviceInput>): DeviceInput {
+  return { ...base, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// FDA Tests
+// ---------------------------------------------------------------------------
+describe('FDA classification', () => {
+  it('REQ-CLASSIFY-001: active implantable → Class III / PMA', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'implantable', contactType: 'implant' }),
+    );
+    expect(result.fda.deviceClass).toBe('III');
+    expect(result.fda.pathway).toBe('PMA');
+  });
+
+  it('REQ-CLASSIFY-002: IVD → Class II / 510k', () => {
+    const result = classifyDevice(input({ deviceType: 'ivd', contactType: 'no_contact' }));
+    expect(result.fda.deviceClass).toBe('II');
+    expect(result.fda.pathway).toBe('510k');
+  });
+
+  it('REQ-CLASSIFY-003: software-only with AI/ML → Class II / 510k', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'software_only', contactType: 'no_contact', hasAiMl: true }),
+    );
+    expect(result.fda.deviceClass).toBe('II');
+    expect(result.fda.pathway).toBe('510k');
+    expect(result.fda.rationale).toContain('AI/ML');
+  });
+
+  it('REQ-CLASSIFY-004: active device no patient contact → Class I exempt', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'active', contactType: 'no_contact' }),
+    );
+    expect(result.fda.deviceClass).toBe('I');
+    expect(result.fda.pathway).toBe('exempt');
+  });
+
+  it('REQ-CLASSIFY-005: active device internal contact → Class III / PMA', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'active', contactType: 'internal' }),
+    );
+    expect(result.fda.deviceClass).toBe('III');
+    expect(result.fda.pathway).toBe('PMA');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EU MDR Tests
+// ---------------------------------------------------------------------------
+describe('EU MDR classification', () => {
+  it('REQ-CLASSIFY-006: IVD → Class B / notified_body', () => {
+    const result = classifyDevice(input({ deviceType: 'ivd', contactType: 'no_contact' }));
+    expect(result.eu.deviceClass).toBe('B');
+    expect(result.eu.requiresNotifiedBody).toBe(true);
+    expect(result.eu.rule).toBe('IVDR Rule 3');
+  });
+
+  it('REQ-CLASSIFY-007: active implantable → Class III / Rule 8', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'implantable', contactType: 'implant' }),
+    );
+    expect(result.eu.deviceClass).toBe('III');
+    expect(result.eu.rule).toBe('Rule 8');
+    expect(result.eu.requiresNotifiedBody).toBe(true);
+  });
+
+  it('REQ-CLASSIFY-008: software-only with AI/ML → Class IIb / Rule 11', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'software_only', hasAiMl: true }),
+    );
+    expect(result.eu.deviceClass).toBe('IIb');
+    expect(result.eu.rule).toBe('Rule 11');
+  });
+
+  it('REQ-CLASSIFY-009: software-only without AI/ML → Class IIa / Rule 11', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'software_only', hasAiMl: false }),
+    );
+    expect(result.eu.deviceClass).toBe('IIa');
+    expect(result.eu.rule).toBe('Rule 11');
+  });
+
+  it('REQ-CLASSIFY-010: non-invasive external contact → Class I self_cert', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'non_active', contactType: 'external' }),
+    );
+    expect(result.eu.deviceClass).toBe('I');
+    expect(result.eu.pathway).toBe('self_cert');
+    expect(result.eu.requiresNotifiedBody).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MFDS Tests
+// ---------------------------------------------------------------------------
+describe('MFDS classification', () => {
+  it('REQ-CLASSIFY-011: implantable contact → Class 4', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'active', contactType: 'implant' }),
+    );
+    expect(result.mfds.deviceClass).toBe('4');
+  });
+
+  it('REQ-CLASSIFY-012: IVD → Class 3', () => {
+    const result = classifyDevice(input({ deviceType: 'ivd', contactType: 'no_contact' }));
+    expect(result.mfds.deviceClass).toBe('3');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NMPA Tests
+// ---------------------------------------------------------------------------
+describe('NMPA classification', () => {
+  it('REQ-CLASSIFY-013: implantable contact → Class III', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'active', contactType: 'implant' }),
+    );
+    expect(result.nmpa.deviceClass).toBe('III');
+  });
+
+  it('REQ-CLASSIFY-014: general non-active device → Class II', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'non_active', contactType: 'external' }),
+    );
+    expect(result.nmpa.deviceClass).toBe('II');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PMDA Tests
+// ---------------------------------------------------------------------------
+describe('PMDA classification', () => {
+  it('REQ-CLASSIFY-015: AI/ML software → Class III', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'software_only', hasAiMl: true }),
+    );
+    expect(result.pmda.deviceClass).toBe('III');
+    expect(result.pmda.pathway).toBe('製造販売承認');
+  });
+
+  it('REQ-CLASSIFY-016: no patient contact non-active → Class I届出', () => {
+    const result = classifyDevice(
+      input({ deviceType: 'non_active', contactType: 'no_contact' }),
+    );
+    expect(result.pmda.deviceClass).toBe('I');
+    expect(result.pmda.pathway).toBe('届出');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Applicable Standards Tests
+// ---------------------------------------------------------------------------
+describe('applicableStandardTypes', () => {
+  it('REQ-CLASSIFY-017: always includes ISO 14971', () => {
+    const result = classifyDevice(base);
+    expect(result.applicableStandardTypes).toContain('ISO 14971 (Risk Management)');
+  });
+
+  it('REQ-CLASSIFY-018: software device includes IEC 62304', () => {
+    const result = classifyDevice(input({ deviceType: 'software_only' }));
+    expect(result.applicableStandardTypes).toContain('IEC 62304 (Software Lifecycle)');
+  });
+
+  it('REQ-CLASSIFY-019: sterile device includes ISO 11607', () => {
+    const result = classifyDevice(input({ isSterile: true }));
+    expect(result.applicableStandardTypes).toContain('ISO 11607 (Packaging)');
+  });
+
+  it('REQ-CLASSIFY-020: implantable device includes ISO 10993-1', () => {
+    const result = classifyDevice(input({ contactType: 'implant' }));
+    expect(result.applicableStandardTypes).toContain('ISO 10993-1 (Biocompatibility)');
+  });
+});

--- a/app/(app)/workflows/classification/_components/ClassificationWizard.tsx
+++ b/app/(app)/workflows/classification/_components/ClassificationWizard.tsx
@@ -1,0 +1,329 @@
+'use client';
+// @MX:SPEC SPEC-REGULA-CLASSIFY-001 (REQ-CLASSIFY-001~020)
+// Multi-jurisdiction device classification wizard with SSE streaming.
+
+import { useState } from 'react';
+import type { ClassificationResult, JurisdictionResult } from '@/lib/classification/classification-engine';
+
+type DeviceType = 'active' | 'non_active' | 'software_only' | 'ivd' | 'implantable';
+type ContactType = 'no_contact' | 'external' | 'internal' | 'implant';
+
+interface FormState {
+  deviceDescription: string;
+  deviceType: DeviceType | '';
+  contactType: ContactType | '';
+  hasSoftware: boolean;
+  hasAiMl: boolean;
+  isSterile: boolean;
+}
+
+interface StreamEvent {
+  event: 'parsing' | 'classifying' | 'result' | 'error' | 'done';
+  message?: string;
+  classification?: ClassificationResult;
+  classificationId?: string;
+}
+
+const DEVICE_TYPE_LABELS: Record<DeviceType, string> = {
+  active: 'Active Device',
+  non_active: 'Non-Active Device',
+  software_only: 'Software Only (SaMD)',
+  ivd: 'In Vitro Diagnostic (IVD)',
+  implantable: 'Implantable',
+};
+
+const CONTACT_TYPE_LABELS: Record<ContactType, string> = {
+  no_contact: 'No Patient Contact',
+  external: 'External (skin contact)',
+  internal: 'Internal (body cavity)',
+  implant: 'Implantable',
+};
+
+function JurisdictionCard({ result }: { result: JurisdictionResult }) {
+  const isHighRisk =
+    result.deviceClass === 'III' || result.deviceClass === 'IIb' || result.deviceClass === '4';
+
+  return (
+    <div
+      className={[
+        'rounded-lg border p-4',
+        isHighRisk ? 'border-red-200 bg-red-50' : 'border-ink-200 bg-white',
+      ].join(' ')}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-sm font-medium text-ink-700">{result.jurisdiction}</span>
+        <span
+          className={[
+            'rounded px-2 py-0.5 text-xs font-bold',
+            isHighRisk
+              ? 'bg-red-100 text-red-700'
+              : 'bg-brand-100 text-brand-700',
+          ].join(' ')}
+        >
+          Class {result.deviceClass}
+        </span>
+      </div>
+      <p className="mt-1 text-xs text-ink-500">
+        Pathway: <span className="font-medium">{result.pathway}</span>
+        {result.rule ? ` — ${result.rule}` : ''}
+      </p>
+      {result.requiresNotifiedBody && (
+        <p className="mt-1 text-xs font-medium text-amber-700">
+          Requires Notified Body
+        </p>
+      )}
+      <p className="mt-2 text-xs text-ink-600 leading-relaxed">{result.rationale}</p>
+    </div>
+  );
+}
+
+export function ClassificationWizard() {
+  const [form, setForm] = useState<FormState>({
+    deviceDescription: '',
+    deviceType: '',
+    contactType: '',
+    hasSoftware: false,
+    hasAiMl: false,
+    isSterile: false,
+  });
+  const [status, setStatus] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  const [statusMessage, setStatusMessage] = useState('');
+  const [result, setResult] = useState<ClassificationResult | null>(null);
+  const [classificationId, setClassificationId] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.deviceDescription || form.deviceDescription.length < 10) return;
+
+    setStatus('loading');
+    setResult(null);
+    setClassificationId(null);
+    setStatusMessage('Starting classification...');
+
+    try {
+      const response = await fetch('/api/ra/classification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceDescription: form.deviceDescription,
+          deviceType: form.deviceType || undefined,
+          contactType: form.contactType || undefined,
+          hasSoftware: form.hasSoftware,
+          hasAiMl: form.hasAiMl,
+          isSterile: form.isSterile,
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        const lines = chunk.split('\n');
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const event = JSON.parse(line.slice(6)) as StreamEvent;
+            if (event.event === 'parsing' || event.event === 'classifying') {
+              setStatusMessage(event.message ?? '');
+            } else if (event.event === 'result') {
+              setResult(event.classification ?? null);
+              setClassificationId(event.classificationId ?? null);
+            } else if (event.event === 'done') {
+              setStatus('done');
+            } else if (event.event === 'error') {
+              setStatus('error');
+              setStatusMessage(event.message ?? 'Classification failed');
+            }
+          } catch {
+            // skip malformed SSE line
+          }
+        }
+      }
+    } catch (err) {
+      setStatus('error');
+      setStatusMessage(err instanceof Error ? err.message : 'Unknown error');
+    }
+  };
+
+  const handleReset = () => {
+    setStatus('idle');
+    setResult(null);
+    setClassificationId(null);
+    setStatusMessage('');
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Input form */}
+      <form onSubmit={handleSubmit} className="rounded-lg border border-ink-200 bg-white p-6">
+        <h2 className="font-serif text-xl text-brand-800">Device Information</h2>
+        <p className="mt-1 text-sm text-ink-600">
+          Describe your device. The AI will extract classification characteristics automatically.
+        </p>
+
+        <div className="mt-4 flex flex-col gap-4">
+          <div>
+            <label className="block text-sm font-medium text-ink-700" htmlFor="deviceDescription">
+              Device Description <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              id="deviceDescription"
+              required
+              minLength={10}
+              maxLength={2000}
+              rows={4}
+              className="mt-1 w-full rounded border border-ink-300 px-3 py-2 text-sm text-ink-800 placeholder:text-ink-400 focus:border-brand-500 focus:outline-none"
+              placeholder="Describe the medical device, its intended use, patient contact, and any software or AI/ML components..."
+              value={form.deviceDescription}
+              onChange={(e) => setForm((f) => ({ ...f, deviceDescription: e.target.value }))}
+            />
+          </div>
+
+          {/* Optional overrides */}
+          <details className="rounded border border-ink-200 p-3">
+            <summary className="cursor-pointer text-sm font-medium text-ink-700">
+              Manual Classification Overrides (optional)
+            </summary>
+            <div className="mt-3 grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-medium text-ink-600" htmlFor="deviceType">
+                  Device Type
+                </label>
+                <select
+                  id="deviceType"
+                  className="mt-1 w-full rounded border border-ink-300 px-2 py-1.5 text-sm text-ink-800"
+                  value={form.deviceType}
+                  onChange={(e) => setForm((f) => ({ ...f, deviceType: e.target.value as DeviceType | '' }))}
+                >
+                  <option value="">Auto-detect</option>
+                  {(Object.entries(DEVICE_TYPE_LABELS) as [DeviceType, string][]).map(
+                    ([value, label]) => (
+                      <option key={value} value={value}>{label}</option>
+                    ),
+                  )}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-ink-600" htmlFor="contactType">
+                  Contact Type
+                </label>
+                <select
+                  id="contactType"
+                  className="mt-1 w-full rounded border border-ink-300 px-2 py-1.5 text-sm text-ink-800"
+                  value={form.contactType}
+                  onChange={(e) => setForm((f) => ({ ...f, contactType: e.target.value as ContactType | '' }))}
+                >
+                  <option value="">Auto-detect</option>
+                  {(Object.entries(CONTACT_TYPE_LABELS) as [ContactType, string][]).map(
+                    ([value, label]) => (
+                      <option key={value} value={value}>{label}</option>
+                    ),
+                  )}
+                </select>
+              </div>
+            </div>
+            <div className="mt-3 flex gap-6">
+              {(['hasSoftware', 'hasAiMl', 'isSterile'] as const).map((field) => (
+                <label key={field} className="flex items-center gap-1.5 text-sm text-ink-700">
+                  <input
+                    type="checkbox"
+                    checked={form[field]}
+                    onChange={(e) => setForm((f) => ({ ...f, [field]: e.target.checked }))}
+                    className="rounded border-ink-300"
+                  />
+                  {field === 'hasSoftware' ? 'Has Software' : field === 'hasAiMl' ? 'Has AI/ML' : 'Is Sterile'}
+                </label>
+              ))}
+            </div>
+          </details>
+        </div>
+
+        <div className="mt-4 flex gap-3">
+          <button
+            type="submit"
+            disabled={status === 'loading' || form.deviceDescription.length < 10}
+            className="rounded bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+          >
+            {status === 'loading' ? 'Classifying...' : 'Classify Device'}
+          </button>
+          {(status === 'done' || status === 'error') && (
+            <button
+              type="button"
+              onClick={handleReset}
+              className="rounded border border-ink-300 px-4 py-2 text-sm text-ink-700 hover:bg-ink-50"
+            >
+              Reset
+            </button>
+          )}
+        </div>
+
+        {/* Loading status */}
+        {status === 'loading' && (
+          <div className="mt-3 flex items-center gap-2 text-sm text-brand-600">
+            <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-brand-300 border-t-brand-600" />
+            {statusMessage}
+          </div>
+        )}
+
+        {/* Error */}
+        {status === 'error' && (
+          <div className="mt-3 rounded bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+            {statusMessage}
+          </div>
+        )}
+      </form>
+
+      {/* Classification results */}
+      {result && status === 'done' && (
+        <div className="flex flex-col gap-4">
+          {classificationId && (
+            <p className="text-xs text-ink-400">
+              Classification ID: <code className="font-mono">{classificationId}</code>
+            </p>
+          )}
+
+          <div className="rounded-lg border border-brand-200 bg-brand-50 p-4">
+            <h2 className="font-serif text-lg text-brand-800">Classification Results</h2>
+            <p className="mt-1 text-xs text-ink-500">
+              Deterministic rules based on FDA 21 CFR, EU MDR 2017/745, MFDS (의료기기법), NMPA 分类, and PMDA 薬機法
+            </p>
+          </div>
+
+          {/* 5-jurisdiction grid */}
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <JurisdictionCard result={result.fda} />
+            <JurisdictionCard result={result.eu} />
+            <JurisdictionCard result={result.mfds} />
+            <JurisdictionCard result={result.nmpa} />
+            <JurisdictionCard result={result.pmda} />
+          </div>
+
+          {/* Applicable standards */}
+          {result.applicableStandardTypes.length > 0 && (
+            <div className="rounded-lg border border-ink-200 bg-white p-4">
+              <h3 className="text-sm font-medium text-ink-700">Applicable Standards</h3>
+              <ul className="mt-2 flex flex-wrap gap-2">
+                {result.applicableStandardTypes.map((standard) => (
+                  <li
+                    key={standard}
+                    className="rounded bg-ink-100 px-2 py-0.5 text-xs text-ink-600"
+                  >
+                    {standard}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/workflows/classification/page.tsx
+++ b/app/(app)/workflows/classification/page.tsx
@@ -1,0 +1,29 @@
+// @MX:SPEC SPEC-REGULA-CLASSIFY-001 (REQ-CLASSIFY-001)
+import { BetaBadge } from '@/components/ui/BetaBadge';
+import { ClassificationWizard } from './_components/ClassificationWizard';
+
+export const metadata = {
+  title: 'Device Classification Wizard — Regula',
+  description:
+    'Multi-jurisdiction medical device classification for FDA, EU MDR, MFDS, NMPA, and PMDA',
+};
+
+export default function ClassificationPage() {
+  return (
+    <section className="mx-auto flex max-w-content flex-col gap-6">
+      <header>
+        <div className="flex items-center gap-2">
+          <h1 className="font-serif text-3xl text-brand-800">
+            Device Classification Wizard
+          </h1>
+          <BetaBadge />
+        </div>
+        <p className="mt-2 text-sm text-ink-600">
+          Multi-jurisdiction classification — FDA, EU MDR, MFDS, NMPA, PMDA
+        </p>
+      </header>
+
+      <ClassificationWizard />
+    </section>
+  );
+}

--- a/app/api/ra/classification/route.ts
+++ b/app/api/ra/classification/route.ts
@@ -1,0 +1,156 @@
+// @MX:SPEC SPEC-REGULA-CLASSIFY-001 (REQ-CLASSIFY-001, REQ-CLASSIFY-015)
+import { withPermission } from '@/lib/auth/with-permission';
+import type { AuthSession } from '@/lib/auth/with-permission';
+import { writeAudit } from '@/lib/audit';
+import { classifyDevice } from '@/lib/classification/classification-engine';
+import { parseDeviceIntent } from '@/lib/classification/intent-parser';
+import { db } from '@/lib/db/client';
+import { deviceClassifications } from '@/lib/db/schema';
+import { z } from 'zod';
+
+const RequestSchema = z.object({
+  deviceDescription: z.string().min(10).max(2000),
+  deviceType: z
+    .enum(['active', 'non_active', 'software_only', 'ivd', 'implantable'])
+    .optional(),
+  contactType: z
+    .enum(['no_contact', 'external', 'internal', 'implant'])
+    .optional(),
+  hasSoftware: z.boolean().default(false),
+  hasAiMl: z.boolean().default(false),
+  isSterile: z.boolean().default(false),
+});
+
+function sse(data: unknown): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+async function postClassification(
+  request: Request,
+  session: AuthSession,
+): Promise<Response> {
+  const orgId = session.user.organizationId;
+  if (!orgId) {
+    return new Response(JSON.stringify({ error: 'No organization' }), { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400 });
+  }
+
+  const parsed = RequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid input', details: parsed.error.format() }),
+      { status: 400 },
+    );
+  }
+
+  const { deviceDescription, hasSoftware, hasAiMl, isSterile } = parsed.data;
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        controller.enqueue(
+          encoder.encode(
+            sse({ event: 'parsing', message: 'Analyzing device description...' }),
+          ),
+        );
+
+        const parsedIntent = await parseDeviceIntent(deviceDescription);
+        const deviceType = parsed.data.deviceType ?? parsedIntent.deviceType;
+        const contactType = parsed.data.contactType ?? parsedIntent.contactType;
+
+        controller.enqueue(
+          encoder.encode(
+            sse({
+              event: 'classifying',
+              message: 'Applying classification rules for 5 jurisdictions...',
+            }),
+          ),
+        );
+
+        const result = classifyDevice({
+          deviceDescription,
+          deviceType,
+          contactType,
+          hasSoftware: parsedIntent.hasSoftware || hasSoftware,
+          hasAiMl: parsedIntent.hasAiMl || hasAiMl,
+          isSterile: parsedIntent.isSterile || isSterile,
+        });
+
+        // Persist classification result
+        const [saved] = await db
+          .insert(deviceClassifications)
+          .values({
+            orgId,
+            userId: session.user.id,
+            deviceDescription,
+            deviceType,
+            contactType,
+            hasSoftware: parsedIntent.hasSoftware || hasSoftware,
+            hasAiMl: parsedIntent.hasAiMl || hasAiMl,
+            isSterile: parsedIntent.isSterile || isSterile,
+            fdaClass: result.fda.deviceClass,
+            fdaPathway: result.fda.pathway,
+            euClass: result.eu.deviceClass,
+            euPathway: result.eu.pathway,
+            euRule: result.eu.rule ?? null,
+            mfdsClass: result.mfds.deviceClass,
+            nmpaClass: result.nmpa.deviceClass,
+            pmdaClass: result.pmda.deviceClass,
+            classificationRationale: result as unknown as Record<string, unknown>,
+          })
+          .returning();
+
+        await writeAudit({
+          actor_id: session.user.id,
+          action: 'device_classified',
+          resource_type: 'device_classification',
+          resource_id: saved?.id ?? 'unknown',
+          meta_json: {
+            classificationId: saved?.id,
+            deviceType,
+            fdaClass: result.fda.deviceClass,
+            euClass: result.eu.deviceClass,
+          },
+        });
+
+        controller.enqueue(
+          encoder.encode(
+            sse({ event: 'result', classification: result, classificationId: saved?.id }),
+          ),
+        );
+        controller.enqueue(encoder.encode(sse({ event: 'done' })));
+      } catch (err) {
+        controller.enqueue(
+          encoder.encode(
+            sse({
+              event: 'error',
+              message: err instanceof Error ? err.message : 'Classification failed',
+            }),
+          ),
+        );
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}
+
+export const POST = withPermission(
+  'consult.create',
+  async (request, _ctx, session) => postClassification(request, session),
+);

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -138,7 +138,9 @@ export type AuditAction =
   // SPEC-REGULA-STANDARDS-001 — standards tracker audit actions via 0048_standards_applicability.sql:
   | 'standards_searched'
   | 'standards_gap_analyzed'
-  | 'standards_compliance_updated';
+  | 'standards_compliance_updated'
+  // SPEC-REGULA-CLASSIFY-001 — classification audit actions via 0051_classification_audit_actions.sql:
+  | 'device_classified';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/classification/classification-engine.ts
+++ b/lib/classification/classification-engine.ts
@@ -1,0 +1,313 @@
+// @MX:ANCHOR: [AUTO] Multi-jurisdiction classification engine — called by API route and tests
+// @MX:REASON: Public API boundary; deterministic rule engine for 5 jurisdictions (FDA, EU MDR, MFDS, NMPA, PMDA)
+// @MX:SPEC: SPEC-REGULA-CLASSIFY-001 REQ-CLASSIFY-001~020
+
+export interface DeviceInput {
+  deviceDescription: string;
+  deviceType: 'active' | 'non_active' | 'software_only' | 'ivd' | 'implantable';
+  contactType: 'no_contact' | 'external' | 'internal' | 'implant';
+  hasSoftware: boolean;
+  hasAiMl: boolean;
+  isSterile: boolean;
+}
+
+export interface JurisdictionResult {
+  jurisdiction: string;
+  deviceClass: string;
+  pathway: string;
+  rule?: string;
+  rationale: string;
+  requiresNotifiedBody?: boolean;
+}
+
+export interface ClassificationResult {
+  fda: JurisdictionResult;
+  eu: JurisdictionResult;
+  mfds: JurisdictionResult;
+  nmpa: JurisdictionResult;
+  pmda: JurisdictionResult;
+  applicableStandardTypes: string[];
+}
+
+// FDA Classification (21 CFR §860-892, simplified deterministic rules)
+function classifyFDA(input: DeviceInput): JurisdictionResult {
+  // Active implantable → Class III PMA
+  if (input.deviceType === 'implantable' && input.contactType === 'implant') {
+    return {
+      jurisdiction: 'FDA',
+      deviceClass: 'III',
+      pathway: 'PMA',
+      rationale: 'Active implantable devices default to Class III/PMA per 21 CFR §860.3',
+    };
+  }
+  // IVD
+  if (input.deviceType === 'ivd') {
+    return {
+      jurisdiction: 'FDA',
+      deviceClass: 'II',
+      pathway: '510k',
+      rationale: 'Most IVDs are Class II requiring 510(k)',
+    };
+  }
+  // Software-only (SaMD)
+  if (input.deviceType === 'software_only') {
+    if (input.hasAiMl) {
+      return {
+        jurisdiction: 'FDA',
+        deviceClass: 'II',
+        pathway: '510k',
+        rationale:
+          'AI/ML SaMD with moderate risk typically Class II; may require De Novo for novel algorithms',
+      };
+    }
+    return {
+      jurisdiction: 'FDA',
+      deviceClass: 'II',
+      pathway: '510k',
+      rationale: 'Software-only medical devices generally Class II/510(k)',
+    };
+  }
+  // Active device, no patient contact → Class I exempt
+  if (input.deviceType === 'active' && input.contactType === 'no_contact') {
+    return {
+      jurisdiction: 'FDA',
+      deviceClass: 'I',
+      pathway: 'exempt',
+      rationale: 'Active devices without patient contact are typically Class I exempt',
+    };
+  }
+  // Internal contact active device → Class III
+  if (input.deviceType === 'active' && input.contactType === 'internal') {
+    return {
+      jurisdiction: 'FDA',
+      deviceClass: 'III',
+      pathway: 'PMA',
+      rationale: 'Active devices with internal contact typically Class III/PMA',
+    };
+  }
+  // Default: Class II 510(k)
+  return {
+    jurisdiction: 'FDA',
+    deviceClass: 'II',
+    pathway: '510k',
+    rationale:
+      'Devices with moderate risk and established predicate typically Class II/510(k)',
+  };
+}
+
+// EU MDR Classification (MDR 2017/745 Annex VIII Rules 1-22, simplified)
+function classifyEU(input: DeviceInput): JurisdictionResult {
+  // IVD → IVDR
+  if (input.deviceType === 'ivd') {
+    return {
+      jurisdiction: 'EU MDR',
+      deviceClass: 'B',
+      pathway: 'notified_body',
+      rule: 'IVDR Rule 3',
+      rationale:
+        'IVD devices regulated under EU IVDR 2017/746 — most require Notified Body',
+      requiresNotifiedBody: true,
+    };
+  }
+  // Active implantable → Class III (Rule 7/8)
+  if (input.deviceType === 'implantable' && input.contactType === 'implant') {
+    return {
+      jurisdiction: 'EU MDR',
+      deviceClass: 'III',
+      pathway: 'notified_body',
+      rule: 'Rule 8',
+      rationale: 'Active implantable devices: Class III per Annex VIII Rule 8',
+      requiresNotifiedBody: true,
+    };
+  }
+  // Software (Rule 11)
+  if (input.deviceType === 'software_only') {
+    const cls = input.hasAiMl ? 'IIb' : 'IIa';
+    return {
+      jurisdiction: 'EU MDR',
+      deviceClass: cls,
+      pathway: 'notified_body',
+      rule: 'Rule 11',
+      rationale: `Software medical device: Class ${cls} per MDR Annex VIII Rule 11`,
+      requiresNotifiedBody: true,
+    };
+  }
+  // Implantable non-active (Rule 6)
+  if (input.contactType === 'implant') {
+    return {
+      jurisdiction: 'EU MDR',
+      deviceClass: 'III',
+      pathway: 'notified_body',
+      rule: 'Rule 6',
+      rationale: 'Non-active implantable devices: Class III per Annex VIII Rule 6',
+      requiresNotifiedBody: true,
+    };
+  }
+  // Internal short-term contact (Rule 5/6)
+  if (input.contactType === 'internal') {
+    return {
+      jurisdiction: 'EU MDR',
+      deviceClass: 'IIa',
+      pathway: 'notified_body',
+      rule: 'Rule 5',
+      rationale: 'Devices in contact with internal body surfaces: Class IIa per Rule 5',
+      requiresNotifiedBody: true,
+    };
+  }
+  // External contact (Rule 1-4)
+  if (input.contactType === 'external') {
+    return {
+      jurisdiction: 'EU MDR',
+      deviceClass: 'I',
+      pathway: 'self_cert',
+      rule: 'Rule 1',
+      rationale: 'Non-invasive devices in contact with intact skin: Class I per Rule 1',
+      requiresNotifiedBody: false,
+    };
+  }
+  return {
+    jurisdiction: 'EU MDR',
+    deviceClass: 'I',
+    pathway: 'self_cert',
+    rule: 'Rule 1',
+    rationale: 'Non-invasive device without patient contact: Class I',
+    requiresNotifiedBody: false,
+  };
+}
+
+// MFDS (Korea — 의료기기법 등급)
+function classifyMFDS(input: DeviceInput): JurisdictionResult {
+  if (
+    input.contactType === 'implant' ||
+    (input.deviceType === 'active' && input.contactType === 'internal')
+  ) {
+    return {
+      jurisdiction: 'MFDS',
+      deviceClass: '4',
+      pathway: '품목허가',
+      rationale: '이식형/고위험 능동기기 — 4등급 품목허가',
+    };
+  }
+  if (input.deviceType === 'software_only') {
+    return {
+      jurisdiction: 'MFDS',
+      deviceClass: '2',
+      pathway: '품목허가',
+      rationale: '독립형 의료기기 소프트웨어 — 2~3등급 (기능에 따라 결정)',
+    };
+  }
+  if (input.contactType === 'internal' || input.deviceType === 'ivd') {
+    return {
+      jurisdiction: 'MFDS',
+      deviceClass: '3',
+      pathway: '품목허가',
+      rationale: '체내접촉 또는 체외진단 기기 — 3등급',
+    };
+  }
+  return {
+    jurisdiction: 'MFDS',
+    deviceClass: '2',
+    pathway: '품목허가',
+    rationale: '일반적 의료기기 — 2등급',
+  };
+}
+
+// NMPA (China — 分类)
+function classifyNMPA(input: DeviceInput): JurisdictionResult {
+  if (
+    input.contactType === 'implant' ||
+    (input.deviceType === 'active' && input.contactType === 'internal')
+  ) {
+    return {
+      jurisdiction: 'NMPA',
+      deviceClass: 'III',
+      pathway: '注册审评',
+      rationale: '植入类/高风险有源器械 — 第三类',
+    };
+  }
+  if (input.deviceType === 'ivd' || input.contactType === 'internal') {
+    return {
+      jurisdiction: 'NMPA',
+      deviceClass: 'II',
+      pathway: '注册审评',
+      rationale: '体外诊断/接触体内 — 第二类',
+    };
+  }
+  return {
+    jurisdiction: 'NMPA',
+    deviceClass: 'II',
+    pathway: '注册审评',
+    rationale: '普通医疗器械 — 第二类',
+  };
+}
+
+// PMDA (Japan — 薬機法クラス)
+function classifyPMDA(input: DeviceInput): JurisdictionResult {
+  if (
+    input.contactType === 'implant' ||
+    (input.deviceType === 'active' && input.contactType === 'internal')
+  ) {
+    return {
+      jurisdiction: 'PMDA',
+      deviceClass: 'III',
+      pathway: '製造販売承認',
+      rationale: '植込型/高管理医療機器 — クラスIII',
+    };
+  }
+  if (input.deviceType === 'software_only' && input.hasAiMl) {
+    return {
+      jurisdiction: 'PMDA',
+      deviceClass: 'III',
+      pathway: '製造販売承認',
+      rationale: 'AI/ML含む高度管理医療機器ソフトウェア — クラスIII',
+    };
+  }
+  if (input.deviceType === 'ivd' || input.contactType === 'internal') {
+    return {
+      jurisdiction: 'PMDA',
+      deviceClass: 'II',
+      pathway: '認証',
+      rationale: '管理医療機器 — クラスII',
+    };
+  }
+  return {
+    jurisdiction: 'PMDA',
+    deviceClass: 'I',
+    pathway: '届出',
+    rationale: '一般医療機器 — クラスI (届出)',
+  };
+}
+
+function getApplicableStandardTypes(input: DeviceInput): string[] {
+  const types: string[] = ['ISO 14971 (Risk Management)'];
+  if (input.hasSoftware || input.deviceType === 'software_only') {
+    types.push('IEC 62304 (Software Lifecycle)', 'IEC 62366-1 (Usability)');
+  }
+  if (input.deviceType === 'active' || input.deviceType === 'implantable') {
+    types.push('IEC 60601-1 (Electrical Safety)');
+  }
+  if (input.isSterile) {
+    types.push('ISO 11135 (Sterilization)', 'ISO 11607 (Packaging)');
+  }
+  if (input.contactType === 'implant' || input.contactType === 'internal') {
+    types.push('ISO 10993-1 (Biocompatibility)');
+  }
+  if (input.hasAiMl) {
+    types.push('IEC 62304 (AI/ML Lifecycle)', 'ISO 14971 (AI Risk Management)');
+  }
+  return [...new Set(types)];
+}
+
+// @MX:ANCHOR: [AUTO] classifyDevice — primary classification entry point called by route and tests
+// @MX:REASON: fan_in >= 3: route handler, test suite, and future report generator all call this
+// @MX:SPEC: SPEC-REGULA-CLASSIFY-001 REQ-CLASSIFY-001
+export function classifyDevice(input: DeviceInput): ClassificationResult {
+  return {
+    fda: classifyFDA(input),
+    eu: classifyEU(input),
+    mfds: classifyMFDS(input),
+    nmpa: classifyNMPA(input),
+    pmda: classifyPMDA(input),
+    applicableStandardTypes: getApplicableStandardTypes(input),
+  };
+}

--- a/lib/classification/intent-parser.ts
+++ b/lib/classification/intent-parser.ts
@@ -1,0 +1,66 @@
+// @MX:ANCHOR: [AUTO] parseDeviceIntent — Haiku AI intent extraction for device description
+// @MX:REASON: External AI API boundary; called by classification route; E2E_TEST_MODE guard required
+// @MX:SPEC: SPEC-REGULA-CLASSIFY-001 REQ-CLASSIFY-010
+import Anthropic from '@anthropic-ai/sdk';
+import type { DeviceInput } from './classification-engine';
+
+const client = new Anthropic();
+
+// E2E_TEST_MODE mock — returns deterministic output for test environments.
+const MOCK_DEVICE_INPUT: Omit<DeviceInput, 'deviceDescription'> = {
+  deviceType: 'active',
+  contactType: 'external',
+  hasSoftware: false,
+  hasAiMl: false,
+  isSterile: false,
+};
+
+export async function parseDeviceIntent(
+  description: string,
+): Promise<Omit<DeviceInput, 'deviceDescription'>> {
+  if (process.env.E2E_TEST_MODE === 'true') {
+    return { ...MOCK_DEVICE_INPUT };
+  }
+
+  const response = await client.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 512,
+    messages: [
+      {
+        role: 'user',
+        content: `Analyze this medical device description and extract classification characteristics. Return ONLY valid JSON with these exact fields:
+- deviceType: one of "active"|"non_active"|"software_only"|"ivd"|"implantable"
+- contactType: one of "no_contact"|"external"|"internal"|"implant"
+- hasSoftware: boolean
+- hasAiMl: boolean
+- isSterile: boolean
+
+Device description: "${description}"
+
+JSON response only, no explanation:`,
+      },
+    ],
+  });
+
+  const firstBlock = response.content[0];
+  const text =
+    firstBlock !== undefined && firstBlock.type === 'text' ? firstBlock.text.trim() : '{}';
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    return {
+      deviceType: (parsed.deviceType as DeviceInput['deviceType']) ?? 'non_active',
+      contactType: (parsed.contactType as DeviceInput['contactType']) ?? 'no_contact',
+      hasSoftware: Boolean(parsed.hasSoftware),
+      hasAiMl: Boolean(parsed.hasAiMl),
+      isSterile: Boolean(parsed.isSterile),
+    };
+  } catch {
+    return {
+      deviceType: 'non_active',
+      contactType: 'no_contact',
+      hasSoftware: false,
+      hasAiMl: false,
+      isSterile: false,
+    };
+  }
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -901,3 +901,31 @@ export const standardsApplicability = pgTable(
     uniqueMapping: unique().on(t.deviceTypeKey, t.standardId, t.regulatoryPathway),
   }),
 );
+
+// SPEC-REGULA-CLASSIFY-001 — device classification results.
+// Migration: 0050_device_classifications.sql
+export const deviceClassifications = pgTable('device_classifications', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id').notNull().references(() => users.id),
+  deviceDescription: text('device_description').notNull(),
+  // deviceType CHECK: 'active'|'non_active'|'software_only'|'ivd'|'implantable'
+  deviceType: text('device_type').notNull(),
+  // contactType CHECK: 'no_contact'|'external'|'internal'|'implant'
+  contactType: text('contact_type').notNull(),
+  hasSoftware: boolean('has_software').notNull().default(false),
+  hasAiMl: boolean('has_ai_ml').notNull().default(false),
+  isSterile: boolean('is_sterile').notNull().default(false),
+  fdaClass: text('fda_class'),
+  fdaPathway: text('fda_pathway'),
+  fdaProductCode: text('fda_product_code'),
+  fdaRegulationNumber: text('fda_regulation_number'),
+  euClass: text('eu_class'),
+  euPathway: text('eu_pathway'),
+  euRule: text('eu_rule'),
+  mfdsClass: text('mfds_class'),
+  nmpaClass: text('nmpa_class'),
+  pmdaClass: text('pmda_class'),
+  classificationRationale: jsonb('classification_rationale').notNull().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});

--- a/migrations/0050_device_classifications.sql
+++ b/migrations/0050_device_classifications.sql
@@ -1,0 +1,26 @@
+-- SPEC-REGULA-CLASSIFY-001 — device classification results table.
+-- REQ-CLASSIFY-001: persist multi-jurisdiction classification output.
+CREATE TABLE device_classifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id),
+  device_description TEXT NOT NULL,
+  device_type TEXT NOT NULL,           -- 'active'|'non_active'|'software_only'|'ivd'|'implantable'
+  contact_type TEXT NOT NULL,          -- 'no_contact'|'external'|'internal'|'implant'
+  has_software BOOLEAN NOT NULL DEFAULT FALSE,
+  has_ai_ml BOOLEAN NOT NULL DEFAULT FALSE,
+  is_sterile BOOLEAN NOT NULL DEFAULT FALSE,
+  fda_class TEXT,                      -- 'I'|'II'|'III'|'exempt'
+  fda_pathway TEXT,                    -- '510k'|'PMA'|'DeNovo'|'exempt'
+  fda_product_code TEXT,
+  fda_regulation_number TEXT,
+  eu_class TEXT,                       -- 'I'|'IIa'|'IIb'|'III'
+  eu_pathway TEXT,                     -- 'self_cert'|'notified_body'|'conformity_assessment'
+  eu_rule TEXT,                        -- e.g. 'Rule 9'
+  mfds_class TEXT,                     -- '1'|'2'|'3'|'4'
+  nmpa_class TEXT,                     -- 'I'|'II'|'III'
+  pmda_class TEXT,                     -- 'I'|'II'|'III'
+  classification_rationale JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_device_classifications_org ON device_classifications(org_id);

--- a/migrations/0051_classification_audit_actions.sql
+++ b/migrations/0051_classification_audit_actions.sql
@@ -1,0 +1,4 @@
+-- SPEC-REGULA-CLASSIFY-001 — classification audit action and workflow type.
+-- REQ-CLASSIFY-015: audit device classification events.
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'device_classified';
+ALTER TYPE workflow_type ADD VALUE IF NOT EXISTS 'classification';


### PR DESCRIPTION
## Summary

- FDA/EU MDR/MFDS/NMPA/PMDA 5개 관할권 결정론적 분류 엔진 구현
- Haiku AI 인텐트 파싱 + SSE 스트리밍 API 엔드포인트
- 분류 결과 DB 영속화 + 감사 로그 (device_classified)
- 20개 단위 테스트 (모두 통과), typecheck 클린

## Test plan

- [ ] `npm test -- __tests__/lib/classification/classification-engine.test.ts --run` — 20 tests pass
- [ ] `npm run typecheck` — no errors
- [ ] `/workflows/classification` 페이지 접근 가능
- [ ] 기기 설명 입력 후 5개 관할권 결과 SSE 스트리밍 수신
- [ ] DB에 device_classifications 레코드 저장 확인
- [ ] audit_logs에 device_classified 액션 기록 확인

🗿 MoAI <email@mo.ai.kr>