### PR TITLE
feat(integration): Issue #156 hybrid-ra-saas typed adapter 및 contract tests

### DIFF
--- a/.moai/state/session-memo.md
+++ b/.moai/state/session-memo.md
@@ -2,15 +2,13 @@
 
 ## P1: Session Context
 
-session_id: 2d5f0127-5fe2-4cce-9aa2-9a64e2a0948a
+session_id: 04ebf34f-00d3-41cb-ac7e-43bb1dcfabe7
 cwd: /home/abyz-lab/work/workspace-github/holee9/ra-med-bot
 event: PreCompact
 
-## 2026-06-19 Issue #188 Review/Docs Push
+## 2026-06-20 PR #192 Review/Fix/Merge Session
 
-- Active branch: `main`
-- Work gate: GitHub Issue #18 is active and was checked before review/fix/docs work.
-- Duplicate-work check: `origin/main` was fetched; open PR list was empty.
-- Issue state: #188 is closed; stale branch merge was not used.
-- Local implementation commit before docs: `2a3ac67 fix(webhooks): harden inbound webhook handling`
-- Requested follow-up: update README/docs with results, then push `main`.
+- Active branch: `feat/issue-156-typed-adapter`
+- Active PR: #192 (`feat(integration): Issue #156 hybrid-ra-saas typed adapter 및 contract tests`)
+- Duplicate-work gate: Read GitHub Issue #18, fetched `origin/main`, and confirmed this branch is the active PR branch before fixing CI/review state.
+- Review state: GitHub PR review threads/comments are empty; merge is blocked by CI Gates typecheck failure.

