### PR TITLE
test(contract): hybrid-ra-saas UI 연동 컨트랙트 테스트 20개 추가

### DIFF
--- a/.moai/state/session-memo.md
+++ b/.moai/state/session-memo.md
@@ -18,3 +18,10 @@ event: PreCompact
 - Active branch: `main`
 - Duplicate-work gate: Read GitHub Issue #18, updated local `main` to `origin/main` merge commit `04b6333`, and checked open PRs before docs work.
 - Docs scope: README, API reference, implementation status, and env matrix for Issue #156 hybrid-ra-saas typed adapter.
+
+## 2026-06-20 PR #196 Review/Fix/Merge Session
+
+- Active branch: `feat/issue-168-169-171-contract-tests`
+- Active PR: #196 (`test(contract): hybrid-ra-saas UI 연동 컨트랙트 테스트 20개 추가`)
+- Duplicate-work gate: Read GitHub Issue #18, fetched `origin/main`, confirmed PR #196 is the active branch for Issues #168/#169/#171, and verified PR #197 is a separate docs-only branch.
+- Review state: No reviews, comments, or review threads. CI Gates failed on Biome lint/format in the three new contract test files.

--- a/tests/unit/api/authoring-route.test.ts
+++ b/tests/unit/api/authoring-route.test.ts
@@ -1,0 +1,219 @@
+// @MX:NOTE [AUTO] Contract tests for Authoring BFF routes — MSW fixture-based response schema validation.
+// @MX:SPEC Issue #171 (AC: Contract test with MSW fixture verifying response schema)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' },
+        }),
+  ),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  writeAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/env', () => ({
+  getEnv: vi.fn(),
+}));
+
+import { getEnv } from '@/lib/env';
+
+// Top-level imports (required — await inside describe() is not supported by esbuild)
+const { POST: postSession } = await import('@/app/api/ra/authoring/sessions/route');
+const { GET: getSession } = await import('@/app/api/ra/authoring/sessions/[sessionId]/route');
+const { POST: approveSession } = await import(
+  '@/app/api/ra/authoring/sessions/[sessionId]/approve/route'
+);
+const { POST: rejectSession } = await import(
+  '@/app/api/ra/authoring/sessions/[sessionId]/reject/route'
+);
+
+// ---------------------------------------------------------------------------
+// MSW-style fixtures matching integration-contract.md schema
+// ---------------------------------------------------------------------------
+
+const CONFIGURED_ENV = {
+  HYBRID_RA_API_BASE_URL: 'https://hybrid.example.com',
+  HYBRID_RA_API_TOKEN: 'test-bearer-token',
+  HYBRID_RA_TENANT_ID: 'tenant-abc',
+};
+
+const SESSION_RESPONSE_FIXTURE = {
+  session_id: 'sess-001',
+  status: 'created',
+  created_at: '2026-06-20T00:00:00Z',
+  current_draft: '',
+};
+
+const SESSION_STATE_FIXTURE = {
+  session_id: 'sess-001',
+  section_id: 'sec-001',
+  status: 'in_progress',
+  current_draft: '## Section draft content',
+  created_at: '2026-06-20T00:00:00Z',
+  updated_at: '2026-06-20T01:00:00Z',
+};
+
+const APPROVAL_RESULT_FIXTURE = {
+  session_id: 'sess-001',
+  status: 'approved',
+  decided_at: '2026-06-20T02:00:00Z',
+  approver_comments: 'Looks good',
+};
+
+const REJECTION_RESULT_FIXTURE = {
+  session_id: 'sess-001',
+  status: 'rejected',
+  decided_at: '2026-06-20T02:00:00Z',
+  approver_comments: 'Needs revision',
+};
+
+function mockHybridFetchOk(body: unknown) {
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+function mockHybridFetchError(status: number) {
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(JSON.stringify({ error: 'upstream error' }), {
+      status,
+      statusText: 'Error',
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(getEnv).mockReturnValue(CONFIGURED_ENV as ReturnType<typeof getEnv>);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/ra/authoring/sessions — contract test', () => {
+  it('returns SessionResponse schema with session_id and status', async () => {
+    mockHybridFetchOk(SESSION_RESPONSE_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/authoring/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ section_id: 'sec-001', device_id: 'device-001' }),
+    });
+
+    const res = await postSession(req, { params: Promise.resolve({}) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('session_id');
+    expect(body).toHaveProperty('status');
+    expect(body).toHaveProperty('created_at');
+    expect(typeof body.session_id).toBe('string');
+    expect(['created', 'in_progress', 'approved', 'rejected']).toContain(body.status);
+  });
+
+  it('injects Bearer and X-Tenant-Id headers to upstream', async () => {
+    mockHybridFetchOk(SESSION_RESPONSE_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/authoring/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ section_id: 'sec-001', device_id: 'device-001' }),
+    });
+    await postSession(req, { params: Promise.resolve({}) });
+
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/api/v1/authoring/sessions');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-bearer-token');
+    expect((init.headers as Record<string, string>)['X-Tenant-Id']).toBe('tenant-abc');
+  });
+
+  it('returns 401 body on upstream auth failure', async () => {
+    mockHybridFetchError(401);
+
+    const req = new Request('http://localhost/api/ra/authoring/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ section_id: 'sec-001', device_id: 'device-001' }),
+    });
+    const res = await postSession(req, { params: Promise.resolve({}) });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});
+
+describe('GET /api/ra/authoring/sessions/[sessionId] — contract test', () => {
+  it('returns SessionState schema with current_draft', async () => {
+    mockHybridFetchOk(SESSION_STATE_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/authoring/sessions/sess-001');
+    const res = await getSession(req, { params: Promise.resolve({ sessionId: 'sess-001' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('session_id');
+    expect(body).toHaveProperty('section_id');
+    expect(body).toHaveProperty('status');
+    expect(body).toHaveProperty('current_draft');
+    expect(body).toHaveProperty('created_at');
+    expect(typeof body.current_draft).toBe('string');
+  });
+
+  it('calls upstream with correct sessionId path', async () => {
+    mockHybridFetchOk(SESSION_STATE_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/authoring/sessions/sess-abc');
+    await getSession(req, { params: Promise.resolve({ sessionId: 'sess-abc' }) });
+
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+    expect(url).toContain('/api/v1/authoring/sessions/sess-abc');
+  });
+});
+
+describe('POST /api/ra/authoring/sessions/[sessionId]/approve — contract test', () => {
+  it('returns approval result with status approved', async () => {
+    mockHybridFetchOk(APPROVAL_RESULT_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/authoring/sessions/sess-001/approve', {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'approve', comments: 'Looks good' }),
+    });
+
+    const res = await approveSession(req, { params: Promise.resolve({ sessionId: 'sess-001' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('session_id');
+    expect(body).toHaveProperty('status');
+    expect(body.status).toBe('approved');
+  });
+});
+
+describe('POST /api/ra/authoring/sessions/[sessionId]/reject — contract test', () => {
+  it('returns rejection result with status rejected', async () => {
+    mockHybridFetchOk(REJECTION_RESULT_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/authoring/sessions/sess-001/reject', {
+      method: 'POST',
+      body: JSON.stringify({ decision: 'reject', comments: 'Needs revision' }),
+    });
+
+    const res = await rejectSession(req, { params: Promise.resolve({ sessionId: 'sess-001' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('session_id');
+    expect(body).toHaveProperty('status');
+    expect(body.status).toBe('rejected');
+  });
+});

--- a/tests/unit/api/authoring-route.test.ts
+++ b/tests/unit/api/authoring-route.test.ts
@@ -132,9 +132,12 @@ describe('POST /api/ra/authoring/sessions — contract test', () => {
     });
     await postSession(req, { params: Promise.resolve({}) });
 
-    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     expect(url).toContain('/api/v1/authoring/sessions');
-    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-bearer-token');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-bearer-token');
     expect((init.headers as Record<string, string>)['X-Tenant-Id']).toBe('tenant-abc');
   });
 

--- a/tests/unit/api/evidence-route.test.ts
+++ b/tests/unit/api/evidence-route.test.ts
@@ -124,14 +124,21 @@ describe('POST /api/ra/evidence/link — contract test', () => {
 
     const req = new Request('http://localhost/api/ra/evidence/link', {
       method: 'POST',
-      body: JSON.stringify({ requirement_id: 'REQ-001', evidence_type: 'clinical', description: 'x' }),
+      body: JSON.stringify({
+        requirement_id: 'REQ-001',
+        evidence_type: 'clinical',
+        description: 'x',
+      }),
     });
 
     await postLink(req, { params: Promise.resolve({}) });
 
-    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     expect(url).toContain('/api/v1/evidence/link');
-    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-bearer-token');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-bearer-token');
     expect((init.headers as Record<string, string>)['X-Tenant-Id']).toBe('tenant-abc');
   });
 
@@ -140,7 +147,11 @@ describe('POST /api/ra/evidence/link — contract test', () => {
 
     const req = new Request('http://localhost/api/ra/evidence/link', {
       method: 'POST',
-      body: JSON.stringify({ requirement_id: 'REQ-001', evidence_type: 'clinical', description: 'x' }),
+      body: JSON.stringify({
+        requirement_id: 'REQ-001',
+        evidence_type: 'clinical',
+        description: 'x',
+      }),
     });
 
     const res = await postLink(req, { params: Promise.resolve({}) });
@@ -156,7 +167,7 @@ describe('GET /api/ra/evidence/links/[reqId] — contract test', () => {
 
     const req = new Request('http://localhost/api/ra/evidence/links/req-001');
     const res = await getLinks(req, { params: Promise.resolve({ reqId: 'req-001' }) });
-    const body = await res.json() as unknown[];
+    const body = (await res.json()) as unknown[];
 
     expect(res.status).toBe(200);
     expect(Array.isArray(body)).toBe(true);

--- a/tests/unit/api/evidence-route.test.ts
+++ b/tests/unit/api/evidence-route.test.ts
@@ -1,0 +1,219 @@
+// @MX:NOTE [AUTO] Contract tests for Evidence BFF routes — MSW fixture-based response schema validation.
+// @MX:SPEC Issue #168 (AC: Contract test with MSW fixture verifying response schema)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-member', organizationId: 'org-001' },
+        }),
+  ),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  writeAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/env', () => ({
+  getEnv: vi.fn(),
+}));
+
+import { getEnv } from '@/lib/env';
+
+// Top-level imports (required — await inside describe() is not supported by esbuild)
+const { POST: postLink } = await import('@/app/api/ra/evidence/link/route');
+const { GET: getLinks } = await import('@/app/api/ra/evidence/links/[reqId]/route');
+const { POST: postBinder } = await import('@/app/api/ra/evidence/binder/route');
+
+// ---------------------------------------------------------------------------
+// MSW-style fixtures (static response bodies matching integration-contract.md)
+// ---------------------------------------------------------------------------
+
+const CONFIGURED_ENV = {
+  HYBRID_RA_API_BASE_URL: 'https://hybrid.example.com',
+  HYBRID_RA_API_TOKEN: 'test-bearer-token',
+  HYBRID_RA_TENANT_ID: 'tenant-abc',
+};
+
+const LINK_RESPONSE_FIXTURE = {
+  req_id: 'req-001',
+  status: 'pending',
+  created_at: '2026-06-20T00:00:00Z',
+  message: 'Link created',
+};
+
+const EVIDENCE_LINKS_FIXTURE = [
+  {
+    req_id: 'req-001',
+    requirement_id: 'REQ-001',
+    evidence_type: 'clinical',
+    description: 'Clinical study data',
+    status: 'pending',
+    created_at: '2026-06-20T00:00:00Z',
+  },
+];
+
+const BINDER_RESPONSE_FIXTURE = {
+  binder_id: 'binder-001',
+  name: 'Clinical Evidence Pack',
+  status: 'created',
+  created_at: '2026-06-20T00:00:00Z',
+  link_count: 1,
+};
+
+function mockHybridFetchOk(body: unknown) {
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+function mockHybridFetchError(status: number) {
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(JSON.stringify({ error: 'upstream error' }), {
+      status,
+      statusText: 'Error',
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(getEnv).mockReturnValue(CONFIGURED_ENV as ReturnType<typeof getEnv>);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/ra/evidence/link — contract test', () => {
+  it('proxies request and returns LinkResponse schema', async () => {
+    mockHybridFetchOk(LINK_RESPONSE_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/evidence/link', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requirement_id: 'REQ-001',
+        evidence_type: 'clinical',
+        description: 'Clinical study data',
+      }),
+    });
+
+    const res = await postLink(req, { params: Promise.resolve({}) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('req_id');
+    expect(body).toHaveProperty('status');
+    expect(body).toHaveProperty('created_at');
+    expect(typeof body.req_id).toBe('string');
+    expect(['pending', 'completed', 'failed']).toContain(body.status);
+  });
+
+  it('injects Bearer and X-Tenant-Id headers to upstream', async () => {
+    mockHybridFetchOk(LINK_RESPONSE_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/evidence/link', {
+      method: 'POST',
+      body: JSON.stringify({ requirement_id: 'REQ-001', evidence_type: 'clinical', description: 'x' }),
+    });
+
+    await postLink(req, { params: Promise.resolve({}) });
+
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/api/v1/evidence/link');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-bearer-token');
+    expect((init.headers as Record<string, string>)['X-Tenant-Id']).toBe('tenant-abc');
+  });
+
+  it('returns 401 error body on upstream auth failure', async () => {
+    mockHybridFetchError(401);
+
+    const req = new Request('http://localhost/api/ra/evidence/link', {
+      method: 'POST',
+      body: JSON.stringify({ requirement_id: 'REQ-001', evidence_type: 'clinical', description: 'x' }),
+    });
+
+    const res = await postLink(req, { params: Promise.resolve({}) });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});
+
+describe('GET /api/ra/evidence/links/[reqId] — contract test', () => {
+  it('returns EvidenceLink[] schema', async () => {
+    mockHybridFetchOk(EVIDENCE_LINKS_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/evidence/links/req-001');
+    const res = await getLinks(req, { params: Promise.resolve({ reqId: 'req-001' }) });
+    const body = await res.json() as unknown[];
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body)).toBe(true);
+    const link = body[0] as Record<string, unknown>;
+    expect(link).toHaveProperty('req_id');
+    expect(link).toHaveProperty('requirement_id');
+    expect(link).toHaveProperty('evidence_type');
+    expect(link).toHaveProperty('status');
+    expect(link).toHaveProperty('created_at');
+  });
+
+  it('calls upstream with correct reqId path', async () => {
+    mockHybridFetchOk(EVIDENCE_LINKS_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/evidence/links/req-abc');
+    await getLinks(req, { params: Promise.resolve({ reqId: 'req-abc' }) });
+
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+    expect(url).toContain('/api/v1/evidence/links/req-abc');
+  });
+});
+
+describe('POST /api/ra/evidence/binder — contract test', () => {
+  it('returns BinderResponse schema', async () => {
+    mockHybridFetchOk(BINDER_RESPONSE_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/evidence/binder', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Clinical Evidence Pack', link_ids: ['req-001'] }),
+    });
+
+    const res = await postBinder(req, { params: Promise.resolve({}) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('binder_id');
+    expect(body).toHaveProperty('name');
+    expect(body).toHaveProperty('status');
+    expect(body).toHaveProperty('link_count');
+    expect(['created', 'failed']).toContain(body.status);
+  });
+
+  it('returns 503 error when hybrid-ra is unconfigured', async () => {
+    vi.mocked(getEnv).mockReturnValueOnce({
+      HYBRID_RA_API_BASE_URL: undefined,
+      HYBRID_RA_API_TOKEN: undefined,
+      HYBRID_RA_TENANT_ID: undefined,
+    } as ReturnType<typeof getEnv>);
+
+    const req = new Request('http://localhost/api/ra/evidence/binder', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'pack', link_ids: [] }),
+    });
+
+    const res = await postBinder(req, { params: Promise.resolve({}) });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/tests/unit/api/traceability-route.test.ts
+++ b/tests/unit/api/traceability-route.test.ts
@@ -49,9 +49,7 @@ const TRACE_GRAPH_FIXTURE = {
     { id: 'node-1', type: 'requirement', label: 'REQ-001' },
     { id: 'node-2', type: 'test', label: 'TC-001' },
   ],
-  edges: [
-    { source: 'node-1', target: 'node-2', relationship: 'verified_by' },
-  ],
+  edges: [{ source: 'node-1', target: 'node-2', relationship: 'verified_by' }],
   metadata: {
     total_nodes: 2,
     total_edges: 1,
@@ -60,9 +58,7 @@ const TRACE_GRAPH_FIXTURE = {
 };
 
 const IMPACT_RESULT_FIXTURE = {
-  affected_nodes: [
-    { id: 'node-2', type: 'test', label: 'TC-001', impact_level: 'high' },
-  ],
+  affected_nodes: [{ id: 'node-2', type: 'test', label: 'TC-001', impact_level: 'high' }],
   total_affected: 1,
   analysis_id: 'analysis-001',
   timestamp: '2026-06-20T00:00:00Z',
@@ -126,9 +122,12 @@ describe('POST /api/ra/traceability/scan — contract test', () => {
     });
     await postScan(req, { params: Promise.resolve({}) });
 
-    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     expect(url).toContain('/api/v1/traceability/scan');
-    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-bearer-token');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-bearer-token');
     expect((init.headers as Record<string, string>)['X-Tenant-Id']).toBe('tenant-abc');
   });
 

--- a/tests/unit/api/traceability-route.test.ts
+++ b/tests/unit/api/traceability-route.test.ts
@@ -1,0 +1,199 @@
+// @MX:NOTE [AUTO] Contract tests for Traceability BFF routes — MSW fixture-based response schema validation.
+// @MX:SPEC SPEC-INTEGRATION-001, Issue #169 (AC: Contract test with MSW fixture verifying response schema)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-member', organizationId: 'org-001' },
+        }),
+  ),
+}));
+
+vi.mock('@/lib/env', () => ({
+  getEnv: vi.fn(),
+}));
+
+import { getEnv } from '@/lib/env';
+
+// Top-level imports (required — await inside describe() is not supported by esbuild)
+const { POST: postScan } = await import('@/app/api/ra/traceability/scan/route');
+const { GET: getGraph } = await import('@/app/api/ra/traceability/graph/route');
+const { POST: postImpact } = await import('@/app/api/ra/traceability/impact/route');
+
+// ---------------------------------------------------------------------------
+// MSW-style fixtures matching integration-contract.md schema
+// ---------------------------------------------------------------------------
+
+const CONFIGURED_ENV = {
+  HYBRID_RA_API_BASE_URL: 'https://hybrid.example.com',
+  HYBRID_RA_API_TOKEN: 'test-bearer-token',
+  HYBRID_RA_TENANT_ID: 'tenant-abc',
+};
+
+const SCAN_RESULT_FIXTURE = {
+  scan_id: 'scan-001',
+  nodes_scanned: 42,
+  status: 'completed',
+  timestamp: '2026-06-20T00:00:00Z',
+};
+
+const TRACE_GRAPH_FIXTURE = {
+  nodes: [
+    { id: 'node-1', type: 'requirement', label: 'REQ-001' },
+    { id: 'node-2', type: 'test', label: 'TC-001' },
+  ],
+  edges: [
+    { source: 'node-1', target: 'node-2', relationship: 'verified_by' },
+  ],
+  metadata: {
+    total_nodes: 2,
+    total_edges: 1,
+    scan_id: 'scan-001',
+  },
+};
+
+const IMPACT_RESULT_FIXTURE = {
+  affected_nodes: [
+    { id: 'node-2', type: 'test', label: 'TC-001', impact_level: 'high' },
+  ],
+  total_affected: 1,
+  analysis_id: 'analysis-001',
+  timestamp: '2026-06-20T00:00:00Z',
+};
+
+function mockHybridFetchOk(body: unknown) {
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+function mockHybridFetchError(status: number) {
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(JSON.stringify({ error: 'upstream error' }), {
+      status,
+      statusText: 'Error',
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(getEnv).mockReturnValue(CONFIGURED_ENV as ReturnType<typeof getEnv>);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/ra/traceability/scan — contract test', () => {
+  it('returns ScanResult schema with nodes_scanned and scan_id', async () => {
+    mockHybridFetchOk(SCAN_RESULT_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/traceability/scan', {
+      method: 'POST',
+      body: JSON.stringify({ filters: {} }),
+    });
+
+    const res = await postScan(req, { params: Promise.resolve({}) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('scan_id');
+    expect(body).toHaveProperty('nodes_scanned');
+    expect(body).toHaveProperty('status');
+    expect(body).toHaveProperty('timestamp');
+    expect(typeof body.scan_id).toBe('string');
+    expect(typeof body.nodes_scanned).toBe('number');
+    expect(['completed', 'in_progress', 'failed']).toContain(body.status);
+  });
+
+  it('injects Bearer and X-Tenant-Id headers to upstream', async () => {
+    mockHybridFetchOk(SCAN_RESULT_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/traceability/scan', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    await postScan(req, { params: Promise.resolve({}) });
+
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/api/v1/traceability/scan');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-bearer-token');
+    expect((init.headers as Record<string, string>)['X-Tenant-Id']).toBe('tenant-abc');
+  });
+
+  it('returns 401 body on upstream auth failure', async () => {
+    mockHybridFetchError(401);
+
+    const req = new Request('http://localhost/api/ra/traceability/scan', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    const res = await postScan(req, { params: Promise.resolve({}) });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});
+
+describe('GET /api/ra/traceability/graph — contract test', () => {
+  it('returns TraceGraph schema with nodes and edges', async () => {
+    mockHybridFetchOk(TRACE_GRAPH_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/traceability/graph');
+    const res = await getGraph(req, { params: Promise.resolve({}) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('nodes');
+    expect(body).toHaveProperty('edges');
+    expect(body).toHaveProperty('metadata');
+    expect(Array.isArray(body.nodes)).toBe(true);
+    expect(Array.isArray(body.edges)).toBe(true);
+    const node = body.nodes[0] as Record<string, unknown>;
+    expect(node).toHaveProperty('id');
+    expect(node).toHaveProperty('type');
+    expect(node).toHaveProperty('label');
+  });
+
+  it('forwards scan_id query parameter to upstream', async () => {
+    mockHybridFetchOk(TRACE_GRAPH_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/traceability/graph?scan_id=scan-001');
+    await getGraph(req, { params: Promise.resolve({}) });
+
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+    expect(url).toContain('scan_id=scan-001');
+  });
+});
+
+describe('POST /api/ra/traceability/impact — contract test', () => {
+  it('returns ImpactResult schema with affected_nodes', async () => {
+    mockHybridFetchOk(IMPACT_RESULT_FIXTURE);
+
+    const req = new Request('http://localhost/api/ra/traceability/impact', {
+      method: 'POST',
+      body: JSON.stringify({ node_id: 'node-1', change_type: 'modification' }),
+    });
+
+    const res = await postImpact(req, { params: Promise.resolve({}) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('affected_nodes');
+    expect(body).toHaveProperty('total_affected');
+    expect(body).toHaveProperty('analysis_id');
+    expect(Array.isArray(body.affected_nodes)).toBe(true);
+    expect(typeof body.total_affected).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary

- Evidence BFF routes (`/api/ra/evidence/*`) 컨트랙트 테스트 7개 추가 — Closes #168
- Traceability BFF routes (`/api/ra/traceability/*`) 컨트랙트 테스트 6개 추가 — Closes #169
- Authoring BFF routes (`/api/ra/authoring/*`) 컨트랙트 테스트 7개 추가 — Closes #171

## Test Coverage (20/20 pass)

각 테스트 파일은 다음을 검증합니다:
- 응답 스키마 필드 존재 및 타입 검증 (MSW fixture 기반)
- `Authorization: Bearer <token>` 및 `X-Tenant-Id` 헤더 주입 검증
- 401/503 등 upstream 에러 상태 코드 전파 검증
- 동적 경로 파라미터(`sessionId`, `reqId`, `scan_id`) 전달 검증

## 버그 수정 패턴 (vi.mock + vi.clearAllMocks 충돌)

`vi.mock()` 팩토리에서 `vi.fn().mockReturnValue(...)` 설정 후
`vi.clearAllMocks()`로 초기화되는 문제를 수정:

```typescript
// ❌ 잘못된 패턴 (clearAllMocks가 factory 설정 제거)
vi.mock('@/lib/env', () => ({ getEnv: vi.fn().mockReturnValue(CONFIG) }));
beforeEach(() => { vi.clearAllMocks(); });

// ✅ 올바른 패턴 (beforeEach에서 매번 재설정)
vi.mock('@/lib/env', () => ({ getEnv: vi.fn() }));
import { getEnv } from '@/lib/env';
beforeEach(() => { vi.mocked(getEnv).mockReturnValue(CONFIG); });
afterEach(() => { vi.clearAllMocks(); });
```

## Test plan

- [x] `pnpm vitest run tests/unit/api/evidence-route.test.ts` — 7/7 pass
- [x] `pnpm vitest run tests/unit/api/traceability-route.test.ts` — 6/6 pass
- [x] `pnpm vitest run tests/unit/api/authoring-route.test.ts` — 7/7 pass
- [x] 총 20/20 테스트 통과 확인

🗿 MoAI <email@mo.ai.kr>