### PR TITLE
feat(calendar): 규제 캘린더 & 데드라인 관리 — MVP (#44)

### DIFF
--- a/.moai/specs/SPEC-REGULA-CALENDAR-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CALENDAR-001/spec.md
@@ -1,0 +1,91 @@
+# SPEC-REGULA-CALENDAR-001 — Regulatory Calendar & Deadline Management
+
+**Status**: Approved (MVP)
+**Issue**: #44
+**Wave**: 4
+**Created**: 2026-06-21
+
+## 1. Purpose
+
+RA work is structured around regulatory deadlines. Currently these are scattered
+across spreadsheets and personal calendars. This SPEC provides a centralized,
+project-scoped deadline tracker inside Regula.
+
+## 2. Scope (MVP)
+
+### In scope
+- **A. Data model**: `regulatory_deadlines` table with type, jurisdiction, due date, status
+- **B. CRUD API**: create / list / update / delete deadlines (project-scoped)
+- **C. List view**: `/(app)/calendar` with filtering by project, jurisdiction, type, status
+
+### Out of scope (follow-up)
+- Email reminders (sub-feature C of issue #44)
+- Holiday-aware clock calculation engine (sub-feature D)
+- Auto-generation triggers (510(k) receipt → clock start)
+- Month/week calendar grid UI
+
+## 3. Requirements (EARS)
+
+### REQ-CAL-001 (Create)
+**WHEN** an ra-lead creates a regulatory deadline for a project, **THE SYSTEM SHALL**
+store a `regulatory_deadlines` row with type, jurisdiction, due_date, and status.
+
+### REQ-CAL-002 (Project scoping)
+**THE SYSTEM SHALL** scope every deadline to a `projectId`, and enforce project
+membership via the standard `project` scope RBAC check.
+
+### REQ-CAL-003 (List + filter)
+**WHEN** an ra-member lists deadlines, **THE SYSTEM SHALL** return deadlines for
+projects they belong to, filterable by jurisdiction, type, and status, ordered by
+due_date ascending.
+
+### REQ-CAL-004 (RBAC)
+- `deadline.view` (minRole: ra-member, scope: project) — list + get
+- `deadline.manage` (minRole: ra-lead, scope: project) — create + update + delete
+
+### REQ-CAL-005 (Audit)
+**THE SYSTEM SHALL** write audit rows for create, update, and delete operations.
+
+### REQ-CAL-006 (Status lifecycle)
+**THE SYSTEM SHALL** support statuses: `upcoming`, `due_soon`, `overdue`, `completed`,
+`cancelled`. Status is user-set (no automatic computation in MVP).
+
+## 4. Data Model
+
+```sql
+CREATE TABLE regulatory_deadlines (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id    UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  title         TEXT NOT NULL,
+  deadline_type TEXT NOT NULL,  -- fda_510k_clock | eu_mdr_cert_expiry | iso13485_surveillance | pmda_reexam | custom
+  jurisdiction  TEXT NOT NULL,  -- FDA | EU_MDR | MFDS | PMDA | NMPA | GLOBAL
+  due_date      DATE NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'upcoming',
+  reference     TEXT,           -- submission ID, certificate number, etc.
+  notes         TEXT DEFAULT '',
+  created_by    UUID REFERENCES users(id),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+## 5. API Contract
+
+| Method | Path | Permission |
+|--------|------|-----------|
+| GET    | `/api/ra/deadlines?projectId=&jurisdiction=&type=&status=` | deadline.view |
+| POST   | `/api/ra/deadlines` | deadline.manage |
+| GET    | `/api/ra/deadlines/[id]` | deadline.view |
+| PATCH  | `/api/ra/deadlines/[id]` | deadline.manage |
+| DELETE | `/api/ra/deadlines/[id]` | deadline.manage |
+
+## 6. Acceptance Criteria
+
+- [ ] AC-1: ra-lead can create a deadline → 201 + row in DB
+- [ ] AC-2: ra-member can list deadlines for their project
+- [ ] AC-3: Non-project-member → 403
+- [ ] AC-4: ra-member cannot create/update/delete (manage requires ra-lead) → 403
+- [ ] AC-5: Filters by jurisdiction, type, status work
+- [ ] AC-6: Audit rows on create/update/delete
+- [ ] AC-7: Calendar view renders deadline list with filters
+- [ ] AC-8: Unauthenticated → 401

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -1,0 +1,169 @@
+// @MX:NOTE [AUTO] Calendar view — regulatory deadline list with filters.
+// @MX:SPEC SPEC-REGULA-CALENDAR-001 (REQ-CAL-003, Issue #44)
+
+'use client';
+
+import { useProjects } from '@/lib/queries/useProjects';
+import { useUIStore } from '@/stores/ui';
+import { useCallback, useEffect, useState } from 'react';
+
+interface Deadline {
+  id: string;
+  projectId: string;
+  title: string;
+  deadlineType: string;
+  jurisdiction: string;
+  dueDate: string;
+  status: string;
+  reference: string | null;
+  notes: string;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  fda_510k_clock: 'FDA 510(k) 클락',
+  eu_mdr_cert_expiry: 'EU MDR 인증서 만료',
+  iso13485_surveillance: 'ISO 13485 감시심사',
+  pmda_reexam: 'PMDA 재심사',
+  custom: '사용자 정의',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  upcoming: 'text-ink-600',
+  due_soon: 'text-warning',
+  overdue: 'text-danger',
+  completed: 'text-success',
+  cancelled: 'text-ink-400',
+};
+
+export default function CalendarPage() {
+  const { data: projectsData = [] } = useProjects();
+  const currentProjectId = useUIStore((s) => s.currentProjectId);
+  const projects = projectsData as { id: string; name: string }[];
+  const [selectedProjectId, setSelectedProjectId] = useState<string>(
+    currentProjectId ?? projects[0]?.id ?? '',
+  );
+  const [deadlines, setDeadlines] = useState<Deadline[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [jurisdiction, setJurisdiction] = useState('');
+  const [status, setStatus] = useState('');
+
+  const fetchDeadlines = useCallback(async () => {
+    if (!selectedProjectId) {
+      setDeadlines([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    const params = new URLSearchParams({ projectId: selectedProjectId });
+    if (jurisdiction) params.set('jurisdiction', jurisdiction);
+    if (status) params.set('status', status);
+    const res = await fetch(`/api/ra/deadlines?${params}`, { cache: 'no-store' });
+    if (!res.ok) {
+      setError('데드라인을 불러오지 못했습니다.');
+      setDeadlines([]);
+      setLoading(false);
+      return;
+    }
+    const body = await res.json();
+    setDeadlines(body.deadlines ?? []);
+    setLoading(false);
+  }, [selectedProjectId, jurisdiction, status]);
+
+  useEffect(() => {
+    fetchDeadlines();
+  }, [fetchDeadlines]);
+
+  return (
+    <section className="mx-auto flex max-w-content flex-col gap-6 px-6 py-8">
+      <header>
+        <h1 className="font-serif text-3xl text-brand-800">규제 캘린더</h1>
+        <p className="mt-2 text-sm text-ink-600">
+          프로젝트별 규제 데드라인을 추적합니다. FDA 클락, EU MDR 갱신, ISO 감시심사 등.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <select
+          value={selectedProjectId}
+          onChange={(e) => setSelectedProjectId(e.target.value)}
+          className="rounded-md border border-ink-150 bg-surface px-3 py-2 text-sm text-ink-900"
+          aria-label="프로젝트 선택"
+        >
+          <option value="">프로젝트 선택</option>
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={jurisdiction}
+          onChange={(e) => setJurisdiction(e.target.value)}
+          className="rounded-md border border-ink-150 bg-surface px-3 py-2 text-sm text-ink-900"
+          aria-label="관할권 필터"
+        >
+          <option value="">전체 관할권</option>
+          {['FDA', 'EU_MDR', 'MFDS', 'PMDA', 'NMPA', 'GLOBAL'].map((j) => (
+            <option key={j} value={j}>
+              {j}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          className="rounded-md border border-ink-150 bg-surface px-3 py-2 text-sm text-ink-900"
+          aria-label="상태 필터"
+        >
+          <option value="">전체 상태</option>
+          {['upcoming', 'due_soon', 'overdue', 'completed', 'cancelled'].map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {loading && <p className="text-sm text-ink-500">불러오는 중…</p>}
+      {error && <p className="text-sm text-danger">{error}</p>}
+      {!loading && !error && deadlines.length === 0 && (
+        <p className="rounded-lg border border-ink-150 bg-surface p-4 text-sm text-ink-500">
+          이 프로젝트에 등록된 규제 데드라인이 없습니다.
+        </p>
+      )}
+
+      <div className="flex flex-col gap-3">
+        {deadlines.map((d) => (
+          <article
+            key={d.id}
+            className="rounded-lg border border-ink-150 bg-surface p-4"
+            data-testid="deadline-card"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="text-sm font-medium text-ink-900">{d.title}</h2>
+              <span
+                className={`shrink-0 rounded-full bg-ink-50 px-2 py-0.5 text-xs font-medium ${
+                  STATUS_COLORS[d.status] ?? 'text-ink-600'
+                }`}
+              >
+                {d.status}
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-ink-500">
+              {TYPE_LABELS[d.deadlineType] ?? d.deadlineType} · {d.jurisdiction}
+            </p>
+            <p className="mt-2 text-sm font-medium text-brand-700">
+              마감: {new Date(d.dueDate).toLocaleDateString('ko-KR')}
+            </p>
+            {d.reference && <p className="mt-1 text-xs text-ink-500">참조: {d.reference}</p>}
+            {d.notes && <p className="mt-2 whitespace-pre-wrap text-sm text-ink-700">{d.notes}</p>}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/api/ra/deadlines/[id]/route.ts
+++ b/app/api/ra/deadlines/[id]/route.ts
@@ -1,0 +1,121 @@
+// @MX:NOTE [AUTO] GET/PATCH/DELETE /api/ra/deadlines/[id] — single deadline CRUD.
+// @MX:SPEC SPEC-REGULA-CALENDAR-001 (REQ-CAL-002, 005, 006, Issue #44)
+//
+// Project membership is resolved from the deadline's projectId, then enforced.
+
+import { writeAudit } from '@/lib/audit';
+import { isProjectMember } from '@/lib/auth/acl';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { regulatoryDeadlines } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const PatchSchema = z.object({
+  title: z.string().min(1).max(300).optional(),
+  deadlineType: z
+    .enum([
+      'fda_510k_clock',
+      'eu_mdr_cert_expiry',
+      'iso13485_surveillance',
+      'pmda_reexam',
+      'custom',
+    ])
+    .optional(),
+  jurisdiction: z.enum(['FDA', 'EU_MDR', 'MFDS', 'PMDA', 'NMPA', 'GLOBAL']).optional(),
+  dueDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  status: z.enum(['upcoming', 'due_soon', 'overdue', 'completed', 'cancelled']).optional(),
+  reference: z.string().max(300).nullable().optional(),
+  notes: z.string().max(5000).optional(),
+});
+
+async function resolveAndCheck(id: string, userId: string) {
+  const [row] = await db
+    .select()
+    .from(regulatoryDeadlines)
+    .where(eq(regulatoryDeadlines.id, id))
+    .limit(1);
+  if (!row) return { row: null, allowed: false, notFound: true };
+  const member = await isProjectMember(userId, row.projectId);
+  return { row, allowed: member, notFound: false };
+}
+
+// GET /api/ra/deadlines/[id]
+export const GET = withPermission('deadline.view', async (_req, ctx, session) => {
+  const params = ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {});
+  const id = params.id ?? '';
+  const { row, allowed, notFound } = await resolveAndCheck(id, session.user.id);
+  if (notFound) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  if (!allowed)
+    return NextResponse.json({ error: 'not_a_member', resource_type: 'project' }, { status: 403 });
+  return NextResponse.json({ deadline: row });
+});
+
+// PATCH /api/ra/deadlines/[id]
+export const PATCH = withPermission('deadline.manage', async (req, ctx, session) => {
+  const params = ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {});
+  const id = params.id ?? '';
+  const { row, allowed, notFound } = await resolveAndCheck(id, session.user.id);
+  if (notFound) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  if (!allowed)
+    return NextResponse.json({ error: 'not_a_member', resource_type: 'project' }, { status: 403 });
+
+  const body = await req.json().catch(() => null);
+  const parsed = PatchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (parsed.data.title !== undefined) updates.title = parsed.data.title;
+  if (parsed.data.deadlineType !== undefined) updates.deadlineType = parsed.data.deadlineType;
+  if (parsed.data.jurisdiction !== undefined) updates.jurisdiction = parsed.data.jurisdiction;
+  if (parsed.data.dueDate !== undefined) updates.dueDate = new Date(parsed.data.dueDate);
+  if (parsed.data.status !== undefined) updates.status = parsed.data.status;
+  if (parsed.data.reference !== undefined) updates.reference = parsed.data.reference;
+  if (parsed.data.notes !== undefined) updates.notes = parsed.data.notes;
+
+  const [updated] = await db
+    .update(regulatoryDeadlines)
+    .set(updates)
+    .where(eq(regulatoryDeadlines.id, id))
+    .returning({ id: regulatoryDeadlines.id, updatedAt: regulatoryDeadlines.updatedAt });
+
+  if (!updated) return NextResponse.json({ error: 'update_failed' }, { status: 500 });
+
+  await writeAudit({
+    action: 'deadline.updated',
+    actor_id: session.user.id,
+    resource_type: 'deadline',
+    resource_id: id,
+    meta_json: { fields: Object.keys(updates) },
+  });
+
+  return NextResponse.json({ deadline: updated });
+});
+
+// DELETE /api/ra/deadlines/[id]
+export const DELETE = withPermission('deadline.manage', async (_req, ctx, session) => {
+  const params = ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {});
+  const id = params.id ?? '';
+  const { row, allowed, notFound } = await resolveAndCheck(id, session.user.id);
+  if (notFound) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  if (!allowed)
+    return NextResponse.json({ error: 'not_a_member', resource_type: 'project' }, { status: 403 });
+
+  await db.delete(regulatoryDeadlines).where(eq(regulatoryDeadlines.id, id));
+
+  await writeAudit({
+    action: 'deadline.deleted',
+    actor_id: session.user.id,
+    resource_type: 'deadline',
+    resource_id: id,
+    meta_json: { projectId: row?.projectId },
+  });
+
+  return NextResponse.json({ ok: true });
+});

--- a/app/api/ra/deadlines/__tests__/route.test.ts
+++ b/app/api/ra/deadlines/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+// @MX:NOTE [AUTO] Regulatory deadline route tests for SPEC-REGULA-CALENDAR-001.
+// @MX:SPEC SPEC-REGULA-CALENDAR-001 (REQ-CAL-001..006, Issue #44)
+//
+// Source-level RBAC + contract tests. Full integration tests require a running DB.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const routeBase = path.resolve(__dirname, '..');
+
+describe('CALENDAR — route files exist', () => {
+  const expected = ['route.ts', '[id]/route.ts'];
+  for (const route of expected) {
+    it(`route file exists: ${route}`, () => {
+      expect(fs.existsSync(path.join(routeBase, route))).toBe(true);
+    });
+  }
+});
+
+describe('REQ-CAL-004 — RBAC permission assignment', () => {
+  it('GET /api/ra/deadlines uses deadline.view', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'route.ts'), 'utf8');
+    expect(src).toContain("'deadline.view'");
+  });
+
+  it('POST /api/ra/deadlines uses deadline.manage', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'route.ts'), 'utf8');
+    expect(src).toContain("'deadline.manage'");
+  });
+
+  it('GET /api/ra/deadlines/[id] uses deadline.view', () => {
+    const src = fs.readFileSync(path.join(routeBase, '[id]/route.ts'), 'utf8');
+    expect(src).toContain("'deadline.view'");
+  });
+
+  it('PATCH/DELETE /api/ra/deadlines/[id] uses deadline.manage', () => {
+    const src = fs.readFileSync(path.join(routeBase, '[id]/route.ts'), 'utf8');
+    expect(src).toContain("'deadline.manage'");
+  });
+});
+
+describe('REQ-CAL-002 — project membership enforced', () => {
+  it('GET /api/ra/deadlines checks isProjectMember', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'route.ts'), 'utf8');
+    expect(src).toContain('isProjectMember');
+    expect(src).toContain("'not_a_member'");
+  });
+
+  it('POST /api/ra/deadlines checks isProjectMember', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'route.ts'), 'utf8');
+    const memberChecks = src.match(/isProjectMember/g);
+    expect(memberChecks?.length ?? 0).toBeGreaterThanOrEqual(2); // GET + POST
+  });
+
+  it('[id]/route.ts checks isProjectMember for GET, PATCH, DELETE', () => {
+    const src = fs.readFileSync(path.join(routeBase, '[id]/route.ts'), 'utf8');
+    const memberChecks = src.match(/isProjectMember/g);
+    expect(memberChecks?.length ?? 0).toBeGreaterThanOrEqual(1); // resolveAndCheck
+  });
+});
+
+describe('REQ-CAL-003 — filters', () => {
+  it('GET /api/ra/deadlines supports jurisdiction, type, status filters', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'route.ts'), 'utf8');
+    expect(src).toMatch(/jurisdiction/);
+    expect(src).toMatch(/type/);
+    expect(src).toMatch(/status/);
+  });
+
+  it('GET orders by due_date ascending', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'route.ts'), 'utf8');
+    expect(src).toMatch(/asc/);
+    expect(src).toMatch(/dueDate/);
+  });
+});
+
+describe('REQ-CAL-005 — audit', () => {
+  it('POST writes deadline.created', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'route.ts'), 'utf8');
+    expect(src).toContain("'deadline.created'");
+    expect(src).toContain('writeAudit');
+  });
+
+  it('PATCH writes deadline.updated', () => {
+    const src = fs.readFileSync(path.join(routeBase, '[id]/route.ts'), 'utf8');
+    expect(src).toContain("'deadline.updated'");
+  });
+
+  it('DELETE writes deadline.deleted', () => {
+    const src = fs.readFileSync(path.join(routeBase, '[id]/route.ts'), 'utf8');
+    expect(src).toContain("'deadline.deleted'");
+  });
+});
+
+describe('REQ-CAL-006 — status lifecycle', () => {
+  it('CreateSchema includes status with 5 lifecycle values', () => {
+    const src = fs.readFileSync(path.join(routeBase, 'route.ts'), 'utf8');
+    expect(src).toContain("'upcoming'");
+    expect(src).toContain("'due_soon'");
+    expect(src).toContain("'overdue'");
+    expect(src).toContain("'completed'");
+    expect(src).toContain("'cancelled'");
+  });
+});

--- a/app/api/ra/deadlines/route.ts
+++ b/app/api/ra/deadlines/route.ts
@@ -1,0 +1,114 @@
+// @MX:NOTE [AUTO] GET/POST /api/ra/deadlines — regulatory deadline list + create.
+// @MX:SPEC SPEC-REGULA-CALENDAR-001 (REQ-CAL-001..005, Issue #44)
+//
+// Project membership is enforced inside handlers via isProjectMember() because
+// projectId arrives via query string (GET) or body (POST), not route params.
+
+import { writeAudit } from '@/lib/audit';
+import { isProjectMember } from '@/lib/auth/acl';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { regulatoryDeadlines } from '@/lib/db/schema';
+import { and, asc, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const DEADLINE_TYPES = [
+  'fda_510k_clock',
+  'eu_mdr_cert_expiry',
+  'iso13485_surveillance',
+  'pmda_reexam',
+  'custom',
+] as const;
+const JURISDICTIONS = ['FDA', 'EU_MDR', 'MFDS', 'PMDA', 'NMPA', 'GLOBAL'] as const;
+const STATUSES = ['upcoming', 'due_soon', 'overdue', 'completed', 'cancelled'] as const;
+
+const CreateSchema = z.object({
+  projectId: z.string().uuid(),
+  title: z.string().min(1).max(300),
+  deadlineType: z.enum(DEADLINE_TYPES),
+  jurisdiction: z.enum(JURISDICTIONS),
+  dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  status: z.enum(STATUSES).default('upcoming'),
+  reference: z.string().max(300).optional(),
+  notes: z.string().max(5000).optional(),
+});
+
+// GET /api/ra/deadlines?projectId=&jurisdiction=&type=&status=
+export const GET = withPermission('deadline.view', async (req, _ctx, session) => {
+  const url = new URL(req.url);
+  const projectId = url.searchParams.get('projectId') ?? '';
+  if (!projectId) {
+    return NextResponse.json({ error: 'projectId required' }, { status: 400 });
+  }
+
+  // REQ-CAL-002: project membership enforced.
+  const member = await isProjectMember(session.user.id, projectId);
+  if (!member) {
+    return NextResponse.json({ error: 'not_a_member', resource_type: 'project' }, { status: 403 });
+  }
+
+  const conditions = [eq(regulatoryDeadlines.projectId, projectId)];
+  const jurisdiction = url.searchParams.get('jurisdiction');
+  if (jurisdiction) conditions.push(eq(regulatoryDeadlines.jurisdiction, jurisdiction));
+  const type = url.searchParams.get('type');
+  if (type) conditions.push(eq(regulatoryDeadlines.deadlineType, type));
+  const status = url.searchParams.get('status');
+  if (status) conditions.push(eq(regulatoryDeadlines.status, status));
+
+  const rows = await db
+    .select()
+    .from(regulatoryDeadlines)
+    .where(and(...conditions))
+    .orderBy(asc(regulatoryDeadlines.dueDate));
+
+  return NextResponse.json({ deadlines: rows, count: rows.length });
+});
+
+// POST /api/ra/deadlines
+export const POST = withPermission('deadline.manage', async (req, _ctx, session) => {
+  const body = await req.json().catch(() => null);
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  // REQ-CAL-002: project membership enforced.
+  const member = await isProjectMember(session.user.id, parsed.data.projectId);
+  if (!member) {
+    return NextResponse.json({ error: 'not_a_member', resource_type: 'project' }, { status: 403 });
+  }
+
+  const [created] = await db
+    .insert(regulatoryDeadlines)
+    .values({
+      projectId: parsed.data.projectId,
+      title: parsed.data.title,
+      deadlineType: parsed.data.deadlineType,
+      jurisdiction: parsed.data.jurisdiction,
+      dueDate: new Date(parsed.data.dueDate),
+      status: parsed.data.status,
+      reference: parsed.data.reference ?? null,
+      notes: parsed.data.notes ?? '',
+      createdBy: session.user.id,
+    })
+    .returning({ id: regulatoryDeadlines.id, createdAt: regulatoryDeadlines.createdAt });
+
+  if (!created) {
+    return NextResponse.json({ error: 'insert_failed' }, { status: 500 });
+  }
+
+  await writeAudit({
+    action: 'deadline.created',
+    actor_id: session.user.id,
+    resource_type: 'deadline',
+    resource_id: created.id,
+    meta_json: {
+      projectId: parsed.data.projectId,
+      deadlineType: parsed.data.deadlineType,
+      jurisdiction: parsed.data.jurisdiction,
+    },
+  });
+
+  return NextResponse.json({ deadline: created }, { status: 201 });
+});

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -23,6 +23,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: '홈', href: '/' },
   { label: '새 상담', href: '/chat', testId: 'nav-chat' },
   { label: '히스토리', href: '/history' },
+  { label: '규제 캘린더', href: '/calendar', testId: 'nav-calendar' },
   { label: '템플릿', href: '/templates' },
   { label: '지식 베이스', href: '/knowledge' },
   { label: '규제 업데이트', href: '/updates' },

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -182,7 +182,14 @@ export type AuditAction =
   //   audit.package.generated — auditor generated a 1-click audit package ZIP
   | 'audit.access'
   | 'audit.denied'
-  | 'audit.package.generated';
+  | 'audit.package.generated'
+  // SPEC-REGULA-CALENDAR-001 — regulatory deadline events (Issue #44):
+  //   deadline.created — ra-lead created a regulatory deadline
+  //   deadline.updated — deadline fields (status, due date, notes) changed
+  //   deadline.deleted — deadline removed
+  | 'deadline.created'
+  | 'deadline.updated'
+  | 'deadline.deleted';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -46,7 +46,10 @@ export type PermissionAction =
   // Auditor view actions (SPEC-REGULA-AUDITOR-VIEW-001, Issue #92)
   // Read-only audit log access and audit package generation.
   | 'audit.read'
-  | 'audit.package.generate';
+  | 'audit.package.generate'
+  // Regulatory calendar actions (SPEC-REGULA-CALENDAR-001, Issue #44)
+  | 'deadline.view'
+  | 'deadline.manage';
 
 export interface PermissionSpec {
   minRole: Role;
@@ -165,4 +168,12 @@ export const PERMISSIONS: Record<PermissionAction, PermissionSpec> = {
     scope: 'org',
     resourceType: 'auditPackage',
   },
+
+  // @MX:NOTE [AUTO] deadline.view/manage — regulatory deadline RBAC.
+  // @MX:SPEC SPEC-REGULA-CALENDAR-001 (REQ-CAL-004, Issue #44)
+  // scope: org — projectId arrives via query/body (not route param), so project
+  // membership is enforced inside each handler via isProjectMember().
+  // ra-member can view; ra-lead required to manage.
+  'deadline.view': { minRole: 'ra-member', scope: 'org', resourceType: 'deadline' },
+  'deadline.manage': { minRole: 'ra-lead', scope: 'org', resourceType: 'deadline' },
 };

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -233,6 +233,9 @@ export const auditActionEnum = pgEnum('audit_action', [
   'audit.access',
   'audit.denied',
   'audit.package.generated',
+  'deadline.created',
+  'deadline.updated',
+  'deadline.deleted',
 ]);
 
 // REQ-WF-049: workflow_type pgEnum — workflow kinds.
@@ -1450,5 +1453,42 @@ export const answerSignatures = pgTable(
     messageIdx: index('idx_answer_signatures_message').on(t.messageId),
     // Performance: look up all signatures by signer (audit queries)
     signerIdx: index('idx_answer_signatures_signer').on(t.signerId),
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// SPEC-REGULA-CALENDAR-001 — Regulatory Calendar & Deadline Management (Issue #44)
+// Migration: 0063_regulatory_deadlines.sql
+// Project-scoped deadline tracker for FDA clocks, EU MDR renewals, ISO surveillance.
+// ---------------------------------------------------------------------------
+
+// @MX:NOTE [AUTO] regulatoryDeadlines — project-scoped regulatory deadline records.
+// @MX:SPEC SPEC-REGULA-CALENDAR-001 (REQ-CAL-001..006)
+export const regulatoryDeadlines = pgTable(
+  'regulatory_deadlines',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    title: text('title').notNull(),
+    // deadline_type: fda_510k_clock | eu_mdr_cert_expiry | iso13485_surveillance | pmda_reexam | custom
+    deadlineType: text('deadline_type').notNull(),
+    // jurisdiction: FDA | EU_MDR | MFDS | PMDA | NMPA | GLOBAL
+    jurisdiction: text('jurisdiction').notNull(),
+    dueDate: date('due_date', { mode: 'date' }).notNull(),
+    // status: upcoming | due_soon | overdue | completed | cancelled (user-set in MVP)
+    status: text('status').notNull().default('upcoming'),
+    reference: text('reference'),
+    notes: text('notes').notNull().default(''),
+    createdBy: uuid('created_by').references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    // Primary access pattern: list deadlines for a project, ordered by due date.
+    projectIdx: index('idx_regulatory_deadlines_project').on(t.projectId, t.dueDate),
+    // Filter by jurisdiction.
+    jurisdictionIdx: index('idx_regulatory_deadlines_jurisdiction').on(t.jurisdiction),
   }),
 );

--- a/migrations/0063_regulatory_deadlines.sql
+++ b/migrations/0063_regulatory_deadlines.sql
@@ -1,0 +1,47 @@
+-- SPEC-REGULA-CALENDAR-001: Regulatory Calendar & Deadline Management (Issue #44)
+-- Migration: 0063_regulatory_deadlines.sql
+--
+-- Project-scoped deadline tracker for FDA clocks, EU MDR renewals, ISO surveillance.
+
+-- Add deadline events to the persisted audit_action enum.
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'deadline.created';
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'deadline.updated';
+ALTER TYPE "audit_action" ADD VALUE IF NOT EXISTS 'deadline.deleted';
+
+CREATE TABLE IF NOT EXISTS "regulatory_deadlines" (
+  "id"             uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "project_id"     uuid NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "title"          text NOT NULL,
+  "deadline_type"  text NOT NULL,
+  "jurisdiction"   text NOT NULL,
+  "due_date"       date NOT NULL,
+  "status"         text NOT NULL DEFAULT 'upcoming',
+  "reference"      text,
+  "notes"          text NOT NULL DEFAULT '',
+  "created_by"     uuid REFERENCES "users"("id"),
+  "created_at"     timestamptz NOT NULL DEFAULT now(),
+  "updated_at"     timestamptz NOT NULL DEFAULT now()
+);
+
+-- Primary access pattern: list deadlines for a project, ordered by due date.
+CREATE INDEX IF NOT EXISTS "idx_regulatory_deadlines_project"
+  ON "regulatory_deadlines"("project_id", "due_date");
+
+-- Filter by jurisdiction.
+CREATE INDEX IF NOT EXISTS "idx_regulatory_deadlines_jurisdiction"
+  ON "regulatory_deadlines"("jurisdiction");
+
+-- updated_at maintenance trigger.
+CREATE OR REPLACE FUNCTION "set_updated_at"()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW."updated_at" = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "trg_regulatory_deadlines_updated_at" ON "regulatory_deadlines";
+CREATE TRIGGER "trg_regulatory_deadlines_updated_at"
+  BEFORE UPDATE ON "regulatory_deadlines"
+  FOR EACH ROW
+  EXECUTE FUNCTION "set_updated_at"();

--- a/tests/regression/foundation.test.ts
+++ b/tests/regression/foundation.test.ts
@@ -33,11 +33,11 @@ describe('FOUNDATION regression', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Permissions matrix has exactly 35 actions (32 base + signature.sign — SPEC-REGULA-ESIG-001
+  // Permissions matrix has exactly 37 actions (32 base + signature.sign — SPEC-REGULA-ESIG-001
   // + audit.read, audit.package.generate — SPEC-REGULA-AUDITOR-VIEW-001)
   // ---------------------------------------------------------------------------
-  it('has 35 permission actions defined', () => {
-    expect(Object.keys(PERMISSIONS).length).toBe(35);
+  it('has 37 permission actions defined', () => {
+    expect(Object.keys(PERMISSIONS).length).toBe(37);
   });
 
   it('profile.edit permission exists with user scope', () => {

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -71,7 +71,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(101); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001)
+    expect(values).toHaveLength(104); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001) +3 deadline.* (CALENDAR-001)
   });
 
   it.each([

--- a/tests/unit/auth/permissions.test.ts
+++ b/tests/unit/auth/permissions.test.ts
@@ -42,14 +42,16 @@ const EXPECTED_ACTIONS: PermissionAction[] = [
   'signature.sign',
   'audit.read',
   'audit.package.generate',
+  'deadline.view',
+  'deadline.manage',
 ];
 
 const VALID_ROLES = ['admin', 'qa-lead', 'ra-lead', 'ra-member', 'viewer', 'auditor'] as const;
 const VALID_SCOPES = ['org', 'project', 'user', 'none'] as const;
 
 describe('lib/auth/permissions.ts (REQ-ENTERPRISE-020) — PERMISSIONS matrix', () => {
-  it('PERMISSIONS contains exactly 35 entries', () => {
-    expect(Object.keys(PERMISSIONS)).toHaveLength(35); // +audit.read, audit.package.generate (SPEC-REGULA-AUDITOR-VIEW-001)
+  it('PERMISSIONS contains exactly 37 entries', () => {
+    expect(Object.keys(PERMISSIONS)).toHaveLength(37); // +audit.read, audit.package.generate (SPEC-REGULA-AUDITOR-VIEW-001)
   });
 
   it.each(EXPECTED_ACTIONS)('PERMISSIONS contains action: %s', (action) => {

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -299,7 +299,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     const values = extractAuditActionEnumValues(src);
     const typeValues = extractAuditActionTypeValues(auditSrc);
     expect(values).toEqual(typeValues);
-    expect(values).toHaveLength(101); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001)
+    expect(values).toHaveLength(104); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001) +3 deadline.* (CALENDAR-001)
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -348,7 +348,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(101); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001)
+    expect(values).toHaveLength(104); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001) +3 deadline.* (CALENDAR-001)
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(

--- a/tests/unit/frontend-shell.test.ts
+++ b/tests/unit/frontend-shell.test.ts
@@ -170,6 +170,7 @@ describe('app/(app) route coverage — Phase 4 navigation contract', () => {
       'app/(app)/page.tsx',
       'app/(app)/chat/page.tsx',
       'app/(app)/history/page.tsx',
+      'app/(app)/calendar/page.tsx',
       'app/(app)/templates/page.tsx',
       'app/(app)/knowledge/page.tsx',
       'app/(app)/updates/page.tsx',
@@ -208,7 +209,7 @@ describe('app/(auth)/login/page.tsx — REQ-FND-018, 058', () => {
 });
 
 describe('components/shell/Sidebar.tsx — REQ-FND-019', () => {
-  it('renders all 8 navigation links in correct order', async () => {
+  it('renders all 9 navigation links in correct order', async () => {
     const mod = await import('../../components/shell/Sidebar');
     const { container } = render(React.createElement(mod.default));
     // Scope to the <nav> region so the primary "새 상담" action button
@@ -223,6 +224,7 @@ describe('components/shell/Sidebar.tsx — REQ-FND-019', () => {
       ['홈', '/'],
       ['채팅', '/chat'], // ko locale label (CHAT_LABELS.ko = '채팅')
       ['히스토리', '/history'],
+      ['규제 캘린더', '/calendar'], // SPEC-REGULA-CALENDAR-001
       ['템플릿', '/templates'],
       ['지식 베이스', '/knowledge'],
       ['규제 업데이트', '/updates'],


### PR DESCRIPTION
## 요약

SPEC-REGULA-CALENDAR-001 MVP 구현. RA 팀의 규제 데드라인(FDA 클락, EU MDR 갱신, ISO 감시심사 등)을 프로젝트 단위로 중앙 추적.

## Gate 0 — 착수 전 정합성

- [x] #18 Work Gate 확인: 최신 main, clean working tree
- [x] SPEC: `.moai/specs/SPEC-REGULA-CALENDAR-001/spec.md` 작성 (Gate 0)
- [x] 영향 축: schema(R), API(R), RBAC(R), audit(R), UI(R)

## 구현 범위 (MVP)

| 레이어 | 내용 |
|--------|------|
| **데이터** | `regulatory_deadlines` 테이블 + 마이그레이션 0063 (project FK cascade, project/jurisdiction 인덱스, updated_at 트리거) |
| **RBAC** | `deadline.view` (ra-member, 조회), `deadline.manage` (ra-lead, 변경) |
| **API** | `/api/ra/deadlines` (GET list + POST), `/api/ra/deadlines/[id]` (GET/PATCH/DELETE) |
| **UI** | `/(app)/calendar` 뷰 + Sidebar 진입점 |
| **감사** | `deadline.created` / `.updated` / `.deleted` |

## 프로젝트 멤버십 (REQ-CAL-002)

projectId가 query string/body로 전달되므로 `withPermission`의 `project` scope 대신 핸들러 내에서 `isProjectMember()`로 검증. 비멤버 → `403 not_a_member`.

## QA evidence

```bash
pnpm typecheck          # PASS
pnpm lint               # PASS (0 errors)
pnpm vitest run app/api/ra/deadlines  # 15/15 PASS
pnpm test               # 2883 passed / 7 skipped
```

회귀 테스트 카운트 갱신 (5개):
- 권한 수: 35 → 37 (`deadline.view`, `deadline.manage` 추가)
- AuditAction 수: 101 → 104 (`deadline.created/.updated/.deleted` 추가)
- Sidebar 네비: 8 → 9 (`규제 캘린더` 추가)

## 범위 외 (follow-up — 별도 PR)

- 이메일 알림 (이슈 #44 §C) — 기존 notifier 재활용
- 공휴일 기반 클락 계산 엔진 (이슈 #44 §D)
- 510(k) 접수 기록 → 클락 자동 시작 트리거
- 월별/주별 캘린더 그리드 UI

Closes #44 (MVP 범위)

🗿 MoAI <email@mo.ai.kr>