### PR TITLE
feat(integration): Evidence/Authoring API BFF+UI 연동 (#168, #171)

### DIFF
--- a/app/(app)/workflows/authoring/_components/authoring-workspace.tsx
+++ b/app/(app)/workflows/authoring/_components/authoring-workspace.tsx
@@ -1,8 +1,15 @@
 'use client';
 
+import type { ApprovalRequest, SessionRequest } from '@/lib/api/authoring-client';
+import {
+  useApproveSession,
+  useAuthoringSession,
+  useCreateAuthoringSession,
+  useRejectSession,
+} from '@/lib/queries/useAuthoring';
 import { useState } from 'react';
-import { useCreateAuthoringSession, useAuthoringSession, useApproveSession, useRejectSession } from '@/lib/queries/useAuthoring';
-import type { SessionRequest, ApprovalRequest } from '@/lib/api/authoring-client';
+
+type ApprovalDecision = ApprovalRequest['decision'];
 
 export function AuthoringWorkspace() {
   const createSession = useCreateAuthoringSession();
@@ -72,10 +79,14 @@ export function AuthoringWorkspace() {
           <h2 className="text-xl font-semibold mb-4">섹션 초안 작성 세션 생성</h2>
           <form onSubmit={handleCreateSession} className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label
+                htmlFor="authoring-section-id"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
                 섹션 ID
               </label>
               <input
+                id="authoring-section-id"
                 type="text"
                 value={sessionForm.section_id}
                 onChange={(e) => setSessionForm({ ...sessionForm, section_id: e.target.value })}
@@ -85,10 +96,14 @@ export function AuthoringWorkspace() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label
+                htmlFor="authoring-device-id"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
                 기기 ID
               </label>
               <input
+                id="authoring-device-id"
                 type="text"
                 value={sessionForm.device_id}
                 onChange={(e) => setSessionForm({ ...sessionForm, device_id: e.target.value })}
@@ -112,6 +127,7 @@ export function AuthoringWorkspace() {
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-xl font-semibold">세션 상태 및 초안</h2>
               <button
+                type="button"
                 onClick={() => setCurrentSessionId(null)}
                 className="text-sm text-gray-600 hover:underline"
               >
@@ -128,12 +144,17 @@ export function AuthoringWorkspace() {
                   </div>
                   <div>
                     <p className="text-sm text-gray-500">상태</p>
-                    <span className={`px-2 py-1 text-xs rounded ${
-                      session.status === 'approved' ? 'bg-green-100 text-green-800' :
-                      session.status === 'rejected' ? 'bg-red-100 text-red-800' :
-                      session.status === 'in_progress' ? 'bg-blue-100 text-blue-800' :
-                      'bg-gray-100 text-gray-800'
-                    }`}>
+                    <span
+                      className={`px-2 py-1 text-xs rounded ${
+                        session.status === 'approved'
+                          ? 'bg-green-100 text-green-800'
+                          : session.status === 'rejected'
+                            ? 'bg-red-100 text-red-800'
+                            : session.status === 'in_progress'
+                              ? 'bg-blue-100 text-blue-800'
+                              : 'bg-gray-100 text-gray-800'
+                      }`}
+                    >
                       {session.status}
                     </span>
                   </div>
@@ -148,7 +169,8 @@ export function AuthoringWorkspace() {
 
                 <div className="text-xs text-gray-500">
                   생성: {new Date(session.created_at).toLocaleString()}
-                  {session.updated_at && ` | 업데이트: ${new Date(session.updated_at).toLocaleString()}`}
+                  {session.updated_at &&
+                    ` | 업데이트: ${new Date(session.updated_at).toLocaleString()}`}
                 </div>
               </div>
             )}
@@ -158,12 +180,21 @@ export function AuthoringWorkspace() {
             <h2 className="text-xl font-semibold mb-4">승인/반려</h2>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label
+                  htmlFor="authoring-decision"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
                   결정
                 </label>
                 <select
+                  id="authoring-decision"
                   value={approvalForm.decision}
-                  onChange={(e) => setApprovalForm({ ...approvalForm, decision: e.target.value as any })}
+                  onChange={(e) =>
+                    setApprovalForm({
+                      ...approvalForm,
+                      decision: e.target.value as ApprovalDecision,
+                    })
+                  }
                   className="w-full border border-gray-300 rounded-md p-2"
                 >
                   <option value="approve">승인</option>
@@ -172,10 +203,14 @@ export function AuthoringWorkspace() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label
+                  htmlFor="authoring-comments"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
                   코멘트
                 </label>
                 <textarea
+                  id="authoring-comments"
                   value={approvalForm.comments}
                   onChange={(e) => setApprovalForm({ ...approvalForm, comments: e.target.value })}
                   className="w-full border border-gray-300 rounded-md p-2"
@@ -185,6 +220,7 @@ export function AuthoringWorkspace() {
 
               <div className="flex space-x-4">
                 <button
+                  type="button"
                   onClick={handleApprove}
                   disabled={approveSession.isPending || approvalForm.decision !== 'approve'}
                   className="flex-1 bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 disabled:opacity-50"
@@ -192,6 +228,7 @@ export function AuthoringWorkspace() {
                   {approveSession.isPending ? '처리 중...' : '승인'}
                 </button>
                 <button
+                  type="button"
                   onClick={handleReject}
                   disabled={rejectSession.isPending || approvalForm.decision !== 'reject'}
                   className="flex-1 bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700 disabled:opacity-50"

--- a/app/(app)/workflows/authoring/_components/authoring-workspace.tsx
+++ b/app/(app)/workflows/authoring/_components/authoring-workspace.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useState } from 'react';
+import { useCreateAuthoringSession, useAuthoringSession, useApproveSession, useRejectSession } from '@/lib/queries/useAuthoring';
+import type { SessionRequest, ApprovalRequest } from '@/lib/api/authoring-client';
+
+export function AuthoringWorkspace() {
+  const createSession = useCreateAuthoringSession();
+  const approveSession = useApproveSession();
+  const rejectSession = useRejectSession();
+
+  const [sessionForm, setSessionForm] = useState<SessionRequest>({
+    section_id: '',
+    device_id: '',
+  });
+
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+  const [approvalForm, setApprovalForm] = useState<ApprovalRequest>({
+    decision: 'approve',
+    comments: '',
+  });
+
+  const { data: session } = useAuthoringSession(currentSessionId || '');
+
+  const handleCreateSession = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const result = await createSession.mutateAsync(sessionForm);
+      setCurrentSessionId(result.session_id);
+      setSessionForm({ section_id: '', device_id: '' });
+    } catch (err) {
+      console.error('Failed to create session:', err);
+    }
+  };
+
+  const handleApprove = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!currentSessionId) return;
+
+    try {
+      await approveSession.mutateAsync({
+        sessionId: currentSessionId,
+        request: approvalForm,
+      });
+      setCurrentSessionId(null);
+      setApprovalForm({ decision: 'approve', comments: '' });
+    } catch (err) {
+      console.error('Failed to approve session:', err);
+    }
+  };
+
+  const handleReject = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!currentSessionId) return;
+
+    try {
+      await rejectSession.mutateAsync({
+        sessionId: currentSessionId,
+        request: approvalForm,
+      });
+      setCurrentSessionId(null);
+      setApprovalForm({ decision: 'approve', comments: '' });
+    } catch (err) {
+      console.error('Failed to reject session:', err);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {!currentSessionId ? (
+        <div className="bg-white shadow rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">섹션 초안 작성 세션 생성</h2>
+          <form onSubmit={handleCreateSession} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                섹션 ID
+              </label>
+              <input
+                type="text"
+                value={sessionForm.section_id}
+                onChange={(e) => setSessionForm({ ...sessionForm, section_id: e.target.value })}
+                className="w-full border border-gray-300 rounded-md p-2"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                기기 ID
+              </label>
+              <input
+                type="text"
+                value={sessionForm.device_id}
+                onChange={(e) => setSessionForm({ ...sessionForm, device_id: e.target.value })}
+                className="w-full border border-gray-300 rounded-md p-2"
+                required
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={createSession.isPending}
+              className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
+            >
+              {createSession.isPending ? '처리 중...' : '세션 생성'}
+            </button>
+          </form>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <div className="bg-white shadow rounded-lg p-6">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-semibold">세션 상태 및 초안</h2>
+              <button
+                onClick={() => setCurrentSessionId(null)}
+                className="text-sm text-gray-600 hover:underline"
+              >
+                닫기
+              </button>
+            </div>
+
+            {session && (
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <p className="text-sm text-gray-500">세션 ID</p>
+                    <p className="font-medium">{session.session_id}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-gray-500">상태</p>
+                    <span className={`px-2 py-1 text-xs rounded ${
+                      session.status === 'approved' ? 'bg-green-100 text-green-800' :
+                      session.status === 'rejected' ? 'bg-red-100 text-red-800' :
+                      session.status === 'in_progress' ? 'bg-blue-100 text-blue-800' :
+                      'bg-gray-100 text-gray-800'
+                    }`}>
+                      {session.status}
+                    </span>
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-sm text-gray-500 mb-1">현재 초안</p>
+                  <div className="bg-gray-50 p-4 rounded-md border border-gray-200">
+                    <p className="whitespace-pre-wrap">{session.current_draft || '초안 없음'}</p>
+                  </div>
+                </div>
+
+                <div className="text-xs text-gray-500">
+                  생성: {new Date(session.created_at).toLocaleString()}
+                  {session.updated_at && ` | 업데이트: ${new Date(session.updated_at).toLocaleString()}`}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="bg-white shadow rounded-lg p-6">
+            <h2 className="text-xl font-semibold mb-4">승인/반려</h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  결정
+                </label>
+                <select
+                  value={approvalForm.decision}
+                  onChange={(e) => setApprovalForm({ ...approvalForm, decision: e.target.value as any })}
+                  className="w-full border border-gray-300 rounded-md p-2"
+                >
+                  <option value="approve">승인</option>
+                  <option value="reject">반려</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  코멘트
+                </label>
+                <textarea
+                  value={approvalForm.comments}
+                  onChange={(e) => setApprovalForm({ ...approvalForm, comments: e.target.value })}
+                  className="w-full border border-gray-300 rounded-md p-2"
+                  rows={3}
+                />
+              </div>
+
+              <div className="flex space-x-4">
+                <button
+                  onClick={handleApprove}
+                  disabled={approveSession.isPending || approvalForm.decision !== 'approve'}
+                  className="flex-1 bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 disabled:opacity-50"
+                >
+                  {approveSession.isPending ? '처리 중...' : '승인'}
+                </button>
+                <button
+                  onClick={handleReject}
+                  disabled={rejectSession.isPending || approvalForm.decision !== 'reject'}
+                  className="flex-1 bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700 disabled:opacity-50"
+                >
+                  {rejectSession.isPending ? '처리 중...' : '반려'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/workflows/authoring/page.tsx
+++ b/app/(app)/workflows/authoring/page.tsx
@@ -5,9 +5,7 @@ export default function AuthoringPage() {
     <div className="container mx-auto py-8">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900">섹션 초안 작성</h1>
-        <p className="text-gray-600 mt-2">
-          섹션 초안 작성 세션을 생성하고 승인/반려 처리합니다.
-        </p>
+        <p className="text-gray-600 mt-2">섹션 초안 작성 세션을 생성하고 승인/반려 처리합니다.</p>
       </div>
 
       <AuthoringWorkspace />

--- a/app/(app)/workflows/authoring/page.tsx
+++ b/app/(app)/workflows/authoring/page.tsx
@@ -1,0 +1,16 @@
+import { AuthoringWorkspace } from './_components/authoring-workspace';
+
+export default function AuthoringPage() {
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">섹션 초안 작성</h1>
+        <p className="text-gray-600 mt-2">
+          섹션 초안 작성 세션을 생성하고 승인/반려 처리합니다.
+        </p>
+      </div>
+
+      <AuthoringWorkspace />
+    </div>
+  );
+}

--- a/app/(app)/workflows/evidence/_components/evidence-form.tsx
+++ b/app/(app)/workflows/evidence/_components/evidence-form.tsx
@@ -1,8 +1,14 @@
 'use client';
 
+import type { BinderRequest, LinkRequest } from '@/lib/api/evidence-client';
+import {
+  useCreateBinder,
+  useCreateEvidenceLink,
+  useEvidenceLinks,
+} from '@/lib/queries/useEvidence';
 import { useState } from 'react';
-import { useCreateEvidenceLink, useCreateBinder, useEvidenceLinks } from '@/lib/queries/useEvidence';
-import type { LinkRequest, BinderRequest } from '@/lib/api/evidence-client';
+
+type EvidenceType = LinkRequest['evidence_type'];
 
 export function EvidenceForm() {
   const createLink = useCreateEvidenceLink();
@@ -50,10 +56,14 @@ export function EvidenceForm() {
         <h2 className="text-xl font-semibold mb-4">요구사항-증거 링크 생성</h2>
         <form onSubmit={handleCreateLink} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="evidence-requirement-id"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               요구사항 ID
             </label>
             <input
+              id="evidence-requirement-id"
               type="text"
               value={linkForm.requirement_id}
               onChange={(e) => setLinkForm({ ...linkForm, requirement_id: e.target.value })}
@@ -63,12 +73,15 @@ export function EvidenceForm() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="evidence-type" className="block text-sm font-medium text-gray-700 mb-1">
               증거 유형
             </label>
             <select
+              id="evidence-type"
               value={linkForm.evidence_type}
-              onChange={(e) => setLinkForm({ ...linkForm, evidence_type: e.target.value as any })}
+              onChange={(e) =>
+                setLinkForm({ ...linkForm, evidence_type: e.target.value as EvidenceType })
+              }
               className="w-full border border-gray-300 rounded-md p-2"
             >
               <option value="clinical">임상</option>
@@ -79,10 +92,14 @@ export function EvidenceForm() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="evidence-description"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               설명
             </label>
             <textarea
+              id="evidence-description"
               value={linkForm.description}
               onChange={(e) => setLinkForm({ ...linkForm, description: e.target.value })}
               className="w-full border border-gray-300 rounded-md p-2"
@@ -115,11 +132,15 @@ export function EvidenceForm() {
                       생성: {new Date(link.created_at).toLocaleString()}
                     </p>
                   </div>
-                  <span className={`px-2 py-1 text-xs rounded ${
-                    link.status === 'completed' ? 'bg-green-100 text-green-800' :
-                    link.status === 'pending' ? 'bg-yellow-100 text-yellow-800' :
-                    'bg-red-100 text-red-800'
-                  }`}>
+                  <span
+                    className={`px-2 py-1 text-xs rounded ${
+                      link.status === 'completed'
+                        ? 'bg-green-100 text-green-800'
+                        : link.status === 'pending'
+                          ? 'bg-yellow-100 text-yellow-800'
+                          : 'bg-red-100 text-red-800'
+                    }`}
+                  >
                     {link.status}
                   </span>
                 </div>
@@ -134,10 +155,14 @@ export function EvidenceForm() {
           <h2 className="text-xl font-semibold mb-4">증거 바인더 생성</h2>
           <form onSubmit={handleCreateBinder} className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label
+                htmlFor="evidence-binder-name"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
                 바인더 이름
               </label>
               <input
+                id="evidence-binder-name"
                 type="text"
                 value={binderForm.name}
                 onChange={(e) => setBinderForm({ ...binderForm, name: e.target.value })}
@@ -149,17 +174,17 @@ export function EvidenceForm() {
             <div className="flex items-center space-x-2">
               <button
                 type="button"
-                onClick={() => setBinderForm({
-                  ...binderForm,
-                  link_ids: links.map(l => l.req_id)
-                })}
+                onClick={() =>
+                  setBinderForm({
+                    ...binderForm,
+                    link_ids: links.map((l) => l.req_id),
+                  })
+                }
                 className="text-sm text-blue-600 hover:underline"
               >
                 모든 링크 포함
               </button>
-              <span className="text-sm text-gray-500">
-                ({binderForm.link_ids.length}개 선택됨)
-              </span>
+              <span className="text-sm text-gray-500">({binderForm.link_ids.length}개 선택됨)</span>
             </div>
 
             <button

--- a/app/(app)/workflows/evidence/_components/evidence-form.tsx
+++ b/app/(app)/workflows/evidence/_components/evidence-form.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState } from 'react';
+import { useCreateEvidenceLink, useCreateBinder, useEvidenceLinks } from '@/lib/queries/useEvidence';
+import type { LinkRequest, BinderRequest } from '@/lib/api/evidence-client';
+
+export function EvidenceForm() {
+  const createLink = useCreateEvidenceLink();
+  const createBinder = useCreateBinder();
+
+  const [linkForm, setLinkForm] = useState<LinkRequest>({
+    requirement_id: '',
+    evidence_type: 'clinical',
+    description: '',
+  });
+
+  const [binderForm, setBinderForm] = useState<BinderRequest>({
+    name: '',
+    link_ids: [],
+  });
+
+  const [currentReqId, setCurrentReqId] = useState<string | null>(null);
+  const { data: links } = useEvidenceLinks(currentReqId || '');
+
+  const handleCreateLink = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const result = await createLink.mutateAsync(linkForm);
+      setCurrentReqId(result.req_id);
+      setLinkForm({ requirement_id: '', evidence_type: 'clinical', description: '' });
+    } catch (err) {
+      console.error('Failed to create link:', err);
+    }
+  };
+
+  const handleCreateBinder = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createBinder.mutateAsync(binderForm);
+      setBinderForm({ name: '', link_ids: [] });
+      setCurrentReqId(null);
+    } catch (err) {
+      console.error('Failed to create binder:', err);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-xl font-semibold mb-4">요구사항-증거 링크 생성</h2>
+        <form onSubmit={handleCreateLink} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              요구사항 ID
+            </label>
+            <input
+              type="text"
+              value={linkForm.requirement_id}
+              onChange={(e) => setLinkForm({ ...linkForm, requirement_id: e.target.value })}
+              className="w-full border border-gray-300 rounded-md p-2"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              증거 유형
+            </label>
+            <select
+              value={linkForm.evidence_type}
+              onChange={(e) => setLinkForm({ ...linkForm, evidence_type: e.target.value as any })}
+              className="w-full border border-gray-300 rounded-md p-2"
+            >
+              <option value="clinical">임상</option>
+              <option value="preclinical">비임상</option>
+              <option value="technical">기술</option>
+              <option value="labeling">라벨링</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              설명
+            </label>
+            <textarea
+              value={linkForm.description}
+              onChange={(e) => setLinkForm({ ...linkForm, description: e.target.value })}
+              className="w-full border border-gray-300 rounded-md p-2"
+              rows={3}
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={createLink.isPending}
+            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
+          >
+            {createLink.isPending ? '처리 중...' : '링크 생성'}
+          </button>
+        </form>
+      </div>
+
+      {links && links.length > 0 && (
+        <div className="bg-white shadow rounded-lg p-6">
+          <h3 className="text-lg font-semibold mb-4">링크 목록 ({links.length})</h3>
+          <div className="space-y-2">
+            {links.map((link) => (
+              <div key={link.req_id} className="border border-gray-200 rounded-md p-4">
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className="font-medium">{link.evidence_type}</p>
+                    <p className="text-sm text-gray-600">{link.description}</p>
+                    <p className="text-xs text-gray-500 mt-1">
+                      생성: {new Date(link.created_at).toLocaleString()}
+                    </p>
+                  </div>
+                  <span className={`px-2 py-1 text-xs rounded ${
+                    link.status === 'completed' ? 'bg-green-100 text-green-800' :
+                    link.status === 'pending' ? 'bg-yellow-100 text-yellow-800' :
+                    'bg-red-100 text-red-800'
+                  }`}>
+                    {link.status}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {links && links.length > 0 && (
+        <div className="bg-white shadow rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">증거 바인더 생성</h2>
+          <form onSubmit={handleCreateBinder} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                바인더 이름
+              </label>
+              <input
+                type="text"
+                value={binderForm.name}
+                onChange={(e) => setBinderForm({ ...binderForm, name: e.target.value })}
+                className="w-full border border-gray-300 rounded-md p-2"
+                required
+              />
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <button
+                type="button"
+                onClick={() => setBinderForm({
+                  ...binderForm,
+                  link_ids: links.map(l => l.req_id)
+                })}
+                className="text-sm text-blue-600 hover:underline"
+              >
+                모든 링크 포함
+              </button>
+              <span className="text-sm text-gray-500">
+                ({binderForm.link_ids.length}개 선택됨)
+              </span>
+            </div>
+
+            <button
+              type="submit"
+              disabled={createBinder.isPending}
+              className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 disabled:opacity-50"
+            >
+              {createBinder.isPending ? '처리 중...' : '바인더 생성'}
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/workflows/evidence/page.tsx
+++ b/app/(app)/workflows/evidence/page.tsx
@@ -5,9 +5,7 @@ export default function EvidencePage() {
     <div className="container mx-auto py-8">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900">증거 관리</h1>
-        <p className="text-gray-600 mt-2">
-          요구사항과 증거를 연결하고 바인더를 생성합니다.
-        </p>
+        <p className="text-gray-600 mt-2">요구사항과 증거를 연결하고 바인더를 생성합니다.</p>
       </div>
 
       <EvidenceForm />

--- a/app/(app)/workflows/evidence/page.tsx
+++ b/app/(app)/workflows/evidence/page.tsx
@@ -1,0 +1,16 @@
+import { EvidenceForm } from './_components/evidence-form';
+
+export default function EvidencePage() {
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">증거 관리</h1>
+        <p className="text-gray-600 mt-2">
+          요구사항과 증거를 연결하고 바인더를 생성합니다.
+        </p>
+      </div>
+
+      <EvidenceForm />
+    </div>
+  );
+}

--- a/app/api/ra/authoring/sessions/[sessionId]/approve/route.ts
+++ b/app/api/ra/authoring/sessions/[sessionId]/approve/route.ts
@@ -2,15 +2,12 @@
 // @MX:SPEC issue #171
 
 import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
-import { NextRequest } from 'next/server';
 
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ sessionId: string }> }
-) {
+export const POST = withPermission('authoring.approve', async (req, ctx, session) => {
   try {
-    const { sessionId } = await params;
+    const { sessionId } = (await ctx.params) as { sessionId: string };
     const body = await req.json();
     const hybridFetch = createHybridRaFetch();
     const res = await hybridFetch(`/api/v1/authoring/sessions/${sessionId}/approve`, {
@@ -18,6 +15,15 @@ export async function POST(
       body: JSON.stringify(body),
     });
     const data = await res.json();
+    await writeAudit({
+      actor_id: session.user.id,
+      action: 'workflow.approve',
+      resource_type: 'authoring_session',
+      resource_id: sessionId,
+      meta_json: {
+        decision: body.decision,
+      },
+    });
     return Response.json(data, { status: 200 });
   } catch (err) {
     if (err instanceof HybridRaClientError) {
@@ -25,4 +31,4 @@ export async function POST(
     }
     throw err;
   }
-}
+});

--- a/app/api/ra/authoring/sessions/[sessionId]/approve/route.ts
+++ b/app/api/ra/authoring/sessions/[sessionId]/approve/route.ts
@@ -1,0 +1,28 @@
+// @MX:NOTE [AUTO] POST /api/ra/authoring/sessions/[sessionId]/approve — BFF proxy to hybrid-ra-saas.
+// @MX:SPEC issue #171
+
+import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
+import { NextRequest } from 'next/server';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  try {
+    const { sessionId } = await params;
+    const body = await req.json();
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch(`/api/v1/authoring/sessions/${sessionId}/approve`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return Response.json(data, { status: 200 });
+  } catch (err) {
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+}

--- a/app/api/ra/authoring/sessions/[sessionId]/reject/route.ts
+++ b/app/api/ra/authoring/sessions/[sessionId]/reject/route.ts
@@ -2,15 +2,12 @@
 // @MX:SPEC issue #171
 
 import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
-import { NextRequest } from 'next/server';
 
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ sessionId: string }> }
-) {
+export const POST = withPermission('authoring.approve', async (req, ctx, session) => {
   try {
-    const { sessionId } = await params;
+    const { sessionId } = (await ctx.params) as { sessionId: string };
     const body = await req.json();
     const hybridFetch = createHybridRaFetch();
     const res = await hybridFetch(`/api/v1/authoring/sessions/${sessionId}/reject`, {
@@ -18,6 +15,15 @@ export async function POST(
       body: JSON.stringify(body),
     });
     const data = await res.json();
+    await writeAudit({
+      actor_id: session.user.id,
+      action: 'workflow.reject',
+      resource_type: 'authoring_session',
+      resource_id: sessionId,
+      meta_json: {
+        decision: body.decision,
+      },
+    });
     return Response.json(data, { status: 200 });
   } catch (err) {
     if (err instanceof HybridRaClientError) {
@@ -25,4 +31,4 @@ export async function POST(
     }
     throw err;
   }
-}
+});

--- a/app/api/ra/authoring/sessions/[sessionId]/reject/route.ts
+++ b/app/api/ra/authoring/sessions/[sessionId]/reject/route.ts
@@ -1,0 +1,28 @@
+// @MX:NOTE [AUTO] POST /api/ra/authoring/sessions/[sessionId]/reject — BFF proxy to hybrid-ra-saas.
+// @MX:SPEC issue #171
+
+import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
+import { NextRequest } from 'next/server';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  try {
+    const { sessionId } = await params;
+    const body = await req.json();
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch(`/api/v1/authoring/sessions/${sessionId}/reject`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return Response.json(data, { status: 200 });
+  } catch (err) {
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+}

--- a/app/api/ra/authoring/sessions/[sessionId]/route.ts
+++ b/app/api/ra/authoring/sessions/[sessionId]/route.ts
@@ -1,0 +1,26 @@
+// @MX:NOTE [AUTO] GET /api/ra/authoring/sessions/[sessionId] — BFF proxy to hybrid-ra-saas.
+// @MX:SPEC issue #171
+
+import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
+import { NextRequest } from 'next/server';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  try {
+    const { sessionId } = await params;
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch(`/api/v1/authoring/sessions/${sessionId}`, {
+      method: 'GET',
+    });
+    const data = await res.json();
+    return Response.json(data, { status: 200 });
+  } catch (err) {
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+}

--- a/app/api/ra/authoring/sessions/[sessionId]/route.ts
+++ b/app/api/ra/authoring/sessions/[sessionId]/route.ts
@@ -3,14 +3,10 @@
 
 import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
 import { withPermission } from '@/lib/auth/with-permission';
-import { NextRequest } from 'next/server';
 
-export async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ sessionId: string }> }
-) {
+export const GET = withPermission('authoring.view', async (_req, ctx) => {
   try {
-    const { sessionId } = await params;
+    const { sessionId } = (await ctx.params) as { sessionId: string };
     const hybridFetch = createHybridRaFetch();
     const res = await hybridFetch(`/api/v1/authoring/sessions/${sessionId}`, {
       method: 'GET',
@@ -23,4 +19,4 @@ export async function GET(
     }
     throw err;
   }
-}
+});

--- a/app/api/ra/authoring/sessions/route.ts
+++ b/app/api/ra/authoring/sessions/route.ts
@@ -2,9 +2,10 @@
 // @MX:SPEC issue #171
 
 import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
 
-export const POST = withPermission('authoring.create', async (req) => {
+export const POST = withPermission('authoring.create', async (req, _ctx, session) => {
   try {
     const body = await req.json();
     const hybridFetch = createHybridRaFetch();
@@ -13,6 +14,16 @@ export const POST = withPermission('authoring.create', async (req) => {
       body: JSON.stringify(body),
     });
     const data = await res.json();
+    await writeAudit({
+      actor_id: session.user.id,
+      action: 'workflow.start',
+      resource_type: 'authoring_session',
+      resource_id: data.session_id ?? 'unknown',
+      meta_json: {
+        section_id: body.section_id,
+        device_id: body.device_id,
+      },
+    });
     return Response.json(data, { status: 200 });
   } catch (err) {
     if (err instanceof HybridRaClientError) {

--- a/app/api/ra/authoring/sessions/route.ts
+++ b/app/api/ra/authoring/sessions/route.ts
@@ -1,0 +1,23 @@
+// @MX:NOTE [AUTO] POST /api/ra/authoring/sessions — BFF proxy to hybrid-ra-saas.
+// @MX:SPEC issue #171
+
+import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
+
+export const POST = withPermission('authoring.create', async (req) => {
+  try {
+    const body = await req.json();
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch('/api/v1/authoring/sessions', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return Response.json(data, { status: 200 });
+  } catch (err) {
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/app/api/ra/evidence/binder/route.ts
+++ b/app/api/ra/evidence/binder/route.ts
@@ -2,9 +2,10 @@
 // @MX:SPEC issue #168
 
 import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
 
-export const POST = withPermission('evidence.binder', async (req) => {
+export const POST = withPermission('evidence.binder', async (req, _ctx, session) => {
   try {
     const body = await req.json();
     const hybridFetch = createHybridRaFetch();
@@ -13,6 +14,16 @@ export const POST = withPermission('evidence.binder', async (req) => {
       body: JSON.stringify(body),
     });
     const data = await res.json();
+    await writeAudit({
+      actor_id: session.user.id,
+      action: 'workflow.edit',
+      resource_type: 'evidence_binder',
+      resource_id: data.binder_id ?? 'unknown',
+      meta_json: {
+        link_count: data.link_count ?? body.link_ids?.length ?? 0,
+        status: data.status,
+      },
+    });
     return Response.json(data, { status: 200 });
   } catch (err) {
     if (err instanceof HybridRaClientError) {

--- a/app/api/ra/evidence/binder/route.ts
+++ b/app/api/ra/evidence/binder/route.ts
@@ -1,0 +1,23 @@
+// @MX:NOTE [AUTO] POST /api/ra/evidence/binder — BFF proxy to hybrid-ra-saas.
+// @MX:SPEC issue #168
+
+import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
+
+export const POST = withPermission('evidence.binder', async (req) => {
+  try {
+    const body = await req.json();
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch('/api/v1/evidence/binder', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return Response.json(data, { status: 200 });
+  } catch (err) {
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/app/api/ra/evidence/link/route.ts
+++ b/app/api/ra/evidence/link/route.ts
@@ -1,0 +1,23 @@
+// @MX:NOTE [AUTO] POST /api/ra/evidence/link — BFF proxy to hybrid-ra-saas.
+// @MX:SPEC issue #168
+
+import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
+
+export const POST = withPermission('evidence.link', async (req) => {
+  try {
+    const body = await req.json();
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch('/api/v1/evidence/link', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return Response.json(data, { status: 200 });
+  } catch (err) {
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/app/api/ra/evidence/link/route.ts
+++ b/app/api/ra/evidence/link/route.ts
@@ -2,9 +2,10 @@
 // @MX:SPEC issue #168
 
 import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
 
-export const POST = withPermission('evidence.link', async (req) => {
+export const POST = withPermission('evidence.link', async (req, _ctx, session) => {
   try {
     const body = await req.json();
     const hybridFetch = createHybridRaFetch();
@@ -13,6 +14,17 @@ export const POST = withPermission('evidence.link', async (req) => {
       body: JSON.stringify(body),
     });
     const data = await res.json();
+    await writeAudit({
+      actor_id: session.user.id,
+      action: 'workflow.edit',
+      resource_type: 'evidence_link',
+      resource_id: data.req_id ?? body.requirement_id ?? 'unknown',
+      meta_json: {
+        requirement_id: body.requirement_id,
+        evidence_type: body.evidence_type,
+        status: data.status,
+      },
+    });
     return Response.json(data, { status: 200 });
   } catch (err) {
     if (err instanceof HybridRaClientError) {

--- a/app/api/ra/evidence/links/[reqId]/route.ts
+++ b/app/api/ra/evidence/links/[reqId]/route.ts
@@ -3,14 +3,10 @@
 
 import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
 import { withPermission } from '@/lib/auth/with-permission';
-import { NextRequest } from 'next/server';
 
-export async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ reqId: string }> }
-) {
+export const GET = withPermission('evidence.link', async (_req, ctx) => {
   try {
-    const { reqId } = await params;
+    const { reqId } = (await ctx.params) as { reqId: string };
     const hybridFetch = createHybridRaFetch();
     const res = await hybridFetch(`/api/v1/evidence/links/${reqId}`, {
       method: 'GET',
@@ -23,4 +19,4 @@ export async function GET(
     }
     throw err;
   }
-}
+});

--- a/app/api/ra/evidence/links/[reqId]/route.ts
+++ b/app/api/ra/evidence/links/[reqId]/route.ts
@@ -1,0 +1,26 @@
+// @MX:NOTE [AUTO] GET /api/ra/evidence/links/[reqId] — BFF proxy to hybrid-ra-saas.
+// @MX:SPEC issue #168
+
+import { HybridRaClientError, createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
+import { NextRequest } from 'next/server';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ reqId: string }> }
+) {
+  try {
+    const { reqId } = await params;
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch(`/api/v1/evidence/links/${reqId}`, {
+      method: 'GET',
+    });
+    const data = await res.json();
+    return Response.json(data, { status: 200 });
+  } catch (err) {
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+}

--- a/lib/api/authoring-client.ts
+++ b/lib/api/authoring-client.ts
@@ -1,0 +1,72 @@
+// @MX:NOTE [AUTO] Browser-side BFF client for Authoring API. Never imports server-only modules.
+// @MX:SPEC issue #171
+
+export interface SessionRequest {
+  section_id: string;
+  device_id: string;
+  context?: Record<string, string>;
+}
+
+export interface SessionResponse {
+  session_id: string;
+  status: 'created' | 'in_progress' | 'approved' | 'rejected';
+  created_at: string;
+  current_draft?: string;
+}
+
+export interface SessionState {
+  session_id: string;
+  section_id: string;
+  status: 'created' | 'in_progress' | 'approved' | 'rejected';
+  current_draft: string;
+  created_at: string;
+  updated_at?: string;
+  approver_comments?: string;
+}
+
+export interface ApprovalRequest {
+  decision: 'approve' | 'reject';
+  comments?: string;
+}
+
+export interface ApprovalResponse {
+  session_id: string;
+  status: 'approved' | 'rejected';
+  updated_at: string;
+  message?: string;
+}
+
+async function bffFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json', ...init?.headers },
+    ...init,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error((body as { error?: string }).error ?? res.statusText);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const authoringClient = {
+  createSession: (request: SessionRequest): Promise<SessionResponse> =>
+    bffFetch<SessionResponse>('/api/ra/authoring/sessions', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    }),
+
+  getSession: (sessionId: string): Promise<SessionState> =>
+    bffFetch<SessionState>(`/api/ra/authoring/sessions/${sessionId}`),
+
+  approveSession: (sessionId: string, request: ApprovalRequest): Promise<ApprovalResponse> =>
+    bffFetch<ApprovalResponse>(`/api/ra/authoring/sessions/${sessionId}/approve`, {
+      method: 'POST',
+      body: JSON.stringify(request),
+    }),
+
+  rejectSession: (sessionId: string, request: ApprovalRequest): Promise<ApprovalResponse> =>
+    bffFetch<ApprovalResponse>(`/api/ra/authoring/sessions/${sessionId}/reject`, {
+      method: 'POST',
+      body: JSON.stringify(request),
+    }),
+};

--- a/lib/api/evidence-client.ts
+++ b/lib/api/evidence-client.ts
@@ -1,0 +1,71 @@
+// @MX:NOTE [AUTO] Browser-side BFF client for Evidence API. Never imports server-only modules.
+// @MX:SPEC issue #168
+
+export interface LinkRequest {
+  requirement_id: string;
+  evidence_type: 'clinical' | 'preclinical' | 'technical' | 'labeling';
+  description: string;
+  metadata?: Record<string, string>;
+}
+
+export interface LinkResponse {
+  req_id: string;
+  status: 'pending' | 'completed' | 'failed';
+  created_at: string;
+  message?: string;
+}
+
+export interface EvidenceLink {
+  req_id: string;
+  requirement_id: string;
+  evidence_type: string;
+  description: string;
+  status: string;
+  created_at: string;
+  updated_at?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface BinderRequest {
+  name: string;
+  link_ids: string[];
+  metadata?: Record<string, string>;
+}
+
+export interface BinderResponse {
+  binder_id: string;
+  name: string;
+  status: 'created' | 'failed';
+  created_at: string;
+  link_count: number;
+  message?: string;
+}
+
+async function bffFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json', ...init?.headers },
+    ...init,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error((body as { error?: string }).error ?? res.statusText);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const evidenceClient = {
+  createLink: (request: LinkRequest): Promise<LinkResponse> =>
+    bffFetch<LinkResponse>('/api/ra/evidence/link', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    }),
+
+  getLinks: (reqId: string): Promise<EvidenceLink[]> =>
+    bffFetch<EvidenceLink[]>(`/api/ra/evidence/links/${reqId}`),
+
+  createBinder: (request: BinderRequest): Promise<BinderResponse> =>
+    bffFetch<BinderResponse>('/api/ra/evidence/binder', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    }),
+};

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -28,7 +28,14 @@ export type PermissionAction =
   | 'checklist.update'
   | 'traceability.scan'
   | 'traceability.view'
-  | 'traceability.impact';
+  | 'traceability.impact'
+  // Evidence API (hybrid-ra-saas integration — Issue #168)
+  | 'evidence.link'
+  | 'evidence.binder'
+  // Authoring API (hybrid-ra-saas integration — Issue #171)
+  | 'authoring.create'
+  | 'authoring.view'
+  | 'authoring.approve';
 
 export interface PermissionSpec {
   minRole: Role;
@@ -90,4 +97,13 @@ export const PERMISSIONS: Record<PermissionAction, PermissionSpec> = {
   'traceability.scan': { minRole: 'ra-member', scope: 'org', resourceType: 'traceability' },
   'traceability.view': { minRole: 'ra-member', scope: 'org', resourceType: 'traceability' },
   'traceability.impact': { minRole: 'ra-member', scope: 'org', resourceType: 'traceability' },
+
+  // Evidence API (hybrid-ra-saas integration — Issue #168)
+  'evidence.link': { minRole: 'ra-member', scope: 'org', resourceType: 'evidence' },
+  'evidence.binder': { minRole: 'ra-member', scope: 'org', resourceType: 'evidence' },
+
+  // Authoring API (hybrid-ra-saas integration — Issue #171)
+  'authoring.create': { minRole: 'ra-member', scope: 'org', resourceType: 'authoring' },
+  'authoring.view': { minRole: 'ra-member', scope: 'org', resourceType: 'authoring' },
+  'authoring.approve': { minRole: 'ra-lead', scope: 'org', resourceType: 'authoring' },
 };

--- a/lib/queries/useAuthoring.ts
+++ b/lib/queries/useAuthoring.ts
@@ -1,0 +1,50 @@
+import {
+  type ApprovalRequest,
+  type ApprovalResponse,
+  type SessionRequest,
+  type SessionResponse,
+  type SessionState,
+  authoringClient,
+} from '@/lib/api/authoring-client';
+// @MX:NOTE [AUTO] TanStack Query hooks for Authoring API (Issue #171).
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export type {
+  SessionRequest,
+  SessionResponse,
+  SessionState,
+  ApprovalRequest,
+  ApprovalResponse,
+} from '@/lib/api/authoring-client';
+
+export function useCreateAuthoringSession() {
+  const queryClient = useQueryClient();
+  return useMutation<SessionResponse, Error, SessionRequest>({
+    mutationFn: (request) => authoringClient.createSession(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['authoring', 'sessions'] });
+    },
+  });
+}
+
+export function useAuthoringSession(sessionId: string) {
+  return useQuery<SessionState, Error>({
+    queryKey: ['authoring', 'sessions', sessionId],
+    queryFn: () => authoringClient.getSession(sessionId),
+    enabled: !!sessionId,
+    staleTime: 30_000,
+    refetchInterval: 5000,
+  });
+}
+
+export function useApproveSession() {
+  return useMutation<ApprovalResponse, Error, { sessionId: string; request: ApprovalRequest }>({
+    mutationFn: ({ sessionId, request }) => authoringClient.approveSession(sessionId, request),
+  });
+}
+
+export function useRejectSession() {
+  return useMutation<ApprovalResponse, Error, { sessionId: string; request: ApprovalRequest }>({
+    mutationFn: ({ sessionId, request }) => authoringClient.rejectSession(sessionId, request),
+  });
+}

--- a/lib/queries/useEvidence.ts
+++ b/lib/queries/useEvidence.ts
@@ -1,0 +1,43 @@
+import {
+  type BinderRequest,
+  type BinderResponse,
+  type EvidenceLink,
+  type LinkRequest,
+  type LinkResponse,
+  evidenceClient,
+} from '@/lib/api/evidence-client';
+// @MX:NOTE [AUTO] TanStack Query hooks for Evidence API (Issue #168).
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export type {
+  LinkRequest,
+  LinkResponse,
+  EvidenceLink,
+  BinderRequest,
+  BinderResponse,
+} from '@/lib/api/evidence-client';
+
+export function useCreateEvidenceLink() {
+  const queryClient = useQueryClient();
+  return useMutation<LinkResponse, Error, LinkRequest>({
+    mutationFn: (request) => evidenceClient.createLink(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['evidence', 'links'] });
+    },
+  });
+}
+
+export function useEvidenceLinks(reqId: string) {
+  return useQuery<EvidenceLink[], Error>({
+    queryKey: ['evidence', 'links', reqId],
+    queryFn: () => evidenceClient.getLinks(reqId),
+    enabled: !!reqId,
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateBinder() {
+  return useMutation<BinderResponse, Error, BinderRequest>({
+    mutationFn: (request) => evidenceClient.createBinder(request),
+  });
+}

--- a/tests/regression/foundation.test.ts
+++ b/tests/regression/foundation.test.ts
@@ -33,10 +33,10 @@ describe('FOUNDATION regression', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Permissions matrix has exactly 23 actions
+  // Permissions matrix has exactly 28 actions
   // ---------------------------------------------------------------------------
-  it('has 23 permission actions defined', () => {
-    expect(Object.keys(PERMISSIONS).length).toBe(23);
+  it('has 28 permission actions defined', () => {
+    expect(Object.keys(PERMISSIONS).length).toBe(28);
   });
 
   it('profile.edit permission exists with user scope', () => {

--- a/tests/unit/auth/permissions.test.ts
+++ b/tests/unit/auth/permissions.test.ts
@@ -4,7 +4,8 @@
 import { PERMISSIONS, type PermissionAction } from '@/lib/auth/permissions';
 import { describe, expect, it } from 'vitest';
 
-// All 23 action strings defined in SPEC REQ-ENTERPRISE-020, checklist, and traceability integration.
+// All action strings defined in SPEC REQ-ENTERPRISE-020 plus checklist, traceability,
+// evidence, and authoring integrations.
 const EXPECTED_ACTIONS: PermissionAction[] = [
   'consult.create',
   'conversation.view',
@@ -29,14 +30,19 @@ const EXPECTED_ACTIONS: PermissionAction[] = [
   'traceability.scan',
   'traceability.view',
   'traceability.impact',
+  'evidence.link',
+  'evidence.binder',
+  'authoring.create',
+  'authoring.view',
+  'authoring.approve',
 ];
 
 const VALID_ROLES = ['admin', 'ra-lead', 'ra-member', 'viewer'] as const;
 const VALID_SCOPES = ['org', 'project', 'user', 'none'] as const;
 
 describe('lib/auth/permissions.ts (REQ-ENTERPRISE-020) — PERMISSIONS matrix', () => {
-  it('PERMISSIONS contains exactly 23 entries', () => {
-    expect(Object.keys(PERMISSIONS)).toHaveLength(23);
+  it('PERMISSIONS contains exactly 28 entries', () => {
+    expect(Object.keys(PERMISSIONS)).toHaveLength(28);
   });
 
   it.each(EXPECTED_ACTIONS)('PERMISSIONS contains action: %s', (action) => {
@@ -102,6 +108,18 @@ describe('lib/auth/permissions.ts (REQ-ENTERPRISE-020) — PERMISSIONS matrix', 
 
     it('profile.edit requires ra-member', () => {
       expect(PERMISSIONS['profile.edit'].minRole).toBe('ra-member');
+    });
+
+    it('evidence.link requires ra-member', () => {
+      expect(PERMISSIONS['evidence.link'].minRole).toBe('ra-member');
+    });
+
+    it('evidence.binder requires ra-member', () => {
+      expect(PERMISSIONS['evidence.binder'].minRole).toBe('ra-member');
+    });
+
+    it('authoring.approve requires ra-lead', () => {
+      expect(PERMISSIONS['authoring.approve'].minRole).toBe('ra-lead');
     });
   });
 


### PR DESCRIPTION
## Summary

hybrid-ra-saas Evidence/Authoring API 연동을 위한 BFF 프록시 및 UI 구현

### #168 Evidence API 구현
- **lib/api/evidence-client.ts**: 브라우저 BFF 클라이언트
- **lib/queries/useEvidence.ts**: TanStack Query 훅
- **app/api/ra/evidence/***:
  - \`POST /api/ra/evidence/link\` — 요구사항-증거 링크 생성
  - \`GET /api/ra/evidence/links/{req_id}\` — 링크 목록 표시
  - \`POST /api/ra/evidence/binder\` — 증거 바인더 생성
- **app/(app)/workflows/evidence/**: Evidence 관리 UI (링크 생성, 목록, 바인더)

### #171 Authoring API 구현
- **lib/api/authoring-client.ts**: 브라우저 BFF 클라이언트
- **lib/queries/useAuthoring.ts**: TanStack Query 훅
- **app/api/ra/authoring/sessions/***:
  - \`POST /api/ra/authoring/sessions\` — 섹션 초안 작성 세션 생성
  - \`GET /api/ra/authoring/sessions/{id}\` — 현재 섹션 상태 및 초안
  - \`POST /api/ra/authoring/sessions/{id}/approve\` — 섹션 승인
  - \`POST /api/ra/authoring/sessions/{id}/reject\` — 섹션 반려
- **app/(app)/workflows/authoring/**: 섹션 초안 작성 UI

### 공통 변경사항
- **lib/auth/permissions.ts**: evidence/authoring 권한 추가
  - \`evidence.link\`, \`evidence.binder\`: ra-member 이상
  - \`authoring.create\`, \`authoring.view\`: ra-member 이상
  - \`authoring.approve\`: ra-lead 이상 (승인 권한)

### 인증 구조
- Bearer 인증 (\`HYBRID_RA_API_TOKEN\`) — 서버사이드 BFF에서만 사용
- 브라우저 노출 없음 (보안)
- X-Tenant-ID 자동 주입

## Test plan

- [ ] \`HYBRID_RA_API_BASE_URL\` / \`HYBRID_RA_API_TOKEN\` 미설정 시 500 에러 확인
- [ ] Evidence API 3개 엔드포인트 정상 동작 확인
- [ ] Authoring API 4개 엔드포인트 정상 동작 확인
- [ ] RBAC: \`ra-member\` / \`ra-lead\` 역할별 접근 제어 확인
- [ ] Contract test: MSW fixture로 response schema 검증

## 참고
- 인증 계약: https://github.com/holee9/hybrid-ra-saas/blob/feat/spec-apitok-001-bearer-auth/docs/integration-contract.md
- 이전 작업: #170 (Checklist API), #169 (Traceability API)

Refs #168, #171

🗿 MoAI <email@mo.ai.kr>