### PR TITLE
feat(hybrid): IFU parse/knowledge sync 상태 표시 UX (#199)

### DIFF
--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -1,8 +1,10 @@
 // @MX:NOTE [AUTO] Knowledge base page — switched from hard-coded corpus list to dynamic API-backed view.
 // @MX:SPEC SPEC-REGULA-RELEASE-HARDENING-001 (TASK-002)
+// @MX:SPEC Issue #199 (Hybrid RA sync status section added)
 
 import { headers } from 'next/headers';
 import { Suspense } from 'react';
+import { HybridSyncStatus } from '@/components/knowledge/HybridSyncStatus';
 
 export const dynamic = 'force-dynamic';
 
@@ -169,6 +171,11 @@ export default function KnowledgePage() {
             </div>
           ))}
         </div>
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-ink-900">Hybrid RA 동기화 상태</h2>
+        <HybridSyncStatus />
       </section>
 
       <Suspense fallback={<CorpusGridFallback />}>

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -2,9 +2,9 @@
 // @MX:SPEC SPEC-REGULA-RELEASE-HARDENING-001 (TASK-002)
 // @MX:SPEC Issue #199 (Hybrid RA sync status section added)
 
+import { HybridSyncStatus } from '@/components/knowledge/HybridSyncStatus';
 import { headers } from 'next/headers';
 import { Suspense } from 'react';
-import { HybridSyncStatus } from '@/components/knowledge/HybridSyncStatus';
 
 export const dynamic = 'force-dynamic';
 

--- a/app/api/ra/hybrid/sync-status/route.ts
+++ b/app/api/ra/hybrid/sync-status/route.ts
@@ -5,8 +5,9 @@
 export const runtime = 'nodejs';
 
 import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
 
-export async function GET() {
+export const GET = withPermission('dashboard.view', async () => {
   try {
     const data = await createHybridRaClient().syncManifest();
     return Response.json({ status: 'ok', sync: data });
@@ -21,4 +22,4 @@ export async function GET() {
       kind: e?.kind ?? 'server_error',
     });
   }
-}
+});

--- a/app/api/ra/hybrid/sync-status/route.ts
+++ b/app/api/ra/hybrid/sync-status/route.ts
@@ -1,0 +1,24 @@
+// @MX:NOTE BFF proxy for hybrid-ra-saas sync manifest — GET /api/ra/hybrid/sync-status
+// @MX:SPEC Issue #199 (Hybrid RA IFU parse result & knowledge sync UX)
+// Degrades gracefully: unconfigured env returns { status: 'unconfigured' } (not an error).
+
+export const runtime = 'nodejs';
+
+import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
+
+export async function GET() {
+  try {
+    const data = await createHybridRaClient().syncManifest();
+    return Response.json({ status: 'ok', sync: data });
+  } catch (err) {
+    if (err instanceof HybridRaClientError && err.kind === 'unconfigured') {
+      return Response.json({ status: 'unconfigured' });
+    }
+    const e = err instanceof HybridRaClientError ? err : null;
+    return Response.json({
+      status: 'error',
+      message: e?.message ?? 'Unknown error',
+      kind: e?.kind ?? 'server_error',
+    });
+  }
+}

