### PR TITLE
docs(spec): SPEC-REGULA-RISK-001 ISO 14971 위험관리 통합 4-doc set

### DIFF
--- a/.moai/specs/SPEC-REGULA-RISK-001/design.md
+++ b/.moai/specs/SPEC-REGULA-RISK-001/design.md
@@ -1,0 +1,340 @@
+# SPEC-REGULA-RISK-001 — System Design
+
+> spec.md의 36 REQ를 구현하기 위한 시스템 설계 (HOW). DB schema, API routes, UI components, 도메인 로직, RAG 파이프라인.
+> 코드 식별자는 영문, 설명은 한국어. 기존 CER Builder 패턴을 확장한다.
+
+---
+
+## 1. 아키텍처 개요
+
+```
+[브라우저: app/(app)/workflows/risk/]
+   │  TanStack Query
+   ▼
+[BFF: app/api/ra/risk/*]  ── withPermission(risk.*)
+   │  서버 전용
+   ├──> [도메인 로직: lib/risk/*]
+   │       ├─ hazard-identification.ts  ─┐
+   │       ├─ risk-evaluation.ts          │ createHybridRaFetch
+   │       ├─ control-recommendation.ts ─┤ POST /rag/query
+   │       ├─ residual-risk.ts            │
+   │       └─ report-builder.ts (docx)   ─┘
+   ├──> [DB: Drizzle ORM]
+   │       workflow_runs (type='risk')
+   │       ├─ risk_items
+   │       ├─ risk_controls
+   │       └─ risk_gspr_mappings
+   │       expert_reviews / audit_logs
+   └──> [hybrid-ra-saas RAG] (Bearer auth, server-side)
+```
+
+설계 원칙: CER Builder(SPEC-REGULA-CER-001) 패턴 그대로 재사용 — `workflow_runs`를 spine으로, child 테이블을 cascade FK로, expert review gate로 RA-lead 승인, audit_logs append-only.
+
+---
+
+## 2. DB Schema (Drizzle ORM)
+
+### 2.1 enum 확장
+
+```typescript
+// lib/db/schema.ts — workflowTypeEnum에 'risk' 추가
+export const workflowTypeEnum = pgEnum('workflow_type', [
+  'submission_drafter', 'audit_response', 'indication_impact',
+  'predicate_comparison', 'cer', 'pccp', 'vigilance',
+  'risk', // ← 신규
+]);
+
+// auditActionEnum에 risk 액션 추가
+// 'risk.identify.generate', 'risk.item.edit', 'risk.analysis.update',
+// 'risk.control.decide', 'risk.approve', 'risk.export'
+
+// 신규 enum: 위험도 수준
+export const riskLevelEnum = pgEnum('risk_level', [
+  'acceptable', 'alarp', 'unacceptable',
+]);
+
+// 신규 enum: 통제 옵션 계층 (ISO 14971 §7.1)
+export const controlTierEnum = pgEnum('control_tier', [
+  'inherent_safety',   // 본질적 안전 설계 (최우선)
+  'protective_measure', // 보호 조치
+  'information_safety', // 안전 정보 제공 (최후)
+]);
+```
+
+### 2.2 risk_items 테이블 (Group A, B)
+
+```typescript
+export const riskItems = pgTable('risk_items', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  workflowRunId: uuid('workflow_run_id')
+    .notNull()
+    .references(() => workflowRuns.id, { onDelete: 'cascade' }),
+  // ISO 14971 §3 구조화 (REQ-RISK-006)
+  hazard: text('hazard').notNull(),
+  sequenceOfEvents: text('sequence_of_events'),
+  hazardousSituation: text('hazardous_situation'),
+  harm: text('harm').notNull(),
+  // 초기 추정 (Group B)
+  severity: integer('severity'),       // 1~5
+  probability: integer('probability'),  // 1~5
+  riskLevel: riskLevelEnum('risk_level'),
+  acceptabilityJustification: text('acceptability_justification'), // ALARP/허용 근거 (REQ-RISK-015)
+  // 출처 (REQ-RISK-002): RagCitation[] 구조 저장
+  citations: jsonb('citations').$type<RiskCitation[]>().notNull().default([]),
+  ragConfidence: numeric('rag_confidence', { precision: 3, scale: 2 }),
+  lowConfidence: boolean('low_confidence').notNull().default(false), // REQ-RISK-004
+  source: text('source').notNull().default('rag'), // 'rag' | 'manual'
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+}, (t) => ({
+  runIdx: index('risk_items_run_idx').on(t.workflowRunId),
+}));
+
+export type RiskCitation = {
+  kind: 'standard_clause' | 'adverse_event';
+  sourceId: string;     // RagCitation.source_id 또는 표준 조항 ID
+  title: string;
+  excerpt: string;
+  score: number;
+};
+```
+
+### 2.3 risk_controls 테이블 (Group C)
+
+```typescript
+export const riskControls = pgTable('risk_controls', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  riskItemId: uuid('risk_item_id')
+    .notNull()
+    .references(() => riskItems.id, { onDelete: 'cascade' }), // REQ-RISK-026 traceability
+  tier: controlTierEnum('tier').notNull(), // REQ-RISK-021
+  description: text('description').notNull(),
+  adopted: boolean('adopted').notNull().default(false),
+  // information-only 채택 시 상위 계층 미적용 사유 (REQ-RISK-023)
+  higherTierSkipJustification: text('higher_tier_skip_justification'),
+  // 통제 후 잔류 위험 (REQ-RISK-024)
+  residualSeverity: integer('residual_severity'),
+  residualProbability: integer('residual_probability'),
+  residualRiskLevel: riskLevelEnum('residual_risk_level'),
+  // 잔류 unacceptable 시 추가근거 (REQ-RISK-025)
+  riskBenefitJustification: text('risk_benefit_justification'),
+  introducesNewRisk: boolean('introduces_new_risk').notNull().default(false), // REQ-RISK-027
+  citations: jsonb('citations').$type<RiskCitation[]>().notNull().default([]), // REQ-RISK-022
+  decisionReason: text('decision_reason'), // 채택/거부 사유 (REQ-RISK-029)
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+}, (t) => ({
+  itemIdx: index('risk_controls_item_idx').on(t.riskItemId),
+}));
+```
+
+### 2.4 risk_gspr_mappings 테이블 (Group D)
+
+```typescript
+export const riskGsprMappings = pgTable('risk_gspr_mappings', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  workflowRunId: uuid('workflow_run_id')
+    .notNull()
+    .references(() => workflowRuns.id, { onDelete: 'cascade' }),
+  riskItemId: uuid('risk_item_id').references(() => riskItems.id, { onDelete: 'cascade' }),
+  controlId: uuid('control_id').references(() => riskControls.id, { onDelete: 'set null' }),
+  gsprClause: text('gspr_clause').notNull(), // 예: 'Annex I §4'
+  justification: text('justification').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+}, (t) => ({
+  runIdx: index('risk_gspr_run_idx').on(t.workflowRunId),
+}));
+```
+
+### 2.5 RLS 정책
+
+기존 `workflow_runs` RLS 패턴 상속: child 테이블은 부모 `workflow_runs`의 `organization_id` 기준 멀티테넌트 격리. CER Builder child 테이블 정책과 동일.
+
+### 2.6 마이그레이션
+
+`lib/db/migrations/`의 다음 번호 파일: enum 3종 추가/확장 + 테이블 3종 생성 + RLS 정책 + audit action enum 확장. `drizzle-kit generate` 후 수동 검토 (메모리상 drizzle-kit 버그 주의 — E2E env 메모 참조).
+
+---
+
+## 3. API Routes (BFF)
+
+`app/api/ra/risk/` 하위. 모두 `withPermission`으로 감싸고, RAG 호출은 `createHybridRaFetch` 사용. 패턴은 `app/api/ra/checklists/generate/route.ts`와 동일.
+
+| Route | Method | Permission | REQ | 설명 |
+|-------|--------|-----------|-----|------|
+| `/api/ra/risk/runs` | POST | `risk.generate` | — | 위험관리 run 생성 (workflow_runs, type='risk') |
+| `/api/ra/risk/runs/[id]` | GET | `risk.view` | — | run + items + controls + mappings 조회 |
+| `/api/ra/risk/identify` | POST | `risk.generate` | 001,002,004,010 | 기기 설명 → RAG 위험 식별 생성 |
+| `/api/ra/risk/items/[id]` | PATCH | `risk.update` | 007,020 | 위험 항목 수정 (severity/prob 등) + audit |
+| `/api/ra/risk/items/[id]` | DELETE | `risk.update` | 007 | 위험 항목 삭제 + audit |
+| `/api/ra/risk/items/[id]/evaluate` | POST | `risk.update` | 012,013,015 | severity×prob → 위험도 분류 + ALARP |
+| `/api/ra/risk/controls/recommend` | POST | `risk.update` | 021,022,028 | 통제 조치 추천 (3계층 + RAG) |
+| `/api/ra/risk/controls/[id]` | PATCH | `risk.update` | 024,025,029 | 통제 채택/잔류 위험 + audit |
+| `/api/ra/risk/runs/[id]/gspr` | POST | `risk.update` | 032 | GSPR 매핑 생성/수정 |
+| `/api/ra/risk/runs/[id]/export` | POST | `risk.view` | 031,033,034 | ISO 14971 DOCX export (워터마크 분기) |
+| `/api/ra/risk/runs/[id]/approve` | POST | `risk.approve` | 003,035,036 | RA-lead 승인 (gate) |
+
+권한 매핑 (`lib/auth/permissions.ts` 확장):
+- `risk.generate` → ra-lead, ra-member
+- `risk.view` → ra-lead, ra-member, viewer
+- `risk.update` → ra-lead, ra-member
+- `risk.approve` → **ra-lead only** (REQ-RISK-036)
+
+---
+
+## 4. 도메인 로직 (lib/risk/*)
+
+### 4.1 hazard-identification.ts (Group A)
+
+```typescript
+// 기기 설명 → RAG 위험 식별
+export async function identifyHazards(input: {
+  deviceDescription: string;
+  deviceClass?: string;  // REQ-RISK-005 filter
+}): Promise<{ items: NewRiskItem[]; confidence: number }> {
+  const ragFetch = createHybridRaFetch();
+  const res = await ragFetch('/rag/query', {
+    method: 'POST',
+    body: JSON.stringify({
+      query: buildHazardPrompt(input.deviceDescription),
+      top_k: 8,
+      filter: input.deviceClass ? { device_class: input.deviceClass } : undefined,
+    } satisfies RagQueryRequest),
+  });
+  const data: RagQueryResponse = await res.json();
+  // 응답 파싱 → RiskItem[] (각 항목 citation 필수, REQ-RISK-002)
+  // confidence < 0.6 → lowConfidence=true (REQ-RISK-004)
+  return parseHazardResponse(data);
+}
+```
+
+LLM 프롬프트는 ISO 14971 용어(hazard/sequence/situation/harm)로 구조화 출력을 강제하고, 각 항목에 표준 조항 또는 이상사례 citation을 요구한다.
+
+### 4.2 risk-evaluation.ts (Group B)
+
+```typescript
+// severity × probability → 위험도 수준 (조직 설정 매트릭스 기반, REQ-RISK-012,013)
+export function evaluateRiskLevel(
+  severity: number,    // 1~5
+  probability: number, // 1~5
+  matrix?: RiskAcceptabilityMatrix, // 조직 override
+): RiskLevel {
+  validateScale(severity); validateScale(probability); // REQ-RISK-018
+  return (matrix ?? DEFAULT_RISK_MATRIX)[severity - 1][probability - 1];
+}
+
+export const DEFAULT_RISK_MATRIX: RiskLevel[][] = /* research.md §2.1 5×5 */;
+```
+
+### 4.3 control-recommendation.ts (Group C)
+
+```typescript
+// ISO 14971 §7.1 3계층 통제 추천 + RAG 유사 사례
+export async function recommendControls(riskItem: RiskItem): Promise<{
+  inherent_safety: ControlCandidate[];
+  protective_measure: ControlCandidate[];
+  information_safety: ControlCandidate[];
+}> {
+  const ragFetch = createHybridRaFetch();
+  const res = await ragFetch('/rag/query', { /* 유사 기기 통제 사례 query */ });
+  // 3계층 각각 ≥1 후보 시도, 전부 0개면 빈 결과 → API에서 manual fallback (REQ-RISK-028)
+}
+```
+
+### 4.4 residual-risk.ts (Group C)
+
+```typescript
+// 통제 후 잔류 위험 재산정 (REQ-RISK-024,025)
+export function evaluateResidualRisk(input: {
+  residualSeverity: number; residualProbability: number;
+  matrix?: RiskAcceptabilityMatrix;
+}): { level: RiskLevel; requiresFurtherAction: boolean };
+```
+
+### 4.5 report-builder.ts (Group D)
+
+```typescript
+// ISO 14971 구조 DOCX 생성 (docx@^9.7.1, REQ-RISK-031,032,033,034)
+export async function buildRiskReport(run: RiskRunAggregate): Promise<Buffer> {
+  // 섹션: 1.위험관리 계획 2.위험 분석 3.위험 평가 4.위험 통제
+  //       5.전체 잔류 위험 6.GSPR 매핑 테이블 7.결론
+  // 미승인 run → "DRAFT — Not Approved" 워터마크 (REQ-RISK-034)
+  // 모든 위험 항목 citation 표기 (REQ-RISK-033)
+}
+```
+
+---
+
+## 5. UI Components
+
+`app/(app)/workflows/risk/`에 위저드 + `components/risk/`에 재사용 컴포넌트.
+
+### 5.1 페이지 구조
+
+```
+app/(app)/workflows/risk/
+├── page.tsx                  # 위험관리 run 목록 + 신규 생성
+├── [runId]/
+│   └── page.tsx              # 4단계 위저드 (식별→분석→통제→보고서)
+```
+
+### 5.2 컴포넌트
+
+| 컴포넌트 | REQ | 설명 |
+|----------|-----|------|
+| `RiskWizard.tsx` | 008,014,019 | 4단계 stepper, 단계 순서 강제 |
+| `HazardIdentificationStep.tsx` | 001,007,009 | 기기 설명 입력 + 생성 + 항목 편집 + citation 표시 |
+| `RiskMatrix.tsx` | 011,016,017 | 5×5 grid, 색상 코딩, 셀 배지 |
+| `RiskMatrixCell.tsx` | 012,016 | 셀 (위험도 색상 + 항목 수) |
+| `RiskAnalysisStep.tsx` | 012,015,019 | severity/prob 선택 + ALARP justification |
+| `ControlRecommendationStep.tsx` | 021,023,028 | 3계층 통제 후보 + 채택 + manual fallback |
+| `ResidualRiskPanel.tsx` | 024,025,027 | 잔류 위험 재산정 + 신규 위험 확인 |
+| `GsprMappingStep.tsx` | 032 | GSPR 매핑 테이블 편집 |
+| `RiskReportStep.tsx` | 031,034 | export 버튼 (draft 워터마크 안내) |
+| `ExpertReviewGate.tsx` | 003,034,035,036 | RA-lead 승인 버튼 (권한 분기) |
+| `CitationBadge.tsx` | 009,033 | 클릭 가능 citation (CER Builder 재사용) |
+
+TanStack Query 훅: `useRiskRun(runId)`, `useIdentifyHazards()`, `useEvaluateRisk()`, `useRecommendControls()`, `useApproveRiskRun()`.
+
+### 5.3 expert review gate UI 로직
+
+- run.status !== 'approved' → 모든 단계 결과 "provisional/draft" 배지 (REQ-RISK-019,030)
+- 승인 버튼은 `usePermission('risk.approve')` true (RA-lead)일 때만 활성 (REQ-RISK-036)
+- 미검토 항목 존재 시 승인 버튼 disabled + 안내 (REQ-RISK-003)
+
+---
+
+## 6. RAG 파이프라인
+
+```
+기기 설명/위험 항목
+   │
+   ▼ buildPrompt() — ISO 14971 용어 구조화 + citation 요구
+createHybridRaFetch('/rag/query', { query, top_k, filter })
+   │  (Bearer auth, server-side only)
+   ▼
+RagQueryResponse { answer, citations[], confidence }
+   │
+   ▼ parse — RiskItem[] / ControlCandidate[]
+   │  citation 매핑 (RagCitation → RiskCitation)
+   │  confidence<0.6 → lowConfidence 플래그
+   ▼
+DB 저장 + audit_logs(risk.identify.generate, confidence)
+```
+
+graceful degradation: RAG 실패/빈 응답 → manual 입력 fallback (REQ-RISK-028). HybridRaClientError는 BFF에서 statusCode 그대로 반환.
+
+---
+
+## 7. 감사 추적 (audit_logs)
+
+모든 위험 판단·변경은 append-only audit_logs 기록 (21 CFR Part 11). 신규 action: `risk.identify.generate`, `risk.item.edit`, `risk.analysis.update`, `risk.control.decide`, `risk.approve`, `risk.export`. metaJson에 변경 전/후, confidence, 사유 포함.
+
+---
+
+## 8. promptfoo Eval (Group G7)
+
+`evals/risk/` (또는 기존 promptfoo 디렉터리 컨벤션 따름):
+- `risk-identification.yaml`: 인슐린 펌프·인공호흡기 기기 설명 → 생성 위험 목록을 ground truth(research.md §4)와 비교, hazard recall + 통제 계층 적합성 측정
+- pass threshold: 정확도 >85% (AC7)
+- assertion: 알려진 critical hazard 포함 여부, 통제 계층 우선순위 준수, citation 존재

