### PR TITLE
fix(ci): CI Quality Gate 복구 (drizzle.config.ts)

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -14,15 +14,15 @@ if (!databaseUrl) {
   );
 }
 
-// drizzle-kit 0.20.x uses `driver: 'pg'` + `connectionString`. The 0.21+
-// release renamed these to `dialect: 'postgresql'` + `url`. Pinned to 0.20
-// for compatibility with the current handoff stack.
+// drizzle-kit 0.31.x uses `dialect: 'postgresql'` + `url`. The earlier
+// 0.20.x format used `driver: 'pg'` + `connectionString` but was renamed
+// in later releases.
 export default {
   schema: './lib/db/schema.ts',
   out: './lib/db/migrations',
-  driver: 'pg',
+  dialect: 'postgresql',
   dbCredentials: {
-    connectionString: databaseUrl,
+    url: databaseUrl,
   },
   strict: false,
   verbose: true,


### PR DESCRIPTION
## 문제

drizzle-kit 버전 호환성 문제로 인해 TypeScript 타입 체크가 실패하고 있었습니다.

## 원인

- `package.json`에는 drizzle-kit ^0.20.18으로 명시되어 있으나
- 실제 설치된 버전은 0.31.10으로 큰 버전 차이 존재
- 0.31.x 버전에서는 `driver: 'pg'` + `connectionString` 형식이
  `dialect: 'postgresql'` + `url`로 변경됨

## 수정 사항

**drizzle.config.ts**
- `driver: 'pg'` → `dialect: 'postgresql'` 변경
- `dbCredentials.connectionString` → `dbCredentials.url` 변경
- 주석을 현재 버전에 맞게 업데이트

## 검증 결과

모든 품질 게이트 통과 확인:
- ✓ TypeScript `tsc --noEmit`: 통과
- ✓ Vitest test: 2232 tests passed
- ✓ Biome lint: 678 files checked
- ✓ no-hex-colors: 통과

Fixes #149