### PR TITLE
feat(notifications): 이메일 디스패처 SendGrid 연동 (Issue #214)

### DIFF
--- a/.moai/state/session-memo.md
+++ b/.moai/state/session-memo.md
@@ -45,3 +45,42 @@
 - Main checked: `origin/main` fetched before review-fix work; only open PR is #206.
 - Review fix scope: allow auditor `POST /api/ra/audit-package` through `withPermission`, add persisted `auditor` `user_role`, and ship `audit.access` / `audit.denied` / `audit.package.generated` enum migration.
 - Local verification: targeted auditor tests PASS, `pnpm typecheck` PASS, `pnpm lint` PASS, `pnpm ci:migrations` PASS, `pnpm audit:check` PASS, full `pnpm test` PASS (2854 passed / 7 skipped).
+
+## Active Work — 2026-06-21 QA 메타 루프 마무리 + 프로덕션 감사
+
+### 병합된 작업 (main)
+- **PR #212** — Gate 1~5 SPEC(#75-79) Draft→Active 승격 + 문서 동기화. Closes #75~#79.
+
+### 진행 중 (오픈 PR)
+- **PR #217** `fix/issue-213-gate5-ssot` — Gate 5 SSoT 범위 정합 13→9건 (#213). MERGEABLE.
+- **PR #218** `fix/issue-74-gate0-spec` — Gate 0 SPEC Draft→Active (#74). MERGEABLE. **Gate 0~5 패밀리 전체 Active 통일 완료.**
+
+### 프로덕션 준비도 감사로 신규 등록된 gap 이슈
+- **#214** 이메일 디스패처 stub (Resend/SendGrid 미연동) — 착수 전 결정: provider 통합(Resend vs SendGrid), API key 프로비저닝 필요
+- **#215** 문서 렌더링 placeholder (PCCP/CER/Export-Hub PDF·DOCX) — 착수 전 결정: 렌더링 엔진(react-pdf vs Puppeteer vs docx lib)
+- **#216** Inngest 백그라운드 잡 인프라 unwired — 착수 전 결정: Inngest vs Cloudflare Cron(#9 정합) vs QStash
+- 기존 추적: #35 (gap-replay stub), #39 (워크플로우 LLM synthetic) — OPEN
+
+### 다음 세션 시작 지점
+1. PR #217, #218 병합 → QA Gate 프레임워크 100% 완결
+2. #214 이메일: provider 결정 + API key 확보 후 착수 (digest email-sender가 SendGrid 사용 중 → 통합 권장)
+3. Tier 2(#215/#216)는 기술 결정 후 착수. Tier 3(#39)는 /moai plan 선후.
+
+## ✅ 완료 — 2026-06-21 QA 메타 루프 완결 (Tier 1)
+
+**main HEAD: `4f17b51`** (모든 CI PASS, 열린 PR 0건, main only)
+
+- ✅ **PR #217** Gate 5 SSoT 정합 #213 — squash merge (`6e117f2`). #213 CLOSED.
+  - 리뷰(manager-quality) HIGH fix: qa-matrix §Gate Assignment Summary per-row 정합 (Gate 2: 38→34, Gate 5: 11→9), drift 방지 노트 추가
+- ✅ **PR #218** Gate 0 SPEC 승격 #74 — squash merge (`4f17b51`). #74 CLOSED.
+  - 리뷰(manager-quality) PASS (LOW fix: AC #6 impact axis SSoT 9축 정합)
+  - sync: implementation-status.md "Gate 0-5 SPEC promotion" 행 확장
+
+### 결과: Gate 0~5 SPEC 패밀리 6개 전부 Active 통일 완료
+- SPEC-REGULA-QA-{SPEC-READINESS, IMPLEMENTATION-CHECKPOINT, PR-ACCEPTANCE, WAVE-INTEGRATION, DOMAIN-UAT, OPERATIONS}-001 → 모두 Active
+
+### 다음 세션 시작 지점 (Tier 1 잔여 → Tier 2)
+1. **#214 이메일 연동** — provider 결정(Resend vs SendGrid, SendGrid 권장) + API key 프로비저닝 후 착수
+2. **#215 문서 렌더링** — 엔진 결정(react-pdf vs Puppeteer vs docx lib) 후 착수
+3. **#216 Inngest infra** — 잡 인프라 결정(Inngest vs Cloudflare Cron vs QStash) 후 착수
+4. **#39 워크플로우 LLM** — /moai plan 으로 SPEC-REGULA-WORKFLOWS-LLM-002 구현 계획 수립 후 착수 (CRITICAL, 대규모)

--- a/lib/notifications/__tests__/dispatcher.test.ts
+++ b/lib/notifications/__tests__/dispatcher.test.ts
@@ -94,8 +94,9 @@ describe('dispatch — email channel (SendGrid wiring, REQ-NOTIFY-004)', () => {
     expect(result.email).toBe('error');
   });
 
-  it('returns email "error" when SENDGRID_API_KEY is unset (misconfigured production)', async () => {
-    // No env set — sendEmail throws synchronously, caught by dispatcher.
+  it('returns email "skipped" (not error) when SENDGRID_API_KEY is unset (dev/test)', async () => {
+    // Env unset is a dev-environment signal, not a dispatch failure.
+    // Matches radar/notifier-channels/email.ts skip behavior.
     process.env.SENDGRID_API_KEY = '';
     const result = await dispatch({
       eventType: 'batch_query.completed',
@@ -104,7 +105,7 @@ describe('dispatch — email channel (SendGrid wiring, REQ-NOTIFY-004)', () => {
       recipientEmail: 'user@example.test',
     });
 
-    expect(result.email).toBe('error');
+    expect(result.email).toBe('skipped');
   });
 
   it('skips email channel when recipientEmail is absent', async () => {

--- a/lib/notifications/__tests__/dispatcher.test.ts
+++ b/lib/notifications/__tests__/dispatcher.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+// Unit tests for notification dispatcher — SPEC-REGULA-NOTIFICATIONS-001
+// Verifies SendGrid email wiring (REQ-NOTIFY-004), Slack/Teams parity,
+// and per-channel fire-and-forget isolation.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dispatch } from '../dispatcher';
+
+const originalFetch = globalThis.fetch;
+const originalSendgridKey = process.env.SENDGRID_API_KEY;
+const originalSendgridFrom = process.env.SENDGRID_FROM_EMAIL;
+
+beforeEach(() => {
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+  // Restore env (avoid `delete process.env` per biome noDelete).
+  if (originalSendgridKey === undefined) process.env.SENDGRID_API_KEY = '';
+  else process.env.SENDGRID_API_KEY = originalSendgridKey;
+  if (originalSendgridFrom === undefined) process.env.SENDGRID_FROM_EMAIL = '';
+  else process.env.SENDGRID_FROM_EMAIL = originalSendgridFrom;
+});
+
+function mockFetchOk(): ReturnType<typeof vi.fn> {
+  return vi.fn(async () => new Response('', { status: 202 })) as never;
+}
+
+describe('dispatch — email channel (SendGrid wiring, REQ-NOTIFY-004)', () => {
+  it('sends email via SendGrid when recipientEmail and SENDGRID_API_KEY are set', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    process.env.SENDGRID_FROM_EMAIL = 'noreply@regula.test';
+    const fetchMock = mockFetchOk();
+    globalThis.fetch = fetchMock as never;
+
+    const result = await dispatch({
+      eventType: 'expert_review.assigned',
+      title: 'Review requested',
+      body: 'Please review the drafted answer.',
+      recipientEmail: 'reviewer@example.test',
+      actionUrl: 'https://app.regula.test/answers/123',
+    });
+
+    expect(result.email).toBe('sent');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.sendgrid.com/v3/mail/send');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer SG.test-key');
+
+    const body = JSON.parse(init.body as string) as {
+      personalizations: Array<{ to: Array<{ email: string }> }>;
+      from: { email: string };
+      subject: string;
+      content: Array<{ type: string; value: string }>;
+    };
+    expect(body.personalizations[0]?.to[0]?.email).toBe('reviewer@example.test');
+    expect(body.from.email).toBe('noreply@regula.test');
+    expect(body.subject).toBe('Review requested');
+    expect(body.content[0]?.type).toBe('text/html');
+    expect(body.content[0]?.value).toContain('https://app.regula.test/answers/123');
+  });
+
+  it('renders body text without CTA when actionUrl is omitted', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    const fetchMock = mockFetchOk();
+    globalThis.fetch = fetchMock as never;
+
+    await dispatch({
+      eventType: 'workflow.completed',
+      title: 'Done',
+      body: 'Workflow finished successfully.',
+      recipientEmail: 'user@example.test',
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { content: Array<{ value: string }> };
+    expect(body.content[0]?.value).toContain('Workflow finished successfully.');
+  });
+
+  it('returns email "error" when SendGrid responds non-2xx', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    globalThis.fetch = vi.fn(async () => new Response('', { status: 401 })) as never;
+
+    const result = await dispatch({
+      eventType: 'knowledge_gap.detected',
+      title: 'Gap',
+      body: 'b',
+      recipientEmail: 'user@example.test',
+    });
+
+    expect(result.email).toBe('error');
+  });
+
+  it('returns email "error" when SENDGRID_API_KEY is unset (misconfigured production)', async () => {
+    // No env set — sendEmail throws synchronously, caught by dispatcher.
+    process.env.SENDGRID_API_KEY = '';
+    const result = await dispatch({
+      eventType: 'batch_query.completed',
+      title: 't',
+      body: 'b',
+      recipientEmail: 'user@example.test',
+    });
+
+    expect(result.email).toBe('error');
+  });
+
+  it('skips email channel when recipientEmail is absent', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    const fetchMock = mockFetchOk();
+    globalThis.fetch = fetchMock as never;
+
+    const result = await dispatch({
+      eventType: 'workflow.completed',
+      title: 't',
+      body: 'b',
+      orgSlackWebhookUrl: 'https://hooks.slack.example/xyz',
+    });
+
+    expect(result.email).toBe('skipped');
+    // Only Slack fetch should have fired.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('hooks.slack.example');
+  });
+});
+
+describe('dispatch — Slack/Teams parity (fire-and-forget isolation)', () => {
+  it('email failure does not block Slack/Teams results', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    // First call (Slack) ok, second (Teams) ok, third (email) 401.
+    let calls = 0;
+    globalThis.fetch = vi.fn(async () => {
+      calls += 1;
+      if (calls === 3) return new Response('', { status: 401 });
+      return new Response('', { status: 200 });
+    }) as never;
+
+    const result = await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'SLA warning',
+      body: 'Approaching SLA breach.',
+      recipientEmail: 'user@example.test',
+      orgSlackWebhookUrl: 'https://hooks.slack.example/x',
+      orgTeamsWebhookUrl: 'https://hooks.teams.example/y',
+    });
+
+    expect(result.slack).toBe('sent');
+    expect(result.teams).toBe('sent');
+    expect(result.email).toBe('error');
+  });
+});

--- a/lib/notifications/dispatcher.ts
+++ b/lib/notifications/dispatcher.ts
@@ -149,15 +149,22 @@ export async function dispatch(payload: NotificationPayload): Promise<DispatchRe
     }
   }
 
-  // Email: SendGrid v3 REST API. Failures are logged but non-blocking
-  // (fire-and-forget per channel, consistent with Slack/Teams handling).
+  // Email: SendGrid v3 REST API. Skipped silently when SENDGRID_API_KEY is
+  // unset (dev/test environments) to avoid surfacing env misconfiguration as a
+  // hard error — matches radar/notifier-channels/email.ts skip behavior.
+  // Actual API failures (auth, network, non-2xx) are logged as 'error'.
   if (payload.recipientEmail) {
-    try {
-      await sendEmail(payload.recipientEmail, payload.title, payload.body, payload.actionUrl);
-      result.email = 'sent';
-    } catch (err) {
-      logger.error('[notifications] Email dispatch failed:', err);
-      result.email = 'error';
+    if (!process.env.SENDGRID_API_KEY) {
+      logger.info('[notifications] Email skipped — SENDGRID_API_KEY not set');
+      result.email = 'skipped';
+    } else {
+      try {
+        await sendEmail(payload.recipientEmail, payload.title, payload.body, payload.actionUrl);
+        result.email = 'sent';
+      } catch (err) {
+        logger.error('[notifications] Email dispatch failed:', err);
+        result.email = 'error';
+      }
     }
   }
 

--- a/lib/notifications/dispatcher.ts
+++ b/lib/notifications/dispatcher.ts
@@ -40,6 +40,70 @@ async function sendSlack(webhookUrl: string, title: string, body: string): Promi
   }
 }
 
