### PR TITLE
feat(risk): SPEC-REGULA-RISK-001 ISO 14971 위험관리 통합 구현

### DIFF
--- a/app/(app)/workflows/risk/[runId]/page.tsx
+++ b/app/(app)/workflows/risk/[runId]/page.tsx
@@ -1,4 +1,6 @@
 // @MX:SPEC SPEC-REGULA-RISK-001 (T5.4, REQ-RISK-001~020)
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
 import { RiskMatrix } from '@/components/risk/RiskMatrix';
 import { HazardTable } from '@/components/risk/HazardTable';
 import { RiskApprovalGate } from '@/components/risk/RiskApprovalGate';
@@ -8,7 +10,11 @@ interface RiskRunPageProps {
 }
 
 export default async function RiskRunPage({ params }: RiskRunPageProps) {
+  const session = await auth();
+  if (!session?.user?.id) redirect('/login');
+
   const { runId } = await params;
+  const currentUserRole = (session.user as { role?: string }).role ?? 'viewer';
 
   return (
     <section className="mx-auto flex max-w-content flex-col gap-8">
@@ -29,12 +35,12 @@ export default async function RiskRunPage({ params }: RiskRunPageProps) {
         <HazardTable items={[]} />
       </div>
 
-      {/* Approval gate — only ra-lead can approve */}
+      {/* Approval gate — only ra-lead can approve (RBAC enforced at BFF layer too) */}
       <RiskApprovalGate
         runId={runId}
         isApproved={false}
         approvedBy={null}
-        currentUserRole="ra-member"
+        currentUserRole={currentUserRole}
       />
     </section>
   );

--- a/app/(app)/workflows/risk/[runId]/page.tsx
+++ b/app/(app)/workflows/risk/[runId]/page.tsx
@@ -1,0 +1,41 @@
+// @MX:SPEC SPEC-REGULA-RISK-001 (T5.4, REQ-RISK-001~020)
+import { RiskMatrix } from '@/components/risk/RiskMatrix';
+import { HazardTable } from '@/components/risk/HazardTable';
+import { RiskApprovalGate } from '@/components/risk/RiskApprovalGate';
+
+interface RiskRunPageProps {
+  params: Promise<{ runId: string }>;
+}
+
+export default async function RiskRunPage({ params }: RiskRunPageProps) {
+  const { runId } = await params;
+
+  return (
+    <section className="mx-auto flex max-w-content flex-col gap-8">
+      <header>
+        <h1 className="font-serif text-3xl text-brand-800">Risk Assessment</h1>
+        <p className="mt-1 font-mono text-xs text-ink-500">{runId}</p>
+      </header>
+
+      {/* Risk Matrix visualization */}
+      <div className="rounded-lg border border-ink-200 bg-white p-6">
+        <h2 className="mb-4 text-base font-semibold text-ink-800">Risk Matrix (ISO 14971)</h2>
+        <RiskMatrix />
+      </div>
+
+      {/* Hazard table */}
+      <div className="rounded-lg border border-ink-200 bg-white p-6">
+        <h2 className="mb-4 text-base font-semibold text-ink-800">Hazard Items</h2>
+        <HazardTable items={[]} />
+      </div>
+
+      {/* Approval gate — only ra-lead can approve */}
+      <RiskApprovalGate
+        runId={runId}
+        isApproved={false}
+        approvedBy={null}
+        currentUserRole="ra-member"
+      />
+    </section>
+  );
+}

--- a/app/(app)/workflows/risk/page.tsx
+++ b/app/(app)/workflows/risk/page.tsx
@@ -1,0 +1,57 @@
+// @MX:SPEC SPEC-REGULA-RISK-001 (T5.4, REQ-RISK-001)
+import { BetaBadge } from '@/components/ui/BetaBadge';
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'Risk Management — Regula',
+  description: 'ISO 14971 Risk Management workflow — hazard identification, risk evaluation, and control measures',
+};
+
+export default function RiskWorkflowPage() {
+  return (
+    <section className="mx-auto flex max-w-content flex-col gap-6">
+      <header>
+        <div className="flex items-center gap-2">
+          <h1 className="font-serif text-3xl text-brand-800">Risk Management</h1>
+          <BetaBadge />
+        </div>
+        <p className="mt-2 text-sm text-ink-600">
+          ISO 14971 Risk Management — Hazard Identification · Risk Evaluation · Control Measures · Residual Risk
+        </p>
+      </header>
+
+      <RiskRunList />
+    </section>
+  );
+}
+
+async function RiskRunList() {
+  // Server component: list risk runs for the current org
+  // Data fetched from /api/ra/risk/runs at runtime
+  return (
+    <div data-testid="risk-run-list" className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-medium text-ink-800">Risk Assessment Runs</h2>
+        <Link
+          href="/workflows/risk/new"
+          className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700"
+        >
+          New Risk Assessment
+        </Link>
+      </div>
+
+      {/* Run list rendered client-side to avoid blocking page shell */}
+      <RiskRunListClient />
+    </div>
+  );
+}
+
+function RiskRunListClient() {
+  // Placeholder: full list component lives in _components/RiskRunList.tsx
+  // Imported here as a lightweight stub until the component is fully built
+  return (
+    <div className="rounded-lg border border-ink-200 bg-white p-8 text-center text-ink-500">
+      <p className="text-sm">No risk assessment runs yet. Start a new assessment above.</p>
+    </div>
+  );
+}

--- a/app/api/ra/risk/__tests__/bff-routes.test.ts
+++ b/app/api/ra/risk/__tests__/bff-routes.test.ts
@@ -1,0 +1,94 @@
+// @MX:NOTE [AUTO] BFF route tests for SPEC-REGULA-RISK-001 Phase 2.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.1~T2.10)
+// Tests verify RBAC enforcement and source-level route existence.
+// Full integration tests require a running DB; these are smoke + RBAC tests.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const routeBase = path.resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// T2.1 — Source-level: all required route files exist
+// ---------------------------------------------------------------------------
+describe('T2.1~T2.10 — BFF route files exist', () => {
+  const expectedRoutes = [
+    'runs/route.ts',
+    'runs/[id]/route.ts',
+    'identify/route.ts',
+    'items/[id]/route.ts',
+    'items/[id]/evaluate/route.ts',
+    'controls/recommend/route.ts',
+    'controls/[id]/route.ts',
+    'runs/[id]/gspr/route.ts',
+    'runs/[id]/export/route.ts',
+    'runs/[id]/approve/route.ts',
+  ];
+
+  for (const route of expectedRoutes) {
+    it(`route file exists: ${route}`, () => {
+      const fullPath = path.join(routeBase, route);
+      expect(fs.existsSync(fullPath)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// T2.10 — Source-level: approve route uses risk.approve permission (ra-lead ONLY)
+// ---------------------------------------------------------------------------
+describe('T2.10 — approve route enforces ra-lead permission', () => {
+  it('runs/[id]/approve/route.ts uses withPermission("risk.approve")', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'runs/[id]/approve/route.ts'), 'utf8');
+    expect(src).toContain("'risk.approve'");
+    // Must NOT use risk.generate or risk.update (would allow ra-member)
+    expect(src).not.toContain("'risk.generate'");
+    expect(src).not.toContain("'risk.update'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T2.1 — Source-level: runs POST uses risk.generate
+// ---------------------------------------------------------------------------
+describe('T2.1 — runs route uses risk.generate permission', () => {
+  it('runs/route.ts uses withPermission("risk.generate")', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'runs/route.ts'), 'utf8');
+    expect(src).toContain("'risk.generate'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T2.9 — Source-level: export route exists and generates DOCX
+// ---------------------------------------------------------------------------
+describe('T2.9 — export route', () => {
+  it('runs/[id]/export/route.ts uses risk.generate or risk.view permission', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'runs/[id]/export/route.ts'), 'utf8');
+    // Export can be triggered by ra-member (generate) or read (view)
+    expect(src).toMatch(/'risk\.(generate|view)'/);
+  });
+
+  it('runs/[id]/export/route.ts references report-builder', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'runs/[id]/export/route.ts'), 'utf8');
+    expect(src).toContain('report-builder');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T2.2 — Source-level: identify route audits risk.hazard_identified
+// ---------------------------------------------------------------------------
+describe('T2.2 — identify route audit action', () => {
+  it('identify/route.ts references risk.hazard_identified audit action', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'identify/route.ts'), 'utf8');
+    expect(src).toContain('risk.hazard_identified');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T2.8 — Source-level: gspr route audits risk.gspr_mapped
+// ---------------------------------------------------------------------------
+describe('T2.8 — GSPR route audit action', () => {
+  it('runs/[id]/gspr/route.ts references risk.gspr_mapped audit action', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'runs/[id]/gspr/route.ts'), 'utf8');
+    expect(src).toContain('risk.gspr_mapped');
+  });
+});

--- a/app/api/ra/risk/controls/[id]/route.ts
+++ b/app/api/ra/risk/controls/[id]/route.ts
@@ -33,12 +33,11 @@ export const PATCH = withPermission('risk.update', async (req, ctx, session) => 
   }
 
   await writeAudit({
-    userId: session.user.id,
+    actor_id: session.user.id,
     action: 'risk.control_adopted',
-    resourceType: 'risk_control',
-    resourceId: id,
-    organizationId: session.user.organizationId,
-    metadata: { tier: body.tier, isAdopted: body.isAdopted, residualResult },
+    resource_type: 'risk_control',
+    resource_id: id,
+    meta_json: { tier: body.tier, isAdopted: body.isAdopted },
   });
 
   return Response.json({ id, ...body, residualResult });

--- a/app/api/ra/risk/controls/[id]/route.ts
+++ b/app/api/ra/risk/controls/[id]/route.ts
@@ -1,0 +1,45 @@
+// @MX:NOTE [AUTO] PATCH /api/ra/risk/controls/[id] — adopt control + residual risk.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.7, REQ-RISK-021~027)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { validateControlHierarchy } from '@/lib/risk/control-recommendation';
+import { evaluateResidualRisk } from '@/lib/risk/residual-risk';
+import type { ControlTier } from '@/lib/risk/control-recommendation';
+
+export const PATCH = withPermission('risk.update', async (req, ctx, session) => {
+  const params = await (ctx.params as Promise<Record<string, string>>);
+  const id = params?.id as string;
+  const body = await req.json() as {
+    tier: ControlTier;
+    rationale?: string;
+    isAdopted: boolean;
+    residualSeverity?: number;
+    residualProbability?: number;
+    alarpJustification?: string;
+  };
+
+  // Validate control tier hierarchy (information requires rationale)
+  validateControlHierarchy(body.tier, body.rationale);
+
+  // Evaluate residual risk if provided
+  let residualResult;
+  if (body.residualSeverity !== undefined && body.residualProbability !== undefined) {
+    residualResult = evaluateResidualRisk(
+      body.residualSeverity,
+      body.residualProbability,
+      body.alarpJustification,
+    );
+  }
+
+  await writeAudit({
+    userId: session.user.id,
+    action: 'risk.control_adopted',
+    resourceType: 'risk_control',
+    resourceId: id,
+    organizationId: session.user.organizationId,
+    metadata: { tier: body.tier, isAdopted: body.isAdopted, residualResult },
+  });
+
+  return Response.json({ id, ...body, residualResult });
+});

--- a/app/api/ra/risk/controls/recommend/route.ts
+++ b/app/api/ra/risk/controls/recommend/route.ts
@@ -1,0 +1,13 @@
+// @MX:NOTE [AUTO] POST /api/ra/risk/controls/recommend — 3-tier control recommendations.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.6, REQ-RISK-021~027)
+
+import { withPermission } from '@/lib/auth/with-permission';
+import { createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { recommendControls } from '@/lib/risk/control-recommendation';
+
+export const POST = withPermission('risk.generate', async (req) => {
+  const { riskItemId } = await req.json() as { riskItemId: string };
+  const hybridFetch = createHybridRaFetch();
+  const controls = await recommendControls(riskItemId, hybridFetch);
+  return Response.json({ controls });
+});

--- a/app/api/ra/risk/identify/route.ts
+++ b/app/api/ra/risk/identify/route.ts
@@ -18,12 +18,11 @@ export const POST = withPermission('risk.generate', async (req, _ctx, session) =
     const result = await identifyHazards(deviceDescription, deviceClass, hybridFetch);
 
     await writeAudit({
-      userId: session.user.id,
+      actor_id: session.user.id,
       action: 'risk.hazard_identified',
-      resourceType: 'risk_run',
-      resourceId: workflowRunId,
-      organizationId: session.user.organizationId,
-      metadata: { itemCount: result.items.length, lowConfidenceCount: result.lowConfidenceCount },
+      resource_type: 'risk_run',
+      resource_id: workflowRunId,
+      meta_json: { itemCount: result.items.length, lowConfidenceCount: result.lowConfidenceCount },
     });
 
     return Response.json(result, { status: 201 });

--- a/app/api/ra/risk/identify/route.ts
+++ b/app/api/ra/risk/identify/route.ts
@@ -1,0 +1,37 @@
+// @MX:NOTE [AUTO] POST /api/ra/risk/identify — RAG-based hazard identification.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.3, REQ-RISK-001~010)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { identifyHazards } from '@/lib/risk/hazard-identification';
+
+export const POST = withPermission('risk.generate', async (req, _ctx, session) => {
+  try {
+    const { deviceDescription, deviceClass, workflowRunId } = await req.json() as {
+      deviceDescription: string;
+      deviceClass: string;
+      workflowRunId: string;
+    };
+
+    const hybridFetch = createHybridRaFetch();
+    const result = await identifyHazards(deviceDescription, deviceClass, hybridFetch);
+
+    await writeAudit({
+      userId: session.user.id,
+      action: 'risk.hazard_identified',
+      resourceType: 'risk_run',
+      resourceId: workflowRunId,
+      organizationId: session.user.organizationId,
+      metadata: { itemCount: result.items.length, lowConfidenceCount: result.lowConfidenceCount },
+    });
+
+    return Response.json(result, { status: 201 });
+  } catch (err) {
+    const { HybridRaClientError } = await import('@/lib/api/hybrid-ra-client');
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/app/api/ra/risk/items/[id]/evaluate/route.ts
+++ b/app/api/ra/risk/items/[id]/evaluate/route.ts
@@ -13,12 +13,11 @@ export const POST = withPermission('risk.update', async (req, ctx, session) => {
   const riskLevel = evaluateRiskLevel(severity, probability);
 
   await writeAudit({
-    userId: session.user.id,
+    actor_id: session.user.id,
     action: 'risk.matrix_evaluated',
-    resourceType: 'risk_item',
-    resourceId: id,
-    organizationId: session.user.organizationId,
-    metadata: { severity, probability, riskLevel },
+    resource_type: 'risk_item',
+    resource_id: id,
+    meta_json: { severity, probability, riskLevel },
   });
 
   return Response.json({ id, severity, probability, riskLevel });

--- a/app/api/ra/risk/items/[id]/evaluate/route.ts
+++ b/app/api/ra/risk/items/[id]/evaluate/route.ts
@@ -3,12 +3,19 @@
 
 import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
-import { evaluateRiskLevel } from '@/lib/risk/risk-evaluation';
+import { evaluateRiskLevel, validateScale } from '@/lib/risk/risk-evaluation';
 
 export const POST = withPermission('risk.update', async (req, ctx, session) => {
   const params = await (ctx.params as Promise<Record<string, string>>);
   const id = params?.id as string;
   const { severity, probability } = await req.json() as { severity: number; probability: number };
+
+  if (!validateScale(severity) || !validateScale(probability)) {
+    return Response.json(
+      { error: 'severity and probability must be integers 1–5' },
+      { status: 400 },
+    );
+  }
 
   const riskLevel = evaluateRiskLevel(severity, probability);
 

--- a/app/api/ra/risk/items/[id]/evaluate/route.ts
+++ b/app/api/ra/risk/items/[id]/evaluate/route.ts
@@ -1,0 +1,25 @@
+// @MX:NOTE [AUTO] POST /api/ra/risk/items/[id]/evaluate — evaluate severity×probability.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.5, REQ-RISK-011~015)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { evaluateRiskLevel } from '@/lib/risk/risk-evaluation';
+
+export const POST = withPermission('risk.update', async (req, ctx, session) => {
+  const params = await (ctx.params as Promise<Record<string, string>>);
+  const id = params?.id as string;
+  const { severity, probability } = await req.json() as { severity: number; probability: number };
+
+  const riskLevel = evaluateRiskLevel(severity, probability);
+
+  await writeAudit({
+    userId: session.user.id,
+    action: 'risk.matrix_evaluated',
+    resourceType: 'risk_item',
+    resourceId: id,
+    organizationId: session.user.organizationId,
+    metadata: { severity, probability, riskLevel },
+  });
+
+  return Response.json({ id, severity, probability, riskLevel });
+});

--- a/app/api/ra/risk/items/[id]/route.ts
+++ b/app/api/ra/risk/items/[id]/route.ts
@@ -1,0 +1,50 @@
+// @MX:NOTE [AUTO] PATCH/DELETE /api/ra/risk/items/[id] — edit or delete hazard item.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.4, REQ-RISK-011~015)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+
+async function handlePatch(req: Request, ctx: { params?: unknown }, session: { user: { id: string; organizationId?: string } }) {
+  const params = await (ctx.params as Promise<Record<string, string>>);
+  const id = params?.id as string;
+  const body = await req.json();
+
+  const { createHybridRaFetch } = await import('@/lib/api/hybrid-ra-client');
+  const hybridFetch = createHybridRaFetch();
+  const res = await hybridFetch(`/api/v1/risk/items/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+
+  await writeAudit({
+    userId: session.user.id,
+    action: 'risk.matrix_evaluated',
+    resourceType: 'risk_item',
+    resourceId: id,
+    organizationId: session.user.organizationId,
+  });
+
+  return Response.json(data);
+}
+
+export const PATCH = withPermission('risk.update', handlePatch);
+
+export const DELETE = withPermission('risk.update', async (_req, ctx, session) => {
+  const params = await (ctx.params as Promise<Record<string, string>>);
+  const id = params?.id as string;
+
+  const { createHybridRaFetch } = await import('@/lib/api/hybrid-ra-client');
+  const hybridFetch = createHybridRaFetch();
+  await hybridFetch(`/api/v1/risk/items/${id}`, { method: 'DELETE' });
+
+  await writeAudit({
+    userId: session.user.id,
+    action: 'risk.matrix_evaluated',
+    resourceType: 'risk_item',
+    resourceId: id,
+    organizationId: session.user.organizationId,
+  });
+
+  return new Response(null, { status: 204 });
+});

--- a/app/api/ra/risk/items/[id]/route.ts
+++ b/app/api/ra/risk/items/[id]/route.ts
@@ -39,7 +39,7 @@ export const DELETE = withPermission('risk.update', async (_req, ctx, session) =
 
   await writeAudit({
     actor_id: session.user.id,
-    action: 'risk.matrix_evaluated',
+    action: 'risk.item_deleted',
     resource_type: 'risk_item',
     resource_id: id,
   });

--- a/app/api/ra/risk/items/[id]/route.ts
+++ b/app/api/ra/risk/items/[id]/route.ts
@@ -18,11 +18,10 @@ async function handlePatch(req: Request, ctx: { params?: unknown }, session: { u
   const data = await res.json();
 
   await writeAudit({
-    userId: session.user.id,
+    actor_id: session.user.id,
     action: 'risk.matrix_evaluated',
-    resourceType: 'risk_item',
-    resourceId: id,
-    organizationId: session.user.organizationId,
+    resource_type: 'risk_item',
+    resource_id: id,
   });
 
   return Response.json(data);
@@ -39,11 +38,10 @@ export const DELETE = withPermission('risk.update', async (_req, ctx, session) =
   await hybridFetch(`/api/v1/risk/items/${id}`, { method: 'DELETE' });
 
   await writeAudit({
-    userId: session.user.id,
+    actor_id: session.user.id,
     action: 'risk.matrix_evaluated',
-    resourceType: 'risk_item',
-    resourceId: id,
-    organizationId: session.user.organizationId,
+    resource_type: 'risk_item',
+    resource_id: id,
   });
 
   return new Response(null, { status: 204 });

--- a/app/api/ra/risk/runs/[id]/approve/route.ts
+++ b/app/api/ra/risk/runs/[id]/approve/route.ts
@@ -1,0 +1,34 @@
+// @MX:ANCHOR [AUTO] RA-lead approval gate — RBAC critical invariant.
+// @MX:REASON risk.approve requires minRole 'ra-lead'. Only this route enforces risk report sign-off.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.10, REQ-RISK-037~038)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+
+// CRITICAL: Only withPermission('risk.approve') is acceptable here.
+// minRole 'ra-lead' is required by ISO 14971 §10 for final risk report sign-off.
+// Using any other permission action would lower the RBAC bar to ra-member, violating the standard.
+export const POST = withPermission('risk.approve', async (req, ctx, session) => {
+  const params = await (ctx.params as Promise<Record<string, string>>);
+  const id = params?.id as string;
+  const { comment } = (await req.json()) as { comment?: string };
+
+  const { createHybridRaFetch } = await import('@/lib/api/hybrid-ra-client');
+  const hybridFetch = createHybridRaFetch();
+  const res = await hybridFetch(`/api/v1/risk/runs/${id}/approve`, {
+    method: 'POST',
+    body: JSON.stringify({ approvedBy: session.user.id, comment }),
+  });
+  const data = await res.json();
+
+  await writeAudit({
+    userId: session.user.id,
+    action: 'risk.report_approved',
+    resourceType: 'risk_run',
+    resourceId: id,
+    organizationId: session.user.organizationId,
+    metadata: { comment },
+  });
+
+  return Response.json(data);
+});

--- a/app/api/ra/risk/runs/[id]/approve/route.ts
+++ b/app/api/ra/risk/runs/[id]/approve/route.ts
@@ -22,12 +22,11 @@ export const POST = withPermission('risk.approve', async (req, ctx, session) => 
   const data = await res.json();
 
   await writeAudit({
-    userId: session.user.id,
+    actor_id: session.user.id,
     action: 'risk.report_approved',
-    resourceType: 'risk_run',
-    resourceId: id,
-    organizationId: session.user.organizationId,
-    metadata: { comment },
+    resource_type: 'risk_run',
+    resource_id: id,
+    meta_json: { comment },
   });
 
   return Response.json(data);

--- a/app/api/ra/risk/runs/[id]/export/route.ts
+++ b/app/api/ra/risk/runs/[id]/export/route.ts
@@ -1,0 +1,47 @@
+// @MX:ANCHOR [AUTO] buildRiskReport export route — DOCX generation entry point.
+// @MX:REASON Called by UI download button and E2E test. Fan_in >= 3.
+// @MX:WARN [AUTO] DOCX binary generation inside export route.
+// @MX:REASON Binary file generation — large memory allocation for complex reports.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.9, T3.1~T3.4, REQ-RISK-034~036)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { buildRiskReport } from '@/lib/risk/report-builder';
+
+export const POST = withPermission('risk.generate', async (req, ctx, session) => {
+  const params = await (ctx.params as Promise<Record<string, string>>);
+  const id = params?.id as string;
+
+  try {
+    const { createHybridRaFetch } = await import('@/lib/api/hybrid-ra-client');
+    const hybridFetch = createHybridRaFetch();
+
+    // Fetch run aggregate (items + controls + GSPR mappings)
+    const runRes = await hybridFetch(`/api/v1/risk/runs/${id}`, { method: 'GET' });
+    const runData = await runRes.json() as Parameters<typeof buildRiskReport>[0];
+
+    const docxBuffer = await buildRiskReport(runData);
+
+    await writeAudit({
+      userId: session.user.id,
+      action: 'workflow.download',
+      resourceType: 'risk_run',
+      resourceId: id,
+      organizationId: session.user.organizationId,
+    });
+
+    return new Response(docxBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'Content-Disposition': `attachment; filename="risk-management-report-${id}.docx"`,
+      },
+    });
+  } catch (err) {
+    const { HybridRaClientError } = await import('@/lib/api/hybrid-ra-client');
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/app/api/ra/risk/runs/[id]/export/route.ts
+++ b/app/api/ra/risk/runs/[id]/export/route.ts
@@ -23,14 +23,13 @@ export const POST = withPermission('risk.generate', async (req, ctx, session) =>
     const docxBuffer = await buildRiskReport(runData);
 
     await writeAudit({
-      userId: session.user.id,
+      actor_id: session.user.id,
       action: 'workflow.download',
-      resourceType: 'risk_run',
-      resourceId: id,
-      organizationId: session.user.organizationId,
+      resource_type: 'risk_run',
+      resource_id: id,
     });
 
-    return new Response(docxBuffer, {
+    return new Response(docxBuffer as unknown as BodyInit, {
       status: 200,
       headers: {
         'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/app/api/ra/risk/runs/[id]/gspr/route.ts
+++ b/app/api/ra/risk/runs/[id]/gspr/route.ts
@@ -1,0 +1,29 @@
+// @MX:NOTE [AUTO] POST /api/ra/risk/runs/[id]/gspr — EU MDR GSPR mapping.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.8, REQ-RISK-030~033)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+
+export const POST = withPermission('risk.update', async (req, ctx, session) => {
+  const params = await (ctx.params as Promise<Record<string, string>>);
+  const id = params?.id as string;
+  const body = await req.json();
+
+  const { createHybridRaFetch } = await import('@/lib/api/hybrid-ra-client');
+  const hybridFetch = createHybridRaFetch();
+  const res = await hybridFetch(`/api/v1/risk/runs/${id}/gspr`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+
+  await writeAudit({
+    userId: session.user.id,
+    action: 'risk.gspr_mapped',
+    resourceType: 'risk_run',
+    resourceId: id,
+    organizationId: session.user.organizationId,
+  });
+
+  return Response.json(data, { status: 201 });
+});

--- a/app/api/ra/risk/runs/[id]/gspr/route.ts
+++ b/app/api/ra/risk/runs/[id]/gspr/route.ts
@@ -18,11 +18,10 @@ export const POST = withPermission('risk.update', async (req, ctx, session) => {
   const data = await res.json();
 
   await writeAudit({
-    userId: session.user.id,
+    actor_id: session.user.id,
     action: 'risk.gspr_mapped',
-    resourceType: 'risk_run',
-    resourceId: id,
-    organizationId: session.user.organizationId,
+    resource_type: 'risk_run',
+    resource_id: id,
   });
 
   return Response.json(data, { status: 201 });

--- a/app/api/ra/risk/runs/[id]/route.ts
+++ b/app/api/ra/risk/runs/[id]/route.ts
@@ -1,0 +1,23 @@
+// @MX:NOTE [AUTO] GET /api/ra/risk/runs/[id] — aggregate: items + controls + mappings.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.2, REQ-RISK-029)
+
+import { withPermission } from '@/lib/auth/with-permission';
+
+export const GET = withPermission('risk.view', async (req, ctx) => {
+  const params = await ctx.params;
+  const id = params?.id as string;
+
+  try {
+    const { HybridRaClientError, createHybridRaFetch } = await import('@/lib/api/hybrid-ra-client');
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch(`/api/v1/risk/runs/${id}`, { method: 'GET' });
+    const data = await res.json();
+    return Response.json(data);
+  } catch (err) {
+    const { HybridRaClientError } = await import('@/lib/api/hybrid-ra-client');
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/app/api/ra/risk/runs/route.ts
+++ b/app/api/ra/risk/runs/route.ts
@@ -1,0 +1,34 @@
+// @MX:NOTE [AUTO] POST /api/ra/risk/runs — create a new risk management workflow run.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T2.1, REQ-RISK-028)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+
+export const POST = withPermission('risk.generate', async (req, _ctx, session) => {
+  try {
+    const body = await req.json();
+    const { HybridRaClientError, createHybridRaFetch } = await import('@/lib/api/hybrid-ra-client');
+    const hybridFetch = createHybridRaFetch();
+    const res = await hybridFetch('/api/v1/risk/runs', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+
+    await writeAudit({
+      userId: session.user.id,
+      action: 'workflow.start',
+      resourceType: 'risk_run',
+      resourceId: (data as Record<string, unknown>)['id'] as string | undefined,
+      organizationId: session.user.organizationId,
+    });
+
+    return Response.json(data, { status: 201 });
+  } catch (err) {
+    const { HybridRaClientError } = await import('@/lib/api/hybrid-ra-client');
+    if (err instanceof HybridRaClientError) {
+      return Response.json({ error: err.message }, { status: err.statusCode });
+    }
+    throw err;
+  }
+});

--- a/app/api/ra/risk/runs/route.ts
+++ b/app/api/ra/risk/runs/route.ts
@@ -16,11 +16,10 @@ export const POST = withPermission('risk.generate', async (req, _ctx, session) =
     const data = await res.json();
 
     await writeAudit({
-      userId: session.user.id,
+      actor_id: session.user.id,
       action: 'workflow.start',
-      resourceType: 'risk_run',
-      resourceId: (data as Record<string, unknown>)['id'] as string | undefined,
-      organizationId: session.user.organizationId,
+      resource_type: 'risk_run',
+      resource_id: ((data as Record<string, unknown>)['id'] as string | undefined) ?? 'unknown',
     });
 
     return Response.json(data, { status: 201 });

--- a/components/risk/ControlWizard.tsx
+++ b/components/risk/ControlWizard.tsx
@@ -1,0 +1,150 @@
+'use client';
+// @MX:NOTE [AUTO] 3-tier control selection wizard per ISO 14971 §7.1.
+// Enforces: information tier requires rationale before adoption.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T4.3, REQ-RISK-021~027)
+
+import { useState } from 'react';
+import { validateControlHierarchy, type ControlTier } from '@/lib/risk/control-recommendation';
+
+interface ControlCandidate {
+  id: string;
+  tier: ControlTier;
+  description: string;
+  rationale: string | null;
+}
+
+interface ControlWizardProps {
+  riskItemId: string;
+  candidates: ControlCandidate[];
+  onAdopt: (control: ControlCandidate & { rationale: string | null; alarpJustification?: string }) => void;
+  disabled?: boolean;
+}
+
+const TIER_ORDER: ControlTier[] = ['inherent', 'protective', 'information'];
+
+const TIER_LABELS: Record<ControlTier, string> = {
+  inherent: 'Inherent Safety Design',
+  protective: 'Protective Measures',
+  information: 'Information for Safety',
+};
+
+const TIER_DESCRIPTIONS: Record<ControlTier, string> = {
+  inherent: 'Eliminate or reduce risk through design changes (highest priority)',
+  protective: 'Add protective devices, safeguards, or alarms',
+  information: 'Warn users via labels, IFU, or training (last resort — requires rationale)',
+};
+
+export function ControlWizard({ riskItemId, candidates, onAdopt, disabled = false }: ControlWizardProps) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [rationale, setRationale] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedControl = candidates.find((c) => c.id === selected);
+
+  function handleAdopt() {
+    if (!selectedControl) return;
+    setError(null);
+
+    try {
+      validateControlHierarchy(selectedControl.tier, rationale || undefined);
+    } catch (e) {
+      setError((e as Error).message);
+      return;
+    }
+
+    onAdopt({
+      ...selectedControl,
+      rationale: rationale || selectedControl.rationale,
+    });
+    setSelected(null);
+    setRationale('');
+  }
+
+  const groupedByTier = TIER_ORDER.map((tier) => ({
+    tier,
+    controls: candidates.filter((c) => c.tier === tier),
+  }));
+
+  return (
+    <div className="space-y-4">
+      <div className="text-sm text-gray-500 mb-2">
+        Risk Item: <span className="font-mono text-gray-700">{riskItemId}</span>
+      </div>
+
+      {groupedByTier.map(({ tier, controls }) => (
+        <div key={tier} className="border rounded-md p-3">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-xs font-bold uppercase tracking-wide text-gray-600">
+              {TIER_LABELS[tier]}
+            </span>
+            {tier === 'information' && (
+              <span className="text-[10px] bg-orange-100 text-orange-700 px-1.5 py-0.5 rounded">
+                Requires Rationale
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-gray-400 mb-2">{TIER_DESCRIPTIONS[tier]}</p>
+
+          {controls.length === 0 ? (
+            <p className="text-xs text-gray-300 italic">No candidates for this tier</p>
+          ) : (
+            <div className="space-y-1">
+              {controls.map((control) => (
+                <label key={control.id} className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="selected-control"
+                    value={control.id}
+                    checked={selected === control.id}
+                    onChange={() => {
+                      setSelected(control.id);
+                      setError(null);
+                      if (tier !== 'information') setRationale('');
+                    }}
+                    disabled={disabled}
+                    className="mt-0.5"
+                  />
+                  <span className="text-sm">{control.description}</span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {selectedControl?.tier === 'information' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Rationale (required for information controls — ISO 14971 §7.1)
+          </label>
+          <textarea
+            className="w-full border rounded p-2 text-sm min-h-[80px] focus:ring-1 focus:ring-blue-400"
+            placeholder="Explain why inherent safety design and protective measures are insufficient..."
+            value={rationale}
+            onChange={(e) => {
+              setRationale(e.target.value);
+              setError(null);
+            }}
+            disabled={disabled}
+          />
+        </div>
+      )}
+
+      {error && (
+        <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
+          {error}
+        </div>
+      )}
+
+      <button
+        onClick={handleAdopt}
+        disabled={!selected || disabled}
+        className="px-4 py-2 bg-blue-600 text-white rounded text-sm font-medium disabled:opacity-50 hover:bg-blue-700"
+      >
+        Adopt Control Measure
+      </button>
+    </div>
+  );
+}
+
+export default ControlWizard;

--- a/components/risk/HazardTable.tsx
+++ b/components/risk/HazardTable.tsx
@@ -1,0 +1,124 @@
+'use client';
+// @MX:NOTE [AUTO] Editable hazard item table for risk management workflow.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T4.2, REQ-RISK-001~015)
+
+import type { RiskLevel } from '@/lib/risk/risk-evaluation';
+
+interface HazardItem {
+  id: string;
+  hazard: string;
+  sequenceOfEvents: string;
+  hazardousSituation: string;
+  harm: string;
+  severity: number;
+  probability: number;
+  riskLevel: RiskLevel;
+  lowConfidence: boolean;
+  citation: Array<{ source: string; id: string }>;
+}
+
+const RISK_BADGE: Record<RiskLevel, string> = {
+  acc: 'bg-green-100 text-green-800',
+  alarp: 'bg-yellow-100 text-yellow-800',
+  unacc: 'bg-red-100 text-red-800',
+};
+
+const RISK_TEXT: Record<RiskLevel, string> = {
+  acc: 'Acceptable',
+  alarp: 'ALARP',
+  unacc: 'Unacceptable',
+};
+
+interface HazardTableProps {
+  items: HazardItem[];
+  onEdit?: (item: HazardItem) => void;
+  onDelete?: (id: string) => void;
+  loading?: boolean;
+}
+
+export function HazardTable({ items, onEdit, onDelete, loading = false }: HazardTableProps) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-32 text-gray-500">
+        Identifying hazards...
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-24 text-gray-400 border rounded-md">
+        No hazards identified yet. Run hazard identification to populate this table.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50 border-b">
+          <tr>
+            <th className="px-3 py-2 text-left font-semibold text-gray-700">Hazard</th>
+            <th className="px-3 py-2 text-left font-semibold text-gray-700">Harm</th>
+            <th className="px-3 py-2 text-center font-semibold text-gray-700">Severity</th>
+            <th className="px-3 py-2 text-center font-semibold text-gray-700">Probability</th>
+            <th className="px-3 py-2 text-center font-semibold text-gray-700">Risk Level</th>
+            <th className="px-3 py-2 text-center font-semibold text-gray-700">Citations</th>
+            {(onEdit || onDelete) && (
+              <th className="px-3 py-2 text-center font-semibold text-gray-700">Actions</th>
+            )}
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {items.map((item) => (
+            <tr key={item.id} className={item.lowConfidence ? 'bg-orange-50' : 'bg-white hover:bg-gray-50'}>
+              <td className="px-3 py-2">
+                {item.hazard}
+                {item.lowConfidence && (
+                  <span className="ml-1 text-[10px] text-orange-600 font-medium">[low confidence]</span>
+                )}
+              </td>
+              <td className="px-3 py-2 text-gray-700">{item.harm}</td>
+              <td className="px-3 py-2 text-center font-mono">{item.severity}</td>
+              <td className="px-3 py-2 text-center font-mono">{item.probability}</td>
+              <td className="px-3 py-2 text-center">
+                <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${RISK_BADGE[item.riskLevel]}`}>
+                  {RISK_TEXT[item.riskLevel]}
+                </span>
+              </td>
+              <td className="px-3 py-2 text-center text-xs text-gray-500">
+                {item.citation.length > 0
+                  ? item.citation.map((c) => `${c.source}:${c.id}`).join(', ')
+                  : '—'}
+              </td>
+              {(onEdit || onDelete) && (
+                <td className="px-3 py-2 text-center">
+                  <div className="flex items-center justify-center gap-2">
+                    {onEdit && (
+                      <button
+                        onClick={() => onEdit(item)}
+                        className="text-xs text-blue-600 hover:underline"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    {onDelete && (
+                      <button
+                        onClick={() => onDelete(item.id)}
+                        className="text-xs text-red-500 hover:underline"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default HazardTable;

--- a/components/risk/RiskApprovalGate.tsx
+++ b/components/risk/RiskApprovalGate.tsx
@@ -1,0 +1,116 @@
+'use client';
+// @MX:ANCHOR [AUTO] RiskApprovalGate — UI-level ra-lead enforcement gate.
+// @MX:REASON Mirrors server-side risk.approve RBAC. Only renders approve button for ra-lead role.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T4.4, T2.10, REQ-RISK-037~038)
+
+import { useState } from 'react';
+
+interface RiskApprovalGateProps {
+  runId: string;
+  isApproved: boolean;
+  approvedBy: string | null;
+  /** Current user's role — only 'ra-lead' can trigger approval */
+  currentUserRole: string;
+  onApprove?: (runId: string, comment: string) => Promise<void>;
+}
+
+/**
+ * RA-lead approval gate for risk management reports.
+ *
+ * Visibility rules per ISO 14971 §10 + project RBAC:
+ * - ra-lead: sees approval form + submit button
+ * - ra-member / other: sees read-only pending banner
+ *
+ * NOTE: The server-side withPermission('risk.approve') enforces the same check.
+ * This component is a UX gate, NOT a security gate — never bypass server auth.
+ */
+export function RiskApprovalGate({
+  runId,
+  isApproved,
+  approvedBy,
+  currentUserRole,
+  onApprove,
+}: RiskApprovalGateProps) {
+  const [comment, setComment] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isRaLead = currentUserRole === 'ra-lead';
+
+  async function handleApprove() {
+    if (!onApprove) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await onApprove(runId, comment);
+    } catch (e) {
+      setError((e as Error).message ?? 'Approval failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (isApproved) {
+    return (
+      <div className="rounded-md bg-green-50 border border-green-200 p-4">
+        <p className="text-sm text-green-800 font-semibold">
+          Report Approved
+        </p>
+        <p className="text-xs text-green-600 mt-1">
+          Approved by RA-Lead (ID: {approvedBy}) per ISO 14971 §10
+        </p>
+      </div>
+    );
+  }
+
+  if (!isRaLead) {
+    return (
+      <div className="rounded-md bg-yellow-50 border border-yellow-200 p-4">
+        <p className="text-sm text-yellow-800 font-semibold">
+          Pending RA-Lead Approval
+        </p>
+        <p className="text-xs text-yellow-600 mt-1">
+          This risk management report requires sign-off from an RA-Lead before distribution.
+          Only users with the ra-lead role can approve.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border p-4 space-y-3">
+      <p className="text-sm font-semibold text-gray-800">RA-Lead Approval</p>
+      <p className="text-xs text-gray-500">
+        By approving, you confirm this risk management report complies with ISO 14971:2019 §10
+        and all identified risks have been evaluated, controlled, and accepted (ALARP where applicable).
+      </p>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">
+          Approval comment (optional)
+        </label>
+        <textarea
+          className="w-full border rounded p-2 text-sm min-h-[64px] focus:ring-1 focus:ring-blue-400"
+          placeholder="Add any approval notes or conditions..."
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          disabled={loading}
+        />
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">{error}</div>
+      )}
+
+      <button
+        onClick={handleApprove}
+        disabled={loading}
+        className="px-4 py-2 bg-green-600 text-white rounded text-sm font-medium hover:bg-green-700 disabled:opacity-50"
+      >
+        {loading ? 'Approving...' : 'Approve Risk Management Report'}
+      </button>
+    </div>
+  );
+}
+
+export default RiskApprovalGate;

--- a/components/risk/RiskMatrix.tsx
+++ b/components/risk/RiskMatrix.tsx
@@ -1,0 +1,88 @@
+'use client';
+// @MX:NOTE [AUTO] 5×5 ISO 14971 risk matrix visualization component.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T4.1, REQ-RISK-011~015)
+
+import { DEFAULT_RISK_MATRIX, type RiskLevel } from '@/lib/risk/risk-evaluation';
+
+const RISK_COLORS: Record<RiskLevel, string> = {
+  acc: 'bg-green-100 text-green-800 border-green-300',
+  alarp: 'bg-yellow-100 text-yellow-800 border-yellow-300',
+  unacc: 'bg-red-100 text-red-800 border-red-300',
+};
+
+const RISK_LABELS: Record<RiskLevel, string> = {
+  acc: 'Acc',
+  alarp: 'ALARP',
+  unacc: 'Unacc',
+};
+
+const SEVERITY_LABELS = ['Negligible', 'Marginal', 'Serious', 'Critical', 'Catastrophic'];
+const PROBABILITY_LABELS = ['Incredible', 'Remote', 'Occasional', 'Probable', 'Frequent'];
+
+interface RiskMatrixProps {
+  /** Optional highlighted cell (severity 1-5, probability 1-5) */
+  highlight?: { severity: number; probability: number };
+  className?: string;
+}
+
+export function RiskMatrix({ highlight, className = '' }: RiskMatrixProps) {
+  return (
+    <div className={`overflow-auto ${className}`}>
+      <table className="border-collapse text-xs font-mono">
+        <thead>
+          <tr>
+            <th className="p-1 border text-left text-gray-500 min-w-[80px]">S \ P</th>
+            {PROBABILITY_LABELS.map((label, pi) => (
+              <th key={pi} className="p-1 border text-center min-w-[70px] text-gray-700">
+                P{pi + 1}
+                <br />
+                <span className="text-[10px] font-normal">{label}</span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {DEFAULT_RISK_MATRIX.map((row, si) => (
+            <tr key={si}>
+              <td className="p-1 border text-gray-700 font-semibold">
+                S{si + 1}
+                <br />
+                <span className="text-[10px] font-normal">{SEVERITY_LABELS[si]}</span>
+              </td>
+              {row.map((level, pi) => {
+                const isHighlighted =
+                  highlight?.severity === si + 1 && highlight?.probability === pi + 1;
+                return (
+                  <td
+                    key={pi}
+                    className={`p-1 border text-center font-semibold ${RISK_COLORS[level]} ${
+                      isHighlighted ? 'ring-2 ring-blue-500 ring-inset' : ''
+                    }`}
+                  >
+                    {RISK_LABELS[level]}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-2 flex gap-3 text-xs">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded bg-green-200 border border-green-300" />
+          Acceptable
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded bg-yellow-200 border border-yellow-300" />
+          ALARP
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded bg-red-200 border border-red-300" />
+          Unacceptable
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default RiskMatrix;

--- a/components/risk/__tests__/RiskMatrix.test.tsx
+++ b/components/risk/__tests__/RiskMatrix.test.tsx
@@ -1,0 +1,88 @@
+// @MX:NOTE [AUTO] RiskMatrix component tests — SPEC-REGULA-RISK-001 Phase 4 (T4.1~T4.2).
+// @MX:SPEC SPEC-REGULA-RISK-001 (T4.1~T4.2, REQ-RISK-011~015)
+
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const componentDir = path.resolve(__dirname, '..');
+
+// T4.1 — RiskMatrix component file exists
+describe('T4.1 — RiskMatrix component', () => {
+  it('RiskMatrix.tsx exists', () => {
+    expect(fs.existsSync(path.join(componentDir, 'RiskMatrix.tsx'))).toBe(true);
+  });
+
+  it('exports RiskMatrix as default or named export', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'RiskMatrix.tsx'), 'utf8');
+    expect(src).toMatch(/export (default|function RiskMatrix|const RiskMatrix)/);
+  });
+
+  it('renders 5×5 grid (25 cells) — source contains 5×5 data reference', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'RiskMatrix.tsx'), 'utf8');
+    // Must reference DEFAULT_RISK_MATRIX or render a 5×5 grid
+    expect(src).toContain('DEFAULT_RISK_MATRIX');
+  });
+
+  it('uses risk level color coding (acc/alarp/unacc)', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'RiskMatrix.tsx'), 'utf8');
+    expect(src).toContain('acc');
+    expect(src).toContain('alarp');
+    expect(src).toContain('unacc');
+  });
+});
+
+// T4.2 — HazardTable component
+describe('T4.2 — HazardTable component', () => {
+  it('HazardTable.tsx exists', () => {
+    expect(fs.existsSync(path.join(componentDir, 'HazardTable.tsx'))).toBe(true);
+  });
+
+  it('exports HazardTable', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'HazardTable.tsx'), 'utf8');
+    expect(src).toMatch(/export (default|function HazardTable|const HazardTable)/);
+  });
+
+  it('renders columns: hazard, harm, severity, probability, riskLevel', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'HazardTable.tsx'), 'utf8');
+    expect(src.toLowerCase()).toContain('hazard');
+    expect(src.toLowerCase()).toContain('harm');
+    expect(src.toLowerCase()).toContain('severity');
+    expect(src.toLowerCase()).toContain('probability');
+  });
+});
+
+// T4.3 — ControlWizard component
+describe('T4.3 — ControlWizard component', () => {
+  it('ControlWizard.tsx exists', () => {
+    expect(fs.existsSync(path.join(componentDir, 'ControlWizard.tsx'))).toBe(true);
+  });
+
+  it('exports ControlWizard', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'ControlWizard.tsx'), 'utf8');
+    expect(src).toMatch(/export (default|function ControlWizard|const ControlWizard)/);
+  });
+
+  it('enforces information tier rationale (validateControlHierarchy)', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'ControlWizard.tsx'), 'utf8');
+    expect(src).toContain('information');
+    expect(src).toContain('rationale');
+  });
+});
+
+// T4.4 — RiskApprovalGate component
+describe('T4.4 — RiskApprovalGate component', () => {
+  it('RiskApprovalGate.tsx exists', () => {
+    expect(fs.existsSync(path.join(componentDir, 'RiskApprovalGate.tsx'))).toBe(true);
+  });
+
+  it('exports RiskApprovalGate', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'RiskApprovalGate.tsx'), 'utf8');
+    expect(src).toMatch(/export (default|function RiskApprovalGate|const RiskApprovalGate)/);
+  });
+
+  it('references risk.approve permission gate', () => {
+    const src = fs.readFileSync(path.join(componentDir, 'RiskApprovalGate.tsx'), 'utf8');
+    expect(src).toContain('ra-lead');
+  });
+});

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -158,7 +158,14 @@ export type AuditAction =
   // SPEC-REGULA-ESUBMIT-001 audit actions — added via 0056_submission_packages.sql:
   | 'submission_package_created'
   | 'submission_package_submitted'
-  | 'submission_validation_completed';
+  | 'submission_validation_completed'
+  // SPEC-REGULA-RISK-001 — risk management audit actions (REQ-RISK-028~038):
+  | 'risk.hazard_identified'
+  | 'risk.matrix_evaluated'
+  | 'risk.control_adopted'
+  | 'risk.residual_accepted'
+  | 'risk.gspr_mapped'
+  | 'risk.report_approved';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -162,6 +162,7 @@ export type AuditAction =
   // SPEC-REGULA-RISK-001 — risk management audit actions (REQ-RISK-028~038):
   | 'risk.hazard_identified'
   | 'risk.matrix_evaluated'
+  | 'risk.item_deleted'
   | 'risk.control_adopted'
   | 'risk.residual_accepted'
   | 'risk.gspr_mapped'

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -35,7 +35,12 @@ export type PermissionAction =
   // Authoring API (hybrid-ra-saas integration — Issue #171)
   | 'authoring.create'
   | 'authoring.view'
-  | 'authoring.approve';
+  | 'authoring.approve'
+  // Risk management actions (SPEC-REGULA-RISK-001, Issue #46)
+  | 'risk.generate'
+  | 'risk.view'
+  | 'risk.update'
+  | 'risk.approve';
 
 export interface PermissionSpec {
   minRole: Role;
@@ -106,4 +111,13 @@ export const PERMISSIONS: Record<PermissionAction, PermissionSpec> = {
   'authoring.create': { minRole: 'ra-member', scope: 'org', resourceType: 'authoring' },
   'authoring.view': { minRole: 'ra-member', scope: 'org', resourceType: 'authoring' },
   'authoring.approve': { minRole: 'ra-lead', scope: 'org', resourceType: 'authoring' },
+
+  // @MX:ANCHOR [AUTO] risk.approve — RA-lead ONLY approval gate invariant.
+  // @MX:REASON ISO 14971 legal responsibility: only qualified RA-lead may approve risk management report. Critical RBAC invariant.
+  // @MX:SPEC SPEC-REGULA-RISK-001 (T0.8, REQ-RISK-034)
+  // Risk management actions (SPEC-REGULA-RISK-001, Issue #46)
+  'risk.generate': { minRole: 'ra-member', scope: 'org', resourceType: 'risk' },
+  'risk.view': { minRole: 'ra-member', scope: 'org', resourceType: 'risk' },
+  'risk.update': { minRole: 'ra-member', scope: 'org', resourceType: 'risk' },
+  'risk.approve': { minRole: 'ra-lead', scope: 'org', resourceType: 'risk' },
 };

--- a/lib/db/migrations/0001_salty_pet_avengers.sql
+++ b/lib/db/migrations/0001_salty_pet_avengers.sql
@@ -1,0 +1,60 @@
+CREATE TYPE "public"."control_tier" AS ENUM('inherent', 'protective', 'information');--> statement-breakpoint
+CREATE TYPE "public"."risk_level" AS ENUM('acc', 'alarp', 'unacc');--> statement-breakpoint
+ALTER TYPE "public"."audit_action" ADD VALUE 'risk.hazard_identified';--> statement-breakpoint
+ALTER TYPE "public"."audit_action" ADD VALUE 'risk.matrix_evaluated';--> statement-breakpoint
+ALTER TYPE "public"."audit_action" ADD VALUE 'risk.control_adopted';--> statement-breakpoint
+ALTER TYPE "public"."audit_action" ADD VALUE 'risk.residual_accepted';--> statement-breakpoint
+ALTER TYPE "public"."audit_action" ADD VALUE 'risk.gspr_mapped';--> statement-breakpoint
+ALTER TYPE "public"."audit_action" ADD VALUE 'risk.report_approved';--> statement-breakpoint
+ALTER TYPE "public"."workflow_type" ADD VALUE 'risk';--> statement-breakpoint
+CREATE TABLE "risk_controls" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"risk_item_id" uuid NOT NULL,
+	"tier" "control_tier" NOT NULL,
+	"description" text NOT NULL,
+	"rationale" text,
+	"is_adopted" boolean DEFAULT false NOT NULL,
+	"residual_severity" integer,
+	"residual_probability" integer,
+	"residual_risk_level" "risk_level",
+	"alarp_justification" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "risk_gspr_mappings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workflow_run_id" uuid NOT NULL,
+	"risk_item_id" uuid,
+	"gspr_clause" text NOT NULL,
+	"requirement" text NOT NULL,
+	"compliance" text NOT NULL,
+	"evidence" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "risk_items" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workflow_run_id" uuid NOT NULL,
+	"hazard" text NOT NULL,
+	"sequence_of_events" text NOT NULL,
+	"hazardous_situation" text NOT NULL,
+	"harm" text NOT NULL,
+	"citation" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"severity" integer NOT NULL,
+	"probability" integer NOT NULL,
+	"risk_level" "risk_level" NOT NULL,
+	"low_confidence" boolean DEFAULT false NOT NULL,
+	"edited_by" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "risk_controls" ADD CONSTRAINT "risk_controls_risk_item_id_risk_items_id_fk" FOREIGN KEY ("risk_item_id") REFERENCES "public"."risk_items"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "risk_gspr_mappings" ADD CONSTRAINT "risk_gspr_mappings_workflow_run_id_workflow_runs_id_fk" FOREIGN KEY ("workflow_run_id") REFERENCES "public"."workflow_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "risk_gspr_mappings" ADD CONSTRAINT "risk_gspr_mappings_risk_item_id_risk_items_id_fk" FOREIGN KEY ("risk_item_id") REFERENCES "public"."risk_items"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "risk_items" ADD CONSTRAINT "risk_items_workflow_run_id_workflow_runs_id_fk" FOREIGN KEY ("workflow_run_id") REFERENCES "public"."workflow_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "risk_items" ADD CONSTRAINT "risk_items_edited_by_users_id_fk" FOREIGN KEY ("edited_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_risk_controls_item" ON "risk_controls" USING btree ("risk_item_id");--> statement-breakpoint
+CREATE INDEX "idx_risk_gspr_run" ON "risk_gspr_mappings" USING btree ("workflow_run_id");--> statement-breakpoint
+CREATE INDEX "idx_risk_items_run" ON "risk_items" USING btree ("workflow_run_id");

--- a/lib/db/migrations/meta/0001_snapshot.json
+++ b/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,5745 @@
+{
+  "id": "4c6d1231-f7d4-4684-963f-33ff728f7d64",
+  "prevId": "b0bc8d72-fe8f-47d9-a393-86a749663fcd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adverse_events": {
+      "name": "adverse_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_model": {
+          "name": "device_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_outcome": {
+          "name": "patient_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awareness_date": {
+          "name": "awareness_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_name": {
+          "name": "reporter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_role": {
+          "name": "reporter_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adverse_events_workflow_run_id_workflow_runs_id_fk": {
+          "name": "adverse_events_workflow_run_id_workflow_runs_id_fk",
+          "tableFrom": "adverse_events",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "workflow_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_actor_created": {
+          "name": "idx_audit_logs_actor_created",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action_created": {
+          "name": "idx_audit_logs_action_created",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_resource": {
+          "name": "idx_audit_logs_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_actor_id_users_id_fk": {
+          "name": "audit_logs_actor_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_logs_conversation_id_conversations_id_fk": {
+          "name": "audit_logs_conversation_id_conversations_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cer_literature": {
+      "name": "cer_literature",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cer_run_id": {
+          "name": "cer_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vancouver_citation": {
+          "name": "vancouver_citation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sign50_level": {
+          "name": "sign50_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_quality": {
+          "name": "grade_quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included": {
+          "name": "included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cer_literature_cer_run_id_workflow_runs_id_fk": {
+          "name": "cer_literature_cer_run_id_workflow_runs_id_fk",
+          "tableFrom": "cer_literature",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "cer_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_user": {
+          "name": "idx_conversations_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_project": {
+          "name": "idx_conversations_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conversations_status": {
+          "name": "idx_conversations_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_project_id_projects_id_fk": {
+          "name": "conversations_project_id_projects_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crawler_runs": {
+      "name": "crawler_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "crawler_name": {
+          "name": "crawler_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "records_added": {
+          "name": "records_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors_json": {
+          "name": "errors_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_crawler_runs_crawler_name": {
+          "name": "idx_crawler_runs_crawler_name",
+          "columns": [
+            {
+              "expression": "crawler_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crawler_runs_started_at": {
+          "name": "idx_crawler_runs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawler_runs_org_id_organizations_id_fk": {
+          "name": "crawler_runs_org_id_organizations_id_fk",
+          "tableFrom": "crawler_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.design_history_files": {
+      "name": "design_history_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_model": {
+          "name": "device_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intended_use": {
+          "name": "intended_use",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FDA'"
+        },
+        "regulatory_framework": {
+          "name": "regulatory_framework",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'QSR_QMSR'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "completeness_score": {
+          "name": "completeness_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "design_freeze_date": {
+          "name": "design_freeze_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_dhf_org": {
+          "name": "idx_dhf_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "design_history_files_org_id_organizations_id_fk": {
+          "name": "design_history_files_org_id_organizations_id_fk",
+          "tableFrom": "design_history_files",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "design_history_files_created_by_users_id_fk": {
+          "name": "design_history_files_created_by_users_id_fk",
+          "tableFrom": "design_history_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.design_inputs": {
+      "name": "design_inputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "dhf_id": {
+          "name": "dhf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_type": {
+          "name": "input_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'must'"
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_design_inputs_dhf": {
+          "name": "idx_design_inputs_dhf",
+          "columns": [
+            {
+              "expression": "dhf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "design_inputs_dhf_id_design_history_files_id_fk": {
+          "name": "design_inputs_dhf_id_design_history_files_id_fk",
+          "tableFrom": "design_inputs",
+          "tableTo": "design_history_files",
+          "columnsFrom": [
+            "dhf_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.design_reviews": {
+      "name": "design_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "dhf_id": {
+          "name": "dhf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_stage": {
+          "name": "review_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_date": {
+          "name": "review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "decisions": {
+          "name": "decisions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_actions": {
+          "name": "open_actions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_design_reviews_dhf": {
+          "name": "idx_design_reviews_dhf",
+          "columns": [
+            {
+              "expression": "dhf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "design_reviews_dhf_id_design_history_files_id_fk": {
+          "name": "design_reviews_dhf_id_design_history_files_id_fk",
+          "tableFrom": "design_reviews",
+          "tableTo": "design_history_files",
+          "columnsFrom": [
+            "dhf_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.design_verifications": {
+      "name": "design_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "dhf_id": {
+          "name": "dhf_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "design_input_id": {
+          "name": "design_input_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_type": {
+          "name": "verification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_title": {
+          "name": "protocol_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_date": {
+          "name": "test_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_design_verifications_dhf": {
+          "name": "idx_design_verifications_dhf",
+          "columns": [
+            {
+              "expression": "dhf_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "design_verifications_dhf_id_design_history_files_id_fk": {
+          "name": "design_verifications_dhf_id_design_history_files_id_fk",
+          "tableFrom": "design_verifications",
+          "tableTo": "design_history_files",
+          "columnsFrom": [
+            "dhf_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "design_verifications_design_input_id_design_inputs_id_fk": {
+          "name": "design_verifications_design_input_id_design_inputs_id_fk",
+          "tableFrom": "design_verifications",
+          "tableTo": "design_inputs",
+          "columnsFrom": [
+            "design_input_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_classifications": {
+      "name": "device_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_description": {
+          "name": "device_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_type": {
+          "name": "contact_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_software": {
+          "name": "has_software",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_ai_ml": {
+          "name": "has_ai_ml",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_sterile": {
+          "name": "is_sterile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fda_class": {
+          "name": "fda_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fda_pathway": {
+          "name": "fda_pathway",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fda_product_code": {
+          "name": "fda_product_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fda_regulation_number": {
+          "name": "fda_regulation_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eu_class": {
+          "name": "eu_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eu_pathway": {
+          "name": "eu_pathway",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eu_rule": {
+          "name": "eu_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfds_class": {
+          "name": "mfds_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nmpa_class": {
+          "name": "nmpa_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pmda_class": {
+          "name": "pmda_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification_rationale": {
+          "name": "classification_rationale",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_classifications_org_id_organizations_id_fk": {
+          "name": "device_classifications_org_id_organizations_id_fk",
+          "tableFrom": "device_classifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_classifications_user_id_users_id_fk": {
+          "name": "device_classifications_user_id_users_id_fk",
+          "tableFrom": "device_classifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence_syntheses": {
+      "name": "evidence_syntheses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "search_id": {
+          "name": "search_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade_summary": {
+          "name": "grade_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative_synthesis": {
+          "name": "narrative_synthesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cer_section6_draft": {
+          "name": "cer_section6_draft",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cer_section7_draft": {
+          "name": "cer_section7_draft",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cer_section8_draft": {
+          "name": "cer_section8_draft",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "moderate_count": {
+          "name": "moderate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "very_low_count": {
+          "name": "very_low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evidence_syntheses_search_id_literature_searches_id_fk": {
+          "name": "evidence_syntheses_search_id_literature_searches_id_fk",
+          "tableFrom": "evidence_syntheses",
+          "tableTo": "literature_searches",
+          "columnsFrom": [
+            "search_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.expert_reviews": {
+      "name": "expert_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "expert_review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_expert_reviews_status_assigned": {
+          "name": "idx_expert_reviews_status_assigned",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "expert_reviews_conversation_id_conversations_id_fk": {
+          "name": "expert_reviews_conversation_id_conversations_id_fk",
+          "tableFrom": "expert_reviews",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "expert_reviews_message_id_messages_id_fk": {
+          "name": "expert_reviews_message_id_messages_id_fk",
+          "tableFrom": "expert_reviews",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "expert_reviews_requested_by_users_id_fk": {
+          "name": "expert_reviews_requested_by_users_id_fk",
+          "tableFrom": "expert_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "expert_reviews_assigned_to_users_id_fk": {
+          "name": "expert_reviews_assigned_to_users_id_fk",
+          "tableFrom": "expert_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_action_items": {
+      "name": "impact_action_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_reference": {
+          "name": "section_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "impact_action_items_assessment_id_regulatory_impact_assessments_id_fk": {
+          "name": "impact_action_items_assessment_id_regulatory_impact_assessments_id_fk",
+          "tableFrom": "impact_action_items",
+          "tableTo": "regulatory_impact_assessments",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "impact_action_items_project_id_projects_id_fk": {
+          "name": "impact_action_items_project_id_projects_id_fk",
+          "tableFrom": "impact_action_items",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "impact_action_items_assigned_to_users_id_fk": {
+          "name": "impact_action_items_assigned_to_users_id_fk",
+          "tableFrom": "impact_action_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.literature_references": {
+      "name": "literature_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "search_id": {
+          "name": "search_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pmid": {
+          "name": "pmid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "journal": {
+          "name": "journal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vancouver_citation": {
+          "name": "vancouver_citation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sign50_level": {
+          "name": "sign50_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade_quality": {
+          "name": "grade_quality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screening_decision": {
+          "name": "screening_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "screening_reason": {
+          "name": "screening_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included": {
+          "name": "included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "literature_references_search_id_literature_searches_id_fk": {
+          "name": "literature_references_search_id_literature_searches_id_fk",
+          "tableFrom": "literature_references",
+          "tableTo": "literature_searches",
+          "columnsFrom": [
+            "search_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.literature_searches": {
+      "name": "literature_searches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cer_run_id": {
+          "name": "cer_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "device_description": {
+          "name": "device_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pico_patient": {
+          "name": "pico_patient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pico_intervention": {
+          "name": "pico_intervention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pico_comparator": {
+          "name": "pico_comparator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pico_outcome": {
+          "name": "pico_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_query": {
+          "name": "search_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mesh_terms": {
+          "name": "mesh_terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "total_records": {
+          "name": "total_records",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "after_dedup": {
+          "name": "after_dedup",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "after_title_abstract": {
+          "name": "after_title_abstract",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "after_full_text": {
+          "name": "after_full_text",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "included_count": {
+          "name": "included_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "literature_searches_cer_run_id_workflow_runs_id_fk": {
+          "name": "literature_searches_cer_run_id_workflow_runs_id_fk",
+          "tableFrom": "literature_searches",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "cer_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_blocks": {
+      "name": "message_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "block_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_json": {
+          "name": "block_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_blocks_message_order_idx": {
+          "name": "message_blocks_message_order_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_blocks_message_id_messages_id_fk": {
+          "name": "message_blocks_message_id_messages_id_fk",
+          "tableFrom": "message_blocks",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_sources": {
+      "name": "message_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quoted_offset": {
+          "name": "quoted_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quoted_length": {
+          "name": "quoted_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cite_index": {
+          "name": "cite_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_sources_message_id_messages_id_fk": {
+          "name": "message_sources_message_id_messages_id_fk",
+          "tableFrom": "message_sources",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sources_source_id_sources_id_fk": {
+          "name": "message_sources_source_id_sources_id_fk",
+          "tableFrom": "message_sources",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_sources_message_cite_idx": {
+          "name": "message_sources_message_cite_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "cite_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_prose": {
+          "name": "content_prose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "confidence_level": {
+          "name": "confidence_level",
+          "type": "confidence_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_score": {
+          "name": "confidence_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expert_review_required": {
+          "name": "expert_review_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tokens_in": {
+          "name": "tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_out": {
+          "name": "tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_created": {
+          "name": "idx_messages_conversation_created",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_expert_review": {
+          "name": "idx_messages_expert_review",
+          "columns": [
+            {
+              "expression": "expert_review_required",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_digest_preferences": {
+      "name": "org_digest_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "send_day_of_week": {
+          "name": "send_day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "send_hour": {
+          "name": "send_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 9
+        },
+        "min_severity": {
+          "name": "min_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "include_immediate_alerts": {
+          "name": "include_immediate_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "recipient_emails": {
+          "name": "recipient_emails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_digest_preferences_org_id_organizations_id_fk": {
+          "name": "org_digest_preferences_org_id_organizations_id_fk",
+          "tableFrom": "org_digest_preferences",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_digest_preferences_org_id_unique": {
+          "name": "org_digest_preferences_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_members_org_id": {
+          "name": "idx_org_members_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_user_id_users_id_fk": {
+          "name": "org_members_user_id_users_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_org_id_organizations_id_fk": {
+          "name": "org_members_org_id_organizations_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_notification_settings": {
+      "name": "org_notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_webhook_url": {
+          "name": "slack_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams_webhook_url": {
+          "name": "teams_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_notification_settings_org_id_organizations_id_fk": {
+          "name": "org_notification_settings_org_id_organizations_id_fk",
+          "tableFrom": "org_notification_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_notification_settings_org_id_unique": {
+          "name": "org_notification_settings_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_update_relevance": {
+      "name": "org_update_relevance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "update_id": {
+          "name": "update_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_score": {
+          "name": "impact_score",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matched_product_categories": {
+          "name": "matched_product_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_update_relevance_org_impact": {
+          "name": "idx_org_update_relevance_org_impact",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "impact_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_update_relevance_update": {
+          "name": "idx_org_update_relevance_update",
+          "columns": [
+            {
+              "expression": "update_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_update_relevance_org_id_organizations_id_fk": {
+          "name": "org_update_relevance_org_id_organizations_id_fk",
+          "tableFrom": "org_update_relevance",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_update_relevance_update_id_regulatory_updates_id_fk": {
+          "name": "org_update_relevance_update_id_regulatory_updates_id_fk",
+          "tableFrom": "org_update_relevance",
+          "tableTo": "regulatory_updates",
+          "columnsFrom": [
+            "update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_update_relevance_org_update_key": {
+          "name": "org_update_relevance_org_update_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "update_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pccp_components": {
+      "name": "pccp_components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pccp_version_id": {
+          "name": "pccp_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "component_type": {
+          "name": "component_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_jsonb": {
+          "name": "content_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pccp_components_pccp_version_id_pccp_versions_id_fk": {
+          "name": "pccp_components_pccp_version_id_pccp_versions_id_fk",
+          "tableFrom": "pccp_components",
+          "tableTo": "pccp_versions",
+          "columnsFrom": [
+            "pccp_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pccp_components_pccp_version_id_component_type_unique": {
+          "name": "pccp_components_pccp_version_id_component_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pccp_version_id",
+            "component_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pccp_versions": {
+      "name": "pccp_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "baseline_snapshot_jsonb": {
+          "name": "baseline_snapshot_jsonb",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_workflow_id": {
+          "name": "parent_workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indication": {
+          "name": "indication",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_members_project_id": {
+          "name": "idx_project_members_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_class": {
+          "name": "device_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_markets": {
+          "name": "target_markets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_date": {
+          "name": "submission_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_org": {
+          "name": "idx_projects_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_status": {
+          "name": "idx_projects_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regulatory_impact_assessments": {
+      "name": "regulatory_impact_assessments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "regulatory_update_id": {
+          "name": "regulatory_update_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_level": {
+          "name": "impact_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affected_sections": {
+          "name": "affected_sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "analysis_summary": {
+          "name": "analysis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ria_project_impact": {
+          "name": "idx_ria_project_impact",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "impact_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ria_update": {
+          "name": "idx_ria_update",
+          "columns": [
+            {
+              "expression": "regulatory_update_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regulatory_impact_assessments_regulatory_update_id_regulatory_updates_id_fk": {
+          "name": "regulatory_impact_assessments_regulatory_update_id_regulatory_updates_id_fk",
+          "tableFrom": "regulatory_impact_assessments",
+          "tableTo": "regulatory_updates",
+          "columnsFrom": [
+            "regulatory_update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "regulatory_impact_assessments_project_id_projects_id_fk": {
+          "name": "regulatory_impact_assessments_project_id_projects_id_fk",
+          "tableFrom": "regulatory_impact_assessments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "regulatory_impact_assessments_created_by_users_id_fk": {
+          "name": "regulatory_impact_assessments_created_by_users_id_fk",
+          "tableFrom": "regulatory_impact_assessments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ria_update_project_key": {
+          "name": "ria_update_project_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "regulatory_update_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regulatory_updates": {
+      "name": "regulatory_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affected_product_types": {
+          "name": "affected_product_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_analysis_text": {
+          "name": "impact_analysis_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_crawler": {
+          "name": "source_crawler",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_content_en": {
+          "name": "raw_content_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_content_ko": {
+          "name": "raw_content_ko",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impact_type_hint": {
+          "name": "impact_type_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier1_relevant": {
+          "name": "tier1_relevant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impact_score": {
+          "name": "impact_score",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reportability_assessments": {
+      "name": "reportability_assessments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "adverse_event_id": {
+          "name": "adverse_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fda_mdr_required": {
+          "name": "fda_mdr_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fda_mdr_deadline_days": {
+          "name": "fda_mdr_deadline_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eu_mdv_required": {
+          "name": "eu_mdv_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eu_mdv_deadline_days": {
+          "name": "eu_mdv_deadline_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fsca_required": {
+          "name": "fsca_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_rationale": {
+          "name": "assessment_rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessed_by_ai": {
+          "name": "assessed_by_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reportability_assessments_adverse_event_id_adverse_events_id_fk": {
+          "name": "reportability_assessments_adverse_event_id_adverse_events_id_fk",
+          "tableFrom": "reportability_assessments",
+          "tableTo": "adverse_events",
+          "columnsFrom": [
+            "adverse_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.risk_controls": {
+      "name": "risk_controls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "risk_item_id": {
+          "name": "risk_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "control_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adopted": {
+          "name": "is_adopted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "residual_severity": {
+          "name": "residual_severity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residual_probability": {
+          "name": "residual_probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residual_risk_level": {
+          "name": "residual_risk_level",
+          "type": "risk_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alarp_justification": {
+          "name": "alarp_justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_risk_controls_item": {
+          "name": "idx_risk_controls_item",
+          "columns": [
+            {
+              "expression": "risk_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "risk_controls_risk_item_id_risk_items_id_fk": {
+          "name": "risk_controls_risk_item_id_risk_items_id_fk",
+          "tableFrom": "risk_controls",
+          "tableTo": "risk_items",
+          "columnsFrom": [
+            "risk_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.risk_gspr_mappings": {
+      "name": "risk_gspr_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_item_id": {
+          "name": "risk_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gspr_clause": {
+          "name": "gspr_clause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance": {
+          "name": "compliance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_risk_gspr_run": {
+          "name": "idx_risk_gspr_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "risk_gspr_mappings_workflow_run_id_workflow_runs_id_fk": {
+          "name": "risk_gspr_mappings_workflow_run_id_workflow_runs_id_fk",
+          "tableFrom": "risk_gspr_mappings",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "workflow_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "risk_gspr_mappings_risk_item_id_risk_items_id_fk": {
+          "name": "risk_gspr_mappings_risk_item_id_risk_items_id_fk",
+          "tableFrom": "risk_gspr_mappings",
+          "tableTo": "risk_items",
+          "columnsFrom": [
+            "risk_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.risk_items": {
+      "name": "risk_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hazard": {
+          "name": "hazard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_of_events": {
+          "name": "sequence_of_events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hazardous_situation": {
+          "name": "hazardous_situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harm": {
+          "name": "harm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citation": {
+          "name": "citation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "risk_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "low_confidence": {
+          "name": "low_confidence",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_risk_items_run": {
+          "name": "idx_risk_items_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "risk_items_workflow_run_id_workflow_runs_id_fk": {
+          "name": "risk_items_workflow_run_id_workflow_runs_id_fk",
+          "tableFrom": "risk_items",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "workflow_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "risk_items_edited_by_users_id_fk": {
+          "name": "risk_items_edited_by_users_id_fk",
+          "tableFrom": "risk_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "edited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.samd_assessments": {
+      "name": "samd_assessments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_description": {
+          "name": "device_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intended_use": {
+          "name": "intended_use",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_ml_type": {
+          "name": "ai_ml_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imdrf_clinical_situation": {
+          "name": "imdrf_clinical_situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imdrf_healthcare_situation": {
+          "name": "imdrf_healthcare_situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imdrf_category": {
+          "name": "imdrf_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fda_pathway": {
+          "name": "fda_pathway",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eu_ai_risk_level": {
+          "name": "eu_ai_risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pccp_required": {
+          "name": "pccp_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "generated_model_card": {
+          "name": "generated_model_card",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_checklist": {
+          "name": "generated_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_monitoring_plan": {
+          "name": "generated_monitoring_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expert_review_approved_by": {
+          "name": "expert_review_approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expert_review_approved_at": {
+          "name": "expert_review_approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "samd_assessments_org_id_organizations_id_fk": {
+          "name": "samd_assessments_org_id_organizations_id_fk",
+          "tableFrom": "samd_assessments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "samd_assessments_created_by_users_id_fk": {
+          "name": "samd_assessments_created_by_users_id_fk",
+          "tableFrom": "samd_assessments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_sections": {
+      "name": "source_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_sections_source_id_sources_id_fk": {
+          "name": "source_sections_source_id_sources_id_fk",
+          "tableFrom": "source_sections",
+          "tableTo": "sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_sections_source_anchor_idx": {
+          "name": "source_sections_source_anchor_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "anchor"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_label": {
+          "name": "org_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text_tsv": {
+          "name": "full_text_tsv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sources_org": {
+          "name": "idx_sources_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sources_type": {
+          "name": "idx_sources_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sources_region": {
+          "name": "idx_sources_region",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sources_organization_id_organizations_id_fk": {
+          "name": "sources_organization_id_organizations_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.standards_applicability": {
+      "name": "standards_applicability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_type_key": {
+          "name": "device_type_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standard_id": {
+          "name": "standard_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicability_reason": {
+          "name": "applicability_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regulatory_pathway": {
+          "name": "regulatory_pathway",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mandatory": {
+          "name": "is_mandatory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "standards_applicability_standard_id_standards_catalog_id_fk": {
+          "name": "standards_applicability_standard_id_standards_catalog_id_fk",
+          "tableFrom": "standards_applicability",
+          "tableTo": "standards_catalog",
+          "columnsFrom": [
+            "standard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "standards_applicability_device_type_key_standard_id_regulatory_pathway_unique": {
+          "name": "standards_applicability_device_type_key_standard_id_regulatory_pathway_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_type_key",
+            "standard_id",
+            "regulatory_pathway"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.standards_catalog": {
+      "name": "standards_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "standard_number": {
+          "name": "standard_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_year": {
+          "name": "publication_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'current'"
+        },
+        "supersedes": {
+          "name": "supersedes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_keywords": {
+          "name": "scope_keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['']::text[]"
+        },
+        "fda_recognized": {
+          "name": "fda_recognized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "eu_harmonized": {
+          "name": "eu_harmonized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "standards_catalog_standard_number_unique": {
+          "name": "standards_catalog_standard_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "standard_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submission_interactions": {
+      "name": "submission_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interaction_type": {
+          "name": "interaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_number": {
+          "name": "reference_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submission_interactions_pkg": {
+          "name": "idx_submission_interactions_pkg",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_interactions_package_id_submission_packages_id_fk": {
+          "name": "submission_interactions_package_id_submission_packages_id_fk",
+          "tableFrom": "submission_interactions",
+          "tableTo": "submission_packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submission_packages": {
+      "name": "submission_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_number": {
+          "name": "submission_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "package_manifest": {
+          "name": "package_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "validation_results": {
+          "name": "validation_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submission_packages_org": {
+          "name": "idx_submission_packages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_packages_org_id_organizations_id_fk": {
+          "name": "submission_packages_org_id_organizations_id_fk",
+          "tableFrom": "submission_packages",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submission_packages_created_by_users_id_fk": {
+          "name": "submission_packages_created_by_users_id_fk",
+          "tableFrom": "submission_packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ra-member'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko'"
+        },
+        "theme_pref": {
+          "name": "theme_pref",
+          "type": "theme_pref",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "notification_pref": {
+          "name": "notification_pref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "department": {
+          "name": "department",
+          "type": "user_department",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_status": {
+          "name": "idx_users_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vigilance_reports": {
+      "name": "vigilance_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "adverse_event_id": {
+          "name": "adverse_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_format": {
+          "name": "report_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submission_deadline": {
+          "name": "submission_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vigilance_reports_adverse_event_id_adverse_events_id_fk": {
+          "name": "vigilance_reports_adverse_event_id_adverse_events_id_fk",
+          "tableFrom": "vigilance_reports",
+          "tableTo": "adverse_events",
+          "columnsFrom": [
+            "adverse_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_digests": {
+      "name": "weekly_digests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_id": {
+          "name": "week_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "update_count": {
+          "name": "update_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "critical_count": {
+          "name": "critical_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "medium_count": {
+          "name": "medium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "digest_json": {
+          "name": "digest_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "email_sent_at": {
+          "name": "email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weekly_digests_org_id_organizations_id_fk": {
+          "name": "weekly_digests_org_id_organizations_id_fk",
+          "tableFrom": "weekly_digests",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "weekly_digests_share_token_unique": {
+          "name": "weekly_digests_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_type": {
+          "name": "workflow_type",
+          "type": "workflow_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input_json": {
+          "name": "input_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_progress": {
+          "name": "step_progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_aggregate": {
+          "name": "confidence_aggregate",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_required": {
+          "name": "review_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloudflare_workflow_instance_id": {
+          "name": "cloudflare_workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_runs_user": {
+          "name": "idx_workflow_runs_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_runs_org": {
+          "name": "idx_workflow_runs_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_runs_project": {
+          "name": "idx_workflow_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_runs_status": {
+          "name": "idx_workflow_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_runs_reviewer": {
+          "name": "idx_workflow_runs_reviewer",
+          "columns": [
+            {
+              "expression": "reviewer_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_user_id_users_id_fk": {
+          "name": "workflow_runs_user_id_users_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_runs_organization_id_organizations_id_fk": {
+          "name": "workflow_runs_organization_id_organizations_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_runs_project_id_projects_id_fk": {
+          "name": "workflow_runs_project_id_projects_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_runs_reviewer_user_id_users_id_fk": {
+          "name": "workflow_runs_reviewer_user_id_users_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "llm.call",
+        "source.access",
+        "expert_review.flag",
+        "conversations.list",
+        "conversation.view",
+        "conversation.delete",
+        "message.feedback",
+        "template.list",
+        "template.download",
+        "updates.list",
+        "dashboard.view",
+        "projects.list",
+        "project.create",
+        "project.update",
+        "auth.login",
+        "auth.logout",
+        "session.invalidate",
+        "expert_review.create",
+        "expert_review.assign",
+        "expert_review.resolve",
+        "rbac.permission_deny",
+        "profile.theme_update",
+        "profile.locale_update",
+        "checklist.toggle",
+        "consult.expert_review_auto_flag",
+        "project.switch",
+        "profile.update",
+        "workflow.start",
+        "workflow.step.complete",
+        "workflow.step.fail",
+        "workflow.pause",
+        "workflow.resume",
+        "workflow.pending_review",
+        "workflow.approve",
+        "workflow.reject",
+        "workflow.download",
+        "workflow.edit",
+        "document.upload",
+        "document.access",
+        "document.redact",
+        "document.chunk",
+        "document.search",
+        "redaction_map.access",
+        "radar.crawler_run",
+        "radar.notification",
+        "radar.search",
+        "chat.query",
+        "answer.refine",
+        "predicate_search",
+        "predicate_comparison_generated",
+        "predicate_comparison_exported",
+        "cer_created",
+        "cer_stage_completed",
+        "cer_expert_approved",
+        "cer_exported",
+        "cer_literature_search",
+        "impact.assessment_created",
+        "impact.critical_detected",
+        "impact.action_item_created",
+        "pccp_created",
+        "pccp_component_completed",
+        "pccp_expert_approved",
+        "pccp_algorithm_change_triggered",
+        "pccp_status_changed",
+        "vigilance_event_created",
+        "vigilance_reportability_assessed",
+        "vigilance_report_drafted",
+        "vigilance_report_exported",
+        "standards_searched",
+        "standards_gap_analyzed",
+        "standards_compliance_updated",
+        "device_classified",
+        "digest_generated",
+        "digest_emailed",
+        "samd_assessment_created",
+        "samd_assessment_updated",
+        "samd_review_approved",
+        "dhf_created",
+        "dhf_updated",
+        "dhf_design_freeze",
+        "dhf_review_approved",
+        "submission_package_created",
+        "submission_package_submitted",
+        "submission_validation_completed",
+        "risk.hazard_identified",
+        "risk.matrix_evaluated",
+        "risk.control_adopted",
+        "risk.residual_accepted",
+        "risk.gspr_mapped",
+        "risk.report_approved"
+      ]
+    },
+    "public.block_type": {
+      "name": "block_type",
+      "schema": "public",
+      "values": [
+        "prose",
+        "checklist",
+        "comparison",
+        "timeline",
+        "sources",
+        "related",
+        "workflow_result"
+      ]
+    },
+    "public.confidence_level": {
+      "name": "confidence_level",
+      "schema": "public",
+      "values": [
+        "high",
+        "med",
+        "low"
+      ]
+    },
+    "public.control_tier": {
+      "name": "control_tier",
+      "schema": "public",
+      "values": [
+        "inherent",
+        "protective",
+        "information"
+      ]
+    },
+    "public.expert_review_status": {
+      "name": "expert_review_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "resolved"
+      ]
+    },
+    "public.locale": {
+      "name": "locale",
+      "schema": "public",
+      "values": [
+        "ko",
+        "en"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.risk_level": {
+      "name": "risk_level",
+      "schema": "public",
+      "values": [
+        "acc",
+        "alarp",
+        "unacc"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "Regulation",
+        "Guidance",
+        "Standard",
+        "Industry",
+        "Internal"
+      ]
+    },
+    "public.theme_pref": {
+      "name": "theme_pref",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark",
+        "system"
+      ]
+    },
+    "public.user_department": {
+      "name": "user_department",
+      "schema": "public",
+      "values": [
+        "RA",
+        "Dev",
+        "Exec",
+        "External"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "ra-lead",
+        "ra-member",
+        "viewer"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disabled"
+      ]
+    },
+    "public.workflow_status": {
+      "name": "workflow_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "paused",
+        "pending_review",
+        "approved",
+        "rejected",
+        "failed"
+      ]
+    },
+    "public.workflow_type": {
+      "name": "workflow_type",
+      "schema": "public",
+      "values": [
+        "submission_drafter",
+        "audit_response",
+        "indication_impact",
+        "predicate_comparison",
+        "cer",
+        "pccp",
+        "vigilance",
+        "risk"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1781742992088,
       "tag": "0000_magical_roulette",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781915327045,
+      "tag": "0001_salty_pet_avengers",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -203,9 +203,10 @@ export const auditActionEnum = pgEnum('audit_action', [
   'submission_package_created',
   'submission_package_submitted',
   'submission_validation_completed',
-  // SPEC-REGULA-RISK-001 — risk management audit actions (6):
+  // SPEC-REGULA-RISK-001 — risk management audit actions (7):
   'risk.hazard_identified',
   'risk.matrix_evaluated',
+  'risk.item_deleted',
   'risk.control_adopted',
   'risk.residual_accepted',
   'risk.gspr_mapped',

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -203,6 +203,13 @@ export const auditActionEnum = pgEnum('audit_action', [
   'submission_package_created',
   'submission_package_submitted',
   'submission_validation_completed',
+  // SPEC-REGULA-RISK-001 — risk management audit actions (6):
+  'risk.hazard_identified',
+  'risk.matrix_evaluated',
+  'risk.control_adopted',
+  'risk.residual_accepted',
+  'risk.gspr_mapped',
+  'risk.report_approved',
 ]);
 
 // REQ-WF-049: workflow_type pgEnum — workflow kinds.
@@ -212,6 +219,7 @@ export const auditActionEnum = pgEnum('audit_action', [
 // (SPEC-REGULA-PREDICATE-001). Enum values must each be in their own migration.
 // REQ-CER-012: cer added via 0035_cer_workflow_type.sql.
 // REQ-PCCP-025: 'pccp' added via 0038_pccp_workflow_type.sql (SPEC-REGULA-PCCP-001).
+// SPEC-REGULA-RISK-001: 'risk' added via 0057_risk_workflow_type.sql.
 export const workflowTypeEnum = pgEnum('workflow_type', [
   'submission_drafter',
   'audit_response',
@@ -220,6 +228,7 @@ export const workflowTypeEnum = pgEnum('workflow_type', [
   'cer',
   'pccp',
   'vigilance',
+  'risk',
 ]);
 
 // REQ-WF-049: workflow_status pgEnum — lifecycle states for workflow_runs.
@@ -1282,5 +1291,93 @@ export const submissionInteractions = pgTable(
   },
   (t) => ({
     pkgIdx: index('idx_submission_interactions_pkg').on(t.packageId),
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// SPEC-REGULA-RISK-001 — ISO 14971 Risk Management tables
+// Migration: 0057_risk_workflow_type.sql (workflowType 'risk')
+//            0058_risk_tables.sql (riskLevelEnum, controlTierEnum, tables)
+// ---------------------------------------------------------------------------
+
+// Risk level classification per ISO 14971 Annex E
+export const riskLevelEnum = pgEnum('risk_level', ['acc', 'alarp', 'unacc']);
+
+// ISO 14971 §7.1 risk control option hierarchy
+export const controlTierEnum = pgEnum('control_tier', [
+  'inherent',
+  'protective',
+  'information',
+]);
+
+// @MX:ANCHOR [AUTO] riskItems — central risk analysis record.
+// @MX:REASON Referenced by riskControls, riskGsprMappings, BFF routes, and report builder. fan_in >= 3.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T0.3, REQ-RISK-001~010)
+export const riskItems = pgTable(
+  'risk_items',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    workflowRunId: uuid('workflow_run_id')
+      .notNull()
+      .references(() => workflowRuns.id, { onDelete: 'cascade' }),
+    hazard: text('hazard').notNull(),
+    sequenceOfEvents: text('sequence_of_events').notNull(),
+    hazardousSituation: text('hazardous_situation').notNull(),
+    harm: text('harm').notNull(),
+    citation: jsonb('citation').notNull().default(sql`'[]'::jsonb`),
+    severity: integer('severity').notNull(),
+    probability: integer('probability').notNull(),
+    riskLevel: riskLevelEnum('risk_level').notNull(),
+    lowConfidence: boolean('low_confidence').notNull().default(false),
+    editedBy: uuid('edited_by').references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    runIdx: index('idx_risk_items_run').on(t.workflowRunId),
+  }),
+);
+
+// Risk control measures per ISO 14971 §7.1
+export const riskControls = pgTable(
+  'risk_controls',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    riskItemId: uuid('risk_item_id')
+      .notNull()
+      .references(() => riskItems.id, { onDelete: 'cascade' }),
+    tier: controlTierEnum('tier').notNull(),
+    description: text('description').notNull(),
+    rationale: text('rationale'),
+    isAdopted: boolean('is_adopted').notNull().default(false),
+    residualSeverity: integer('residual_severity'),
+    residualProbability: integer('residual_probability'),
+    residualRiskLevel: riskLevelEnum('residual_risk_level'),
+    alarpJustification: text('alarp_justification'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    itemIdx: index('idx_risk_controls_item').on(t.riskItemId),
+  }),
+);
+
+// EU MDR Annex I (GSPR) clause mappings
+export const riskGsprMappings = pgTable(
+  'risk_gspr_mappings',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    workflowRunId: uuid('workflow_run_id')
+      .notNull()
+      .references(() => workflowRuns.id, { onDelete: 'cascade' }),
+    riskItemId: uuid('risk_item_id').references(() => riskItems.id, { onDelete: 'cascade' }),
+    gsprClause: text('gspr_clause').notNull(),
+    requirement: text('requirement').notNull(),
+    compliance: text('compliance').notNull(),
+    evidence: text('evidence').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    runIdx: index('idx_risk_gspr_run').on(t.workflowRunId),
   }),
 );

--- a/lib/risk/__tests__/control-recommendation.test.ts
+++ b/lib/risk/__tests__/control-recommendation.test.ts
@@ -1,0 +1,77 @@
+// @MX:NOTE [AUTO] Unit tests for control-recommendation.ts — SPEC-REGULA-RISK-001 Phase 1 (T1.9~T1.10).
+
+import { describe, expect, it, vi } from 'vitest';
+import { recommendControls, validateControlHierarchy } from '../control-recommendation';
+
+// ---------------------------------------------------------------------------
+// T1.9 — recommendControls (RAG integration, mocked)
+// ---------------------------------------------------------------------------
+describe('recommendControls', () => {
+  const mockControls = {
+    controls: [
+      {
+        tier: 'inherent' as const,
+        description: 'Design dose-limiting hardware interlock',
+        rationale: null,
+      },
+      {
+        tier: 'protective' as const,
+        description: 'Implement software watchdog with automatic shutdown',
+        rationale: null,
+      },
+      {
+        tier: 'information' as const,
+        description: 'Label: maximum recommended dosage',
+        rationale: 'Information for safety as last resort measure',
+      },
+    ],
+  };
+
+  it('returns 3-tier control candidates from RAG', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ answer: JSON.stringify(mockControls) }),
+    });
+
+    const result = await recommendControls('risk-item-uuid-123', mockFetch);
+    expect(result).toHaveLength(3);
+
+    const tiers = result.map((c) => c.tier);
+    expect(tiers).toContain('inherent');
+    expect(tiers).toContain('protective');
+    expect(tiers).toContain('information');
+  });
+
+  it('propagates RAG fetch errors', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    await expect(recommendControls('risk-item-uuid-123', mockFetch)).rejects.toThrow(
+      'Network error',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.10 — validateControlHierarchy
+// ---------------------------------------------------------------------------
+describe('validateControlHierarchy', () => {
+  it('inherent tier without rationale → valid', () => {
+    expect(() => validateControlHierarchy('inherent')).not.toThrow();
+  });
+
+  it('protective tier without rationale → valid', () => {
+    expect(() => validateControlHierarchy('protective')).not.toThrow();
+  });
+
+  it('information tier with rationale → valid', () => {
+    expect(() => validateControlHierarchy('information', 'Safety label as last resort')).not.toThrow();
+  });
+
+  it('information tier without rationale → throws (ISO 14971 §7.1 hierarchy violation)', () => {
+    expect(() => validateControlHierarchy('information')).toThrow(
+      /rationale.*required/i,
+    );
+  });
+
+  it('information tier with empty rationale → throws', () => {
+    expect(() => validateControlHierarchy('information', '')).toThrow();
+  });
+});

--- a/lib/risk/__tests__/hazard-identification.test.ts
+++ b/lib/risk/__tests__/hazard-identification.test.ts
@@ -65,8 +65,10 @@ describe('parseHazardResponse', () => {
 
   it('maps fields correctly', () => {
     const result = parseHazardResponse(validResponse);
-    expect(result.items[0].hazard).toBe('Electrical failure');
-    expect(result.items[0].citation).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result.items[0]!.hazard).toBe('Electrical failure');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result.items[0]!.citation).toHaveLength(1);
   });
 
   it('lowConfidenceCount is 0 for all high-confidence items', () => {
@@ -89,7 +91,8 @@ describe('parseHazardResponse', () => {
     });
     const result = parseHazardResponse(lowConfResponse);
     expect(result.lowConfidenceCount).toBe(1);
-    expect(result.items[0].lowConfidence).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result.items[0]!.lowConfidence).toBe(true);
   });
 
   it('sets lowConfidence=true for items without citation', () => {
@@ -106,7 +109,8 @@ describe('parseHazardResponse', () => {
       ],
     });
     const result = parseHazardResponse(noCiteResponse);
-    expect(result.items[0].lowConfidence).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result.items[0]!.lowConfidence).toBe(true);
   });
 
   it('throws on invalid JSON', () => {

--- a/lib/risk/__tests__/hazard-identification.test.ts
+++ b/lib/risk/__tests__/hazard-identification.test.ts
@@ -1,0 +1,145 @@
+// @MX:NOTE [AUTO] Unit tests for hazard-identification.ts — SPEC-REGULA-RISK-001 Phase 1 (T1.6~T1.8).
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildHazardPrompt,
+  parseHazardResponse,
+  identifyHazards,
+} from '../hazard-identification';
+
+// ---------------------------------------------------------------------------
+// T1.6 — buildHazardPrompt
+// ---------------------------------------------------------------------------
+describe('buildHazardPrompt', () => {
+  it('includes device description in prompt', () => {
+    const prompt = buildHazardPrompt('Insulin pump with wireless telemetry', 'Class III');
+    expect(prompt).toContain('Insulin pump with wireless telemetry');
+  });
+
+  it('includes device class in prompt', () => {
+    const prompt = buildHazardPrompt('Ventilator', 'Class II');
+    expect(prompt).toContain('Class II');
+  });
+
+  it('includes ISO 14971 terminology (hazard, harm, probability)', () => {
+    const prompt = buildHazardPrompt('Device', 'Class I');
+    expect(prompt.toLowerCase()).toContain('hazard');
+    expect(prompt.toLowerCase()).toContain('harm');
+  });
+
+  it('includes JSON format instruction', () => {
+    const prompt = buildHazardPrompt('Device', 'Class I');
+    expect(prompt).toContain('JSON');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.7 — parseHazardResponse
+// ---------------------------------------------------------------------------
+describe('parseHazardResponse', () => {
+  const validResponse = JSON.stringify({
+    items: [
+      {
+        hazard: 'Electrical failure',
+        sequenceOfEvents: 'Battery depletes → pump stops',
+        hazardousSituation: 'Patient without insulin delivery',
+        harm: 'Diabetic ketoacidosis',
+        citation: [{ source: 'MAUDE', id: '123' }],
+        confidence: 0.9,
+      },
+      {
+        hazard: 'Over-infusion',
+        sequenceOfEvents: 'Software bug → excess dose',
+        hazardousSituation: 'Hypoglycemia risk',
+        harm: 'Hypoglycaemic shock',
+        citation: [{ source: 'FDA guidance', id: 'abc' }],
+        confidence: 0.85,
+      },
+    ],
+  });
+
+  it('returns correct number of items', () => {
+    const result = parseHazardResponse(validResponse);
+    expect(result.items).toHaveLength(2);
+  });
+
+  it('maps fields correctly', () => {
+    const result = parseHazardResponse(validResponse);
+    expect(result.items[0].hazard).toBe('Electrical failure');
+    expect(result.items[0].citation).toHaveLength(1);
+  });
+
+  it('lowConfidenceCount is 0 for all high-confidence items', () => {
+    const result = parseHazardResponse(validResponse);
+    expect(result.lowConfidenceCount).toBe(0);
+  });
+
+  it('marks items with confidence < 0.7 as lowConfidence', () => {
+    const lowConfResponse = JSON.stringify({
+      items: [
+        {
+          hazard: 'Uncertain hazard',
+          sequenceOfEvents: '...',
+          hazardousSituation: '...',
+          harm: 'Unknown',
+          citation: [{ source: 'MAUDE', id: '1' }],
+          confidence: 0.5,
+        },
+      ],
+    });
+    const result = parseHazardResponse(lowConfResponse);
+    expect(result.lowConfidenceCount).toBe(1);
+    expect(result.items[0].lowConfidence).toBe(true);
+  });
+
+  it('sets lowConfidence=true for items without citation', () => {
+    const noCiteResponse = JSON.stringify({
+      items: [
+        {
+          hazard: 'No citation hazard',
+          sequenceOfEvents: '...',
+          hazardousSituation: '...',
+          harm: 'Unknown',
+          citation: [],
+          confidence: 0.95,
+        },
+      ],
+    });
+    const result = parseHazardResponse(noCiteResponse);
+    expect(result.items[0].lowConfidence).toBe(true);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseHazardResponse('not json')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.8 — identifyHazards (RAG integration, mocked)
+// ---------------------------------------------------------------------------
+describe('identifyHazards', () => {
+  it('calls fetchFn with correct endpoint and prompt', async () => {
+    const mockItems = [
+      {
+        hazard: 'Electrical failure',
+        sequenceOfEvents: 'Battery fault',
+        hazardousSituation: 'No insulin',
+        harm: 'DKA',
+        citation: [{ source: 'MAUDE', id: '1' }],
+        confidence: 0.9,
+      },
+    ];
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ answer: JSON.stringify({ items: mockItems }) }),
+    });
+
+    const result = await identifyHazards('Insulin pump', 'Class III', mockFetch);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(result.items).toHaveLength(1);
+  });
+
+  it('propagates RAG errors', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('RAG unavailable'));
+    await expect(identifyHazards('Device', 'Class I', mockFetch)).rejects.toThrow('RAG unavailable');
+  });
+});

--- a/lib/risk/__tests__/report-builder.test.ts
+++ b/lib/risk/__tests__/report-builder.test.ts
@@ -1,0 +1,125 @@
+// @MX:NOTE [AUTO] Unit tests for report-builder.ts — SPEC-REGULA-RISK-001 Phase 3 (T3.1~T3.4).
+// @MX:SPEC SPEC-REGULA-RISK-001 (T3.1~T3.4, REQ-RISK-034~036)
+
+import { describe, expect, it } from 'vitest';
+import { buildRiskReport, type RiskRunPayload } from '../report-builder';
+
+const sampleRun: RiskRunPayload = {
+  id: 'run-abc-123',
+  deviceDescription: 'Insulin pump with wireless BLE telemetry',
+  deviceClass: 'Class III',
+  createdAt: '2026-06-20T00:00:00Z',
+  approvedBy: null,
+  items: [
+    {
+      id: 'item-001',
+      hazard: 'Electrical failure',
+      sequenceOfEvents: 'Battery depletes → pump stops',
+      hazardousSituation: 'No insulin delivery',
+      harm: 'Diabetic ketoacidosis',
+      severity: 5,
+      probability: 2,
+      riskLevel: 'unacc',
+      lowConfidence: false,
+      citation: [{ source: 'MAUDE', id: 'MDR123' }],
+      controls: [
+        {
+          id: 'ctrl-001',
+          tier: 'inherent',
+          description: 'Redundant battery design',
+          rationale: null,
+          isAdopted: true,
+          residualSeverity: 3,
+          residualProbability: 1,
+          residualRiskLevel: 'acc',
+          alarpJustification: null,
+        },
+      ],
+    },
+  ],
+  gsprMappings: [
+    {
+      gsprClause: 'Annex I §4',
+      requirement: 'Devices must be designed to eliminate or reduce risks',
+      compliance: 'compliant',
+      evidence: 'Redundant battery design reduces risk to acceptable level',
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// T3.1 — buildRiskReport returns a non-empty Buffer
+// ---------------------------------------------------------------------------
+describe('T3.1 — buildRiskReport output', () => {
+  it('returns a Buffer (Uint8Array)', async () => {
+    const result = await buildRiskReport(sampleRun);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('returns content that looks like a DOCX (PK zip magic bytes)', async () => {
+    const result = await buildRiskReport(sampleRun);
+    // DOCX is a zip file starting with PK\x03\x04 magic bytes
+    expect(result[0]).toBe(0x50); // P
+    expect(result[1]).toBe(0x4b); // K
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.2 — Type validation: RiskRunPayload
+// ---------------------------------------------------------------------------
+describe('T3.2 — RiskRunPayload type contract', () => {
+  it('accepts run with empty items array', async () => {
+    const emptyRun: RiskRunPayload = { ...sampleRun, items: [], gsprMappings: [] };
+    const result = await buildRiskReport(emptyRun);
+    expect(result).toBeInstanceOf(Uint8Array);
+  });
+
+  it('accepts run with unapproved status (approvedBy: null)', async () => {
+    const unapproved: RiskRunPayload = { ...sampleRun, approvedBy: null };
+    const result = await buildRiskReport(unapproved);
+    expect(result).toBeInstanceOf(Uint8Array);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.3 — Run with no GSPR mappings
+// ---------------------------------------------------------------------------
+describe('T3.3 — GSPR mapping section', () => {
+  it('handles run with no GSPR mappings', async () => {
+    const noGspr: RiskRunPayload = { ...sampleRun, gsprMappings: [] };
+    const result = await buildRiskReport(noGspr);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.4 — Multi-item run
+// ---------------------------------------------------------------------------
+describe('T3.4 — Multi-item report', () => {
+  it('handles multiple risk items and controls', async () => {
+    const multiRun: RiskRunPayload = {
+      ...sampleRun,
+      items: [
+        ...sampleRun.items,
+        {
+          id: 'item-002',
+          hazard: 'Software over-infusion bug',
+          sequenceOfEvents: 'Software error → excess dose',
+          hazardousSituation: 'Hypoglycemia',
+          harm: 'Hypoglycaemic shock, death',
+          severity: 5,
+          probability: 3,
+          riskLevel: 'unacc',
+          lowConfidence: false,
+          citation: [],
+          controls: [],
+        },
+      ],
+    };
+    const result = await buildRiskReport(multiRun);
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/risk/__tests__/residual-risk.test.ts
+++ b/lib/risk/__tests__/residual-risk.test.ts
@@ -1,0 +1,41 @@
+// @MX:NOTE [AUTO] Unit tests for residual-risk.ts — SPEC-REGULA-RISK-001 Phase 1 (T1.5).
+
+import { describe, expect, it } from 'vitest';
+import { evaluateResidualRisk } from '../residual-risk';
+
+describe('evaluateResidualRisk', () => {
+  it('acc residual → no further action, valid', () => {
+    const result = evaluateResidualRisk(1, 1);
+    expect(result.level).toBe('acc');
+    expect(result.requiresFurtherAction).toBe(false);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('unacc residual → requiresFurtherAction true', () => {
+    const result = evaluateResidualRisk(5, 5);
+    expect(result.level).toBe('unacc');
+    expect(result.requiresFurtherAction).toBe(true);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('alarp with justification → valid', () => {
+    const result = evaluateResidualRisk(2, 3, 'ALARP justified: cost-benefit analysis shows further reduction impractical');
+    expect(result.level).toBe('alarp');
+    expect(result.requiresFurtherAction).toBe(false);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('alarp without justification → isValid false', () => {
+    const result = evaluateResidualRisk(2, 3);
+    expect(result.level).toBe('alarp');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('invalid severity → throws', () => {
+    expect(() => evaluateResidualRisk(0, 1)).toThrow();
+  });
+
+  it('invalid probability → throws', () => {
+    expect(() => evaluateResidualRisk(1, 6)).toThrow();
+  });
+});

--- a/lib/risk/__tests__/risk-evaluation.test.ts
+++ b/lib/risk/__tests__/risk-evaluation.test.ts
@@ -1,0 +1,116 @@
+// @MX:NOTE [AUTO] Unit tests for risk-evaluation.ts — SPEC-REGULA-RISK-001 Phase 1 (T1.2~T1.4).
+// Tests exhaust all 25 cells of the 5×5 ISO 14971 Annex E risk matrix.
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_RISK_MATRIX,
+  evaluateRiskLevel,
+  requiresControl,
+  validateScale,
+} from '../risk-evaluation';
+
+// ---------------------------------------------------------------------------
+// T1.2 / T1.3 — DEFAULT_RISK_MATRIX structure
+// ---------------------------------------------------------------------------
+describe('DEFAULT_RISK_MATRIX', () => {
+  it('has 5 severity rows', () => {
+    expect(DEFAULT_RISK_MATRIX).toHaveLength(5);
+  });
+
+  it('each row has 5 probability columns', () => {
+    for (const row of DEFAULT_RISK_MATRIX) {
+      expect(row).toHaveLength(5);
+    }
+  });
+
+  it('all values are acc | alarp | unacc', () => {
+    const valid = new Set(['acc', 'alarp', 'unacc']);
+    for (const row of DEFAULT_RISK_MATRIX) {
+      for (const cell of row) {
+        expect(valid.has(cell)).toBe(true);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.2 — evaluateRiskLevel: exhaustive 25-cell matrix test
+// ISO 14971 Annex E matrix (severity=row index+1, probability=col index+1)
+// Expected layout (S5..S1, P1..P5):
+//   S5: alarp unacc unacc unacc unacc
+//   S4: acc   alarp unacc unacc unacc
+//   S3: acc   alarp alarp unacc unacc
+//   S2: acc   acc   alarp alarp unacc
+//   S1: acc   acc   acc   alarp alarp
+// ---------------------------------------------------------------------------
+describe('evaluateRiskLevel — 25-cell exhaustive', () => {
+  type Level = 'acc' | 'alarp' | 'unacc';
+  const expected: Level[][] = [
+    // S1 (index 0), P1..P5
+    ['acc', 'acc', 'acc', 'alarp', 'alarp'],
+    // S2
+    ['acc', 'acc', 'alarp', 'alarp', 'unacc'],
+    // S3
+    ['acc', 'alarp', 'alarp', 'unacc', 'unacc'],
+    // S4
+    ['acc', 'alarp', 'unacc', 'unacc', 'unacc'],
+    // S5
+    ['alarp', 'unacc', 'unacc', 'unacc', 'unacc'],
+  ];
+
+  for (let s = 1; s <= 5; s++) {
+    for (let p = 1; p <= 5; p++) {
+      const cell = expected[s - 1][p - 1];
+      it(`S${s}×P${p} → ${cell}`, () => {
+        expect(evaluateRiskLevel(s, p)).toBe(cell);
+      });
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// T1.2 — custom matrix override
+// ---------------------------------------------------------------------------
+describe('evaluateRiskLevel — custom matrix', () => {
+  const customMatrix: Array<Array<'acc' | 'alarp' | 'unacc'>> = [
+    ['unacc', 'unacc', 'unacc', 'unacc', 'unacc'],
+    ['unacc', 'unacc', 'unacc', 'unacc', 'unacc'],
+    ['unacc', 'unacc', 'unacc', 'unacc', 'unacc'],
+    ['unacc', 'unacc', 'unacc', 'unacc', 'unacc'],
+    ['unacc', 'unacc', 'unacc', 'unacc', 'unacc'],
+  ];
+
+  it('uses custom matrix when provided', () => {
+    expect(evaluateRiskLevel(1, 1, customMatrix)).toBe('unacc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T1.3 — validateScale
+// ---------------------------------------------------------------------------
+describe('validateScale', () => {
+  it('returns true for 1', () => expect(validateScale(1)).toBe(true));
+  it('returns true for 5', () => expect(validateScale(5)).toBe(true));
+  it('returns true for 3', () => expect(validateScale(3)).toBe(true));
+  it('returns false for 0', () => expect(validateScale(0)).toBe(false));
+  it('returns false for 6', () => expect(validateScale(6)).toBe(false));
+  it('returns false for -1', () => expect(validateScale(-1)).toBe(false));
+  it('returns false for 1.5 (non-integer)', () => expect(validateScale(1.5)).toBe(false));
+});
+
+// ---------------------------------------------------------------------------
+// T1.4 — requiresControl
+// ---------------------------------------------------------------------------
+describe('requiresControl', () => {
+  it('acc → false (acceptable risk, no control required)', () => {
+    expect(requiresControl('acc')).toBe(false);
+  });
+
+  it('alarp → true (control measures must be considered)', () => {
+    expect(requiresControl('alarp')).toBe(true);
+  });
+
+  it('unacc → true (unacceptable, control mandatory)', () => {
+    expect(requiresControl('unacc')).toBe(true);
+  });
+});

--- a/lib/risk/__tests__/risk-evaluation.test.ts
+++ b/lib/risk/__tests__/risk-evaluation.test.ts
@@ -60,7 +60,8 @@ describe('evaluateRiskLevel — 25-cell exhaustive', () => {
 
   for (let s = 1; s <= 5; s++) {
     for (let p = 1; p <= 5; p++) {
-      const cell = expected[s - 1][p - 1];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const cell = expected[s - 1]![p - 1]!;
       it(`S${s}×P${p} → ${cell}`, () => {
         expect(evaluateRiskLevel(s, p)).toBe(cell);
       });

--- a/lib/risk/__tests__/schema.test.ts
+++ b/lib/risk/__tests__/schema.test.ts
@@ -1,0 +1,153 @@
+// @MX:NOTE [AUTO] Schema smoke tests for SPEC-REGULA-RISK-001 Phase 0.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T0.1~T0.8)
+// Tests run against source text — no DB connection required.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const schemaPath = path.resolve(__dirname, '../../db/schema.ts');
+const schemaSource = fs.readFileSync(schemaPath, 'utf8');
+
+const permissionsPath = path.resolve(__dirname, '../../auth/permissions.ts');
+const permissionsSource = fs.readFileSync(permissionsPath, 'utf8');
+
+// ---------------------------------------------------------------------------
+// T0.1 — workflowTypeEnum includes 'risk'
+// ---------------------------------------------------------------------------
+describe('T0.1 — workflowTypeEnum includes risk', () => {
+  it("workflowTypeEnum contains 'risk' value", () => {
+    expect(schemaSource).toMatch(/'risk'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T0.2 — auditActionEnum includes 6 new risk actions
+// ---------------------------------------------------------------------------
+describe('T0.2 — auditActionEnum includes risk audit actions', () => {
+  const riskActions = [
+    'risk.hazard_identified',
+    'risk.matrix_evaluated',
+    'risk.control_adopted',
+    'risk.residual_accepted',
+    'risk.gspr_mapped',
+    'risk.report_approved',
+  ];
+
+  for (const action of riskActions) {
+    it(`auditActionEnum contains '${action}'`, () => {
+      expect(schemaSource).toContain(`'${action}'`);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// T0.3 — riskLevelEnum and riskItems table
+// ---------------------------------------------------------------------------
+describe('T0.3 — riskItems table', () => {
+  it('riskLevelEnum is declared', () => {
+    expect(schemaSource).toMatch(/riskLevelEnum\s*=/);
+  });
+
+  it("riskLevelEnum contains 'acc', 'alarp', 'unacc'", () => {
+    expect(schemaSource).toContain("'acc'");
+    expect(schemaSource).toContain("'alarp'");
+    expect(schemaSource).toContain("'unacc'");
+  });
+
+  it('riskItems table is exported', () => {
+    expect(schemaSource).toMatch(/export const riskItems\s*=/);
+  });
+
+  it('riskItems has required columns: hazard, severity, probability', () => {
+    // Check these columns exist near riskItems definition
+    const riskItemsIdx = schemaSource.indexOf('export const riskItems');
+    const riskItemsSlice = schemaSource.slice(riskItemsIdx, riskItemsIdx + 2000);
+    expect(riskItemsSlice).toContain('hazard');
+    expect(riskItemsSlice).toContain('severity');
+    expect(riskItemsSlice).toContain('probability');
+    expect(riskItemsSlice).toContain('sequenceOfEvents');
+    expect(riskItemsSlice).toContain('hazardousSituation');
+    expect(riskItemsSlice).toContain('harm');
+    expect(riskItemsSlice).toContain('citation');
+    expect(riskItemsSlice).toContain('lowConfidence');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T0.4 — controlTierEnum and riskControls table
+// ---------------------------------------------------------------------------
+describe('T0.4 — riskControls table', () => {
+  it('controlTierEnum is declared', () => {
+    expect(schemaSource).toMatch(/controlTierEnum\s*=/);
+  });
+
+  it("controlTierEnum contains 'inherent', 'protective', 'information'", () => {
+    expect(schemaSource).toContain("'inherent'");
+    expect(schemaSource).toContain("'protective'");
+    expect(schemaSource).toContain("'information'");
+  });
+
+  it('riskControls table is exported', () => {
+    expect(schemaSource).toMatch(/export const riskControls\s*=/);
+  });
+
+  it('riskControls has required columns', () => {
+    const idx = schemaSource.indexOf('export const riskControls');
+    const slice = schemaSource.slice(idx, idx + 2000);
+    expect(slice).toContain('riskItemId');
+    expect(slice).toContain('tier');
+    expect(slice).toContain('description');
+    expect(slice).toContain('isAdopted');
+    expect(slice).toContain('residualSeverity');
+    expect(slice).toContain('alarpJustification');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T0.5 — riskGsprMappings table
+// ---------------------------------------------------------------------------
+describe('T0.5 — riskGsprMappings table', () => {
+  it('riskGsprMappings table is exported', () => {
+    expect(schemaSource).toMatch(/export const riskGsprMappings\s*=/);
+  });
+
+  it('riskGsprMappings has gsprClause, requirement, compliance, evidence', () => {
+    const idx = schemaSource.indexOf('export const riskGsprMappings');
+    const slice = schemaSource.slice(idx, idx + 1500);
+    expect(slice).toContain('gsprClause');
+    expect(slice).toContain('requirement');
+    expect(slice).toContain('compliance');
+    expect(slice).toContain('evidence');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T0.8 — Permissions matrix includes risk actions
+// ---------------------------------------------------------------------------
+describe('T0.8 — Permissions matrix includes risk actions', () => {
+  const riskPermissions = ['risk.generate', 'risk.view', 'risk.update', 'risk.approve'];
+
+  for (const perm of riskPermissions) {
+    it(`permissions.ts contains '${perm}'`, () => {
+      expect(permissionsSource).toContain(`'${perm}'`);
+    });
+  }
+
+  it("risk.approve requires minRole 'ra-lead'", () => {
+    // Find the risk.approve entry and verify minRole
+    const approveMatch = permissionsSource.match(
+      /'risk\.approve':\s*\{[^}]*minRole:\s*'([^']+)'/
+    );
+    expect(approveMatch).not.toBeNull();
+    expect(approveMatch![1]).toBe('ra-lead');
+  });
+
+  it("risk.generate requires minRole 'ra-member'", () => {
+    const genMatch = permissionsSource.match(
+      /'risk\.generate':\s*\{[^}]*minRole:\s*'([^']+)'/
+    );
+    expect(genMatch).not.toBeNull();
+    expect(genMatch![1]).toBe('ra-member');
+  });
+});

--- a/lib/risk/control-recommendation.ts
+++ b/lib/risk/control-recommendation.ts
@@ -1,0 +1,57 @@
+// @MX:ANCHOR [AUTO] recommendControls — ISO 14971 §7.1 3-tier control recommendation via RAG.
+// @MX:REASON Called by BFF controls/recommend route, wizard UI, and report builder. fan_in >= 3.
+// @MX:WARN [AUTO] External RAG call inside recommendControls.
+// @MX:REASON External RAG call — latency and failure mode. Always mock in unit tests.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T1.9~T1.10, REQ-RISK-021~027)
+
+export type ControlTier = 'inherent' | 'protective' | 'information';
+
+export interface ControlCandidate {
+  tier: ControlTier;
+  description: string;
+  rationale: string | null;
+}
+
+type FetchFn = (endpoint: string, options?: RequestInit) => Promise<{ json: () => Promise<unknown> }>;
+
+/**
+ * Validate ISO 14971 §7.1 control tier hierarchy constraint.
+ * Information-for-safety controls MUST include a rationale explaining why
+ * inherent safety design and protective measures are not sufficient.
+ */
+export function validateControlHierarchy(tier: ControlTier, rationale?: string): void {
+  if (tier === 'information') {
+    const hasRationale = typeof rationale === 'string' && rationale.trim().length > 0;
+    if (!hasRationale) {
+      throw new Error(
+        'Rationale is required for information-for-safety controls per ISO 14971 §7.1. ' +
+          'Explain why inherent safety design and protective measures are insufficient.',
+      );
+    }
+  }
+}
+
+/**
+ * Recommend 3-tier control measures for a risk item via RAG.
+ * Returns candidates ordered by ISO 14971 §7.1 priority hierarchy.
+ *
+ * @param riskItemId UUID of the risk item to fetch controls for
+ * @param fetchFn    Injected fetch function
+ */
+export async function recommendControls(
+  riskItemId: string,
+  fetchFn: FetchFn,
+): Promise<ControlCandidate[]> {
+  const res = await fetchFn('/rag/query', {
+    method: 'POST',
+    body: JSON.stringify({
+      query: `Recommend ISO 14971 §7.1 risk control measures for risk item ${riskItemId}. Return JSON with controls array containing tier (inherent|protective|information), description, and rationale fields.`,
+      mode: 'risk_control',
+      riskItemId,
+    }),
+  });
+
+  const data = (await res.json()) as { answer: string };
+  const parsed = JSON.parse(data.answer) as { controls: ControlCandidate[] };
+  return parsed.controls;
+}

--- a/lib/risk/hazard-identification.ts
+++ b/lib/risk/hazard-identification.ts
@@ -1,0 +1,117 @@
+// @MX:ANCHOR [AUTO] identifyHazards — RAG-based ISO 14971 hazard identification.
+// @MX:REASON Entry point for BFF /identify route, report builder, and eval harness. fan_in >= 3.
+// @MX:WARN [AUTO] External RAG call inside identifyHazards.
+// @MX:REASON External RAG call — latency and failure mode. Always mock in unit tests.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T1.6~T1.8, REQ-RISK-001~010)
+
+export interface HazardCitation {
+  source: string;
+  id: string;
+}
+
+export interface HazardItem {
+  hazard: string;
+  sequenceOfEvents: string;
+  hazardousSituation: string;
+  harm: string;
+  citation: HazardCitation[];
+  confidence: number;
+  lowConfidence: boolean;
+}
+
+export interface ParsedHazardResponse {
+  items: HazardItem[];
+  lowConfidenceCount: number;
+}
+
+type FetchFn = (endpoint: string, options?: RequestInit) => Promise<{ json: () => Promise<unknown> }>;
+
+/**
+ * Build a structured prompt for ISO 14971 hazard identification via RAG.
+ */
+export function buildHazardPrompt(deviceDescription: string, deviceClass: string): string {
+  return `You are a medical device risk management expert applying ISO 14971:2019.
+
+Device Description: ${deviceDescription}
+Device Classification: ${deviceClass}
+
+Task: Identify potential hazards for this medical device following ISO 14971 Annex C methodology.
+
+For each hazard, provide:
+1. hazard: The root cause or energy/material source
+2. sequenceOfEvents: Chain of events from hazard to hazardous situation
+3. hazardousSituation: The situation arising from the hazard sequence
+4. harm: Physical injury or damage to health (patient, operator, or third party)
+5. citation: Array of references supporting this hazard identification (MAUDE, literature, standards)
+6. confidence: Your confidence score (0.0-1.0)
+
+Consider: use errors, software failures, mechanical failures, electrical hazards, biological hazards,
+environmental conditions, and foreseeable misuse.
+
+Return a JSON object with this exact structure:
+{"items": [{"hazard": "...", "sequenceOfEvents": "...", "hazardousSituation": "...", "harm": "...", "citation": [{"source": "...", "id": "..."}], "confidence": 0.0}]}`;
+}
+
+/**
+ * Parse RAG response into structured HazardItem array.
+ * Sets lowConfidence=true for items with confidence < 0.7 or empty citations.
+ */
+export function parseHazardResponse(rawResponse: string): ParsedHazardResponse {
+  let parsed: { items: Array<Record<string, unknown>> };
+  try {
+    parsed = JSON.parse(rawResponse) as { items: Array<Record<string, unknown>> };
+  } catch {
+    throw new SyntaxError(`Invalid JSON from hazard identification response: ${rawResponse.slice(0, 100)}`);
+  }
+
+  if (!Array.isArray(parsed.items)) {
+    throw new TypeError('Hazard response missing "items" array');
+  }
+
+  const LOW_CONFIDENCE_THRESHOLD = 0.7;
+  let lowConfidenceCount = 0;
+
+  const items: HazardItem[] = parsed.items.map((raw) => {
+    const citation = (raw.citation as HazardCitation[]) ?? [];
+    const confidence = (raw.confidence as number) ?? 0;
+    const hasCitation = Array.isArray(citation) && citation.length > 0;
+    const isLowConfidence = confidence < LOW_CONFIDENCE_THRESHOLD || !hasCitation;
+
+    if (isLowConfidence) lowConfidenceCount++;
+
+    return {
+      hazard: raw.hazard as string,
+      sequenceOfEvents: raw.sequenceOfEvents as string,
+      hazardousSituation: raw.hazardousSituation as string,
+      harm: raw.harm as string,
+      citation,
+      confidence,
+      lowConfidence: isLowConfidence,
+    };
+  });
+
+  return { items, lowConfidenceCount };
+}
+
+/**
+ * Identify hazards via RAG query to hybrid-ra-saas.
+ *
+ * @param deviceDescription Human-readable device functional description
+ * @param deviceClass       Device classification (Class I/II/III or SaMD level)
+ * @param fetchFn           Injected fetch function (createHybridRaFetch in prod, vi.fn() in tests)
+ */
+export async function identifyHazards(
+  deviceDescription: string,
+  deviceClass: string,
+  fetchFn: FetchFn,
+): Promise<ParsedHazardResponse> {
+  const prompt = buildHazardPrompt(deviceDescription, deviceClass);
+
+  const res = await fetchFn('/rag/query', {
+    method: 'POST',
+    body: JSON.stringify({ query: prompt, mode: 'risk_identification' }),
+  });
+
+  const data = (await res.json()) as { answer: string };
+  return parseHazardResponse(data.answer);
+}

--- a/lib/risk/report-builder.ts
+++ b/lib/risk/report-builder.ts
@@ -1,0 +1,250 @@
+// @MX:ANCHOR [AUTO] buildRiskReport — ISO 14971 DOCX report builder.
+// @MX:REASON Entry point for export BFF route, E2E test, and unit tests. fan_in >= 3.
+// @MX:WARN [AUTO] DOCX Packer.toBuffer is CPU-intensive and allocates large Buffers.
+// @MX:REASON DOCX generation can be slow for large risk item sets; consider timeout limits.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T3.1~T3.4, REQ-RISK-034~036)
+
+import {
+  Document,
+  Paragraph,
+  Table,
+  TableCell,
+  TableRow,
+  TextRun,
+  HeadingLevel,
+  BorderStyle,
+  AlignmentType,
+  WidthType,
+  Packer,
+} from 'docx';
+import type { RiskLevel } from './risk-evaluation';
+import type { ControlTier } from './control-recommendation';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface RiskControlPayload {
+  id: string;
+  tier: ControlTier;
+  description: string;
+  rationale: string | null;
+  isAdopted: boolean;
+  residualSeverity?: number;
+  residualProbability?: number;
+  residualRiskLevel?: RiskLevel;
+  alarpJustification?: string | null;
+}
+
+export interface RiskItemPayload {
+  id: string;
+  hazard: string;
+  sequenceOfEvents: string;
+  hazardousSituation: string;
+  harm: string;
+  severity: number;
+  probability: number;
+  riskLevel: RiskLevel;
+  lowConfidence: boolean;
+  citation: Array<{ source: string; id: string }>;
+  controls: RiskControlPayload[];
+}
+
+export interface GsprMappingPayload {
+  gsprClause: string;
+  requirement: string;
+  compliance: string;
+  evidence: string;
+}
+
+export interface RiskRunPayload {
+  id: string;
+  deviceDescription: string;
+  deviceClass: string;
+  createdAt: string;
+  approvedBy: string | null;
+  items: RiskItemPayload[];
+  gsprMappings: GsprMappingPayload[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function riskLevelLabel(level: RiskLevel): string {
+  return { acc: 'Acceptable', alarp: 'ALARP', unacc: 'Unacceptable' }[level];
+}
+
+function makeHeading(text: string, level: (typeof HeadingLevel)[keyof typeof HeadingLevel]) {
+  return new Paragraph({ text, heading: level, spacing: { before: 300, after: 150 } });
+}
+
+function makeText(text: string, bold = false): Paragraph {
+  return new Paragraph({ children: [new TextRun({ text, bold })] });
+}
+
+function makeTableCell(text: string, width = 2000): TableCell {
+  return new TableCell({
+    children: [new Paragraph({ children: [new TextRun({ text, size: 18 })] })],
+    width: { size: width, type: WidthType.DXA },
+    borders: {
+      top: { style: BorderStyle.SINGLE, size: 1 },
+      bottom: { style: BorderStyle.SINGLE, size: 1 },
+      left: { style: BorderStyle.SINGLE, size: 1 },
+      right: { style: BorderStyle.SINGLE, size: 1 },
+    },
+  });
+}
+
+function makeHeaderRow(labels: string[]): TableRow {
+  return new TableRow({
+    children: labels.map((l) =>
+      new TableCell({
+        children: [new Paragraph({ children: [new TextRun({ text: l, bold: true, size: 18 })] })],
+        shading: { fill: '4472C4' },
+        borders: {
+          top: { style: BorderStyle.SINGLE, size: 1 },
+          bottom: { style: BorderStyle.SINGLE, size: 1 },
+          left: { style: BorderStyle.SINGLE, size: 1 },
+          right: { style: BorderStyle.SINGLE, size: 1 },
+        },
+      }),
+    ),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Section builders
+// ---------------------------------------------------------------------------
+
+function buildRiskItemsTable(items: RiskItemPayload[]): Table {
+  const headerRow = makeHeaderRow(['#', 'Hazard', 'Harm', 'S', 'P', 'Risk Level', 'Controls']);
+
+  const dataRows = items.map((item, idx) => {
+    const adoptedControls = item.controls.filter((c) => c.isAdopted);
+    return new TableRow({
+      children: [
+        makeTableCell(`${idx + 1}`, 400),
+        makeTableCell(item.hazard, 3000),
+        makeTableCell(item.harm, 2500),
+        makeTableCell(`${item.severity}`, 400),
+        makeTableCell(`${item.probability}`, 400),
+        makeTableCell(riskLevelLabel(item.riskLevel), 1400),
+        makeTableCell(
+          adoptedControls.length > 0
+            ? adoptedControls.map((c) => `[${c.tier}] ${c.description}`).join('; ')
+            : 'None',
+          3000,
+        ),
+      ],
+    });
+  });
+
+  return new Table({ rows: [headerRow, ...dataRows], width: { size: 100, type: WidthType.PERCENTAGE } });
+}
+
+function buildGsprTable(mappings: GsprMappingPayload[]): Table {
+  const headerRow = makeHeaderRow(['GSPR Clause', 'Requirement', 'Compliance', 'Evidence']);
+
+  const dataRows = mappings.map((m) =>
+    new TableRow({
+      children: [
+        makeTableCell(m.gsprClause, 1500),
+        makeTableCell(m.requirement, 3000),
+        makeTableCell(m.compliance, 1500),
+        makeTableCell(m.evidence, 3500),
+      ],
+    }),
+  );
+
+  return new Table({ rows: [headerRow, ...dataRows], width: { size: 100, type: WidthType.PERCENTAGE } });
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate an ISO 14971 Risk Management Report as a DOCX buffer.
+ * Includes: device overview, risk item matrix, GSPR mapping, approval status.
+ */
+export async function buildRiskReport(run: RiskRunPayload): Promise<Uint8Array> {
+  const sections: (Paragraph | Table)[] = [];
+
+  // Title
+  sections.push(
+    new Paragraph({
+      text: 'Risk Management Report',
+      heading: HeadingLevel.TITLE,
+      alignment: AlignmentType.CENTER,
+      spacing: { after: 400 },
+    }),
+  );
+  sections.push(
+    new Paragraph({
+      text: 'ISO 14971:2019 Medical Device Risk Management',
+      alignment: AlignmentType.CENTER,
+      spacing: { after: 600 },
+    }),
+  );
+
+  // Section 1: Device Overview
+  sections.push(makeHeading('1. Device Overview', HeadingLevel.HEADING_1));
+  sections.push(makeText(`Report ID: ${run.id}`));
+  sections.push(makeText(`Device Description: ${run.deviceDescription}`));
+  sections.push(makeText(`Device Classification: ${run.deviceClass}`));
+  sections.push(makeText(`Report Date: ${run.createdAt}`));
+  sections.push(makeText(`Approval Status: ${run.approvedBy ? `Approved by ${run.approvedBy}` : 'Pending RA-Lead Approval'}`));
+  sections.push(new Paragraph({ text: '', spacing: { after: 200 } }));
+
+  // Section 2: Risk Analysis Summary
+  sections.push(makeHeading('2. Risk Analysis Summary', HeadingLevel.HEADING_1));
+  sections.push(makeText(`Total Risk Items Identified: ${run.items.length}`));
+  const unacceptable = run.items.filter((i) => i.riskLevel === 'unacc').length;
+  const alarp = run.items.filter((i) => i.riskLevel === 'alarp').length;
+  const acceptable = run.items.filter((i) => i.riskLevel === 'acc').length;
+  sections.push(makeText(`  Unacceptable: ${unacceptable}`));
+  sections.push(makeText(`  ALARP: ${alarp}`));
+  sections.push(makeText(`  Acceptable: ${acceptable}`));
+  sections.push(new Paragraph({ text: '', spacing: { after: 200 } }));
+
+  // Section 3: Risk Item Matrix
+  sections.push(makeHeading('3. Risk Item Matrix (ISO 14971 Annex E)', HeadingLevel.HEADING_1));
+  if (run.items.length > 0) {
+    sections.push(buildRiskItemsTable(run.items));
+  } else {
+    sections.push(makeText('No risk items identified.'));
+  }
+  sections.push(new Paragraph({ text: '', spacing: { after: 300 } }));
+
+  // Section 4: EU MDR GSPR Mapping
+  sections.push(makeHeading('4. EU MDR Annex I GSPR Mapping', HeadingLevel.HEADING_1));
+  if (run.gsprMappings.length > 0) {
+    sections.push(buildGsprTable(run.gsprMappings));
+  } else {
+    sections.push(makeText('No GSPR mappings recorded.'));
+  }
+  sections.push(new Paragraph({ text: '', spacing: { after: 300 } }));
+
+  // Section 5: Approval
+  sections.push(makeHeading('5. RA-Lead Approval', HeadingLevel.HEADING_1));
+  sections.push(
+    makeText(
+      run.approvedBy
+        ? `This risk management report has been reviewed and approved by RA-Lead (User ID: ${run.approvedBy}) in accordance with ISO 14971:2019 §10.`
+        : 'PENDING: This report awaits RA-Lead approval before distribution.',
+      !run.approvedBy,
+    ),
+  );
+
+  const doc = new Document({
+    sections: [
+      {
+        properties: {},
+        children: sections,
+      },
+    ],
+  });
+
+  return Packer.toBuffer(doc);
+}

--- a/lib/risk/residual-risk.ts
+++ b/lib/risk/residual-risk.ts
@@ -1,0 +1,50 @@
+// @MX:NOTE [AUTO] Residual risk evaluation per ISO 14971 §7.6 / §8.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T1.5, REQ-RISK-016~020)
+
+import { type RiskLevel, evaluateRiskLevel, validateScale } from './risk-evaluation';
+
+export interface ResidualRiskResult {
+  level: RiskLevel;
+  requiresFurtherAction: boolean;
+  isValid: boolean;
+}
+
+/**
+ * Evaluate residual risk after control measures have been applied.
+ *
+ * @param severity         Post-control severity (1–5)
+ * @param probability      Post-control probability (1–5)
+ * @param alarpJustification Required when residual level is 'alarp'
+ */
+export function evaluateResidualRisk(
+  severity: number,
+  probability: number,
+  alarpJustification?: string,
+): ResidualRiskResult {
+  if (!validateScale(severity)) {
+    throw new RangeError(`Invalid residual severity: ${severity}. Must be integer 1–5.`);
+  }
+  if (!validateScale(probability)) {
+    throw new RangeError(`Invalid residual probability: ${probability}. Must be integer 1–5.`);
+  }
+
+  const level = evaluateRiskLevel(severity, probability);
+
+  // 'unacc' residual risk always requires further action (cannot accept).
+  if (level === 'unacc') {
+    return { level, requiresFurtherAction: true, isValid: true };
+  }
+
+  // 'alarp' residual risk requires explicit ALARP justification before acceptance.
+  if (level === 'alarp') {
+    const hasJustification = typeof alarpJustification === 'string' && alarpJustification.trim().length > 0;
+    return {
+      level,
+      requiresFurtherAction: false,
+      isValid: hasJustification,
+    };
+  }
+
+  // 'acc' — acceptable residual risk
+  return { level, requiresFurtherAction: false, isValid: true };
+}

--- a/lib/risk/risk-evaluation.ts
+++ b/lib/risk/risk-evaluation.ts
@@ -33,7 +33,10 @@ export function evaluateRiskLevel(
   probability: number,
   matrix: RiskMatrix = DEFAULT_RISK_MATRIX,
 ): RiskLevel {
-  return matrix[severity - 1][probability - 1];
+  // Non-null assertions safe here: callers must pass severity/probability in [1,5].
+  // validateScale() guards upstream; direct access without check is intentional for hot-path.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return matrix[severity - 1]![probability - 1]!;
 }
 
 /**

--- a/lib/risk/risk-evaluation.ts
+++ b/lib/risk/risk-evaluation.ts
@@ -1,0 +1,52 @@
+// @MX:ANCHOR [AUTO] evaluateRiskLevel — ISO 14971 Annex E risk matrix classification.
+// @MX:REASON Called by residual-risk.ts, BFF evaluate route, and RiskMatrix UI. fan_in >= 3.
+// @MX:SPEC SPEC-REGULA-RISK-001 (T1.1~T1.4, REQ-RISK-011~015)
+
+export type RiskLevel = 'acc' | 'alarp' | 'unacc';
+export type RiskMatrix = RiskLevel[][];
+
+/**
+ * Default 5×5 ISO 14971 Annex E risk matrix.
+ * Index [severity-1][probability-1] → risk level.
+ * Severity 1 (negligible) → row 0; Severity 5 (catastrophic) → row 4.
+ * Probability 1 (incredible) → col 0; Probability 5 (frequent) → col 4.
+ */
+export const DEFAULT_RISK_MATRIX: RiskMatrix = [
+  // S1: negligible
+  ['acc', 'acc', 'acc', 'alarp', 'alarp'],
+  // S2: marginal
+  ['acc', 'acc', 'alarp', 'alarp', 'unacc'],
+  // S3: serious
+  ['acc', 'alarp', 'alarp', 'unacc', 'unacc'],
+  // S4: critical
+  ['acc', 'alarp', 'unacc', 'unacc', 'unacc'],
+  // S5: catastrophic
+  ['alarp', 'unacc', 'unacc', 'unacc', 'unacc'],
+];
+
+/**
+ * Classify risk level from severity × probability using the given matrix.
+ * Severity and probability must be integers 1–5.
+ */
+export function evaluateRiskLevel(
+  severity: number,
+  probability: number,
+  matrix: RiskMatrix = DEFAULT_RISK_MATRIX,
+): RiskLevel {
+  return matrix[severity - 1][probability - 1];
+}
+
+/**
+ * Validate that a scale value is a valid integer in [1, 5].
+ */
+export function validateScale(value: number): boolean {
+  return Number.isInteger(value) && value >= 1 && value <= 5;
+}
+
+/**
+ * Returns true when the risk level requires control measures.
+ * Per ISO 14971: acc is acceptable without controls; alarp and unacc require controls.
+ */
+export function requiresControl(level: RiskLevel): boolean {
+  return level === 'alarp' || level === 'unacc';
+}

--- a/migrations/0057_risk_workflow_type.sql
+++ b/migrations/0057_risk_workflow_type.sql
@@ -1,0 +1,12 @@
+-- SPEC-REGULA-RISK-001: ISO 14971 Risk Management — workflow type + audit actions
+-- Adds 'risk' to workflow_type enum and 7 risk audit action values.
+
+ALTER TYPE workflow_type ADD VALUE IF NOT EXISTS 'risk';
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'risk.hazard_identified';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'risk.matrix_evaluated';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'risk.item_deleted';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'risk.control_adopted';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'risk.residual_accepted';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'risk.gspr_mapped';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'risk.report_approved';

--- a/migrations/0058_risk_tables.sql
+++ b/migrations/0058_risk_tables.sql
@@ -1,0 +1,56 @@
+-- SPEC-REGULA-RISK-001: ISO 14971 Risk Management — risk analysis tables
+-- Creates risk_level_enum, control_tier_enum, risk_items, risk_controls,
+-- and risk_gspr_mappings. Depends on 0057_risk_workflow_type.sql.
+
+CREATE TYPE risk_level AS ENUM ('acc', 'alarp', 'unacc');
+
+CREATE TYPE control_tier AS ENUM ('inherent', 'protective', 'information');
+
+CREATE TABLE risk_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workflow_run_id UUID NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+  hazard TEXT NOT NULL,
+  sequence_of_events TEXT NOT NULL,
+  hazardous_situation TEXT NOT NULL,
+  harm TEXT NOT NULL,
+  citation JSONB NOT NULL DEFAULT '[]',
+  severity INTEGER NOT NULL,
+  probability INTEGER NOT NULL,
+  risk_level risk_level NOT NULL,
+  low_confidence BOOLEAN NOT NULL DEFAULT FALSE,
+  edited_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_risk_items_run ON risk_items(workflow_run_id);
+
+CREATE TABLE risk_controls (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  risk_item_id UUID NOT NULL REFERENCES risk_items(id) ON DELETE CASCADE,
+  tier control_tier NOT NULL,
+  description TEXT NOT NULL,
+  rationale TEXT,
+  is_adopted BOOLEAN NOT NULL DEFAULT FALSE,
+  residual_severity INTEGER,
+  residual_probability INTEGER,
+  residual_risk_level risk_level,
+  alarp_justification TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_risk_controls_item ON risk_controls(risk_item_id);
+
+CREATE TABLE risk_gspr_mappings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workflow_run_id UUID NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+  risk_item_id UUID REFERENCES risk_items(id) ON DELETE CASCADE,
+  gspr_clause TEXT NOT NULL,
+  requirement TEXT NOT NULL,
+  compliance TEXT NOT NULL,
+  evidence TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_risk_gspr_run ON risk_gspr_mappings(workflow_run_id);

--- a/tests/e2e/risk-rbac.spec.ts
+++ b/tests/e2e/risk-rbac.spec.ts
@@ -1,0 +1,102 @@
+// @MX:NOTE: [AUTO] E2E spec: ISO 14971 risk management RBAC enforcement
+// @MX:SPEC: SPEC-REGULA-RISK-001 (T5.3, REQ-RISK-019~020, AC9)
+
+import { expect, test } from '@playwright/test';
+
+const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
+
+// Test risk run ID — must exist in the test database or be created in beforeAll
+const TEST_RISK_RUN_ID = process.env.TEST_RISK_RUN_ID || 'test-risk-run-rbac-001';
+
+test.describe('Risk RBAC (SPEC-REGULA-RISK-001 REQ-RISK-019~020)', () => {
+  test('RBAC: ra-member approve returns 403', async ({ request }) => {
+    const memberToken = process.env.TEST_RA_MEMBER_SESSION_TOKEN;
+    if (!memberToken) {
+      test.skip(true, 'Requires TEST_RA_MEMBER_SESSION_TOKEN env var');
+      return;
+    }
+
+    const resp = await request.post(`${baseUrl}/api/ra/risk/runs`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `authjs.session-token=${memberToken}`,
+      },
+      data: {
+        runId: TEST_RISK_RUN_ID,
+        action: 'approve',
+      },
+    });
+
+    // ra-member does not have risk.approve permission → 403
+    expect(resp.status()).toBe(403);
+
+    const body = await resp.json().catch(() => ({})) as Record<string, unknown>;
+    // Error must indicate permission denial
+    const errMsg = String(body.error ?? body.message ?? '').toLowerCase();
+    expect(errMsg).toMatch(/forbidden|permission|unauthorized|not_allowed/);
+  });
+
+  test('RBAC: ra-lead approve returns 200 or 201', async ({ request }) => {
+    const leadToken = process.env.TEST_RA_LEAD_SESSION_TOKEN;
+    if (!leadToken) {
+      test.skip(true, 'Requires TEST_RA_LEAD_SESSION_TOKEN env var');
+      return;
+    }
+
+    const resp = await request.post(`${baseUrl}/api/ra/risk/runs`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `authjs.session-token=${leadToken}`,
+      },
+      data: {
+        runId: TEST_RISK_RUN_ID,
+        action: 'approve',
+      },
+    });
+
+    // ra-lead has risk.approve permission → 200 or 201
+    expect([200, 201]).toContain(resp.status());
+  });
+
+  test('RBAC: unauthenticated access to risk identify returns 401', async ({ request }) => {
+    const resp = await request.post(`${baseUrl}/api/ra/risk/identify`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        deviceDescription: 'Test device',
+        deviceClass: 'Class II',
+        workflowRunId: TEST_RISK_RUN_ID,
+      },
+    });
+
+    // No session → 401 Unauthorized
+    expect(resp.status()).toBe(401);
+  });
+
+  test('RBAC: unauthenticated access to risk runs returns 401', async ({ request }) => {
+    const resp = await request.get(`${baseUrl}/api/ra/risk/runs`, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(resp.status()).toBe(401);
+  });
+
+  test('RBAC: unauthenticated access to risk controls returns 401', async ({ request }) => {
+    const resp = await request.get(`${baseUrl}/api/ra/risk/controls?runId=${TEST_RISK_RUN_ID}`);
+
+    expect(resp.status()).toBe(401);
+  });
+
+  test('RBAC: unauthenticated access to risk items returns 401', async ({ request }) => {
+    const resp = await request.post(`${baseUrl}/api/ra/risk/items`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        workflowRunId: TEST_RISK_RUN_ID,
+        hazardCategory: 'Energy hazard',
+        severity: 3,
+        probability: 2,
+      },
+    });
+
+    expect(resp.status()).toBe(401);
+  });
+});

--- a/tests/e2e/risk.spec.ts
+++ b/tests/e2e/risk.spec.ts
@@ -1,0 +1,205 @@
+// @MX:NOTE: [AUTO] E2E spec: ISO 14971 risk management full workflow
+// @MX:SPEC: SPEC-REGULA-RISK-001 (T5.2, REQ-RISK-001~020, AC1~AC9)
+
+import { expect, test } from '@playwright/test';
+import { requiresAuthState, requiresLiveServer } from './fixtures/env-guard';
+
+const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
+
+/** Helper: get session token from env or skip */
+function getSessionHeader(): Record<string, string> {
+  const token = process.env.PLAYWRIGHT_SESSION_TOKEN || process.env.TEST_SESSION_TOKEN;
+  if (!token) return {};
+  return { Cookie: `authjs.session-token=${token}` };
+}
+
+test.describe('Risk Management Workflow (SPEC-REGULA-RISK-001)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let riskRunId: string;
+
+  test('risk workflow: identify hazards for a device', async ({ request }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    // Create a risk run first
+    const runResp = await request.post(`${baseUrl}/api/ra/risk/runs`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...getSessionHeader(),
+      },
+      data: {
+        deviceDescription: 'Insulin pump for subcutaneous insulin delivery',
+        deviceClass: 'Class III',
+        projectId: process.env.TEST_PROJECT_ID || 'test-project-001',
+      },
+    });
+    expect(runResp.ok()).toBeTruthy();
+    const runData = await runResp.json();
+    expect(runData.run?.id || runData.id).toBeTruthy();
+    riskRunId = runData.run?.id ?? runData.id;
+
+    // Identify hazards
+    const identifyResp = await request.post(`${baseUrl}/api/ra/risk/identify`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...getSessionHeader(),
+      },
+      data: {
+        deviceDescription: 'Insulin pump for subcutaneous insulin delivery',
+        deviceClass: 'Class III',
+        workflowRunId: riskRunId,
+      },
+    });
+    expect(identifyResp.ok()).toBeTruthy();
+    const identifyData = await identifyResp.json();
+
+    // Must return hazard items
+    expect(identifyData.items).toBeDefined();
+    expect(Array.isArray(identifyData.items)).toBeTruthy();
+    expect(identifyData.items.length).toBeGreaterThan(0);
+
+    // Each item must have required ISO 14971 fields
+    const firstItem = identifyData.items[0];
+    expect(firstItem.hazardCategory).toBeTruthy();
+  });
+
+  test('risk workflow: evaluate risk matrix', async ({ request }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    // Evaluate risk for a hazard item
+    const evalResp = await request.post(`${baseUrl}/api/ra/risk/items`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...getSessionHeader(),
+      },
+      data: {
+        workflowRunId: riskRunId,
+        hazardCategory: 'Energy hazard',
+        hazardousSituation: 'Over-infusion of insulin',
+        sequenceOfEvents: 'Pump malfunction → over-delivery',
+        severity: 4,
+        probability: 3,
+      },
+    });
+    expect(evalResp.ok()).toBeTruthy();
+    const evalData = await evalResp.json();
+
+    // Must return a risk item with risk level
+    const item = evalData.item ?? evalData;
+    expect(item.riskLevel ?? item.risk_level).toBeTruthy();
+    // Risk level must be one of the ISO 14971 levels
+    const level = (item.riskLevel ?? item.risk_level ?? '').toLowerCase();
+    expect(['acc', 'alarp', 'unacc']).toContain(level);
+  });
+
+  test('risk workflow: adopt control measures', async ({ request }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    // Get available controls for the run
+    const controlsResp = await request.get(`${baseUrl}/api/ra/risk/controls?runId=${riskRunId}`, {
+      headers: getSessionHeader(),
+    });
+    // Controls endpoint may not require items to exist yet
+    expect(controlsResp.status()).toBeLessThan(500);
+
+    // Adopt a control measure
+    const adoptResp = await request.post(`${baseUrl}/api/ra/risk/controls`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...getSessionHeader(),
+      },
+      data: {
+        workflowRunId: riskRunId,
+        controlType: 'inherent_safety',
+        description: 'Maximum dose limit enforced in software',
+        residualSeverity: 2,
+        residualProbability: 2,
+      },
+    });
+    expect(adoptResp.ok()).toBeTruthy();
+    const adoptData = await adoptResp.json();
+
+    // Must return residual risk assessment
+    const control = adoptData.control ?? adoptData;
+    expect(control).toBeDefined();
+  });
+
+  test('risk workflow: export DOCX report', async ({ request }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    // Request DOCX export
+    const exportResp = await request.post(`${baseUrl}/api/ra/risk/runs`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        ...getSessionHeader(),
+      },
+      data: {
+        runId: riskRunId,
+        format: 'docx',
+        action: 'export',
+      },
+    });
+
+    // Export endpoint must return binary or redirect
+    expect([200, 201, 302]).toContain(exportResp.status());
+
+    if (exportResp.status() === 200 || exportResp.status() === 201) {
+      const contentType = exportResp.headers()['content-type'] ?? '';
+      const isDocx = contentType.includes('wordprocessingml') ||
+        contentType.includes('octet-stream') ||
+        contentType.includes('application/json');
+      expect(isDocx).toBeTruthy();
+    }
+  });
+
+  test('risk workflow: non-ra-lead cannot approve risk report', async ({ request }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+
+    // Use ra-member credentials (no risk.approve permission)
+    const memberToken = process.env.TEST_RA_MEMBER_SESSION_TOKEN;
+    test.skip(!memberToken, 'Requires TEST_RA_MEMBER_SESSION_TOKEN');
+
+    const approveResp = await request.post(`${baseUrl}/api/ra/risk/runs`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `authjs.session-token=${memberToken}`,
+      },
+      data: {
+        runId: riskRunId,
+        action: 'approve',
+      },
+    });
+
+    // ra-member must be forbidden from approving
+    expect(approveResp.status()).toBe(403);
+  });
+});
+
+test.describe('Risk Workflow Pages', () => {
+  test('risk run list page renders', async ({ page }) => {
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    await page.goto('/workflows/risk');
+    await expect(page).toHaveURL('/workflows/risk');
+
+    // The page should render without error
+    await expect(page.locator('h1, h2, [data-testid="risk-run-list"]')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/tests/eval/risk/risk-identification.yaml
+++ b/tests/eval/risk/risk-identification.yaml
@@ -1,0 +1,160 @@
+# ISO 14971 Hazard Identification Quality Eval
+# SPEC-REGULA-RISK-001 — REQ-RISK-001~010, AC7 (pass threshold 85%)
+
+description: ISO 14971 Hazard Identification Quality Eval
+
+providers:
+  - id: http
+    config:
+      url: "{{env.NEXT_PUBLIC_APP_URL}}/api/ra/risk/identify"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Cookie: "authjs.session-token={{env.TEST_SESSION_TOKEN}}"
+      body:
+        deviceDescription: "{{deviceDescription}}"
+        deviceClass: "{{deviceClass}}"
+        workflowRunId: "eval-{{deviceClass}}-001"
+
+defaultTest:
+  options:
+    provider: http
+
+# Pass threshold: ≥ 85% of scenarios must pass (AC7)
+threshold: 0.85
+
+tests:
+  - description: "Insulin pump hazard identification — energy delivery hazards"
+    vars:
+      deviceDescription: >
+        An implantable insulin pump that continuously delivers insulin subcutaneously.
+        The device includes a reservoir, infusion set, and programmable controller
+        with a wireless communication interface.
+      deviceClass: "Class III"
+    assert:
+      - type: javascript
+        value: |
+          const body = JSON.parse(output);
+          const items = body.items || [];
+          const categories = items.map(i => (i.hazardCategory || '').toLowerCase());
+          const hasEnergy = categories.some(c => c.includes('energy') || c.includes('over-infusion') || c.includes('dose'));
+          const hasSoftware = categories.some(c => c.includes('software') || c.includes('control') || c.includes('programming'));
+          return items.length >= 3 && hasEnergy && hasSoftware;
+        threshold: 1
+
+  - description: "Insulin pump — biological/sterility hazards present"
+    vars:
+      deviceDescription: >
+        An implantable insulin pump with subcutaneous infusion catheter.
+        Long-term implant with potential for biocompatibility issues.
+      deviceClass: "Class III"
+    assert:
+      - type: javascript
+        value: |
+          const body = JSON.parse(output);
+          const items = body.items || [];
+          const categories = items.map(i => (i.hazardCategory || '').toLowerCase());
+          const hasBio = categories.some(c =>
+            c.includes('biological') || c.includes('sterility') ||
+            c.includes('infection') || c.includes('biocompatibility'));
+          return items.length >= 2 && hasBio;
+        threshold: 1
+
+  - description: "Cardiac monitor hazard identification — false alarm and signal hazards"
+    vars:
+      deviceDescription: >
+        A bedside cardiac monitor that measures ECG, heart rate, SpO2, blood pressure,
+        and respiratory rate. Includes audible and visual alarms for out-of-range values.
+        Connects to central nursing station via hospital network.
+      deviceClass: "Class II"
+    assert:
+      - type: javascript
+        value: |
+          const body = JSON.parse(output);
+          const items = body.items || [];
+          const categories = items.map(i => (i.hazardCategory || '').toLowerCase());
+          const hasAlarm = categories.some(c =>
+            c.includes('alarm') || c.includes('false') || c.includes('missed') ||
+            c.includes('signal') || c.includes('measurement'));
+          return items.length >= 3 && hasAlarm;
+        threshold: 1
+
+  - description: "Cardiac monitor — cybersecurity and connectivity hazards"
+    vars:
+      deviceDescription: >
+        A networked cardiac monitor with wireless ECG telemetry and remote monitoring
+        capability. Includes USB ports for data export and software update interface.
+      deviceClass: "Class II"
+    assert:
+      - type: javascript
+        value: |
+          const body = JSON.parse(output);
+          const items = body.items || [];
+          const categories = items.map(i => (i.hazardCategory || '').toLowerCase());
+          const hasCyber = categories.some(c =>
+            c.includes('cyber') || c.includes('security') ||
+            c.includes('network') || c.includes('software') || c.includes('connectivity'));
+          return items.length >= 2 && hasCyber;
+        threshold: 1
+
+  - description: "Ventilator hazard identification — gas delivery and mechanical hazards"
+    vars:
+      deviceDescription: >
+        An ICU mechanical ventilator providing invasive ventilation via endotracheal tube.
+        Delivers controlled volumes of gas mixtures with adjustable pressure, flow,
+        and FiO2 settings. Includes battery backup and alarms for disconnect and apnea.
+      deviceClass: "Class III"
+    assert:
+      - type: javascript
+        value: |
+          const body = JSON.parse(output);
+          const items = body.items || [];
+          const categories = items.map(i => (i.hazardCategory || '').toLowerCase());
+          const hasGas = categories.some(c =>
+            c.includes('gas') || c.includes('pressure') ||
+            c.includes('ventilation') || c.includes('mechanical') || c.includes('disconnect'));
+          const hasPower = categories.some(c =>
+            c.includes('power') || c.includes('battery') || c.includes('electrical'));
+          return items.length >= 4 && hasGas && hasPower;
+        threshold: 1
+
+  - description: "Ventilator — software and alarm hazards present"
+    vars:
+      deviceDescription: >
+        A ventilator with touch-screen interface, mode selection (AC, SIMV, CPAP, BiPAP),
+        and integrated apnea and disconnect alarm system. Software controls all ventilation modes.
+      deviceClass: "Class III"
+    assert:
+      - type: javascript
+        value: |
+          const body = JSON.parse(output);
+          const items = body.items || [];
+          const categories = items.map(i => (i.hazardCategory || '').toLowerCase());
+          const hasSoftware = categories.some(c =>
+            c.includes('software') || c.includes('alarm') ||
+            c.includes('mode') || c.includes('usability') || c.includes('interface'));
+          return items.length >= 3 && hasSoftware;
+        threshold: 1
+
+  - description: "Response contains required ISO 14971 fields"
+    vars:
+      deviceDescription: >
+        A general-purpose infusion pump for intravenous fluid delivery in hospital settings.
+        Includes dose error reduction software and drug library.
+      deviceClass: "Class II"
+    assert:
+      - type: javascript
+        value: |
+          const body = JSON.parse(output);
+          const items = body.items || [];
+          if (items.length === 0) return false;
+          const firstItem = items[0];
+          // Each hazard item must include these ISO 14971 required fields
+          const hasCategory = 'hazardCategory' in firstItem;
+          const hasSituation = 'hazardousSituation' in firstItem || 'situation' in firstItem;
+          const hasSequence = 'sequenceOfEvents' in firstItem || 'events' in firstItem || 'description' in firstItem;
+          return hasCategory && (hasSituation || hasSequence);
+        threshold: 1
+
+outputPath: tests/eval/results/risk-identification-latest.json
+sharing: false

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
       'lib/**/__tests__/**/*.test.{ts,tsx}',
       // Co-located app route tests (e.g. app/api/ra/predicate/__tests__) — SPEC-REGULA-PREDICATE-001.
       'app/**/__tests__/**/*.test.{ts,tsx}',
+      // Co-located component tests (e.g. components/risk/__tests__) — SPEC-REGULA-RISK-001.
+      'components/**/__tests__/**/*.test.{ts,tsx}',
       // E2E fixture helpers and globalSetup have vitest unit tests (SPEC-REGULA-E2EFIX-001).
       'tests/e2e/fixtures/**/*.test.{ts,tsx}',
       'playwright/**/*.test.{ts,tsx}',


### PR DESCRIPTION
## Summary

- **SPEC**: SPEC-REGULA-RISK-001 (ISO 14971:2019 Medical Device Risk Management)
- **Issue**: Fixes #46
- **Wave**: 4

### 구현 범위

| Phase | 내용 | 커밋 |
|-------|------|------|
| 0+1 | DB 스키마(riskItems/Controls/GsprMappings), RBAC 권한(risk.approve=ra-lead only), ISO 14971 도메인 로직 | 9b9e455 |
| 2+3 | BFF API 10개 라우트(runs/items/controls/identify/approve/export/gspr), DOCX 리포트 빌더 | 99f9020 |
| 4 | UI 컴포넌트(RiskMatrix/HazardTable/ControlWizard/RiskApprovalGate) | 917fe13 |
| 5 | TypeScript 타입 오류 0개 달성 | 34cd3e5 |
| 5 | E2E 스펙(risk.spec.ts + risk-rbac.spec.ts) + promptfoo eval + 워크플로우 페이지 | 5bea510 |

### 핵심 기능

- **5×5 Risk Matrix** (ISO 14971 Annex E): severity×probability → acc/alarp/unacc
- **§7.1 Control Hierarchy**: inherent → protective → information (3티어 강제)
- **ALARP principle**: residual risk 정당화 텍스트 필수
- **RBAC 강제**: `risk.approve` = ra-lead 전용 (ra-member 접근 시 403)
- **RAG 해저드 식별**: hybrid-ra-saas RAG 쿼리 연동
- **DOCX 리포트**: 7개 ISO 14971 섹션 + EU MDR GSPR 매핑 테이블 + DRAFT 워터마크
- **Audit logs**: append-only (trigger 강제)

### 테스트 현황

- Unit tests: **122 passed** (schema 23 + risk-evaluation 39 + residual-risk 6 + hazard-id 12 + control-recommendation 7 + report-builder 6 + BFF routes 16 + UI 13)
- TypeScript: **0 errors**
- E2E: `tests/e2e/risk.spec.ts` (5 시나리오) + `tests/e2e/risk-rbac.spec.ts` (RBAC 3 시나리오)
- Eval: `tests/eval/risk/risk-identification.yaml` (7 해저드 식별 시나리오, 85% 임계값)

## Test plan

- [ ] `npx vitest run lib/risk/ components/risk/ app/api/ra/risk/` → 122 tests pass
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] DB 마이그레이션 적용 (`0001_salty_pet_avengers.sql`)
- [ ] E2E: `TEST_RA_LEAD_SESSION_TOKEN`, `TEST_RA_MEMBER_SESSION_TOKEN`, `TEST_RISK_RUN_ID` 설정 후 실행
- [ ] ra-member로 `/api/ra/risk/runs/*/approve` POST → 403 확인
- [ ] ra-lead로 동일 엔드포인트 → 200 확인

🗿 MoAI <email@mo.ai.kr>