### PR TITLE
fix(rbac): Issue #162 ra-lead audit log UI 접근 차단 E2E 검증

### DIFF
--- a/tests/e2e/audit-log.spec.ts
+++ b/tests/e2e/audit-log.spec.ts
@@ -118,6 +118,24 @@ test.describe('Audit log — 21 CFR Part 11 (REQ-LAUNCH-020)', () => {
     }
   });
 
+  test('ra-lead is redirected from /admin/audit-logs UI', async ({ browser, baseURL }) => {
+    const auth = requiresAuthState();
+    test.skip(auth.skip, auth.reason);
+
+    // Default storageState (.auth.json) is ra-lead — must be redirected to /403
+    const context = await browser.newContext({
+      storageState: process.env.PLAYWRIGHT_AUTH_STATE ?? 'tests/e2e/fixtures/.auth.json',
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(`${baseURL ?? 'http://localhost:3000'}/admin/audit-logs`);
+      await page.waitForURL(/\/403/, { timeout: 5000 });
+      expect(page.url()).toContain('/403');
+    } finally {
+      await context.close();
+    }
+  });
+
   test('audit log admin UI shows entries table', async ({ browser, baseURL }) => {
     const auth = requiresAuthState();
     test.skip(auth.skip, auth.reason);


### PR DESCRIPTION
## Summary

- `/admin/audit-logs` 페이지에 `hasRole(..., 'admin')` 가드가 이미 구현됨 (page.tsx:14-18)
- ra-lead(`3`) >= admin(`4`) = false → 올바르게 `/403` redirect
- E2E에 API RBAC 검증만 있고 **UI 라우트 redirect 검증이 없어** 이슈 발생
- `tests/e2e/audit-log.spec.ts`에 ra-lead → `/403` redirect E2E 명시 검증 추가

## Test plan

- [x] 신규 테스트: `ra-lead is redirected from /admin/audit-logs UI` (기본 auth state 사용)
- [x] `/admin/audit-logs` 접근 시 `/403`으로 redirect 확인
- [x] 기존 API RBAC 테스트 (`audit log is accessible to admin role only`) 변경 없음

Fixes #162

🗿 MoAI <email@mo.ai.kr>