### PR TITLE
[codex] docs(esig): document Part 11 signature workflow

### DIFF
--- a/.moai/specs/SPEC-REGULA-ESIG-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-ESIG-001/spec.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Issue: #88
-- Status: Draft
+- Status: Complete
 - Created: 2026-06-20
 - Priority: High
 - Category: Wave 5 — 21 CFR Part 11 electronic signature
@@ -52,7 +52,7 @@ WHEN the audit log is queried, THE SYSTEM SHALL return signature events with: si
 ## Dependencies
 - Audit log infrastructure (Phase 7 — append-only, cold storage)
 - Expert review / approval workflow (#171 authoring sessions)
-- RBAC: only `ra-lead` and `qa-lead` roles can sign
+- RBAC: only `admin`, `ra-lead`, and signature-specific `qa-lead` users can sign; `qa-lead` does not inherit unrelated `ra-lead` gates
 
 ## Definition of Done
 - Signature capture, linking, display, and lock working
@@ -60,3 +60,10 @@ WHEN the audit log is queried, THE SYSTEM SHALL return signature events with: si
 - §11.50 manifestation in UI and PDF export
 - §11.70 record/signature linkage with hash
 - Integration tests verifying non-repudiation and immutability
+
+## Implementation Notes
+
+- Implemented via PR #204 and merged to `main` at `e51ebc5`.
+- Signature endpoints authorize `messageId` through conversation/project scope before signature lookup or mutation.
+- `signature.sign` uses `minRole: 'ra-lead'` plus `additionalRoles: ['qa-lead']`; `qa-lead` sits below `ra-lead` in the general hierarchy.
+- Validation evidence: local `typecheck`, `lint`, `ci:rbac`, full `pnpm test` (2,766 passed / 7 skipped), `pnpm build`, PR checks, and post-merge main `CI`/`Security Scan`/`E2E Tests`/`Deploy` all passed.

--- a/.moai/state/session-memo.md
+++ b/.moai/state/session-memo.md
@@ -29,3 +29,10 @@
 - Issue: #88; duplicate-work prevention checked via Issue #18.
 - Main checked: `origin/main` fetched before review-fix work.
 - Review fix scope: enforce message ownership/tenant authorization for signature sign/manifest/revoke endpoints; restrict `qa-lead` to `signature.sign` instead of all `ra-lead` gates.
+
+## Documentation Sync — 2026-06-21
+
+- Branch: `codex/docs-esig-20260621`
+- Base: `main` at `e51ebc5` after PR #204 merge.
+- Work gate: Issue #18 checked; no open PR for duplicate ESIG documentation work.
+- Scope: README + implementation status + API/compliance/Part 11 docs + ESIG SPEC status updated to reflect Issue #88 completion and PR #204 review fixes.

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@
 
 ---
 
-## 구현 현황 대시보드 (2026-06-20 KST 기준)
+## 구현 현황 대시보드 (2026-06-21 KST 기준)
 
 상세 점검 기록: [`docs/implementation-status.md`](docs/implementation-status.md)
 
-### 최신 main 상태 (2026-06-20)
+### 최신 main 상태 (2026-06-21)
 
-현재 `main`은 PR #195 ISO 14971 Risk Management, PR #196 submission-drafter/build/health-check 보강, PR #197 위험관리 문서 동기화, #166 hydration mismatch 수정, QA Gate/Wave 5 SPEC 문서까지 반영된 상태입니다. 2026-06-20 리뷰에서 #166 후속 날짜 렌더링 파일의 Biome format drift를 발견해 수정했으며, 로컬 기준 `biome check .`, `pnpm test`, `next build`가 통과했습니다.
+현재 `main`은 PR #204 21 CFR Part 11 전자서명 구현까지 반영된 상태입니다. PR #204는 Issue #88 / SPEC-REGULA-ESIG-001을 닫았고, 전자서명 적용/조회/철회 API, 답변 잠금, SHA-256 record hash linkage, §11.50 UI/PDF manifestation, signature-specific `qa-lead` 권한을 포함합니다. 2026-06-21 기준 PR 체크와 merge 후 main의 `CI`, `Security Scan`, `E2E Tests`, `Deploy`가 모두 통과했습니다.
 
 | 항목 | 상태 | 근거 |
 |---|---|---|
-| main 리뷰 기준 | PASS | `b2bd5d1 chore(state): 세션 메모 업데이트 (2026-06-20 일괄 처리 완료)` |
-| 리뷰 후 수정 | PASS | #166 hydration mismatch 후속 파일 3개 Biome format gate 복구 |
+| main 리뷰 기준 | PASS | `e51ebc5 feat(esig): implement 21 CFR Part 11 signatures` |
+| 리뷰 후 수정 | PASS | PR #204 reviewer 지적 2건 해소: signature message authorization, `qa-lead` 권한 범위 축소 |
+| PR #204 | MERGED | Issue #88 전자서명 / 답변 잠금 / §11.50·§11.70 구현 |
 | PR #197 | MERGED | `docs(risk): synchronize ISO 14971 implementation docs` |
 | PR #196 | MERGED | build-time env validation, submission-drafter status contract, health-check source import 보강 |
 | PR #195 | MERGED | `feat(risk): SPEC-REGULA-RISK-001 ISO 14971 위험관리 통합 구현` |
@@ -32,9 +33,34 @@
 | E2E Tests | PASS | CI smoke/browser jobs success; staging URL 미설정 job은 의도적 skip |
 | Security Scan | PASS | Dependency Vulnerability Scan, Secret Detection 통과 |
 | Deploy | PASS | GitHub Actions deploy workflow success |
-| 로컬 단위 테스트 | PASS | `pnpm test`: 2,556 passed / 7 skipped |
-| 권한 매트릭스 | PASS | 32 actions, risk.generate/view/update/approve 포함 |
-| AuditAction enum | PASS | 91 actions, risk.* 7종 포함 |
+| 로컬 단위 테스트 | PASS | `pnpm test`: 2,766 passed / 7 skipped |
+| 권한 매트릭스 | PASS | 33 actions, `signature.sign` 포함 |
+| AuditAction enum | PASS | `signature.applied`, `signature.revoked` 포함 |
+
+### 21 CFR Part 11 Electronic Signature 완료 — Issue #88 / PR #204
+
+Regula는 이제 답변 승인 기록에 전자서명을 적용하고, 서명된 답변을 변경 불가 상태로 잠그며, 표시·출력 양식에 §11.50 서명 manifestation을 포함합니다. 서명은 답변 prose와 ordered structured blocks를 canonical JSON으로 묶어 SHA-256 hash를 계산하고 `answer_signatures.record_hash`에 저장해 §11.70 signature/record linkage를 제공합니다.
+
+| 영역 | 구현 내용 |
+|------|---------|
+| API | `POST /api/ra/messages/[messageId]/signature`, `GET /api/ra/messages/[messageId]/signature`, `POST /api/ra/messages/[messageId]/signature/revoke` |
+| DB | `answer_signatures` 테이블, `signature.applied` / `signature.revoked` audit actions, active signature partial unique index |
+| RBAC | `signature.sign`은 `ra-lead` 이상 + signature-specific `qa-lead`; `qa-lead`는 일반 `ra-lead` gate를 상속하지 않음 |
+| Authorization | signature routes는 `messageId` 단독 조회를 금지하고 `conversations`/`projects` 경유 tenant/owner scope를 먼저 확인 |
+| Record linkage | `lib/signature/hash.ts`의 `computeAnswerHash()`가 answer prose + ordered blocks를 SHA-256으로 canonical hashing |
+| Locking | active signature가 있는 답변은 refine/block mutation path에서 `403 answer_locked` 반환 |
+| Manifestation | `SignatureManifestation` UI와 PDF export에 signer, title, meaning, signedAt, recordHash, revocation status 표시 |
+| 문서 | [`docs/electronic-signatures.md`](docs/electronic-signatures.md), [`docs/compliance/part-11-extended.md`](docs/compliance/part-11-extended.md), [`docs/api-reference.md`](docs/api-reference.md) |
+
+검증 결과:
+
+```bash
+corepack pnpm typecheck              # PASS
+corepack pnpm lint                   # PASS
+corepack pnpm ci:rbac                # PASS
+corepack pnpm test                   # PASS: 2766 passed / 7 skipped
+SKIP_ENV_VALIDATION=1 REGULA_ALLOW_ENV_VALIDATION_SKIP=build corepack pnpm build  # PASS
+```
 
 ### ISO 14971 Risk Management 완료 — Issue #46 / PR #195
 
@@ -468,7 +494,7 @@ graph TB
 
 **프로젝트 규모**:
 - TypeScript 파일: 377개
-- API 라우트: 67개  
+- API 라우트: 67개
 - 데이터베이스 테이블: 18개
 - lib 모듈: 27개
 - components 카테고리: 11개
@@ -1062,8 +1088,9 @@ pnpm start
 | **Issues** | 작업 이력, 의도 보존 | [Issues](https://github.com/holee9/ra-med-bot/issues) |
 | **SPEC 문서** | 요구사항 정의 (EARS 포맷) | `.moai/specs/` |
 | **Implementation Status** | 최신 main 상태, 완료 PR/이슈, 검증 증거 | [`docs/implementation-status.md`](docs/implementation-status.md) |
-| **API Reference** | Auth.js session API, webhook, hybrid-ra-saas adapter, risk endpoints | [`docs/api-reference.md`](docs/api-reference.md) |
-| **Architecture** | 시스템 구조, RAG/Risk/data/audit 흐름 | [`docs/architecture.md`](docs/architecture.md) |
+| **API Reference** | Auth.js session API, webhook, hybrid-ra-saas adapter, risk/signature endpoints | [`docs/api-reference.md`](docs/api-reference.md) |
+| **Architecture** | 시스템 구조, RAG/Risk/signature/data/audit 흐름 | [`docs/architecture.md`](docs/architecture.md) |
+| **Electronic Signatures** | 21 CFR Part 11 §11.50/§11.70 전자서명 운영·API·RBAC·audit 상세 | [`docs/electronic-signatures.md`](docs/electronic-signatures.md) |
 | **Risk Management** | ISO 14971 workflow 운영·API·RBAC·audit 상세 | [`docs/risk-management.md`](docs/risk-management.md) |
 | **Environment Matrix** | 배포/로컬 환경변수, build/E2E env guard | [`docs/deployment/env-matrix.md`](docs/deployment/env-matrix.md) |
 | **Design Handoff** | 완전한 스펙 패키지 | `RA-bot-design/design_handoff_regula/README.md` |
@@ -1488,7 +1515,7 @@ Wave 3/4까지 완료되면 Regula는 분류, 근거 수집, 전략, 문서 생�
 | [#85](https://github.com/holee9/ra-med-bot/issues/85) | SPEC-REGULA-CONFIDENCE-EXPLAIN-001 | Confidence 점수 근거 표시·대안 답변 비교 | High |
 | [#86](https://github.com/holee9/ra-med-bot/issues/86) | SPEC-REGULA-PERSONAL-LIB-001 | 개인 RA 라이브러리·북마크·태깅·치트시트 | Medium |
 | [#87](https://github.com/holee9/ra-med-bot/issues/87) | SPEC-REGULA-EXPORT-HUB-001 | 답변 다중 포맷 Export·메일 포워드·외부 공유 허브 | High |
-| [#88](https://github.com/holee9/ra-med-bot/issues/88) | SPEC-REGULA-ESIG-001 | 21 CFR Part 11 전자서명·답변 잠금 | High |
+| [#88](https://github.com/holee9/ra-med-bot/issues/88) | SPEC-REGULA-ESIG-001 | 21 CFR Part 11 전자서명·답변 잠금 | Complete — PR #204 |
 | [#89](https://github.com/holee9/ra-med-bot/issues/89) | SPEC-REGULA-DSAR-001 | GDPR/PIPA 데이터 주체 요청 자동화 워크플로우 | High |
 | [#90](https://github.com/holee9/ra-med-bot/issues/90) | SPEC-REGULA-DATA-RESIDENCY-001 | 데이터 거주성 기반 LLM/임베딩 라우팅 강제·증빙 | High |
 | [#91](https://github.com/holee9/ra-med-bot/issues/91) | SPEC-REGULA-DLP-001 | DLP·자동 redaction·외부 공유 sanitize | High |
@@ -1817,4 +1844,4 @@ MIT License - [LICENSE](LICENSE) 파일 참조
 
 **Built with ❤️ using [abyz-lab](https://abyz-lab.work)**
 
-_마지막 업데이트: 2026-06-15 (Persona 85% Quality Addendum 완료 — RBAC 경계 재검토, PII redaction 통합, UI 진입점 반영, Cloudflare Tunnel 복구. Guest E2E validation 준비 완료. 제품 헌장 `.moai/specs/CHARTER.md` 추가. 주 사용자 RA Lead로 정정)_
+_마지막 업데이트: 2026-06-21 (PR #204 / Issue #88 21 CFR Part 11 전자서명 구현 완료 — message-level authorization, signature-specific `qa-lead`, answer lock, §11.50 UI/PDF manifestation, §11.70 SHA-256 record linkage 반영)_

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # Regula — API Reference
 
-> Version: 1.1.0 | Updated: 2026-06-20
+> Version: 1.2.0 | Updated: 2026-06-21
 > Base URL: `https://regula.app/api`
 
 Application endpoints require a valid Auth.js session cookie. Public inbound
@@ -765,6 +765,105 @@ X-RateLimit-Reset: 1746269260
 ```
 
 ---
+
+## Electronic Signature API
+
+Electronic signature endpoints implement SPEC-REGULA-ESIG-001 for 21 CFR Part 11 §11.50 and §11.70 controls.
+
+All endpoints require an Auth.js session and message-level authorization. A caller must be able to access the answer through the owning conversation or project; unauthorized message IDs return `404` to avoid UUID probing.
+
+### POST /api/ra/messages/[messageId]/signature
+
+Applies an electronic signature to an answer.
+
+Permission: `signature.sign` (`admin`, `ra-lead`, and signature-specific `qa-lead`).
+
+```http
+POST /api/ra/messages/8a8d0f2d-1d6a-4d74-9c4a-3f2b1a64f111/signature
+Content-Type: application/json
+Authorization: session cookie
+
+{
+  "meaning": "Approved for regulatory submission",
+  "signerTitle": "QA Lead"
+}
+```
+
+Response `201 Created`:
+
+```json
+{
+  "id": "sig-001",
+  "messageId": "8a8d0f2d-1d6a-4d74-9c4a-3f2b1a64f111",
+  "signerId": "user-001",
+  "signerName": "Alice Lead",
+  "signerTitle": "QA Lead",
+  "meaning": "Approved for regulatory submission",
+  "recordHash": "64-char-sha256-hex",
+  "signedAt": "2026-06-21T00:00:00.000Z",
+  "revokedAt": null,
+  "revokedBy": null
+}
+```
+
+Error behavior:
+
+- `400` invalid JSON or validation failure.
+- `401` missing session.
+- `403` missing `signature.sign`.
+- `404` message not found or not authorized.
+- `409 answer_already_signed` when an active signature already exists.
+
+Side effects:
+
+- Computes SHA-256 hash over answer prose and ordered structured blocks.
+- Inserts an `answer_signatures` row.
+- Writes append-only audit event `signature.applied`.
+
+### GET /api/ra/messages/[messageId]/signature
+
+Returns the active §11.50 signature manifestation for a signed answer.
+
+Permission: `conversation.view` plus message-level authorization.
+
+Response `200 OK`:
+
+```json
+{
+  "id": "sig-001",
+  "signerName": "Alice Lead",
+  "signerTitle": "QA Lead",
+  "meaning": "Approved for regulatory submission",
+  "signedAt": "2026-06-21T00:00:00.000Z",
+  "recordHash": "64-char-sha256-hex",
+  "isRevoked": false,
+  "revokedAt": null
+}
+```
+
+Error behavior:
+
+- `401` missing session.
+- `403` missing `conversation.view`.
+- `404` message not found, not authorized, or no active signature exists.
+
+### POST /api/ra/messages/[messageId]/signature/revoke
+
+Revokes the active electronic signature. Revocation unlocks the answer for edits, and the answer must be signed again before it is treated as an active signed record.
+
+Permission: `signature.sign`.
+
+```http
+POST /api/ra/messages/8a8d0f2d-1d6a-4d74-9c4a-3f2b1a64f111/signature/revoke
+Authorization: session cookie
+```
+
+Response `200 OK`: revoked signature row with `revokedAt` and `revokedBy` populated.
+
+Side effects:
+
+- Soft-revokes the active signature.
+- Writes append-only audit event `signature.revoked`.
 
 ## Common Error Codes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Regula — System Architecture
 
-> Version: 1.1.0 | Updated: 2026-06-20
+> Version: 1.2.0 | Updated: 2026-06-21
 
 ---
 
@@ -15,6 +15,7 @@ graph TD
     Auth["Auth.js v5\n(SSO / SAML / OIDC)"]
     ConsultAPI["POST /api/ra/consult\n(nodejs runtime, 60s timeout)"]
     RiskAPI["/api/ra/risk/*\nISO 14971 workflow"]
+    SignatureAPI["/api/ra/messages/[messageId]/signature\n21 CFR Part 11 e-sign"]
     RAG["RAG Pipeline\nlib/ai/consult.ts"]
     Intent["Intent Classifier\n(Haiku — 3 classes)"]
     QueryRewrite["Query Rewriter\n(rule-based + LLM)"]
@@ -30,6 +31,7 @@ graph TD
     NextJS --> Auth
     NextJS --> ConsultAPI
     NextJS --> RiskAPI
+    NextJS --> SignatureAPI
     ConsultAPI --> RAG
     RAG --> Intent
     Intent --> QueryRewrite
@@ -42,6 +44,7 @@ graph TD
     ConsultAPI --> DB
     RiskAPI --> DB
     RiskAPI --> RAG
+    SignatureAPI --> DB
     NextJS --> Sentry
     NextJS --> PostHog
     RAG --> Langfuse
@@ -146,6 +149,18 @@ erDiagram
         jsonb meta_json
         timestamp created_at
     }
+    answer_signatures {
+        uuid id PK
+        uuid message_id FK
+        uuid signer_id FK
+        string signer_name
+        string signer_title
+        text meaning
+        string record_hash
+        timestamp signed_at
+        timestamp revoked_at
+        uuid revoked_by FK
+    }
     workflow_runs {
         uuid id PK
         string workflow_type
@@ -187,6 +202,7 @@ erDiagram
     users ||--o{ conversations : "has"
     conversations ||--o{ messages : "contains"
     messages ||--o{ message_sources : "cites"
+    messages ||--o{ answer_signatures : "signed_by"
     sources ||--o{ source_sections : "has"
     message_sources }o--|| sources : "references"
     users ||--o{ audit_logs : "generates"
@@ -200,6 +216,7 @@ erDiagram
 - `audit_logs`: append-only — UPDATE/DELETE/TRUNCATE are blocked at database level
 - `source_sections.embedding`: 1536-dimensional vector (OpenAI `text-embedding-3-small`)
 - `messages.expert_review_required`: set when confidence < 0.6 or query contains high-risk terms
+- `answer_signatures`: one active non-revoked signature per answer; stores §11.50 manifestation fields and §11.70 record hash
 - `risk_items`: stores ISO 14971 hazard / event sequence / hazardous situation / harm terms with citation metadata
 - `risk_controls`: stores ISO 14971 §7.1 control hierarchy and residual risk evaluation
 - `risk_gspr_mappings`: maps risk file evidence to EU MDR Annex I GSPR clauses
@@ -294,7 +311,52 @@ sequenceDiagram
 
 ---
 
-## 7. Deployment Architecture
+## 7. Electronic Signature Architecture
+
+The electronic signature bounded context implements 21 CFR Part 11 §11.50 manifestation and §11.70 signature/record linking for answer approvals.
+
+```mermaid
+sequenceDiagram
+    participant Lead as RA Lead / QA Lead
+    participant API as /api/ra/messages/[messageId]/signature
+    participant Authz as getAuthorizedSignatureMessage
+    participant Hash as computeAnswerHash
+    participant DB as PostgreSQL
+    participant Audit as writeAudit
+
+    Lead->>API: POST {meaning, signerTitle}
+    API->>API: withPermission(signature.sign)
+    API->>Authz: authorize messageId by conversation/project scope
+    Authz->>DB: messages join conversations/projects
+    DB-->>Authz: authorized message or null
+    API->>DB: load ordered message_blocks
+    API->>Hash: contentProse + ordered blocks
+    Hash-->>API: SHA-256 recordHash
+    API->>DB: insert answer_signatures
+    API->>Audit: signature.applied
+    API-->>Lead: 201 signature row
+```
+
+### Signature bounded context
+
+| Layer | Module | Responsibility |
+|---|---|---|
+| API | `app/api/ra/messages/[messageId]/signature/*` | Sign, manifestation lookup, revoke |
+| Authorization | `lib/signature/authorization.ts` | Tenant/owner boundary for UUID-addressable message IDs |
+| Domain | `lib/signature/hash.ts`, `lock.ts`, `queries.ts` | Hashing, active lock check, signature query helpers |
+| UI/export | `components/chat/SignatureManifestation.tsx`, `lib/signature/pdf-inject.ts` | §11.50 displayed and printed manifestation |
+| Compliance | `answer_signatures`, `audit_logs`, `signature.sign` | §11.50/§11.70 traceability and signing gate |
+
+### Signature invariants
+
+- Signature routes authorize the answer before any signature lookup or mutation.
+- A signed answer is locked until the active signature is revoked.
+- `qa-lead` can sign through `signature.sign.additionalRoles` but does not inherit unrelated `ra-lead` permissions.
+- Signature audit events are append-only: `signature.applied`, `signature.revoked`.
+
+---
+
+## 8. Deployment Architecture
 
 ```mermaid
 graph TD
@@ -317,7 +379,7 @@ graph TD
 
 ---
 
-## 8. Security Architecture
+## 9. Security Architecture
 
 | Layer | Control |
 |-------|---------|
@@ -327,6 +389,7 @@ graph TD
 | Auth | Auth.js v5 session (signed JWT, HttpOnly cookies) |
 | RBAC | `withPermission` matrix, including risk.generate/view/update/approve |
 | Risk approval | `risk.approve` RA-lead-only final report gate |
+| Electronic signature | `signature.sign` RA-lead/admin + signature-specific QA lead gate |
 | LLM data | Anthropic ZDR (`anthropic-beta: zero-data-retention`) |
 | Error tracking | Sentry `beforeSend` PII redaction (query, user_id, content, email) |
 | Secrets | gitleaks CI scan on every push |
@@ -336,7 +399,7 @@ For full security documentation, see [`docs/security/`](security/).
 
 ---
 
-## 9. Observability
+## 10. Observability
 
 | Tool | Purpose | Data |
 |------|---------|------|
@@ -349,9 +412,9 @@ Observability is strictly separated from `audit_logs` — observability tools ne
 
 ---
 
-## 10. Codebase Analysis (2026-06-20)
+## 11. Codebase Analysis (2026-06-21)
 
-### 9.1 Project Scale
+### 11.1 Project Scale
 
 - **TypeScript files**: 400+
 - **API routes**: 77+
@@ -359,7 +422,7 @@ Observability is strictly separated from `audit_logs` — observability tools ne
 - **lib modules**: 27
 - **components categories**: 11
 
-### 9.2 Module Structure
+### 11.2 Module Structure
 
 **12 Core Modules**:
 1. `app/(auth)` - Authentication and login pages
@@ -375,7 +438,7 @@ Observability is strictly separated from `audit_logs` — observability tools ne
 11. `stores` - Client state management
 12. `lib/i18n` - Internationalization
 
-### 9.3 Dependency Breakdown
+### 11.3 Dependency Breakdown
 
 **Frontend (30+)**:
 - Next.js 15, React 18, TypeScript 5.4+
@@ -398,12 +461,12 @@ Observability is strictly separated from `audit_logs` — observability tools ne
 - Biome (lint/format), Vitest (testing)
 - Playwright (E2E), Storybook (components)
 
-### 9.4 Key Architecture Decisions
+### 11.4 Key Architecture Decisions
 
 1. **Backend-first implementation** - API → RAG → UI order
 2. **Multi-LLM strategy** - Sonnet (inference) + Haiku (classification)
 3. **PostgreSQL + pgvector** - ACID transactions + vector search
-4. **21 CFR Part 11 audit logging** - Immutable append-only logs, 7-year retention
+4. **21 CFR Part 11 audit and signatures** - Immutable audit logs plus hash-linked electronic signatures
 5. **SSE streaming** - Real-time UI updates with structured data
 
 For detailed codemaps, see:

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,6 +1,6 @@
 # Regula — Compliance Documentation
 
-> Version: 1.0.0 | Updated: 2026-05-03  
+> Version: 1.1.0 | Updated: 2026-06-21
 > Scope: 21 CFR Part 11, GDPR data minimization, OWASP Top 10 2021
 
 ---
@@ -79,6 +79,26 @@ CREATE TABLE audit_logs (
 );
 -- No UPDATE / DELETE / TRUNCATE allowed (enforced via DB policy)
 ```
+
+### 2.6 Electronic Signatures (§11.50, §11.70)
+
+Regula implements electronic signatures for approved answer records through SPEC-REGULA-ESIG-001.
+
+**Implementation:**
+
+- Table: `answer_signatures`
+- API: `POST /api/ra/messages/[messageId]/signature`, `GET /api/ra/messages/[messageId]/signature`, `POST /api/ra/messages/[messageId]/signature/revoke`
+- Record linkage: SHA-256 hash of answer prose plus ordered structured blocks
+- Manifestation: signer name, signer title, timestamp, meaning, record hash, and revocation status
+- Audit events: `signature.applied`, `signature.revoked`
+
+**Controls:**
+
+- Signing is restricted to `ra-lead`, `admin`, and the signature-specific `qa-lead` allowlist via `signature.sign`.
+- `qa-lead` does not inherit unrelated `ra-lead` permissions such as project management, risk approval, or authoring approval.
+- Signature endpoints authorize the `messageId` through conversation/project ownership before loading or mutating signature state.
+- Active signatures lock answer mutation paths; refine and block PATCH handlers return `403 answer_locked`.
+- Revocation soft-revokes the signature row and writes an immutable audit event. Re-signing is required before the answer can be treated as signed again.
 
 ---
 

--- a/docs/compliance/part-11-extended.md
+++ b/docs/compliance/part-11-extended.md
@@ -1,7 +1,7 @@
 # 21 CFR Part 11 Extended Compliance — Phase 7 Cloudflare Integration
 
 SPEC: SPEC-REGULA-CLOUDFLARE-001
-Last Updated: 2026-04-22
+Last Updated: 2026-06-21
 Status: Active
 
 This document extends the Phase 1 21 CFR Part 11 compliance baseline with Phase 7 Cloudflare storage and audit controls.
@@ -105,9 +105,63 @@ The `audit.cold_query` action value is added to the `audit_action_enum` in migra
 
 ---
 
+## 6. Electronic Signature Controls — SPEC-REGULA-ESIG-001
+
+Issue #88 / PR #204 adds the Part 11 electronic signature layer on top of the existing append-only audit and retention controls.
+
+### 6.1 Signature Manifestation (§11.50)
+
+Signed answers expose the required manifestation fields through both the API and user-visible output:
+
+- signer name
+- signer title
+- signing meaning
+- signed timestamp
+- SHA-256 record hash
+- revocation status
+
+Implementation:
+
+- API: `GET /api/ra/messages/[messageId]/signature`
+- UI: `components/chat/SignatureManifestation.tsx`
+- PDF output: `lib/signature/pdf-inject.ts`
+
+### 6.2 Signature/Record Linking (§11.70)
+
+`lib/signature/hash.ts` canonicalizes answer content as:
+
+- `messages.contentProse`
+- ordered `message_blocks` content and block type
+
+The resulting SHA-256 hex digest is persisted as `answer_signatures.record_hash`. This links the signature to the exact answer state that was approved.
+
+### 6.3 Answer Locking
+
+`lib/signature/lock.ts` returns true when an active signature exists. Mutation paths that can change signed answer content must reject edits while locked. The current guards cover:
+
+- answer refine route
+- structured block PATCH route
+
+If the active signature is revoked, the answer is unlocked for changes and must be signed again before use as a signed record.
+
+### 6.4 Authorization and RBAC Boundary
+
+Signature endpoints must not load signatures solely by UUID. They first authorize the requested message through `messages -> conversations -> projects` and return `404` for both "not found" and "not allowed" to avoid UUID probing.
+
+Signing and revocation use `signature.sign`:
+
+- `admin`: allowed through hierarchy
+- `ra-lead`: allowed through `minRole`
+- `qa-lead`: allowed only through `additionalRoles`
+
+`qa-lead` is intentionally below `ra-lead` in the general role hierarchy so it does not inherit unrelated gates such as project management, authoring approval, conversation deletion, or risk approval.
+
+---
+
 ## References
 
 - 21 CFR Part 11: https://www.ecfr.gov/current/title-21/chapter-I/subchapter-A/part-11
 - Cloudflare R2 Object Lock: https://developers.cloudflare.com/r2/buckets/object-lock/
 - Migration files: `migrations/0001_audit_append_only.sql`, `migrations/0011_organizations_data_region.sql`
-- Implementation: `lib/audit/cold-storage.ts`, `lib/audit/cold-query.ts`, `lib/storage/r2.ts`
+- Electronic signature migration: `migrations/0061_answer_signatures.sql`
+- Implementation: `lib/audit/cold-storage.ts`, `lib/audit/cold-query.ts`, `lib/storage/r2.ts`, `lib/signature/*`

--- a/docs/electronic-signatures.md
+++ b/docs/electronic-signatures.md
@@ -1,0 +1,114 @@
+# Regula Electronic Signatures
+
+> Version: 1.0.0 | Updated: 2026-06-21
+> Scope: SPEC-REGULA-ESIG-001, Issue #88, PR #204
+
+Regula supports 21 CFR Part 11 electronic signatures for approved answer records. The implementation covers signature capture, signature/record linkage, displayed and printed signature manifestation, revocation, answer locking, RBAC, and audit logging.
+
+## Functional Surface
+
+| Area | Implementation |
+|---|---|
+| Sign answer | `POST /api/ra/messages/[messageId]/signature` |
+| Manifestation lookup | `GET /api/ra/messages/[messageId]/signature` |
+| Revoke signature | `POST /api/ra/messages/[messageId]/signature/revoke` |
+| Signature table | `answer_signatures` |
+| Hashing | `lib/signature/hash.ts` |
+| Active lock check | `lib/signature/lock.ts` |
+| Query helpers | `lib/signature/queries.ts` |
+| Tenant authorization | `lib/signature/authorization.ts` |
+| UI manifestation | `components/chat/SignatureManifestation.tsx` |
+| PDF manifestation | `lib/signature/pdf-inject.ts` |
+
+## Signature Data Model
+
+`answer_signatures` stores the active and revoked signature records:
+
+- `message_id`
+- `signer_id`
+- `signer_name`
+- `signer_title`
+- `meaning`
+- `record_hash`
+- `signed_at`
+- `revoked_at`
+- `revoked_by`
+
+Only one active signature may exist for a message. Revocation is a soft-revoke; it preserves the signature row and adds revocation metadata.
+
+## 21 CFR Part 11 Mapping
+
+| Requirement | Control |
+|---|---|
+| §11.50 signature manifestation | API/UI/PDF expose signer, title, timestamp, meaning, record hash, revocation status |
+| §11.70 signature/record linking | SHA-256 hash links the signature to answer prose and ordered blocks |
+| §11.10(e) audit trail | `signature.applied` and `signature.revoked` events are written through append-only `writeAudit()` |
+| Post-signature integrity | Active signature locks answer refine and block PATCH mutation paths |
+| Non-repudiation boundary | Signed record stores signer identity, meaning, timestamp, and record hash |
+
+## Authorization Model
+
+The signature routes are UUID-addressable, so authorization must happen before any signature lookup or mutation. `getAuthorizedSignatureMessage()` joins:
+
+```text
+messages -> conversations -> projects
+```
+
+The helper returns the message only when the caller is either the conversation owner or belongs to the message project's organization. It returns `null` for both "not found" and "not allowed" to avoid UUID probing.
+
+## RBAC Model
+
+Signing and revocation use `signature.sign`:
+
+| Role | Can sign | Notes |
+|---|---:|---|
+| `admin` | Yes | Inherits through hierarchy |
+| `ra-lead` | Yes | Meets `minRole: 'ra-lead'` |
+| `qa-lead` | Yes | Explicitly allowed through `additionalRoles` |
+| `ra-member` | No | Can view accessible manifestation through `conversation.view` |
+| `viewer` | No | No signing permission |
+
+`qa-lead` is intentionally below `ra-lead` in the general role hierarchy. It does not inherit unrelated gates such as `conversation.delete`, `project.manage`, `authoring.approve`, or `risk.approve`.
+
+## Signing Flow
+
+1. Caller invokes `POST /signature` with `meaning` and optional `signerTitle`.
+2. `withPermission('signature.sign')` checks role and organization membership.
+3. `getAuthorizedSignatureMessage()` verifies message ownership/tenant scope.
+4. Existing active signature check returns `409 answer_already_signed` if present.
+5. The route loads ordered `message_blocks`.
+6. `computeAnswerHash()` hashes `contentProse` and ordered blocks.
+7. `insertSignature()` writes the signature row.
+8. `writeAudit()` records `signature.applied`.
+
+## Revocation Flow
+
+1. Caller invokes `POST /signature/revoke`.
+2. The same `signature.sign` and message authorization checks run.
+3. The active signature is soft-revoked with `revokedAt` and `revokedBy`.
+4. `writeAudit()` records `signature.revoked`.
+5. The answer becomes editable again and must be re-signed for a new active signed state.
+
+## Mutation Locking
+
+When `isAnswerLocked(messageId)` returns true, answer mutation routes reject changes with:
+
+```json
+{ "error": "answer_locked" }
+```
+
+The current lock guards cover:
+
+- answer refine route
+- structured answer block PATCH route
+
+## Validation Evidence
+
+- Signature/auth targeted tests: 320 tests passed.
+- Full local test suite: 2,766 passed / 7 skipped.
+- `corepack pnpm typecheck`: pass.
+- `corepack pnpm lint`: pass.
+- `corepack pnpm ci:rbac`: pass.
+- `SKIP_ENV_VALIDATION=1 REGULA_ALLOW_ENV_VALIDATION_SKIP=build corepack pnpm build`: pass.
+- PR #204 checks: CI Gates, E2E Smoke, Playwright chromium/firefox/webkit, LLM Eval Harness, Vercel Preview, Security Scan all passed.
+- Post-merge main runs: CI, Security Scan, E2E Tests, Deploy all passed.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,7 +1,7 @@
 # Regula Implementation Status
 
-Reviewed: 2026-06-20 KST (implementation review/fix pass)
-Implementation review baseline commit: `b2bd5d1` (`main` after PR #196, PR #197, #166, QA Gate/Wave 5 SPEC documentation)
+Reviewed: 2026-06-21 KST (implementation review/fix pass)
+Implementation review baseline commit: `e51ebc5` (`main` after PR #204 / Issue #88 electronic signature merge)
 
 This document includes the 2026-06-18 PR cleanup after PR #184 merge,
 PR #177 superseded closure, the completed Predicate Visualization addendum
@@ -9,7 +9,7 @@ for Issue #185 / PR #186, E2E validation MRD completion for Issue #182,
 the Issue #188 hybrid-ra-saas inbound webhook hardening pass,
 the Issue #156 hybrid-ra-saas outbound typed adapter merge,
 the 2026-06-20 security/quality fixes (#162 RBAC, #164 Predicate E2E, #152 workflow mock audit, #163 onboarding E2E seed),
-and the Issue #46 / PR #195 ISO 14971 Risk Management integration plus the follow-up `8065cc8` CI restoration commit. This review also covers PR #196, PR #197, the #166 hydration mismatch fixes, and the QA Gate/Wave 5 SPEC documentation commits now present on `main`.
+the Issue #46 / PR #195 ISO 14971 Risk Management integration plus the follow-up `8065cc8` CI restoration commit, and PR #204 / Issue #88 21 CFR Part 11 electronic signatures. This review also covers PR #196, PR #197, the #166 hydration mismatch fixes, and the QA Gate/Wave 5 SPEC documentation commits now present on `main`.
 
 ## Executive State
 
@@ -51,17 +51,20 @@ latest `main`: the #166 hydration mismatch follow-up added correct
 Biome, causing the `CI Gates` lint/format path to fail. The review fix formats
 those files and refreshes the current verification evidence.
 
-## Verified Repository State (2026-06-20)
+The 2026-06-21 review of PR #204 found and fixed two signature-specific security regressions before merge: signature endpoints now authorize the requested `messageId` through the caller's conversation/project scope before signing, manifestation lookup, or revocation; `qa-lead` no longer inherits every `ra-lead` permission and is instead allowlisted only for `signature.sign`.
+
+## Verified Repository State (2026-06-21)
 
 | Area | State | Evidence |
 |---|---|---|
-| Active branch | `main` | review baseline commit `b2bd5d1` |
-| Completed PRs/issues | #184, #186, #188, #192/#156, #190/#182, #193/#162, #194, #195/#46, #196, #197, #166 | all merged or closed |
+| Active branch | `main` | review baseline commit `e51ebc5` |
+| Completed PRs/issues | #184, #186, #188, #192/#156, #190/#182, #193/#162, #194, #195/#46, #196, #197, #204/#88, #166 | all merged or closed |
 | E2E Validation | COMPLETE | Go/No-Go spec, Smoke Test 8/8 specs, MRD complete |
 | Traceability Integration | COMPLETE | BFF routes, UI, RBAC all implemented |
 | Webhook Integration | COMPLETE | `/api/webhooks/audit`, `ifu`, `knowledge-sync` hardened |
 | hybrid-ra-saas typed adapter | COMPLETE | `createHybridRaClient()` covers 7 upstream endpoint contracts |
 | ISO 14971 Risk Management | COMPLETE | `/workflows/risk`, `/api/ra/risk/*`, `lib/risk/*`, risk DB tables, RA-lead approval |
+| 21 CFR Part 11 Electronic Signature | COMPLETE | `/api/ra/messages/[messageId]/signature`, `answer_signatures`, answer lock, §11.50/§11.70 linkage |
 | Submission drafter contract (#196) | COMPLETE | build env bypass path, `workflow_runs` status contract, source health-check import fixed |
 | Hydration mismatch (#166) | COMPLETE | date render boundaries plus 2026-06-20 Biome format recovery |
 | QA Gate 0 helper (#74) | COMPLETE | `scripts/qa-gate-0-checklist.ts`, shared checklist template, ignored generated outputs |
@@ -70,6 +73,32 @@ those files and refreshes the current verification evidence.
 | Mock workflow audit (#152) | COMPLETE | mock_data, workflow_run_id metadata connected (in PR #190) |
 | Onboarding E2E seed (#163) | COMPLETE | globalSetup.ts bootstrapProjects + empty-state CTA in Sidebar |
 | Work gate | #18 active | mandatory before new P0 work |
+
+## 2026-06-21 Electronic Signature — Issue #88 / PR #204
+
+SPEC-REGULA-ESIG-001 is implemented and merged. The feature adds 21 CFR Part 11 electronic signatures for answer approval records and ties each signature to the exact answer content by hash.
+
+| Area | State | Evidence |
+|---|---|---|
+| Signature API | Complete | `POST`/`GET /api/ra/messages/[messageId]/signature`, `POST /signature/revoke` |
+| Message authorization | Complete | `lib/signature/authorization.ts` validates `messages` through `conversations` and `projects` before lookup side effects |
+| RBAC | Complete | `signature.sign` uses `minRole: ra-lead` plus `additionalRoles: ['qa-lead']`; `qa-lead` is below `ra-lead` in general hierarchy |
+| Record linkage | Complete | `computeAnswerHash()` hashes answer prose + ordered blocks with SHA-256 |
+| Locking | Complete | `isAnswerLocked()` blocks refine and block PATCH mutation paths while a signature is active |
+| Manifestation | Complete | `SignatureManifestation` component and PDF injection include signer, title, meaning, signed timestamp, record hash, revocation state |
+| Audit | Complete | `signature.applied` and `signature.revoked` are written through append-only `writeAudit()` |
+| Documentation | Complete | README, API reference, Part 11 docs, SPEC progress/tasks updated |
+
+Validation evidence:
+
+- `corepack pnpm typecheck` — pass.
+- `corepack pnpm lint` — pass.
+- `corepack pnpm ci:rbac` — pass.
+- Targeted regression tests — 320 tests passed across signature and auth/RBAC suites.
+- `corepack pnpm test` — 2,766 tests passed, 7 skipped.
+- `SKIP_ENV_VALIDATION=1 REGULA_ALLOW_ENV_VALIDATION_SKIP=build corepack pnpm build` — pass.
+- PR #204 checks — CI Gates, E2E Smoke, Playwright chromium/firefox/webkit, LLM Eval Harness, Vercel Preview, Security Scan all pass.
+- Main after merge — CI, Security Scan, E2E Tests, Deploy all success.
 
 ## 2026-06-20 ISO 14971 Risk Management — Issue #46 / PR #195
 


### PR DESCRIPTION
## Summary

- Update README and implementation status for PR #204 / Issue #88 completion.
- Add dedicated electronic signature documentation covering API, RBAC, authorization, locking, audit, and validation evidence.
- Update API, architecture, compliance, Part 11 extended docs, ESIG SPEC status, and session memo.

## Validation

- `git diff --cached --check`
- `pnpm lint`

## Notes

This is documentation-only. The branch was created from `main` at `e51ebc5` after PR #204 merged.