--- a/components/knowledge/HybridSyncStatus.tsx
+++ b/components/knowledge/HybridSyncStatus.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+// @MX:NOTE Hybrid RA 동기화 상태 표시 컴포넌트 — knowledge page 전용.
+// @MX:SPEC Issue #199
+
+import { useEffect, useState } from 'react';
+
+interface SyncData {
+  last_sync: string;
+  total_documents: number;
+  sync_status: 'synced' | 'stale' | 'unknown';
+  tenant_id: string;
+}
+
+type ViewState =
+  | { kind: 'loading' }
+  | { kind: 'unconfigured' }
+  | { kind: 'ok'; sync: SyncData }
+  | { kind: 'error'; message: string };
+
+const STATUS_DOT: Record<'synced' | 'stale' | 'unknown', string> = {
+  synced: 'bg-success-500',
+  stale: 'bg-amber-500',
+  unknown: 'bg-ink-400',
+};
+
+const STATUS_LABEL: Record<'synced' | 'stale' | 'unknown', string> = {
+  synced: '동기화됨',
+  stale: '동기화 오래됨',
+  unknown: '상태 알 수 없음',
+};
+
+function formatDate(iso: string) {
+  try {
+    return new Intl.DateTimeFormat('ko-KR', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+export function HybridSyncStatus() {
+  const [view, setView] = useState<ViewState>({ kind: 'loading' });
+
+  useEffect(() => {
+    fetch('/api/ra/hybrid/sync-status')
+      .then((r) => r.json() as Promise<{ status: string; sync?: SyncData; message?: string }>)
+      .then((data) => {
+        if (data.status === 'unconfigured') {
+          setView({ kind: 'unconfigured' });
+        } else if (data.status === 'ok' && data.sync) {
+          setView({ kind: 'ok', sync: data.sync });
+        } else {
+          setView({ kind: 'error', message: data.message ?? '상태를 불러오지 못했습니다.' });
+        }
+      })
+      .catch(() => setView({ kind: 'error', message: '네트워크 오류가 발생했습니다.' }));
+  }, []);
+
+  if (view.kind === 'loading') {
+    return (
+      <div
+        aria-busy="true"
+        className="h-16 animate-pulse rounded-lg border border-ink-150 bg-ink-50"
+      />
+    );
+  }
+
+  if (view.kind === 'unconfigured') {
+    return (
+      <div className="rounded-lg border border-ink-150 bg-ink-50 px-4 py-3 text-sm text-ink-500">
+        Hybrid RA 연동 미설정 — 환경 변수를 구성하면 여기에 동기화 상태가 표시됩니다.
+      </div>
+    );
+  }
+
+  if (view.kind === 'error') {
+    return (
+      <div
+        role="alert"
+        className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+      >
+        <span className="font-medium">동기화 상태 오류:</span> {view.message}{' '}
+        <span className="text-amber-700">관리자에게 문의하세요.</span>
+      </div>
+    );
+  }
+
+  const { sync } = view;
+  const dot = STATUS_DOT[sync.sync_status];
+  const label = STATUS_LABEL[sync.sync_status];
+
+  return (
+    <div className="flex flex-col gap-1 rounded-lg border border-ink-150 bg-surface px-4 py-3">
+      <div className="flex items-center gap-2">
+        <span className={`h-2 w-2 shrink-0 rounded-full ${dot}`} aria-hidden="true" />
+        <span className="text-sm font-medium text-ink-900">{label}</span>
+        <span className="ml-auto text-xs text-ink-500">테넌트: {sync.tenant_id}</span>
+      </div>
+      <div className="flex gap-4 text-xs text-ink-600">
+        <span>마지막 동기화: {formatDate(sync.last_sync)}</span>
+        <span>문서 수: {sync.total_documents.toLocaleString()}개</span>
+      </div>
+      {sync.sync_status === 'stale' && (
+        <p className="mt-1 text-xs text-amber-700">
+          동기화가 오래되었습니다. 관리자에게 재동기화를 요청하거나 잠시 후 새로고침하세요.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/knowledge/HybridSyncStatus.tsx
+++ b/components/knowledge/HybridSyncStatus.tsx
@@ -8,9 +8,11 @@ import { useEffect, useState } from 'react';
 interface SyncData {
   last_sync: string;
   total_documents: number;
-  sync_status: 'synced' | 'stale' | 'unknown';
+  sync_status: SyncStatus;
   tenant_id: string;
 }
+
+type SyncStatus = 'synced' | 'stale' | 'unknown' | 'failed' | 'pending' | 'retry-needed';
 
 type ViewState =
   | { kind: 'loading' }
@@ -18,16 +20,29 @@ type ViewState =
   | { kind: 'ok'; sync: SyncData }
   | { kind: 'error'; message: string };
 
-const STATUS_DOT: Record<'synced' | 'stale' | 'unknown', string> = {
+const STATUS_DOT: Record<SyncStatus, string> = {
   synced: 'bg-success-500',
   stale: 'bg-amber-500',
   unknown: 'bg-ink-400',
+  failed: 'bg-red-500',
+  pending: 'bg-blue-500',
+  'retry-needed': 'bg-amber-600',
 };
 
-const STATUS_LABEL: Record<'synced' | 'stale' | 'unknown', string> = {
+const STATUS_LABEL: Record<SyncStatus, string> = {
   synced: '동기화됨',
   stale: '동기화 오래됨',
   unknown: '상태 알 수 없음',
+  failed: '동기화 실패',
+  pending: '동기화 대기 중',
+  'retry-needed': '재시도 필요',
+};
+
+const STATUS_MESSAGE: Partial<Record<SyncStatus, string>> = {
+  stale: '동기화가 오래되었습니다. 관리자에게 재동기화를 요청하거나 잠시 후 새로고침하세요.',
+  failed: '마지막 동기화가 실패했습니다. 재시도 또는 관리자 확인이 필요합니다.',
+  pending: '동기화 작업이 대기열에 있습니다. 완료 후 새로고침하면 최신 상태가 표시됩니다.',
+  'retry-needed': '동기화 재시도 조건이 감지되었습니다. 관리자에게 재동기화를 요청하세요.',
 };
 
 function formatDate(iso: string) {
@@ -89,8 +104,10 @@ export function HybridSyncStatus() {
   }
 
   const { sync } = view;
-  const dot = STATUS_DOT[sync.sync_status];
-  const label = STATUS_LABEL[sync.sync_status];
+  const status = sync.sync_status in STATUS_LABEL ? sync.sync_status : 'unknown';
+  const dot = STATUS_DOT[status];
+  const label = STATUS_LABEL[status];
+  const message = STATUS_MESSAGE[status];
 
   return (
     <div className="flex flex-col gap-1 rounded-lg border border-ink-150 bg-surface px-4 py-3">
@@ -103,11 +120,7 @@ export function HybridSyncStatus() {
         <span>마지막 동기화: {formatDate(sync.last_sync)}</span>
         <span>문서 수: {sync.total_documents.toLocaleString()}개</span>
       </div>
-      {sync.sync_status === 'stale' && (
-        <p className="mt-1 text-xs text-amber-700">
-          동기화가 오래되었습니다. 관리자에게 재동기화를 요청하거나 잠시 후 새로고침하세요.
-        </p>
-      )}
+      {message && <p className="mt-1 text-xs text-amber-700">{message}</p>}
     </div>
   );
 }

--- a/lib/api/hybrid-ra-client.ts
+++ b/lib/api/hybrid-ra-client.ts
@@ -43,7 +43,7 @@ export interface HealthResponse {
 export interface SyncManifestResponse {
   last_sync: string; // ISO-8601
   total_documents: number;
-  sync_status: 'synced' | 'stale' | 'unknown';
+  sync_status: 'synced' | 'stale' | 'unknown' | 'failed' | 'pending' | 'retry-needed';
   tenant_id: string;
 }
 

--- a/tests/unit/hybrid-sync-status-component.test.tsx
+++ b/tests/unit/hybrid-sync-status-component.test.tsx
@@ -1,0 +1,60 @@
+/** @vitest-environment jsdom */
+
+import '@testing-library/jest-dom';
+import { HybridSyncStatus } from '@/components/knowledge/HybridSyncStatus';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+function mockSyncStatus(syncStatus: string) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: 'ok',
+          sync: {
+            last_sync: '2026-06-22T10:00:00Z',
+            total_documents: 42,
+            sync_status: syncStatus,
+            tenant_id: 'tenant-001',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ),
+  );
+}
+
+describe('HybridSyncStatus', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('surfaces failed sync state with retry guidance', async () => {
+    mockSyncStatus('failed');
+
+    render(<HybridSyncStatus />);
+
+    await waitFor(() => expect(screen.getByText('동기화 실패')).toBeInTheDocument());
+    expect(screen.getByText(/재시도 또는 관리자 확인이 필요합니다/)).toBeInTheDocument();
+  });
+
+  it('surfaces retry-needed sync state with action guidance', async () => {
+    mockSyncStatus('retry-needed');
+
+    render(<HybridSyncStatus />);
+
+    await waitFor(() => expect(screen.getByText('재시도 필요')).toBeInTheDocument());
+    expect(screen.getByText(/재동기화를 요청하세요/)).toBeInTheDocument();
+  });
+
+  it('surfaces pending sync state without a blank status label', async () => {
+    mockSyncStatus('pending');
+
+    render(<HybridSyncStatus />);
+
+    await waitFor(() => expect(screen.getByText('동기화 대기 중')).toBeInTheDocument());
+    expect(screen.getByText(/동기화 작업이 대기열에 있습니다/)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/hybrid-sync-status-route.test.ts
+++ b/tests/unit/hybrid-sync-status-route.test.ts
@@ -1,6 +1,6 @@
 // @MX:SPEC Issue #199 (Hybrid RA sync status BFF route tests)
 
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock must be declared before imports that use the module
 vi.mock('@/lib/api/hybrid-ra-client', () => {
@@ -18,10 +18,35 @@ vi.mock('@/lib/api/hybrid-ra-client', () => {
   return { HybridRaClientError, createHybridRaClient: vi.fn() };
 });
 
-import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
+const { withPermissionMock } = vi.hoisted(() => ({
+  withPermissionMock: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, {
+          user: {
+            id: 'user-ra-1',
+            role: 'ra-member',
+            organizationId: 'org-1',
+          },
+        }),
+  ),
+}));
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: withPermissionMock,
+}));
+
 import { GET } from '@/app/api/ra/hybrid/sync-status/route';
+import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
 
 const mockSyncManifest = vi.fn();
+
+function makeReq(): Request {
+  return new Request('https://example.com/api/ra/hybrid/sync-status');
+}
 
 beforeEach(() => {
   vi.mocked(createHybridRaClient).mockReturnValue({
@@ -36,11 +61,15 @@ beforeEach(() => {
 });
 
 describe('GET /api/ra/hybrid/sync-status', () => {
+  it('is gated by dashboard read RBAC before proxying', () => {
+    expect(withPermissionMock).toHaveBeenCalledWith('dashboard.view', expect.any(Function));
+  });
+
   it('returns unconfigured when env vars are missing', async () => {
     mockSyncManifest.mockRejectedValue(
       new HybridRaClientError('not configured', 503, '/sync/manifest', 'unconfigured'),
     );
-    const res = await GET();
+    const res = await GET(makeReq(), {});
     const body = await res.json();
     expect(body).toEqual({ status: 'unconfigured' });
     expect(res.status).toBe(200);
@@ -54,7 +83,7 @@ describe('GET /api/ra/hybrid/sync-status', () => {
       tenant_id: 'tenant-001',
     };
     mockSyncManifest.mockResolvedValue(syncData);
-    const res = await GET();
+    const res = await GET(makeReq(), {});
     const body = await res.json();
     expect(body).toEqual({ status: 'ok', sync: syncData });
   });
@@ -63,7 +92,7 @@ describe('GET /api/ra/hybrid/sync-status', () => {
     mockSyncManifest.mockRejectedValue(
       new HybridRaClientError('Request timed out', 504, '/sync/manifest', 'timeout'),
     );
-    const res = await GET();
+    const res = await GET(makeReq(), {});
     const body = await res.json();
     expect(body.status).toBe('error');
     expect(body.kind).toBe('timeout');
@@ -71,7 +100,7 @@ describe('GET /api/ra/hybrid/sync-status', () => {
 
   it('returns error for unexpected exceptions', async () => {
     mockSyncManifest.mockRejectedValue(new Error('Network failure'));
-    const res = await GET();
+    const res = await GET(makeReq(), {});
     const body = await res.json();
     expect(body.status).toBe('error');
     expect(body.kind).toBe('server_error');

--- a/tests/unit/hybrid-sync-status-route.test.ts
+++ b/tests/unit/hybrid-sync-status-route.test.ts
@@ -1,0 +1,79 @@
+// @MX:SPEC Issue #199 (Hybrid RA sync status BFF route tests)
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock must be declared before imports that use the module
+vi.mock('@/lib/api/hybrid-ra-client', () => {
+  const HybridRaClientError = class extends Error {
+    constructor(
+      message: string,
+      public statusCode: number,
+      public endpoint: string,
+      public kind: string,
+    ) {
+      super(message);
+      this.name = 'HybridRaClientError';
+    }
+  };
+  return { HybridRaClientError, createHybridRaClient: vi.fn() };
+});
+
+import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
+import { GET } from '@/app/api/ra/hybrid/sync-status/route';
+
+const mockSyncManifest = vi.fn();
+
+beforeEach(() => {
+  vi.mocked(createHybridRaClient).mockReturnValue({
+    health: vi.fn(),
+    syncManifest: mockSyncManifest,
+    ragQuery: vi.fn(),
+    uploadDocument: vi.fn(),
+    createParseJob: vi.fn(),
+    runGuardrail: vi.fn(),
+    exportAudit: vi.fn(),
+  });
+});
+
+describe('GET /api/ra/hybrid/sync-status', () => {
+  it('returns unconfigured when env vars are missing', async () => {
+    mockSyncManifest.mockRejectedValue(
+      new HybridRaClientError('not configured', 503, '/sync/manifest', 'unconfigured'),
+    );
+    const res = await GET();
+    const body = await res.json();
+    expect(body).toEqual({ status: 'unconfigured' });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns ok with sync data on success', async () => {
+    const syncData = {
+      last_sync: '2026-06-22T10:00:00Z',
+      total_documents: 42,
+      sync_status: 'synced',
+      tenant_id: 'tenant-001',
+    };
+    mockSyncManifest.mockResolvedValue(syncData);
+    const res = await GET();
+    const body = await res.json();
+    expect(body).toEqual({ status: 'ok', sync: syncData });
+  });
+
+  it('returns error with kind for non-unconfigured HybridRaClientError', async () => {
+    mockSyncManifest.mockRejectedValue(
+      new HybridRaClientError('Request timed out', 504, '/sync/manifest', 'timeout'),
+    );
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe('error');
+    expect(body.kind).toBe('timeout');
+  });
+
+  it('returns error for unexpected exceptions', async () => {
+    mockSyncManifest.mockRejectedValue(new Error('Network failure'));
+    const res = await GET();
+    const body = await res.json();
+    expect(body.status).toBe('error');
+    expect(body.kind).toBe('server_error');
+  });
+});


### PR DESCRIPTION
## Summary

- BFF `GET /api/ra/hybrid/sync-status` 추가 — `unconfigured` 종류를 HTTP 200으로 처리해 중립 상태로 표시
- `HybridSyncStatus` 컴포넌트: loading / unconfigured / ok(stale 경고 포함) / error 4개 상태
- knowledge page `app/(app)/knowledge/page.tsx` 에 `<HybridSyncStatus />` 섹션 삽입
- 단위 테스트: `tests/unit/hybrid-sync-status-route.test.ts` (4 케이스)

## Test plan

- [ ] CI vitest 통과 확인
- [ ] hybrid-ra unconfigured 환경 → 중립 회색 카드 표시 (alarming 없음)
- [ ] syncManifest() 성공 → ok/stale 상태 도트 + 라벨 정상 표시
- [ ] server_error/timeout → amber 에러 카드 표시

Closes #199

🗿 MoAI <email@mo.ai.kr>