--- a/app/api/webhooks/audit/__tests__/audit.test.ts
+++ b/app/api/webhooks/audit/__tests__/audit.test.ts
@@ -2,9 +2,9 @@
 // @MX:REASON Verify timing-safe compare prevents timing attacks and correctly validates API keys
 // @MX:SPEC Issue #188 (hybrid-ra-saas inbound webhook)
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { POST } from '../route';
 import { getEnv } from '@/lib/env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '../route';
 
 // Mock timing-safe module
 vi.mock('@/lib/webauth/timing-safe', () => ({

--- a/app/api/webhooks/ifu/__tests__/ifu.test.ts
+++ b/app/api/webhooks/ifu/__tests__/ifu.test.ts
@@ -2,9 +2,9 @@
 // @MX:REASON Verify timing-safe compare prevents timing attacks and correctly validates API keys
 // @MX:SPEC Issue #188 (hybrid-ra-saas inbound webhook)
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { POST } from '../route';
 import { getEnv } from '@/lib/env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '../route';
 
 // Mock timing-safe module
 vi.mock('@/lib/webauth/timing-safe', () => ({

--- a/app/api/webhooks/knowledge-sync/__tests__/knowledge-sync.test.ts
+++ b/app/api/webhooks/knowledge-sync/__tests__/knowledge-sync.test.ts
@@ -2,9 +2,9 @@
 // @MX:REASON Verify timing-safe compare prevents timing attacks and correctly validates API keys
 // @MX:SPEC Issue #188 (hybrid-ra-saas inbound webhook)
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { POST } from '../route';
 import { getEnv } from '@/lib/env';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '../route';
 
 // Mock timing-safe module
 vi.mock('@/lib/webauth/timing-safe', () => ({

--- a/lib/api/hybrid-ra-client.ts
+++ b/lib/api/hybrid-ra-client.ts
@@ -8,7 +8,13 @@ import { getEnv } from '@/lib/env';
 // Error types
 // ---------------------------------------------------------------------------
 
-export type HybridRaErrorKind = 'unconfigured' | 'auth' | 'schema_mismatch' | 'server_error' | 'timeout' | 'network';
+export type HybridRaErrorKind =
+  | 'unconfigured'
+  | 'auth'
+  | 'schema_mismatch'
+  | 'server_error'
+  | 'timeout'
+  | 'network';
 
 export class HybridRaClientError extends Error {
   constructor(
@@ -108,7 +114,7 @@ export interface GuardrailRunResponse {
 // POST /audit/export
 export interface AuditExportRequest {
   from: string; // ISO-8601 date
-  to: string;   // ISO-8601 date
+  to: string; // ISO-8601 date
   format?: 'csv' | 'json';
 }
 
@@ -177,7 +183,12 @@ export function createHybridRaFetch(timeoutMs: number = DEFAULT_TIMEOUT_MS) {
     } catch (err) {
       if (err instanceof HybridRaClientError) throw err;
       if (err instanceof Error && err.name === 'AbortError') {
-        throw new HybridRaClientError(`Request timed out after ${timeoutMs}ms`, 504, path, 'timeout');
+        throw new HybridRaClientError(
+          `Request timed out after ${timeoutMs}ms`,
+          504,
+          path,
+          'timeout',
+        );
       }
       throw new HybridRaClientError(
         err instanceof Error ? err.message : 'Network error',

--- a/lib/api/hybrid-ra-client.ts
+++ b/lib/api/hybrid-ra-client.ts
@@ -4,24 +4,140 @@
 
 import { getEnv } from '@/lib/env';
 
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export type HybridRaErrorKind = 'unconfigured' | 'auth' | 'schema_mismatch' | 'server_error' | 'timeout' | 'network';
+
 export class HybridRaClientError extends Error {
   constructor(
     message: string,
     public statusCode: number,
     public endpoint: string,
+    public kind: HybridRaErrorKind = 'server_error',
   ) {
     super(message);
     this.name = 'HybridRaClientError';
   }
 }
 
-// @MX:ANCHOR [AUTO] createHybridRaFetch — entry point for all hybrid-ra-saas calls.
-// @MX:REASON External system integration point: BFF proxy routes + future callers >= 3.
+// ---------------------------------------------------------------------------
+// Contract types — SPEC-API-001 (hybrid-ra-saas integration-contract.md)
+// ---------------------------------------------------------------------------
+
+// GET /health
+export interface HealthResponse {
+  status: 'ok' | 'degraded' | 'unavailable';
+  version: string;
+  uptime_seconds?: number;
+}
+
+// GET /sync/manifest
+export interface SyncManifestResponse {
+  last_sync: string; // ISO-8601
+  total_documents: number;
+  sync_status: 'synced' | 'stale' | 'unknown';
+  tenant_id: string;
+}
+
+// POST /rag/query
+export interface RagQueryRequest {
+  query: string;
+  top_k?: number;
+  filter?: Record<string, string>;
+}
+
+export interface RagCitation {
+  source_id: string;
+  title: string;
+  excerpt: string;
+  score: number;
+}
+
+export interface RagQueryResponse {
+  answer: string;
+  citations: RagCitation[];
+  confidence: number;
+}
+
+// POST /documents/upload
+export interface DocumentUploadRequest {
+  filename: string;
+  content_base64: string;
+  metadata?: Record<string, string>;
+}
+
+export interface DocumentUploadResponse {
+  document_id: string;
+  status: 'uploaded' | 'failed';
+  created_at: string;
+}
+
+// POST /parse/jobs
+export interface ParseJobRequest {
+  document_id: string;
+  parser_type?: 'ifu' | 'technical' | 'clinical';
+}
+
+export interface ParseJobResponse {
+  job_id: string;
+  status: 'queued' | 'processing' | 'completed' | 'failed';
+  created_at: string;
+}
+
+// POST /guardrail/run
+export interface GuardrailFlag {
+  rule: string;
+  severity: 'low' | 'medium' | 'high';
+  message: string;
+}
+
+export interface GuardrailRunRequest {
+  content: string;
+  context?: string;
+  rules?: string[];
+}
+
+export interface GuardrailRunResponse {
+  safe: boolean;
+  flags: GuardrailFlag[];
+  processed_at: string;
+}
+
+// POST /audit/export
+export interface AuditExportRequest {
+  from: string; // ISO-8601 date
+  to: string;   // ISO-8601 date
+  format?: 'csv' | 'json';
+}
+
+export interface AuditExportResponse {
+  export_id: string;
+  download_url: string;
+  expires_at: string;
+  record_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Low-level fetch wrapper
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function classifyError(statusCode: number): HybridRaErrorKind {
+  if (statusCode === 401 || statusCode === 403) return 'auth';
+  if (statusCode === 422) return 'schema_mismatch';
+  return 'server_error';
+}
+
+// @MX:ANCHOR [AUTO] createHybridRaFetch — low-level fetch wrapper for hybrid-ra-saas calls.
+// @MX:REASON External system integration point: BFF proxy routes + typed client callers >= 3.
 /**
- * Returns a typed fetch wrapper that injects Bearer + Tenant-ID headers.
- * Throws HybridRaClientError when hybrid-ra-saas is not configured or upstream returns non-2xx.
+ * Returns a fetch wrapper that injects Bearer + Tenant-ID headers and enforces a request timeout.
+ * Throws HybridRaClientError for unconfigured env, auth failure, schema mismatch, or 5xx errors.
  */
-export function createHybridRaFetch() {
+export function createHybridRaFetch(timeoutMs: number = DEFAULT_TIMEOUT_MS) {
   const env = getEnv();
   const baseUrl = env.HYBRID_RA_API_BASE_URL ?? '';
   const token = env.HYBRID_RA_API_TOKEN ?? '';
@@ -29,22 +145,113 @@ export function createHybridRaFetch() {
 
   return async function hybridFetch(path: string, options: RequestInit = {}): Promise<Response> {
     if (!baseUrl || !token) {
-      throw new HybridRaClientError('hybrid-ra-saas is not configured', 503, path);
+      throw new HybridRaClientError('hybrid-ra-saas is not configured', 503, path, 'unconfigured');
     }
-    const url = `${baseUrl}${path}`;
-    const res = await fetch(url, {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-        'X-Tenant-Id': tenantId,
-        ...options.headers,
-      },
-    });
-    if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new HybridRaClientError(body || res.statusText, res.status, path);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const res = await fetch(`${baseUrl}${path}`, {
+        ...options,
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          'X-Tenant-Id': tenantId,
+          ...options.headers,
+        },
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new HybridRaClientError(
+          body || res.statusText,
+          res.status,
+          path,
+          classifyError(res.status),
+        );
+      }
+
+      return res;
+    } catch (err) {
+      if (err instanceof HybridRaClientError) throw err;
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new HybridRaClientError(`Request timed out after ${timeoutMs}ms`, 504, path, 'timeout');
+      }
+      throw new HybridRaClientError(
+        err instanceof Error ? err.message : 'Network error',
+        0,
+        path,
+        'network',
+      );
+    } finally {
+      clearTimeout(timer);
     }
-    return res;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// @MX:ANCHOR [AUTO] createHybridRaClient — typed adapter for all hybrid-ra-saas endpoints.
+// @MX:REASON Public API boundary: used by BFF routes + future callers >= 3; single source of truth for endpoint types.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a typed client for all hybrid-ra-saas SPEC-API-001 endpoints.
+ * Use this instead of calling createHybridRaFetch() directly from BFF routes.
+ */
+export function createHybridRaClient(timeoutMs?: number) {
+  const hybridFetch = createHybridRaFetch(timeoutMs);
+
+  return {
+    /** GET /health — check backend availability. */
+    health(): Promise<HealthResponse> {
+      return hybridFetch('/health').then((r) => r.json() as Promise<HealthResponse>);
+    },
+
+    /** GET /sync/manifest — retrieve corpus sync status for this tenant. */
+    syncManifest(): Promise<SyncManifestResponse> {
+      return hybridFetch('/sync/manifest').then((r) => r.json() as Promise<SyncManifestResponse>);
+    },
+
+    /** POST /rag/query — run a RAG query against the tenant corpus. */
+    ragQuery(req: RagQueryRequest): Promise<RagQueryResponse> {
+      return hybridFetch('/rag/query', {
+        method: 'POST',
+        body: JSON.stringify(req),
+      }).then((r) => r.json() as Promise<RagQueryResponse>);
+    },
+
+    /** POST /documents/upload — upload a base64-encoded document. */
+    uploadDocument(req: DocumentUploadRequest): Promise<DocumentUploadResponse> {
+      return hybridFetch('/documents/upload', {
+        method: 'POST',
+        body: JSON.stringify(req),
+      }).then((r) => r.json() as Promise<DocumentUploadResponse>);
+    },
+
+    /** POST /parse/jobs — enqueue a document parsing job. */
+    createParseJob(req: ParseJobRequest): Promise<ParseJobResponse> {
+      return hybridFetch('/parse/jobs', {
+        method: 'POST',
+        body: JSON.stringify(req),
+      }).then((r) => r.json() as Promise<ParseJobResponse>);
+    },
+
+    /** POST /guardrail/run — run guardrail checks on content. */
+    runGuardrail(req: GuardrailRunRequest): Promise<GuardrailRunResponse> {
+      return hybridFetch('/guardrail/run', {
+        method: 'POST',
+        body: JSON.stringify(req),
+      }).then((r) => r.json() as Promise<GuardrailRunResponse>);
+    },
+
+    /** POST /audit/export — export audit log for a date range. */
+    exportAudit(req: AuditExportRequest): Promise<AuditExportResponse> {
+      return hybridFetch('/audit/export', {
+        method: 'POST',
+        body: JSON.stringify(req),
+      }).then((r) => r.json() as Promise<AuditExportResponse>);
+    },
   };
 }

--- a/tests/unit/api/hybrid-ra-client.test.ts
+++ b/tests/unit/api/hybrid-ra-client.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/env', () => ({
+  getEnv: vi.fn(),
+}));
+
+import { getEnv } from '@/lib/env';
+import {
+  HybridRaClientError,
+  createHybridRaClient,
+  createHybridRaFetch,
+} from '@/lib/api/hybrid-ra-client';
+
+// ---------------------------------------------------------------------------
+// Env mock helpers
+// ---------------------------------------------------------------------------
+
+const CONFIGURED_ENV = {
+  HYBRID_RA_API_BASE_URL: 'https://hybrid.example.com',
+  HYBRID_RA_API_TOKEN: 'test-token',
+  HYBRID_RA_TENANT_ID: 'tenant-abc',
+};
+
+const UNCONFIGURED_ENV = {
+  HYBRID_RA_API_BASE_URL: undefined as string | undefined,
+  HYBRID_RA_API_TOKEN: undefined as string | undefined,
+  HYBRID_RA_TENANT_ID: undefined as string | undefined,
+};
+
+function setConfiguredEnv() {
+  vi.mocked(getEnv).mockReturnValue(CONFIGURED_ENV as ReturnType<typeof getEnv>);
+}
+
+function setUnconfiguredEnv() {
+  vi.mocked(getEnv).mockReturnValue(UNCONFIGURED_ENV as ReturnType<typeof getEnv>);
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchOk(body: unknown) {
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+function mockFetchError(status: number, body = '') {
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(body, { status, statusText: 'Error' }),
+  );
+}
+
+function lastFetchCall(): [string, RequestInit] {
+  return (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Unconfigured env
+// ---------------------------------------------------------------------------
+
+describe('createHybridRaFetch — unconfigured env', () => {
+  it('throws kind=unconfigured when HYBRID_RA_API_BASE_URL is missing', async () => {
+    setUnconfiguredEnv();
+    await expect(createHybridRaFetch()('/health')).rejects.toMatchObject({
+      name: 'HybridRaClientError',
+      statusCode: 503,
+      kind: 'unconfigured',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Configured env — header injection + error classification
+// ---------------------------------------------------------------------------
+
+describe('createHybridRaFetch — configured env', () => {
+  it('injects Authorization and X-Tenant-Id headers', async () => {
+    setConfiguredEnv();
+    mockFetchOk({ status: 'ok', version: '1.0.0' });
+    await createHybridRaFetch()('/health');
+
+    const [, init] = lastFetchCall();
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer test-token');
+    expect(headers['X-Tenant-Id']).toBe('tenant-abc');
+  });
+
+  it('throws kind=auth on 401', async () => {
+    setConfiguredEnv();
+    mockFetchError(401, 'Unauthorized');
+    await expect(createHybridRaFetch()('/health')).rejects.toMatchObject({
+      statusCode: 401,
+      kind: 'auth',
+    });
+  });
+
+  it('throws kind=auth on 403', async () => {
+    setConfiguredEnv();
+    mockFetchError(403);
+    await expect(createHybridRaFetch()('/health')).rejects.toMatchObject({
+      statusCode: 403,
+      kind: 'auth',
+    });
+  });
+
+  it('throws kind=schema_mismatch on 422', async () => {
+    setConfiguredEnv();
+    mockFetchError(422, 'Unprocessable Entity');
+    await expect(createHybridRaFetch()('/rag/query')).rejects.toMatchObject({
+      statusCode: 422,
+      kind: 'schema_mismatch',
+    });
+  });
+
+  it('throws kind=server_error on 500', async () => {
+    setConfiguredEnv();
+    mockFetchError(500, 'Internal Server Error');
+    await expect(createHybridRaFetch()('/health')).rejects.toMatchObject({
+      statusCode: 500,
+      kind: 'server_error',
+    });
+  });
+
+  it('throws kind=timeout when AbortError fires', async () => {
+    setConfiguredEnv();
+    global.fetch = vi.fn().mockRejectedValueOnce(
+      Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }),
+    );
+    await expect(createHybridRaFetch(100)('/health')).rejects.toMatchObject({
+      statusCode: 504,
+      kind: 'timeout',
+    });
+  });
+
+  it('throws kind=network on unexpected TypeError', async () => {
+    setConfiguredEnv();
+    global.fetch = vi.fn().mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    await expect(createHybridRaFetch()('/health')).rejects.toMatchObject({
+      kind: 'network',
+      statusCode: 0,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Typed client contract tests
+// ---------------------------------------------------------------------------
+
+describe('createHybridRaClient — endpoint contracts', () => {
+  it('health() GETs /health and returns HealthResponse', async () => {
+    setConfiguredEnv();
+    const payload = { status: 'ok', version: '2.1.0', uptime_seconds: 3600 };
+    mockFetchOk(payload);
+    const result = await createHybridRaClient().health();
+    expect(result).toMatchObject({ status: 'ok', version: '2.1.0' });
+
+    const [url] = lastFetchCall();
+    expect(url).toBe('https://hybrid.example.com/health');
+  });
+
+  it('syncManifest() GETs /sync/manifest and returns SyncManifestResponse', async () => {
+    setConfiguredEnv();
+    mockFetchOk({ last_sync: '2026-06-19T10:00:00Z', total_documents: 42, sync_status: 'synced', tenant_id: 'tenant-abc' });
+    const result = await createHybridRaClient().syncManifest();
+    expect(result.sync_status).toBe('synced');
+    expect(result.total_documents).toBe(42);
+  });
+
+  it('ragQuery() POSTs to /rag/query with request body', async () => {
+    setConfiguredEnv();
+    mockFetchOk({ answer: '30일', citations: [{ source_id: 'src-1', title: 'CFR', excerpt: '...', score: 0.9 }], confidence: 0.9 });
+    const result = await createHybridRaClient().ragQuery({ query: 'FDA deadline?' });
+    expect(result.confidence).toBe(0.9);
+
+    const [url, init] = lastFetchCall();
+    expect(url).toBe('https://hybrid.example.com/rag/query');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toMatchObject({ query: 'FDA deadline?' });
+  });
+
+  it('uploadDocument() POSTs to /documents/upload', async () => {
+    setConfiguredEnv();
+    mockFetchOk({ document_id: 'doc-123', status: 'uploaded', created_at: '2026-06-19T00:00:00Z' });
+    const result = await createHybridRaClient().uploadDocument({ filename: 'ifu.pdf', content_base64: 'base64==' });
+    expect(result.document_id).toBe('doc-123');
+    expect(result.status).toBe('uploaded');
+  });
+
+  it('createParseJob() POSTs to /parse/jobs', async () => {
+    setConfiguredEnv();
+    mockFetchOk({ job_id: 'job-456', status: 'queued', created_at: '2026-06-19T00:00:00Z' });
+    const result = await createHybridRaClient().createParseJob({ document_id: 'doc-123', parser_type: 'ifu' });
+    expect(result.job_id).toBe('job-456');
+    expect(result.status).toBe('queued');
+  });
+
+  it('runGuardrail() POSTs to /guardrail/run', async () => {
+    setConfiguredEnv();
+    mockFetchOk({ safe: false, flags: [{ rule: 'pii_detected', severity: 'high', message: 'PII found' }], processed_at: '2026-06-19T00:00:00Z' });
+    const result = await createHybridRaClient().runGuardrail({ content: 'PII content' });
+    expect(result.safe).toBe(false);
+    expect(result.flags[0].severity).toBe('high');
+  });
+
+  it('exportAudit() POSTs to /audit/export', async () => {
+    setConfiguredEnv();
+    mockFetchOk({ export_id: 'exp-789', download_url: 'https://storage.example.com/audit.csv', expires_at: '2026-06-20T00:00:00Z', record_count: 120 });
+    const result = await createHybridRaClient().exportAudit({ from: '2026-06-01', to: '2026-06-19' });
+    expect(result.record_count).toBe(120);
+    expect(result.download_url).toContain('audit.csv');
+  });
+});

--- a/tests/unit/api/hybrid-ra-client.test.ts
+++ b/tests/unit/api/hybrid-ra-client.test.ts
@@ -4,12 +4,12 @@ vi.mock('@/lib/env', () => ({
   getEnv: vi.fn(),
 }));
 
-import { getEnv } from '@/lib/env';
 import {
   HybridRaClientError,
   createHybridRaClient,
   createHybridRaFetch,
 } from '@/lib/api/hybrid-ra-client';
+import { getEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Env mock helpers
@@ -49,9 +49,7 @@ function mockFetchOk(body: unknown) {
 }
 
 function mockFetchError(status: number, body = '') {
-  global.fetch = vi.fn().mockResolvedValueOnce(
-    new Response(body, { status, statusText: 'Error' }),
-  );
+  global.fetch = vi.fn().mockResolvedValueOnce(new Response(body, { status, statusText: 'Error' }));
 }
 
 function lastFetchCall(): [string, RequestInit] {
@@ -89,7 +87,7 @@ describe('createHybridRaFetch — configured env', () => {
 
     const [, init] = lastFetchCall();
     const headers = init.headers as Record<string, string>;
-    expect(headers['Authorization']).toBe('Bearer test-token');
+    expect(headers.Authorization).toBe('Bearer test-token');
     expect(headers['X-Tenant-Id']).toBe('tenant-abc');
   });
 
@@ -131,9 +129,11 @@ describe('createHybridRaFetch — configured env', () => {
 
   it('throws kind=timeout when AbortError fires', async () => {
     setConfiguredEnv();
-    global.fetch = vi.fn().mockRejectedValueOnce(
-      Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }),
-    );
+    global.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }),
+      );
     await expect(createHybridRaFetch(100)('/health')).rejects.toMatchObject({
       statusCode: 504,
       kind: 'timeout',
@@ -168,7 +168,12 @@ describe('createHybridRaClient — endpoint contracts', () => {
 
   it('syncManifest() GETs /sync/manifest and returns SyncManifestResponse', async () => {
     setConfiguredEnv();
-    mockFetchOk({ last_sync: '2026-06-19T10:00:00Z', total_documents: 42, sync_status: 'synced', tenant_id: 'tenant-abc' });
+    mockFetchOk({
+      last_sync: '2026-06-19T10:00:00Z',
+      total_documents: 42,
+      sync_status: 'synced',
+      tenant_id: 'tenant-abc',
+    });
     const result = await createHybridRaClient().syncManifest();
     expect(result.sync_status).toBe('synced');
     expect(result.total_documents).toBe(42);
@@ -176,7 +181,11 @@ describe('createHybridRaClient — endpoint contracts', () => {
 
   it('ragQuery() POSTs to /rag/query with request body', async () => {
     setConfiguredEnv();
-    mockFetchOk({ answer: '30일', citations: [{ source_id: 'src-1', title: 'CFR', excerpt: '...', score: 0.9 }], confidence: 0.9 });
+    mockFetchOk({
+      answer: '30일',
+      citations: [{ source_id: 'src-1', title: 'CFR', excerpt: '...', score: 0.9 }],
+      confidence: 0.9,
+    });
     const result = await createHybridRaClient().ragQuery({ query: 'FDA deadline?' });
     expect(result.confidence).toBe(0.9);
 
@@ -189,7 +198,10 @@ describe('createHybridRaClient — endpoint contracts', () => {
   it('uploadDocument() POSTs to /documents/upload', async () => {
     setConfiguredEnv();
     mockFetchOk({ document_id: 'doc-123', status: 'uploaded', created_at: '2026-06-19T00:00:00Z' });
-    const result = await createHybridRaClient().uploadDocument({ filename: 'ifu.pdf', content_base64: 'base64==' });
+    const result = await createHybridRaClient().uploadDocument({
+      filename: 'ifu.pdf',
+      content_base64: 'base64==',
+    });
     expect(result.document_id).toBe('doc-123');
     expect(result.status).toBe('uploaded');
   });
@@ -197,23 +209,38 @@ describe('createHybridRaClient — endpoint contracts', () => {
   it('createParseJob() POSTs to /parse/jobs', async () => {
     setConfiguredEnv();
     mockFetchOk({ job_id: 'job-456', status: 'queued', created_at: '2026-06-19T00:00:00Z' });
-    const result = await createHybridRaClient().createParseJob({ document_id: 'doc-123', parser_type: 'ifu' });
+    const result = await createHybridRaClient().createParseJob({
+      document_id: 'doc-123',
+      parser_type: 'ifu',
+    });
     expect(result.job_id).toBe('job-456');
     expect(result.status).toBe('queued');
   });
 
   it('runGuardrail() POSTs to /guardrail/run', async () => {
     setConfiguredEnv();
-    mockFetchOk({ safe: false, flags: [{ rule: 'pii_detected', severity: 'high', message: 'PII found' }], processed_at: '2026-06-19T00:00:00Z' });
+    mockFetchOk({
+      safe: false,
+      flags: [{ rule: 'pii_detected', severity: 'high', message: 'PII found' }],
+      processed_at: '2026-06-19T00:00:00Z',
+    });
     const result = await createHybridRaClient().runGuardrail({ content: 'PII content' });
     expect(result.safe).toBe(false);
-    expect(result.flags[0].severity).toBe('high');
+    expect(result.flags[0]).toMatchObject({ severity: 'high' });
   });
 
   it('exportAudit() POSTs to /audit/export', async () => {
     setConfiguredEnv();
-    mockFetchOk({ export_id: 'exp-789', download_url: 'https://storage.example.com/audit.csv', expires_at: '2026-06-20T00:00:00Z', record_count: 120 });
-    const result = await createHybridRaClient().exportAudit({ from: '2026-06-01', to: '2026-06-19' });
+    mockFetchOk({
+      export_id: 'exp-789',
+      download_url: 'https://storage.example.com/audit.csv',
+      expires_at: '2026-06-20T00:00:00Z',
+      record_count: 120,
+    });
+    const result = await createHybridRaClient().exportAudit({
+      from: '2026-06-01',
+      to: '2026-06-19',
+    });
     expect(result.record_count).toBe(120);
     expect(result.download_url).toContain('audit.csv');
   });


### PR DESCRIPTION
## Summary

- `lib/api/hybrid-ra-client.ts`: 7개 endpoint 전용 request/response 타입 정의 (SPEC-API-001 기준)
- `createHybridRaFetch()`: AbortController 기반 30s timeout, `HybridRaErrorKind` 오류 분류 (auth/schema_mismatch/5xx 등 integration-gap 후보 기록 가능)
- `createHybridRaClient()`: named typed method factory로 BFF route에서 type-safe 호출 가능
- `tests/unit/api/hybrid-ra-client.test.ts`: 15개 contract test — 각 endpoint 계약 + 오류 분류 검증

## Test plan

- [x] `pnpm exec vitest run tests/unit/api/hybrid-ra-client.test.ts` — 15/15 통과
- [x] `HybridRaErrorKind` 분류: unconfigured, auth(401/403), schema_mismatch(422), server_error(5xx), timeout, network
- [x] 기존 BFF routes (`createHybridRaFetch` 하위 호환 유지) — 기존 API 시그니처 변경 없음

Closes #156

🗿 MoAI <email@mo.ai.kr>