+/**
+ * Send a transactional email via SendGrid v3 REST API.
+ * Reuses the SENDGRID_API_KEY / SENDGRID_FROM_EMAIL env pattern from
+ * lib/radar/notifier-channels/email.ts and lib/digest/email-sender.ts.
+ * No SDK dependency — raw fetch keeps the module Edge/Node portable.
+ * @MX:ANCHOR: [AUTO] External system integration point (SendGrid v3 mail/send)
+ * @MX:REASON: REQ-NOTIFY-004 email channel contract; fan_in ≥ 3 callers via dispatch()
+ */
+async function sendEmail(
+  to: string,
+  title: string,
+  body: string,
+  actionUrl?: string,
+): Promise<void> {
+  const apiKey = process.env.SENDGRID_API_KEY;
+  const fromEmail = process.env.SENDGRID_FROM_EMAIL ?? 'noreply@regula.ai';
+
+  if (!apiKey) {
+    throw new Error('SENDGRID_API_KEY not set');
+  }
+
+  // Minimal HTML wrapper. actionUrl renders as a primary CTA when provided.
+  const html = actionUrl
+    ? `<html><body style="font-family:sans-serif;">
+        <h2>${escapeHtml(title)}</h2>
+        <p style="white-space:pre-wrap;">${escapeHtml(body)}</p>
+        <p><a href="${escapeHtml(actionUrl)}" style="display:inline-block;background:midnightblue;color:white;padding:10px 20px;border-radius:4px;text-decoration:none;">Regula에서 보기</a></p>
+      </body></html>`
+    : `<html><body style="font-family:sans-serif;">
+        <h2>${escapeHtml(title)}</h2>
+        <p style="white-space:pre-wrap;">${escapeHtml(body)}</p>
+      </body></html>`;
+
+  const payload = {
+    personalizations: [{ to: [{ email: to }] }],
+    from: { email: fromEmail },
+    subject: title,
+    content: [{ type: 'text/html', value: html }],
+  };
+
+  const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new Error(`SendGrid returned ${res.status}`);
+  }
+}
+
+/** Server-side HTML escape (no DOM dependency). */
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
 /** Send a Teams message via incoming webhook. */
 async function sendTeams(webhookUrl: string, title: string, body: string): Promise<void> {
   const res = await fetch(webhookUrl, {
@@ -85,13 +149,16 @@ export async function dispatch(payload: NotificationPayload): Promise<DispatchRe
     }
   }
 
-  // Email: stub — wire to Resend/SendGrid in production.
+  // Email: SendGrid v3 REST API. Failures are logged but non-blocking
+  // (fire-and-forget per channel, consistent with Slack/Teams handling).
   if (payload.recipientEmail) {
-    if (process.env.RESEND_API_KEY) {
-      // TODO: integrate Resend SDK (pnpm add resend)
-      logger.info('[notifications] Email stub — RESEND_API_KEY present but not yet integrated');
+    try {
+      await sendEmail(payload.recipientEmail, payload.title, payload.body, payload.actionUrl);
+      result.email = 'sent';
+    } catch (err) {
+      logger.error('[notifications] Email dispatch failed:', err);
+      result.email = 'error';
     }
-    result.email = 'skipped';
   }
 
   return result;

--- a/lib/radar/__tests__/notifier-email.test.ts
+++ b/lib/radar/__tests__/notifier-email.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+// Unit tests for radar digest email channel — SPEC-REGULA-RADAR-001
+// Verifies recipient resolution from orgDigestPreferences (no more placeholder
+// addresses) and SendGrid dispatch behavior.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the DB module — email.ts queries orgDigestPreferences.
+// vi.hoisted ensures refs exist when the hoisted vi.mock factory runs.
+const { selectMock, fromMock, whereMock, limitMock, setLimitResolution } = vi.hoisted(() => {
+  let limitResolution: unknown[] = [];
+  const limitMock = vi.fn(async () => limitResolution);
+  const whereMock = vi.fn(() => ({ limit: limitMock }));
+  const fromMock = vi.fn(() => ({ where: whereMock, limit: limitMock }));
+  return {
+    selectMock: vi.fn(() => ({ from: fromMock })),
+    fromMock,
+    whereMock,
+    limitMock,
+    setLimitResolution: (rows: unknown[]) => {
+      limitResolution = rows;
+    },
+  };
+});
+
+vi.mock('@/lib/db/client', () => ({
+  db: {
+    select: selectMock,
+  },
+}));
+
+// Import after mocks are registered.
+import { type RelevantUpdate, sendDigestEmail } from '../notifier-channels/email';
+
+const originalFetch = globalThis.fetch;
+const originalSendgridKey = process.env.SENDGRID_API_KEY;
+const originalSendgridFrom = process.env.SENDGRID_FROM_EMAIL;
+
+beforeEach(() => {
+  vi.useRealTimers();
+  selectMock.mockClear();
+  fromMock.mockClear();
+  whereMock.mockClear();
+  limitMock.mockClear();
+  setLimitResolution([]);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+  if (originalSendgridKey === undefined) process.env.SENDGRID_API_KEY = '';
+  else process.env.SENDGRID_API_KEY = originalSendgridKey;
+  if (originalSendgridFrom === undefined) process.env.SENDGRID_FROM_EMAIL = '';
+  else process.env.SENDGRID_FROM_EMAIL = originalSendgridFrom;
+});
+
+const updates: RelevantUpdate[] = [
+  {
+    id: 'u1',
+    title: 'FDA guidance update',
+    region: 'US',
+    impact_score: 0.9,
+    source_url: 'https://fda.gov/example',
+  },
+];
+
+describe('sendDigestEmail — recipient resolution (REQ-RADAR email channel)', () => {
+  it('skips when SENDGRID_API_KEY is unset', async () => {
+    process.env.SENDGRID_API_KEY = '';
+    const result = await sendDigestEmail('org-1', updates);
+    expect(result).toBeUndefined();
+  });
+
+  it('skips when no recipients configured for org', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    setLimitResolution([]); // orgDigestPreferences returns no recipients
+
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as never;
+
+    await sendDigestEmail('org-1', updates);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends to resolved recipientEmails and never uses placeholder address', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    setLimitResolution([{ recipientEmails: ['lead@example.test', 'exec@example.test'] }]);
+
+    const fetchMock = vi.fn(async () => new Response('', { status: 202 }));
+    globalThis.fetch = fetchMock as never;
+
+    await sendDigestEmail('org-1', updates);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.sendgrid.com/v3/mail/send');
+
+    const body = JSON.parse(init.body as string) as {
+      personalizations: Array<{ to: Array<{ email: string }> }>;
+    };
+    expect(body.personalizations[0]?.to).toHaveLength(2);
+    expect(body.personalizations[0]?.to[0]?.email).toBe('lead@example.test');
+    expect(body.personalizations[0]?.to[1]?.email).toBe('exec@example.test');
+
+    // Critical: no @digest.placeholder leakage.
+    const bodyStr = init.body as string;
+    expect(bodyStr).not.toContain('@digest.placeholder');
+  });
+
+  it('skips when updates list is empty', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    setLimitResolution([{ recipientEmails: ['lead@example.test'] }]);
+
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as never;
+
+    await sendDigestEmail('org-1', []);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('logs error and does not throw when SendGrid returns non-2xx', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    setLimitResolution([{ recipientEmails: ['lead@example.test'] }]);
+    globalThis.fetch = vi.fn(async () => new Response('', { status: 500 })) as never;
+
+    // Must not throw — channel failure is fire-and-forget.
+    await expect(sendDigestEmail('org-1', updates)).resolves.toBeUndefined();
+  });
+});

--- a/lib/radar/notifier-channels/email.ts
+++ b/lib/radar/notifier-channels/email.ts
@@ -13,10 +13,33 @@ export interface RelevantUpdate {
 }
 
 /**
- * Send a daily digest email to the org's primary contact via SendGrid.
+ * Resolve the org's digest recipient email list from orgDigestPreferences.
+ * Skips when frequency is 'disabled' or recipientEmails is empty.
+ * Uses dynamic import so module load does not trigger env validation
+ * (lib/db/client calls getEnv() at init — would break unit tests).
+ */
+async function resolveRecipients(orgId: string): Promise<string[]> {
+  const { db } = await import('@/lib/db/client');
+  const { orgDigestPreferences } = await import('@/lib/db/schema');
+  const { and, eq, ne } = await import('drizzle-orm');
+
+  const rows = await db
+    .select({ recipientEmails: orgDigestPreferences.recipientEmails })
+    .from(orgDigestPreferences)
+    .where(
+      and(eq(orgDigestPreferences.orgId, orgId), ne(orgDigestPreferences.frequency, 'disabled')),
+    )
+    .limit(1);
+
+  return rows[0]?.recipientEmails ?? [];
+}
+
+/**
+ * Send a daily digest email to the org's configured recipient list via SendGrid.
  * Reuses the SENDGRID_API_KEY env var pattern from admin-quarantine.ts.
  *
- * Only sends if org has email_digest_enabled = true (checked by notifier.ts caller).
+ * Recipients are resolved from orgDigestPreferences.recipientEmails.
+ * Caller (notifier.ts) additionally gates on email_digest_enabled.
  */
 export async function sendDigestEmail(orgId: string, updates: RelevantUpdate[]): Promise<void> {
   const apiKey = process.env.SENDGRID_API_KEY;
@@ -29,6 +52,12 @@ export async function sendDigestEmail(orgId: string, updates: RelevantUpdate[]):
 
   if (!updates.length) return;
 
+  const recipients = await resolveRecipients(orgId);
+  if (recipients.length === 0) {
+    logger.info(`[radar/email] No recipients configured for org ${orgId} — skipping`);
+    return;
+  }
+
   const subject = `Regula Radar: ${updates.length} new regulatory update${updates.length > 1 ? 's' : ''} require your attention`;
 
   const htmlBody = `
@@ -39,8 +68,8 @@ export async function sendDigestEmail(orgId: string, updates: RelevantUpdate[]):
         .map(
           (u) =>
             `<li>
-          <strong>${u.title}</strong> (${u.region}) — Impact score: ${(u.impact_score * 100).toFixed(0)}%
-          ${u.source_url ? `<br><a href="${u.source_url}">View source</a>` : ''}
+          <strong>${escapeHtml(u.title)}</strong> (${escapeHtml(u.region)}) — Impact score: ${(u.impact_score * 100).toFixed(0)}%
+          ${u.source_url ? `<br><a href="${escapeHtml(u.source_url)}">View source</a>` : ''}
         </li>`,
         )
         .join('')}
@@ -48,10 +77,8 @@ export async function sendDigestEmail(orgId: string, updates: RelevantUpdate[]):
     <p><a href="${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.regula.ai'}/updates">View all updates in Regula</a></p>
   `;
 
-  // @MX:TODO: [AUTO] Resolve recipient email from org contact lookup (requires DB query).
-  // @MX:SPEC SPEC-REGULA-RADAR-001
   const payload = {
-    personalizations: [{ to: [{ email: `org-${orgId}@digest.placeholder` }] }],
+    personalizations: [{ to: recipients.map((email) => ({ email })) }],
     from: { email: fromEmail },
     subject,
     content: [{ type: 'text/html', value: htmlBody }],
@@ -73,4 +100,14 @@ export async function sendDigestEmail(orgId: string, updates: RelevantUpdate[]):
   } catch (err) {
     logger.error('[radar/email] Failed to send digest email:', err);
   }
+}
+
+/** Server-side HTML escape (no DOM dependency). */
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
 }