--- a/.moai/specs/SPEC-REGULA-RISK-001/research.md
+++ b/.moai/specs/SPEC-REGULA-RISK-001/research.md
@@ -1,0 +1,182 @@
+# SPEC-REGULA-RISK-001 — Domain Research
+
+> ISO 14971:2019 위험관리, EU MDR GSPR 매핑, 위험 매트릭스 패턴 도메인 조사.
+> 본 문서는 spec.md의 규제 근거를 뒷받침하는 배경 자료이며, 구현은 design.md/tasks.md를 따른다.
+
+---
+
+## 1. ISO 14971:2019 위험관리 프로세스
+
+### 1.1 프로세스 개요
+
+ISO 14971:2019는 의료기기 위험관리를 다음 단계로 정의한다 (top-down):
+
+| 단계 | ISO 14971:2019 조항 | 내용 | 본 SPEC 매핑 |
+|------|---------------------|------|--------------|
+| 위험관리 계획 | §4.4 | 계획 수립, 허용 기준 정의 | 조직 설정 / run 메타 |
+| 위험 분석 | §5 | 의도 사용, hazard 식별, 위험 추정 | Group A (식별) + Group B (추정) |
+| 위험 평가 | §6 | 허용 가능 위험 판단 | Group B (매트릭스 분류) |
+| 위험 통제 | §7 | 통제 옵션 분석·실행·잔류 위험 | Group C |
+| 전체 잔류 위험 평가 | §8 | 종합 잔류 위험 + 편익 분석 | Group C + Group D 보고서 |
+| 위험관리 보고서 | §9 | RMF 검토·결론 | Group D |
+| 생산·시판후 활동 | §10 | PMS 피드백 | Non-Goal (Vigilance cross-link) |
+
+### 1.2 핵심 용어 (§3 Terms)
+
+- **Hazard**: 잠재적 harm의 원천
+- **Hazardous situation**: 사람·재산·환경이 하나 이상의 hazard에 노출된 상황
+- **Sequence of events**: hazard → hazardous situation으로 이어지는 사건 연쇄
+- **Harm**: 사람의 건강 손상, 재산·환경 피해
+- **Severity**: harm의 가능한 결과의 정도
+- **Probability of occurrence of harm**: harm 발생 확률 (P1 hazardous situation 발생 × P2 hazardous situation → harm 전이)
+- **Residual risk**: 위험 통제 조치 이후 남은 위험
+
+> 구현 함의: 위험 항목 스키마는 hazard / sequence_of_events / hazardous_situation / harm 4필드를 분리 저장해야 한다 (REQ-RISK-006).
+
+### 1.3 §7.1 위험 통제 옵션 우선순위 (Risk Control Option Hierarchy)
+
+ISO 14971:2019 §7.1은 통제 옵션을 **반드시 다음 우선순위 순서로** 고려할 것을 요구한다:
+
+1. **Inherently safe design and manufacture** (본질적 안전 설계) — 최우선
+2. **Protective measures in the device itself or in the manufacturing process** (보호 조치)
+3. **Information for safety** (안전 정보 제공: 경고, IFU, 라벨) — 최후 수단
+
+> 구현 함의: 통제 추천(REQ-RISK-021)은 3계층 각각에 후보를 생성해야 하며, information-only 통제 채택 시 상위 계층 미적용 사유를 강제(REQ-RISK-023)해야 한다.
+
+### 1.4 Annex E — 위험 개념 (Severity / Probability 분류)
+
+Annex E는 정성적/반정량적 척도 예시를 제공한다. 본 SPEC은 5단계 척도를 채택한다:
+
+**Severity (심각도) 5단계 예시:**
+
+| 레벨 | 라벨 | 정의 |
+|------|------|------|
+| 5 | Catastrophic | 사망 |
+| 4 | Critical | 영구적 손상 / 생명 위협 |
+| 3 | Serious | 의료 개입 필요한 손상 |
+| 2 | Minor | 경미, 일시적 손상 |
+| 1 | Negligible | 불편, 손상 없음 |
+
+**Probability (발생 확률) 5단계 예시:**
+
+| 레벨 | 라벨 | 정의 (빈도 예시) |
+|------|------|-------------------|
+| 5 | Frequent | 빈번 (≥ 10⁻³) |
+| 4 | Probable | 가능 (10⁻³ ~ 10⁻⁴) |
+| 3 | Occasional | 가끔 (10⁻⁴ ~ 10⁻⁵) |
+| 2 | Remote | 드묾 (10⁻⁵ ~ 10⁻⁶) |
+| 1 | Improbable | 거의 없음 (< 10⁻⁶) |
+
+> 구현 함의: 척도 라벨/빈도 임계값은 ISO/TR 24971 권고대로 제조자(조직) 설정이어야 한다 (REQ-RISK-013). 본 SPEC은 기본값을 제공하되 조직 override를 허용한다.
+
+---
+
+## 2. 위험 매트릭스(Risk Acceptability Matrix) 패턴
+
+### 2.1 5×5 매트릭스 위험도 영역 (3-tier)
+
+업계 표준 3-tier 분류 (ISO/TR 24971 Annex C 예시 기반):
+
+```
+Probability →
+Severity ↓   1(Improb) 2(Remote) 3(Occas) 4(Prob)  5(Freq)
+5 (Catastr)    ALARP     UNACC     UNACC    UNACC    UNACC
+4 (Critical)   ACC       ALARP     UNACC    UNACC    UNACC
+3 (Serious)    ACC       ALARP     ALARP    UNACC    UNACC
+2 (Minor)      ACC       ACC       ALARP    ALARP    UNACC
+1 (Negligible) ACC       ACC       ACC      ALARP    ALARP
+```
+
+- **ACC (Acceptable)**: 추가 통제 불필요 (그러나 ALARP 검토 권장)
+- **ALARP (As Low As Reasonably Practicable)**: 합리적으로 실행 가능한 한 위험 저감 + 편익 정당화
+- **UNACC (Unacceptable)**: 통제 필수, 미통제 시 출시 불가
+
+> 구현 함의:
+> - REQ-RISK-012 자동 분류 로직은 위 매트릭스를 데이터로 표현 (조직 설정 가능).
+> - REQ-RISK-014: ALARP/UNACC는 통제 강제.
+> - REQ-RISK-016: 색상 코딩 (ACC=녹, ALARP=황, UNACC=적).
+
+### 2.2 ALARP 판단 요구사항
+
+- 허용 가능(acceptable) 판단 시 justification 필수 (REQ-RISK-015)
+- ALARP 영역: "더 낮출 수 없거나, 추가 저감 비용이 편익에 비해 과도하게 불균형함"을 입증해야 함
+
+---
+
+## 3. EU MDR GSPR 매핑
+
+### 3.1 GSPR (Annex I) 구조
+
+EU MDR Annex I — General Safety and Performance Requirements:
+
+- **Chapter I (§1~§9)**: General requirements
+  - §1: 의도 성능 달성, 환자·사용자 안전
+  - §2: risk reduction (가능한 한 위험 제거/저감)
+  - §3: **위험관리 시스템 (ISO 14971 직접 참조 지점)**
+  - §4: risk control measures
+  - §5: risks related to use error
+  - §8: 감염·미생물 오염
+  - §9: 에너지·물질 관련 위험
+- **Chapter II (§10~§22)**: Design and manufacture requirements
+- **Chapter III (§23)**: Information supplied with the device (라벨/IFU)
+
+### 3.2 위험 통제 → GSPR 매핑 패턴
+
+보고서의 GSPR 매핑 테이블(REQ-RISK-032)은 각 식별 위험·통제를 해당 GSPR 항목으로 연결:
+
+| 위험 항목 ID | 통제 조치 | 관련 GSPR | 적합성 근거 |
+|--------------|-----------|-----------|-------------|
+| RISK-A-001 | 본질적 안전 설계 X | GSPR §4 | 통제 후 잔류 위험 ACC |
+| RISK-A-002 | 사용 오류 경고 라벨 | GSPR §5, §23 | IFU 섹션 Y |
+
+> 구현 함의: `risk_gspr_mappings` 테이블 (risk_item_id, control_id, gspr_clause, justification). RA-lead 검토 후 확정 (자동 승인 금지, R4).
+
+---
+
+## 4. 참조 기기 도메인 (promptfoo eval 대상)
+
+### 4.1 인슐린 펌프 (Insulin Pump) — 대표 위험
+
+- **Over-delivery (과다 주입)**: severity=5 (저혈당 사망), 통제 = occlusion sensor + dose limit (본질적 설계)
+- **Under-delivery (과소 주입)**: severity=4 (고혈당/DKA), 통제 = flow sensor + alarm (보호 조치)
+- **Use error (잘못된 용량 설정)**: severity=4, 통제 = confirmation UI + IFU (정보 제공)
+- **Software failure**: severity=5, 통제 = watchdog + fail-safe (본질적 설계)
+- 관련 표준: IEC 60601-2-24 (infusion pump), IEC 62304 (software)
+
+### 4.2 인공호흡기 (Ventilator) — 대표 위험
+
+- **Apnea / failure to ventilate (환기 실패)**: severity=5, 통제 = backup ventilation mode (보호 조치)
+- **Over-pressure (기압 손상, barotrauma)**: severity=4, 통제 = pressure relief valve (본질적 설계)
+- **Disconnection (회로 분리)**: severity=5, 통제 = disconnect alarm (보호 조치)
+- **Power failure**: severity=5, 통제 = battery backup (본질적 설계)
+- 관련 표준: ISO 80601-2-12 (critical care ventilator), IEC 62304
+
+> 구현 함의: promptfoo eval suite는 위 기기들의 알려진 위험 프로파일을 ground truth로 사용하여, 생성된 위험관리 계획의 hazard 식별 recall과 통제 계층 적합성을 측정 (>85%).
+
+---
+
+## 5. 기존 코드베이스 재사용 분석
+
+| 재사용 대상 | 출처 | RISK 적용 |
+|-------------|------|-----------|
+| `workflowRuns` multi-step run 모델 | `lib/db/schema.ts` | `risk` workflow type 추가 |
+| `expertReviews` + review gate | `lib/db/schema.ts` | RA-lead 승인 게이트 |
+| `auditLogs` append-only (21 CFR Part 11) | `lib/db/schema.ts` | risk.* audit actions |
+| `cerLiterature` child-table cascade 패턴 | `lib/db/schema.ts` | risk_items/controls/gspr_mappings |
+| `createHybridRaFetch` + Rag* 타입 | `lib/api/hybrid-ra-client.ts` | 위험 식별·통제 RAG |
+| `withPermission` BFF wrapper | `lib/auth/with-permission.ts` | risk.* permission |
+| DOCX export (`docx@^9.7.1`) | CER Builder (SPEC-REGULA-CER-001) | ISO 14971 보고서 |
+| BFF proxy route 패턴 | `app/api/ra/checklists/generate/route.ts` | `app/api/ra/risk/*` |
+
+> 결론: RISK 모듈은 신규 인프라 없이 CER Builder 패턴을 확장한다. 신규는 (1) risk 도메인 로직(lib/risk/*), (2) 매트릭스 UI 컴포넌트, (3) 3개 child 테이블, (4) risk.* audit/permission이다.
+
+---
+
+## 6. 참고 표준·문헌
+
+- ISO 14971:2019 — Medical devices — Application of risk management to medical devices
+- ISO/TR 24971:2020 — Guidance on the application of ISO 14971
+- Regulation (EU) 2017/745 (MDR) — Annex I (GSPR)
+- IEC 62304 — Medical device software lifecycle
+- IEC 60601-2-24 — Infusion pumps / ISO 80601-2-12 — Critical care ventilators
+- US FDA 21 CFR Part 11 — Electronic records (audit trail 근거)

--- a/.moai/specs/SPEC-REGULA-RISK-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-RISK-001/spec.md
@@ -1,0 +1,355 @@
+---
+id: SPEC-REGULA-RISK-001
+version: 1.0.0
+status: draft
+phase: wave4
+priority: Medium
+created: 2026-06-20
+updated: 2026-06-20
+author: manager-spec (Regula harness)
+issue_number: 46
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-WORKFLOWS-001
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-REGULA-CER-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+  - priority/medium
+---
+
+# SPEC-REGULA-RISK-001 — ISO 14971 위험관리 통합 (위험 식별·분석 매트릭스·통제 조치 추천)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-20 | manager-spec (Regula harness) | 초기 작성. Wave 4 SPEC, Issue #46 기반. 36 REQ (4 group: 위험 식별 / 분석 매트릭스 / 통제 조치 / 보고서·GSPR). CER Builder(SPEC-REGULA-CER-001) workflow 패턴 재사용. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+**ISO 14971:2019 (Medical devices — Application of risk management to medical devices)** 는 의료기기 전 생애주기에 걸친 위험관리를 의무화하는 국제 표준이다. EU MDR(Regulation (EU) 2017/745) **Annex I (General Safety and Performance Requirements, GSPR)** 의 §3은 제조자가 ISO 14971에 부합하는 위험관리 시스템을 수립·문서화·유지할 것을 명시적으로 요구하며, FDA 역시 510(k)/PMA 심사 시 위험관리 파일(Risk Management File, RMF)을 핵심 검토 자료로 삼는다.
+
+현재 Regula 운영 환경에서 RA 담당자는 다음과 같은 어려움을 겪는다:
+
+- **위험 식별(hazard identification)** 을 수작업 브레인스토밍에 의존하여 누락 위험(특히 기기 특성상 잘 드러나지 않는 use error, software failure)이 빈번하다.
+- **위험 분석 매트릭스(severity × probability)** 의 위험도 수준 분류를 일관성 없이 정성적으로 판단한다.
+- **ISO 14971:2019 §6.2 위험 통제 계층(risk control option hierarchy)** 순서(inherent safety by design → protective measures → information for safety)를 매번 수동으로 적용해야 한다.
+- 유사 기기의 이상사례(MAUDE 등)와 통제 사례를 별도 검색해야 한다.
+- ISO 14971 구조에 맞는 **위험관리 보고서** 작성과 EU MDR GSPR 매핑에 1건당 수십 시간이 소요된다.
+
+본 SPEC은 Wave 4에서 위 작업을 **반자동화(semi-automated)** 하는 ISO 14971 위험관리 모듈을 구축한다. 자동화 대상은 (1) 기기 기능 설명 → RAG 기반 위험 식별 목록 생성, (2) 심각도×발생 확률 매트릭스 UI 및 ISO 14971 Annex E 기준 위험도 분류, (3) §6.2 통제 계층 기반 통제 조치 추천 + 잔류 위험 평가, (4) ISO 14971 구조 준수 보고서 DOCX export + EU MDR GSPR 매핑이다.
+
+**법적 책임이 따르는 위험 판단(허용 가능 위험, 잔류 위험 수용, 최종 보고서)은 모두 expert review gate를 통해 RA-lead 승인 후에만 "approved" 상태로 전환된다.** LLM/RAG는 draft 생성과 보조에만 사용되며, 자동 승인은 발생하지 않는다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- **ISO 14971:2019** — 위험관리 프로세스 전반
+  - §5 Risk analysis (위험 분석: 의도된 사용, hazard 식별, 위험 추정)
+  - §6 Risk evaluation (위험 평가: 허용 가능 위험 판단)
+  - §6.2 (편의상 표기; 2019 판 §7) Risk control option analysis — 통제 계층 우선순위
+  - §7 Risk control (통제 조치 실행, 잔류 위험 평가)
+  - §8 Evaluation of overall residual risk
+  - Annex C — 위험 분석 기법 / Annex E — 위험 개념 (severity/probability 분류 가이드)
+- **ISO/TR 24971:2020** — ISO 14971 적용 가이드 (severity/probability 척도 설계 참조)
+- **EU MDR Annex I (GSPR)** §1~§9 — 위험 통제 결과와의 매핑 대상
+- **ALARP 원칙** (As Low As Reasonably Practicable) — 잔류 위험 수용 판단 기준
+
+> 주의: ISO 14971:2019 판은 통제 조치를 §7로 두고, 통제 옵션 우선순위(inherent safety → protective measures → information for safety)를 §7.1에서 규정한다. Issue #46이 "§6.2"로 표기한 통제 계층 요구사항은 본 SPEC에서 ISO 14971:2019 §7.1의 통제 옵션 우선순위로 해석하여 구현한다. 보고서 섹션 라벨은 사용자가 채택한 판본에 맞춰 설정 가능해야 한다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 위험관리 위저드 UI (`app/(app)/workflows/risk/page.tsx`)
+- 기기 기능 설명 → RAG 기반 위험 식별 (`lib/risk/hazard-identification.ts`, hybrid-ra-saas `POST /rag/query`)
+- 심각도 × 발생 확률 매트릭스 grid UI (`components/risk/RiskMatrix.tsx`)
+- ISO 14971 Annex E 기준 위험도 수준 분류 + ALARP 판단 (`lib/risk/risk-evaluation.ts`)
+- 통제 조치 추천 (ISO 14971 §7.1 계층 + RAG 유사 사례, `lib/risk/control-recommendation.ts`)
+- 잔류 위험 평가 (`lib/risk/residual-risk.ts`)
+- ISO 14971 구조 준수 보고서 DOCX export + EU MDR GSPR 매핑 섹션 (`lib/risk/report-builder.ts`)
+- expert review gate (모든 위험 판단 RA-lead 승인)
+- BFF proxy route handlers (`app/api/ra/risk/*`)
+- DB schema 확장 (`risk` workflow type + `risk_items`, `risk_controls`, `risk_gspr_mappings` 테이블)
+- promptfoo eval (인슐린 펌프, 인공호흡기 2개 기기 정확도 >85%)
+
+---
+
+## §2 Goals and Non-Goals
+
+### 2.1 Goals
+
+| # | Goal | 성공 지표 (KPI) |
+|---|------|-----------------|
+| G1 | 기기 기능 설명 → 위험 식별 목록 자동 생성 | 식별 항목 100%에 citation(표준 조항 또는 유사 기기 이상사례) 포함 |
+| G2 | 위험 분석 매트릭스 UI | severity(1~5) × probability(1~5) grid + ISO 14971 Annex E 위험도 수준 자동 분류 |
+| G3 | 통제 조치 추천 | ISO 14971 §7.1 3계층 순서 강제 + 계층별 ≥1 추천 + RAG 유사 사례 |
+| G4 | 잔류 위험 평가 | 통제 후 재산정된 severity×probability + ALARP 판단 100% 기록 |
+| G5 | ISO 14971 구조 준수 보고서 DOCX export | 보고서에 ISO 14971 필수 섹션 + EU MDR GSPR 매핑 테이블 포함 |
+| G6 | expert review gate | 모든 위험 판단(허용 가능/잔류 위험/최종 보고서)은 RA-lead 승인 후 approved 전환 |
+| G7 | promptfoo eval 정확도 | 인슐린 펌프·인공호흡기 위험관리 계획 생성 정확도 >85% |
+
+### 2.2 Non-Goals (Exclusions — What NOT to Build)
+
+> [HARD] 본 SPEC은 다음을 명시적으로 구현 범위에서 제외한다. 이는 범위 이탈(scope creep) 방지를 위한 계약이다.
+
+- **FMEA 자동화 (Failure Mode and Effects Analysis)**: FMEA는 별도 분석 기법으로, RPN(Risk Priority Number) 계산·worksheet 자동화는 본 SPEC 범위 밖이다. 본 SPEC은 ISO 14971 top-down 위험관리만 다룬다.
+- **real-time 협업 편집**: 위험 항목/매트릭스의 다중 사용자 동시 편집은 SPEC-REGULA-COEDIT-001 범위이다. 본 SPEC은 단일 편집 세션을 가정한다.
+- **위험 라이브러리 관리(reusable hazard library)**: 조직 차원의 재사용 가능한 hazard/control 라이브러리 CRUD·버전 관리는 별도 이슈 범위이다. 본 SPEC은 workflow run 단위 위험 항목만 저장한다.
+- **위험 자동 승인(auto-approval)**: 모든 최종 위험 판단은 RA-lead의 명시적 승인이 필요하다. LLM은 draft 생성·보조에만 사용된다.
+- **MAUDE/이상사례 DB 직접 실시간 통합**: 유사 기기 이상사례는 hybrid-ra-saas에 색인된 RAG 코퍼스를 통해서만 인용한다. 외부 FDA MAUDE API 실시간 조회는 본 SPEC 범위 밖이다.
+- **Notified Body / 규제기관 직접 제출**: 보고서는 DOCX로 출력되어 사용자가 별도 채널로 제출한다. EUDAMED 등 직접 통합은 범위 밖이다.
+- **PMS/Vigilance 데이터 자동 통합**: 시판 후 위험 데이터 자동 갱신은 SPEC-REGULA-VIGILANCE 계열 범위이며 본 SPEC은 cross-link만 제공한다.
+
+---
+
+## §3 Functional Requirements (36 REQ, EARS Format)
+
+각 REQ는 다음 구조를 따른다: EARS 문장 / 근거(rationale) / 검증 방법(verification).
+
+### Group A — 위험 식별 지원 (REQ-RISK-001 ~ REQ-RISK-010)
+
+**REQ-RISK-001** (Event-Driven)
+WHEN 사용자가 기기 기능 설명 텍스트를 입력하고 "위험 식별 생성"을 실행하면, THEN the system SHALL hybrid-ra-saas `POST /rag/query`를 호출하여 위험 식별 후보 목록(hazard, hazardous situation, harm)을 생성한다.
+- 근거: ISO 14971 §5.3 hazard 식별 의무. RAG로 누락 위험 최소화.
+- 검증: 기기 설명 입력 → ≥1 위험 항목 반환 통합 테스트.
+
+**REQ-RISK-002** (Ubiquitous)
+The system SHALL 모든 위험 식별 항목에 최소 1개의 citation(관련 표준 조항 ID 또는 유사 기기 이상사례 source_id)을 첨부한다.
+- 근거: 추적성(traceability)과 근거 기반 위험관리. Issue #46 completion criteria.
+- 검증: citation 없는 위험 항목 생성 시도 → 검증 실패(저장 차단) 테스트.
+
+**REQ-RISK-003** (State-Driven)
+WHILE 위험 식별 결과가 미검토(draft) 상태인 동안, the system SHALL 해당 위험관리 run을 "approved" 상태로 전환하지 못하도록 차단한다.
+- 근거: expert review gate. 미검토 위험 판단의 승인 방지.
+- 검증: 미검토 run에 approve 요청 → 422 반환 테스트.
+
+**REQ-RISK-004** (Event-Driven)
+WHEN RAG 응답의 confidence가 임계값(기본 0.6) 미만이면, THEN the system SHALL 해당 위험 항목을 "low confidence" 플래그로 표시하고 RA 리드 검토를 강제한다.
+- 근거: 저신뢰 자동 생성 결과의 무비판적 채택 방지.
+- 검증: confidence<0.6 mock 응답 → low_confidence 플래그 true 단위 테스트.
+
+**REQ-RISK-005** (Optional)
+WHERE 기기 분류 정보(device class)가 입력되면, the system SHALL RAG filter에 device class를 전달하여 위험 식별 정확도를 높인다.
+- 근거: 분류별 위험 프로파일 차이 반영.
+- 검증: filter 파라미터가 RAG 요청에 포함되는지 단위 테스트.
+
+**REQ-RISK-006** (Ubiquitous)
+The system SHALL 각 위험 항목을 ISO 14971 용어 체계(hazard / sequence of events / hazardous situation / harm)로 구조화하여 저장한다.
+- 근거: ISO 14971 §3 용어 정의 준수.
+- 검증: 위험 항목 스키마 필드 존재 검증.
+
+**REQ-RISK-007** (Event-Driven)
+WHEN 사용자가 자동 생성된 위험 항목을 수정·삭제·추가하면, THEN the system SHALL 변경을 즉시 저장하고 audit_logs에 `risk.item.edit` 액션을 기록한다.
+- 근거: 21 CFR Part 11 감사 추적. 사용자 override 100% 보장.
+- 검증: 위험 항목 수정 → audit_logs 기록 통합 테스트.
+
+**REQ-RISK-008** (Unwanted)
+IF 사용자가 위험 식별 단계를 건너뛰고 위험 분석(매트릭스) 단계로 진행하려 하면, THEN the system SHALL 진행을 차단하고 "위험 항목 ≥1개 필요" 메시지를 표시한다.
+- 근거: 빈 위험 분석 방지. 단계 순서 강제.
+- 검증: 위험 항목 0개 상태 → 분석 단계 진입 차단 테스트.
+
+**REQ-RISK-009** (State-Driven)
+WHILE 위험 식별 결과를 표시하는 동안, the system SHALL 각 항목별로 출처 citation을 클릭 가능한 형태로 렌더링한다.
+- 근거: 검토자의 근거 확인 편의.
+- 검증: citation 클릭 → source 상세 표시 E2E 테스트.
+
+**REQ-RISK-010** (Ubiquitous)
+The system SHALL 위험 식별 RAG 호출 시 `audit_logs`에 `risk.identify.generate` 액션과 RAG confidence를 기록한다.
+- 근거: LLM 호출 추적성.
+- 검증: 식별 생성 → audit 기록 확인 테스트.
+
+### Group B — 위험 분석 매트릭스 (REQ-RISK-011 ~ REQ-RISK-020)
+
+**REQ-RISK-011** (Ubiquitous)
+The system SHALL 심각도(severity, 1~5) × 발생 확률(probability, 1~5)의 5×5 grid 매트릭스 UI를 제공한다.
+- 근거: ISO 14971 §5.5 위험 추정. Annex E 척도.
+- 검증: RiskMatrix 컴포넌트 25셀 렌더링 컴포넌트 테스트.
+
+**REQ-RISK-012** (Event-Driven)
+WHEN 사용자가 위험 항목의 severity와 probability를 선택하면, THEN the system SHALL ISO 14971 Annex E 기준 위험도 수준(예: acceptable / ALARP / unacceptable)을 자동 분류하여 표시한다.
+- 근거: 일관된 위험도 분류. 정성 판단 편차 제거.
+- 검증: (severity=5, probability=4) → "unacceptable" 분류 단위 테스트.
+
+**REQ-RISK-013** (Ubiquitous)
+The system SHALL 위험도 수준 분류 임계값(risk acceptability matrix)을 조직 설정으로 구성 가능하게 한다.
+- 근거: ISO/TR 24971 — 척도·임계값은 제조자가 정의. 조직별 정책 반영.
+- 검증: 임계값 설정 변경 → 분류 결과 반영 단위 테스트.
+
+**REQ-RISK-014** (State-Driven)
+WHILE 위험도가 "unacceptable" 또는 "ALARP" 인 동안, the system SHALL 해당 위험 항목에 통제 조치 입력을 강제(required)한다.
+- 근거: ISO 14971 §7 — 허용 불가/ALARP 위험은 통제 필요.
+- 검증: unacceptable 항목에 통제 없이 진행 → 차단 테스트.
+
+**REQ-RISK-015** (Event-Driven)
+WHEN 사용자가 위험 항목의 허용 가능 위험(acceptable) 여부를 판단하면, THEN the system SHALL ALARP 원칙 적용 근거(justification) 텍스트 입력을 요구한다.
+- 근거: ALARP 판단의 문서화 의무.
+- 검증: 허용 판단 시 justification 미입력 → 저장 차단 테스트.
+
+**REQ-RISK-016** (Ubiquitous)
+The system SHALL 매트릭스를 색상 코딩(녹/황/적)으로 위험도 수준을 시각화한다.
+- 근거: 검토자의 직관적 위험 인지.
+- 검증: 위험도별 셀 색상 클래스 컴포넌트 테스트.
+
+**REQ-RISK-017** (Event-Driven)
+WHEN 다수 위험 항목이 동일 (severity, probability) 셀에 위치하면, THEN the system SHALL 해당 셀에 항목 수를 배지로 표시한다.
+- 근거: 위험 집중 영역 가시화.
+- 검증: 동일 셀 2개 항목 → "2" 배지 렌더링 테스트.
+
+**REQ-RISK-018** (Unwanted)
+IF 사용자가 severity 또는 probability를 정의된 범위(1~5) 밖 값으로 설정하려 하면, THEN the system SHALL 입력을 거부한다.
+- 근거: 척도 무결성.
+- 검증: severity=6 입력 → 검증 실패 단위 테스트.
+
+**REQ-RISK-019** (State-Driven)
+WHILE 위험 분석 결과가 미검토 상태인 동안, the system SHALL 매트릭스 분류 결과를 잠정(provisional)으로 표시한다.
+- 근거: 미승인 분류의 확정 오인 방지.
+- 검증: 미검토 run → provisional 라벨 표시 E2E 테스트.
+
+**REQ-RISK-020** (Ubiquitous)
+The system SHALL 각 위험 항목의 severity·probability·위험도 수준 변경 이력을 audit_logs에 `risk.analysis.update` 액션으로 기록한다.
+- 근거: 위험 판단 추적성.
+- 검증: severity 변경 → audit 기록 테스트.
+
+### Group C — 위험 통제 조치 추천 (REQ-RISK-021 ~ REQ-RISK-030)
+
+**REQ-RISK-021** (Event-Driven)
+WHEN 사용자가 위험 항목에 대한 통제 조치 추천을 요청하면, THEN the system SHALL ISO 14971 §7.1 통제 옵션 우선순위(inherent safety by design → protective measures → information for safety) 3계층 각각에 대해 통제 후보를 생성한다.
+- 근거: ISO 14971 §7.1 — 통제 옵션은 우선순위 순서로 고려해야 함.
+- 검증: 통제 추천 → 3계층 모두 반환 통합 테스트.
+
+**REQ-RISK-022** (Ubiquitous)
+The system SHALL 통제 조치 추천 시 hybrid-ra-saas RAG를 통해 유사 기기의 통제 사례를 인용(citation 포함)하여 함께 제시한다.
+- 근거: 근거 기반 통제 설계. Issue #46 §C.
+- 검증: 통제 추천 응답에 RAG citation 포함 테스트.
+
+**REQ-RISK-023** (State-Driven)
+WHILE 통제 옵션 우선순위를 적용하는 동안, the system SHALL information for safety(라벨/IFU)를 단독 통제로 채택할 경우 상위 계층(inherent/protective) 미적용 사유 입력을 요구한다.
+- 근거: ISO 14971 §7.1 — 정보 제공은 최후 수단. 상위 계층 우선 검토 의무.
+- 검증: information-only 통제 선택 + 사유 미입력 → 저장 차단 테스트.
+
+**REQ-RISK-024** (Event-Driven)
+WHEN 사용자가 통제 조치를 채택하면, THEN the system SHALL 통제 후 잔류 위험(residual severity × residual probability)을 재산정하도록 요구한다.
+- 근거: ISO 14971 §7.4 — 통제 후 잔류 위험 평가 의무.
+- 검증: 통제 채택 → residual risk 입력 필드 활성화 E2E 테스트.
+
+**REQ-RISK-025** (State-Driven)
+WHILE 잔류 위험이 여전히 "unacceptable" 인 동안, the system SHALL 추가 통제 조치 또는 위험/편익 분석(risk-benefit analysis) 근거를 요구한다.
+- 근거: ISO 14971 §7.4/§8 — 허용 불가 잔류 위험은 추가 통제 또는 편익 정당화 필요.
+- 검증: residual unacceptable + 추가 통제·편익 미입력 → 차단 테스트.
+
+**REQ-RISK-026** (Ubiquitous)
+The system SHALL 각 통제 조치를 그것이 완화하는 위험 항목과 연결(traceability)하여 저장한다.
+- 근거: ISO 14971 — 위험-통제 추적성. RMF 무결성.
+- 검증: 통제 ↔ 위험 항목 FK 관계 스키마 검증.
+
+**REQ-RISK-027** (Event-Driven)
+WHEN 새 통제 조치가 새로운 위험(통제 자체가 유발하는 위험)을 발생시킬 수 있으면, THEN the system SHALL "통제 유발 위험" 여부 확인을 사용자에게 요청한다.
+- 근거: ISO 14971 §7.2 — 통제 조치가 새 위험을 만들 수 있음.
+- 검증: 통제 채택 → 신규 위험 확인 프롬프트 표시 테스트.
+
+**REQ-RISK-028** (Unwanted)
+IF 통제 옵션 우선순위 3계층 모두에서 통제 후보가 0개로 생성되면, THEN the system SHALL 자동 추천 실패를 명시하고 수동 입력으로 fallback한다.
+- 근거: RAG/LLM 실패 시 graceful degradation. 작업 중단 방지.
+- 검증: 빈 통제 mock 응답 → 수동 입력 fallback UI 표시 테스트.
+
+**REQ-RISK-029** (Ubiquitous)
+The system SHALL 통제 조치의 채택/거부 결정과 사유를 audit_logs에 `risk.control.decide` 액션으로 기록한다.
+- 근거: 통제 결정 추적성.
+- 검증: 통제 채택 → audit 기록 테스트.
+
+**REQ-RISK-030** (State-Driven)
+WHILE 통제 조치 결과가 미검토 상태인 동안, the system SHALL 잔류 위험 평가 결과를 잠정으로 표시하고 보고서 export를 "draft" 워터마크로 제한한다.
+- 근거: 미승인 통제·잔류 위험의 확정본 오인 방지.
+- 검증: 미검토 run export → draft 워터마크 포함 E2E 테스트.
+
+### Group D — 위험관리 보고서 생성 및 GSPR 매핑 (REQ-RISK-031 ~ REQ-RISK-036)
+
+**REQ-RISK-031** (Event-Driven)
+WHEN 사용자가 위험관리 보고서 export를 요청하면, THEN the system SHALL ISO 14971 구조(위험관리 계획 / 위험 분석 / 위험 평가 / 위험 통제 / 전체 잔류 위험 평가 / 결론)를 준수하는 DOCX 문서를 생성한다.
+- 근거: ISO 14971 — RMF 구조. Issue #46 completion criteria.
+- 검증: export → DOCX 내 ISO 14971 필수 섹션 존재 통합 테스트.
+
+**REQ-RISK-032** (Ubiquitous)
+The system SHALL 보고서에 EU MDR GSPR(General Safety and Performance Requirements) 매핑 섹션을 포함하여, 각 식별 위험·통제를 해당 GSPR 항목과 연결한 테이블을 생성한다.
+- 근거: EU MDR Annex I 적합성 입증. Issue #46 §D.
+- 검증: export → DOCX 내 GSPR 매핑 테이블 존재 테스트.
+
+**REQ-RISK-033** (Ubiquitous)
+The system SHALL 보고서 내 모든 위험 항목에 citation(관련 표준 조항 또는 유사 기기 이상사례)을 표기한다.
+- 근거: 근거 추적성. Issue #46 §D.
+- 검증: export → 위험 항목별 citation 표기 테스트.
+
+**REQ-RISK-034** (State-Driven)
+WHILE 위험관리 run이 RA-lead의 expert review를 통과(approved)하지 않은 동안, the system SHALL 보고서 DOCX에 "DRAFT — Not Approved" 워터마크를 강제 삽입한다.
+- 근거: expert review gate. 미승인 보고서의 제출용 오인 방지.
+- 검증: 미승인 export → 워터마크 포함 / 승인 후 export → 워터마크 제거 E2E 테스트.
+
+**REQ-RISK-035** (Event-Driven)
+WHEN RA-lead가 위험관리 run을 승인(approve)하면, THEN the system SHALL workflow_runs.status를 approved로 전환하고 audit_logs에 `risk.approve` 액션을 기록한다.
+- 근거: expert review gate 완결. 승인 추적성.
+- 검증: RA-lead 승인 → status=approved + audit 기록 통합 테스트.
+
+**REQ-RISK-036** (Unwanted)
+IF RA-member(비 RA-lead) 사용자가 위험관리 run 승인을 시도하면, THEN the system SHALL 권한 거부(403)를 반환하고 audit_logs에 `rbac.permission_deny`를 기록한다.
+- 근거: RBAC. 승인 권한은 RA-lead 전용. Issue #46 — expert review gate.
+- 검증: ra-member 승인 요청 → 403 + audit 기록 통합 테스트.
+
+---
+
+## §4 Acceptance Criteria
+
+Issue #46 completion criteria에 1:1 대응한다. 상세 Given-When-Then 시나리오는 `acceptance.md` 참조.
+
+| # | Completion Criteria | 대응 REQ | 검증 방법 |
+|---|---------------------|----------|-----------|
+| AC1 | 기기 기능 설명 → 위험 식별 목록 자동 생성 (citation 포함) | REQ-RISK-001, 002 | 통합 테스트 + E2E |
+| AC2 | 위험도 매트릭스 UI (심각도 × 발생 확률 grid) | REQ-RISK-011, 012, 016 | 컴포넌트 + E2E |
+| AC3 | 위험 통제 조치 추천 (ISO 14971:2019 기준) | REQ-RISK-021, 022, 023 | 통합 테스트 |
+| AC4 | ISO 14971 구조 준수 보고서 DOCX export | REQ-RISK-031 | 통합 테스트 |
+| AC5 | EU MDR GSPR 매핑 섹션 포함 | REQ-RISK-032 | 통합 테스트 |
+| AC6 | expert review gate (모든 위험 판단 RA-lead 검토 필수) | REQ-RISK-003, 034, 035, 036 | 통합 + E2E |
+| AC7 | promptfoo eval: 인슐린 펌프·인공호흡기 정확도 >85% | G7 | promptfoo eval suite |
+
+---
+
+## §5 Implementation Notes
+
+- **Workflow 패턴**: `workflowRuns` 테이블에 `risk` workflow type을 추가하여 CER Builder(SPEC-REGULA-CER-001)와 동일한 multi-step run 모델을 재사용한다. 위험 항목·통제·GSPR 매핑은 `workflow_runs.id`를 FK로 하는 child 테이블에 저장한다.
+- **RAG 통합**: `lib/api/hybrid-ra-client.ts`의 `createHybridRaFetch` + `RagQueryRequest/RagQueryResponse` 타입을 재사용한다. 신규 클라이언트 추가 없이 기존 BFF 패턴(`app/api/ra/checklists/*` 참조)을 따른다.
+- **DOCX export**: 기존 `docx@^9.7.1` 패키지를 사용한다 (CER Builder와 동일).
+- **권한**: `lib/auth/with-permission.ts`로 route를 감싼다. 신규 permission: `risk.generate`, `risk.view`, `risk.update`, `risk.approve` (RA-lead 전용).
+- **Audit**: 신규 audit action — `risk.identify.generate`, `risk.item.edit`, `risk.analysis.update`, `risk.control.decide`, `risk.approve`, `risk.export`. `auditActionEnum` 확장 필요.
+- **DB 마이그레이션**: `lib/db/migrations/` 다음 번호로 `risk` enum 값 추가 + 3개 신규 테이블 + RLS 정책 + audit action 추가.
+
+---
+
+## §6 Risks
+
+| # | Risk | 영향 | 완화 방안 |
+|---|------|------|-----------|
+| R1 | RAG 위험 식별 정확도 부족 (false negative) | High | expert review gate 강제 + low_confidence 플래그 + promptfoo eval >85% 게이트 |
+| R2 | ISO 14971:2019 vs 이전 판 §번호 혼동 | Medium | 보고서 섹션 라벨 설정화(§1.2 주의 참조), 통제 계층 우선순위 고정 |
+| R3 | severity/probability 척도 임계값 조직별 차이 | Medium | REQ-RISK-013 — 임계값 조직 설정화 |
+| R4 | GSPR 매핑 자동화의 부정확 | High | 매핑은 draft 보조만, RA-lead 검토 후 확정. 자동 승인 금지 |
+| R5 | DOCX 대용량 보고서 성능 | Low | 서버 측 생성 + 스트리밍, CER Builder export 패턴 재사용 |
+
+---
+
+## §7 Dependencies
+
+- **SPEC-REGULA-FOUNDATION-001**: `workflow_runs`, `expert_reviews`, `audit_logs`, RBAC, RLS 기반 스키마
+- **SPEC-REGULA-WORKFLOWS-001**: workflow run 실행·검토 lifecycle
+- **SPEC-REGULA-DOCINGEST-001**: RAG 코퍼스(표준 조항, 이상사례) 색인
+- **SPEC-REGULA-CER-001**: DOCX export 패턴, expert review gate, workflow child 테이블 패턴 (참조 구현)
+
+---
+
+Version: 1.0.0
+Issue: #46
+Status: draft (pending RA-lead annotation review)

--- a/.moai/specs/SPEC-REGULA-RISK-001/tasks.md
+++ b/.moai/specs/SPEC-REGULA-RISK-001/tasks.md
@@ -1,0 +1,112 @@
+# SPEC-REGULA-RISK-001 — Implementation Tasks
+
+> design.md 기반 TDD 단위 작업 분해. RED-GREEN-REFACTOR 사이클로 진행.
+> 각 작업은 테스트 우선. 코드 식별자 영문, 설명 한국어.
+> 우선순위: P(High/Medium/Low). 시간 추정 금지 — 순서만 명시.
+
+---
+
+## Phase 0: 기반 (DB + 권한 + 감사) — Priority High
+
+선행: 다른 모든 Phase의 전제. CER Builder child-table 패턴 재사용.
+
+| # | 작업 | 산출물 | REQ | 테스트 |
+|---|------|--------|-----|--------|
+| T0.1 | enum 확장 (workflowType 'risk', riskLevel, controlTier) | `lib/db/schema.ts` | 005,012,021 | schema 타입 컴파일 + enum 값 단위 테스트 |
+| T0.2 | auditActionEnum에 risk.* 6종 추가 | `lib/db/schema.ts` | 007,010,020,029,035,031 | enum 값 존재 단위 테스트 |
+| T0.3 | risk_items 테이블 정의 | `lib/db/schema.ts` | 006,002,004 | insert/select drizzle 통합 테스트 |
+| T0.4 | risk_controls 테이블 정의 | `lib/db/schema.ts` | 021,023,024,026,027 | FK cascade 통합 테스트 |
+| T0.5 | risk_gspr_mappings 테이블 정의 | `lib/db/schema.ts` | 032 | insert/select 통합 테스트 |
+| T0.6 | RLS 정책 (workflow_runs org 격리 상속) | migration SQL | — | 타 org 접근 차단 통합 테스트 |
+| T0.7 | 마이그레이션 생성·검토 | `lib/db/migrations/00xx_*.sql` | — | migration up/down 검증 |
+| T0.8 | 권한 risk.generate/view/update/approve 추가 | `lib/auth/permissions.ts` | 036 | role→permission 매핑 단위 테스트 (approve=ra-lead only) |
+
+## Phase 1: 도메인 로직 (lib/risk/*) — Priority High
+
+순수 함수 우선 (의존성 적음). RAG 함수는 createHybridRaFetch mocking.
+
+| # | 작업 | 산출물 | REQ | 테스트 |
+|---|------|--------|-----|--------|
+| T1.1 | DEFAULT_RISK_MATRIX 정의 (5×5) | `lib/risk/risk-matrix.ts` | 012 | research.md §2.1 매트릭스 일치 단위 테스트 |
+| T1.2 | evaluateRiskLevel(severity,prob,matrix) | `lib/risk/risk-evaluation.ts` | 012,013 | 25셀 전수 + 조직 override 단위 테스트 |
+| T1.3 | validateScale (1~5 범위 검증) | `lib/risk/risk-evaluation.ts` | 018 | 경계값 0/6 reject 단위 테스트 |
+| T1.4 | requiresControl (ALARP/UNACC 판정) | `lib/risk/risk-evaluation.ts` | 014 | acc/alarp/unacc 분기 단위 테스트 |
+| T1.5 | evaluateResidualRisk | `lib/risk/residual-risk.ts` | 024,025 | 잔류 재산정 + further-action 플래그 단위 테스트 |
+| T1.6 | buildHazardPrompt (ISO 14971 용어 구조화) | `lib/risk/hazard-identification.ts` | 006 | 프롬프트에 hazard/sequence/situation/harm 포함 검증 |
+| T1.7 | parseHazardResponse (citation 필수, confidence 플래그) | `lib/risk/hazard-identification.ts` | 002,004 | citation 누락 항목 reject + lowConfidence 단위 테스트 |
+| T1.8 | identifyHazards (RAG 호출, deviceClass filter) | `lib/risk/hazard-identification.ts` | 001,005 | mock RAG로 filter 전달·결과 매핑 단위 테스트 |
+| T1.9 | recommendControls (3계층 RAG) | `lib/risk/control-recommendation.ts` | 021,022 | 3계층 후보 + 빈 결과 fallback 단위 테스트 |
+| T1.10 | validateControlHierarchy (info-only skip 사유) | `lib/risk/control-recommendation.ts` | 023 | info-only 채택 시 사유 강제 단위 테스트 |
+
+## Phase 2: BFF API Routes — Priority High
+
+withPermission + createHybridRaFetch 패턴. checklists/generate route 참조.
+
+| # | 작업 | 산출물 | REQ | 테스트 |
+|---|------|--------|-----|--------|
+| T2.1 | POST /risk/runs (run 생성) | `app/api/ra/risk/runs/route.ts` | — | 권한·생성 통합 테스트 |
+| T2.2 | GET /risk/runs/[id] (aggregate 조회) | `app/api/ra/risk/runs/[id]/route.ts` | — | items+controls+mappings 조립 테스트 |
+| T2.3 | POST /risk/identify (+ audit) | `app/api/ra/risk/identify/route.ts` | 001,002,004,010 | RAG mock + audit 기록 통합 테스트 |
+| T2.4 | PATCH/DELETE /risk/items/[id] (+ audit) | `app/api/ra/risk/items/[id]/route.ts` | 007,020 | 수정·삭제 audit 통합 테스트 |
+| T2.5 | POST /risk/items/[id]/evaluate | `app/api/ra/risk/items/[id]/evaluate/route.ts` | 012,015 | 분류 + ALARP 사유 검증 테스트 |
+| T2.6 | POST /risk/controls/recommend | `app/api/ra/risk/controls/recommend/route.ts` | 021,028 | 3계층 + 빈 fallback 테스트 |
+| T2.7 | PATCH /risk/controls/[id] (+ audit) | `app/api/ra/risk/controls/[id]/route.ts` | 024,025,029 | 채택·잔류 위험 audit 테스트 |
+| T2.8 | POST /risk/runs/[id]/gspr | `app/api/ra/risk/runs/[id]/gspr/route.ts` | 032 | 매핑 생성 통합 테스트 |
+| T2.9 | POST /risk/runs/[id]/export | `app/api/ra/risk/runs/[id]/export/route.ts` | 031,033,034 | DOCX 생성 + 워터마크 분기 테스트 |
+| T2.10 | POST /risk/runs/[id]/approve (gate) | `app/api/ra/risk/runs/[id]/approve/route.ts` | 003,035,036 | RA-lead 승인 + 비-RA-lead 403 테스트 |
+
+## Phase 3: 보고서 생성 (report-builder) — Priority High
+
+| # | 작업 | 산출물 | REQ | 테스트 |
+|---|------|--------|-----|--------|
+| T3.1 | buildRiskReport DOCX 섹션 구조 (ISO 14971) | `lib/risk/report-builder.ts` | 031 | 7섹션 존재 + 구조 단위 테스트 |
+| T3.2 | GSPR 매핑 테이블 렌더 | `lib/risk/report-builder.ts` | 032 | 매핑 행 렌더 단위 테스트 |
+| T3.3 | 모든 항목 citation 표기 | `lib/risk/report-builder.ts` | 033 | citation 누락 시 검증 실패 테스트 |
+| T3.4 | DRAFT 워터마크 (미승인) | `lib/risk/report-builder.ts` | 034 | 미승인 run 워터마크 존재 테스트 |
+
+## Phase 4: UI Components — Priority Medium
+
+선행: Phase 2 API. TanStack Query 훅 + 컴포넌트. CitationBadge 재사용.
+
+| # | 작업 | 산출물 | REQ | 테스트 |
+|---|------|--------|-----|--------|
+| T4.1 | Query 훅 (useRiskRun 등) | `components/risk/hooks.ts` | — | 훅 fetch·캐시 단위 테스트 |
+| T4.2 | RiskWizard (4단계 stepper, 순서 강제) | `components/risk/RiskWizard.tsx` | 008,014,019 | 단계 잠금 RTL 테스트 |
+| T4.3 | HazardIdentificationStep | `components/risk/HazardIdentificationStep.tsx` | 001,007,009 | 생성·편집·citation 클릭 RTL 테스트 |
+| T4.4 | RiskMatrix + RiskMatrixCell (색상/배지) | `components/risk/RiskMatrix.tsx` | 011,016,017 | 색상 코딩·셀 카운트 RTL 테스트 |
+| T4.5 | RiskAnalysisStep (sev/prob + ALARP) | `components/risk/RiskAnalysisStep.tsx` | 012,015 | ALARP 사유 강제 RTL 테스트 |
+| T4.6 | ControlRecommendationStep (3계층 + manual) | `components/risk/ControlRecommendationStep.tsx` | 021,023,028 | 계층 표시·manual fallback RTL 테스트 |
+| T4.7 | ResidualRiskPanel (재산정 + 신규 위험) | `components/risk/ResidualRiskPanel.tsx` | 024,025,027 | 잔류 재계산·신규 위험 체크 RTL 테스트 |
+| T4.8 | GsprMappingStep | `components/risk/GsprMappingStep.tsx` | 032 | 매핑 편집 RTL 테스트 |
+| T4.9 | RiskReportStep + ExpertReviewGate | `components/risk/RiskReportStep.tsx`, `ExpertReviewGate.tsx` | 003,030,034,036 | 권한 분기·draft 배지 RTL 테스트 |
+| T4.10 | 페이지 (목록 + 위저드 라우트) | `app/(app)/workflows/risk/page.tsx`, `[runId]/page.tsx` | — | 라우팅·렌더 smoke 테스트 |
+
+## Phase 5: Eval + E2E — Priority Medium
+
+| # | 작업 | 산출물 | REQ/AC | 테스트 |
+|---|------|--------|--------|--------|
+| T5.1 | promptfoo risk-identification suite | `evals/risk/risk-identification.yaml` | AC7 | 인슐린펌프·인공호흡기 >85% |
+| T5.2 | E2E 위험관리 전체 플로우 | `e2e/risk.spec.ts` | AC1~AC6 | 식별→분석→통제→승인→export Playwright |
+| T5.3 | E2E 권한 게이트 (비-RA-lead 승인 차단) | `e2e/risk-rbac.spec.ts` | 036 | 403 검증 |
+
+## 의존 그래프
+
+```
+Phase 0 (DB/권한/감사)
+   ├──> Phase 1 (도메인 로직)
+   │       └──> Phase 2 (API) ──> Phase 4 (UI)
+   │                          └──> Phase 3 (보고서) ──┘
+   └──> Phase 5 (Eval/E2E, 최종)
+```
+
+병렬 가능: Phase 1 도메인 순수 함수(T1.1~T1.5)는 Phase 0 완료 후 즉시 병렬. UI(Phase 4)는 해당 API route 완료 시 순차.
+
+## 완료 기준 (Definition of Done)
+
+- [ ] 36 REQ 전부 테스트로 커버
+- [ ] AC1~AC7 충족 (promptfoo >85% 포함)
+- [ ] 커버리지 ≥85% (TRUST 5)
+- [ ] audit_logs append-only 위반 없음 (trigger 검증)
+- [ ] 비-RA-lead 승인 403 (RBAC)
+- [ ] @MX 태그: 신규 exported 함수 NOTE/ANCHOR, RAG·DOCX 위험 지점 WARN
+- [ ] LSP zero error/type/lint (run gate)


### PR DESCRIPTION
## Summary

- SPEC-REGULA-RISK-001 4종 문서 세트 작성 완료 (Issue #46, Wave 4)
- **scope**: A 위험 식별 / B 분석 매트릭스 / C 통제 조치 추천 / D 보고서 생성

## 생성된 문서

| 파일 | 내용 |
|---|---|
| `spec.md` | EARS 형식 36개 REQ, 완료 조건 7개 |
| `research.md` | ISO 14971:2019, Annex E 5×5 매트릭스, EU MDR GSPR 리서치 |
| `design.md` | DB 스키마 (3 enum + 3 테이블), 11개 BFF 라우트, RAG 파이프라인 |
| `tasks.md` | TDD Phase 0~5 단위 분해, AC1~AC7 REQ 매핑 |

## Gate 0 체크

- [x] 이슈 body → SPEC 4-doc set 방식 선택
- [x] `.moai/specs/SPEC-REGULA-RISK-001/` 생성 완료
- [x] 기존 BFF 패턴 (checklists, traceability) 일관성 유지
- [x] ISO 14971:2019 준수 설계

## 다음 단계

구현: `/moai run SPEC-REGULA-RISK-001` (TDD RED-GREEN-REFACTOR)

Relates #46