### PR DESCRIPTION
## 배경

Issue #214 — NOTIFICATIONS-001 #52의 미납 이메일 채널 추적. `dispatcher.ts`가 RESEND stub, `radar/email.ts`가 placeholder 주소를 사용 중이었음.

## 기술 결정: **SendGrid**

이미 프로젝트 표준 (`lib/radar/notifier-channels/email.ts`, `lib/digest/email-sender.ts`, `admin-quarantine.ts` 모두 SendGrid 사용). dispatcher의 `RESEND_API_KEY` 참조는 잘못된 stub.

## 변경

| 파일 | 내용 |
|---|---|
| `lib/notifications/dispatcher.ts` | RESEND stub 제거 → SendGrid v3 REST API (fetch 기반, SDK 무의존). Slack/Teams와 동일한 fire-and-forget 예외 격리 |
| `lib/radar/notifier-channels/email.ts` | `org-@digest.placeholder` → `orgDigestPreferences.recipientEmails` DB 조회 (lazy import로 env 검증 side-effect 회피). HTML escape 적용 |
| `lib/notifications/__tests__/dispatcher.test.ts` | 신규 6개 (SendGrid 발송·에러·skip·CTA 없음·Slack/Teams 격리) |
| `lib/radar/__tests__/notifier-email.test.ts` | 신규 5개 (recipient 해석·placeholder 누출 방지·빈 updates·non-2xx) |

## AC 충족

- [x] SendGrid 단일 provider (SENDGRID_API_KEY)
- [x] dispatcher.ts email stub 제거 → 실제 발송
- [x] radar/email.ts placeholder → org contact DB 조회
- [x] 단위 테스트 (mock provider)
- [x] `notification_preferences.emailEnabled` → 존재하지 않는 컬럼. 실제 게이트는 `orgDigestPreferences.frequency ≠ 'disabled'` + notifier.ts의 `email_digest_enabled`이며 본 PR에서 실제 적용 확인

## 검증

```
pnpm typecheck     PASS
pnpm lint (biome)  PASS
pnpm audit:check   PASS
pnpm test          2949 passed / 7 skipped (+11 신규)
```

## 환경 변수 (운영 배포 시)

```
SENDGRID_API_KEY=SG.xxx
SENDGRID_FROM_EMAIL=noreply@your-domain.com
```

Fixes #214

🗿 MoAI <email@mo.ai.kr>