### PR TITLE
feat(hybrid): RAG 라우팅 경로(local/hybrid/regula) 뱃지 표시 (#200)

### DIFF
--- a/components/chat/AnswerBlock.tsx
+++ b/components/chat/AnswerBlock.tsx
@@ -19,6 +19,7 @@ import type {
   ChecklistItem,
   ComparisonEvent,
   ConfidenceEvent,
+  RagRouteEvent,
   SourceItem,
   TimelineEvent,
 } from '../../types/streaming';
@@ -30,6 +31,7 @@ import { Callout } from './Callout';
 import { Checklist } from './Checklist';
 import { ComparisonTable } from './ComparisonTable';
 import { ConfidenceBadge } from './ConfidenceBadge';
+import { RagRouteBadge } from './RagRouteBadge';
 import { SourcesGrid } from './SourcesGrid';
 import { SuggestionPill } from './SuggestionPill';
 import { Timeline } from './Timeline';
@@ -65,6 +67,7 @@ interface AnswerBlockProps {
   comparison?: ComparisonEvent | undefined;
   timeline?: TimelineEvent | undefined;
   related?: string[] | undefined;
+  ragRoute?: RagRouteEvent | undefined;
   onSuggestionClick?: (text: string) => void;
 }
 
@@ -82,6 +85,7 @@ export function AnswerBlock({
   comparison,
   timeline,
   related,
+  ragRoute,
   onSuggestionClick,
 }: AnswerBlockProps) {
   const [refinedProse, setRefinedProse] = useState<string | null>(null);
@@ -106,6 +110,7 @@ export function AnswerBlock({
       {/* Section 1: Meta row */}
       <div className="flex flex-wrap items-center gap-3 text-xs text-ink-500">
         {confidence && <ConfidenceBadge level={confidence.level} score={confidence.score} />}
+        {ragRoute && <RagRouteBadge route={ragRoute} />}
         <span>{sourceCount} 출처</span>
         {durationSec && <span>분석 {durationSec}s</span>}
         {/* Action buttons — copy / export / regenerate */}

--- a/components/chat/ChatShell.tsx
+++ b/components/chat/ChatShell.tsx
@@ -39,6 +39,7 @@ export function ChatShell() {
     structured,
     error,
     duration_ms: durationMs,
+    ragRoute,
     start,
     abort,
   } = useStreamingAnswer();
@@ -135,6 +136,7 @@ export function ChatShell() {
             expertReviewReason={structured.expertReviewReason}
             conversationId={meta?.conversationId}
             messageId={meta?.messageId}
+            ragRoute={ragRoute}
           />
         </div>
       )}

--- a/components/chat/RagRouteBadge.tsx
+++ b/components/chat/RagRouteBadge.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+// @MX:NOTE RagRouteBadge — displays which RAG path served the answer: local/hybrid/regula.
+// @MX:SPEC Issue #200
+
+import type { RagRouteEvent } from '@/types/streaming';
+
+interface RagRouteBadgeProps {
+  route: RagRouteEvent;
+}
+
+const PATH_STYLES: Record<'local' | 'hybrid' | 'regula', { dot: string; label: string; badge: string }> =
+  {
+    local: {
+      dot: 'bg-ink-400',
+      label: '고객 Runtime',
+      badge: 'bg-ink-50 text-ink-700 border-ink-150',
+    },
+    hybrid: {
+      dot: 'bg-brand-500',
+      label: '하이브리드',
+      badge: 'bg-brand-50 text-brand-700 border-brand-200',
+    },
+    regula: {
+      dot: 'bg-brand-700',
+      label: 'Regula',
+      badge: 'bg-brand-100 text-brand-800 border-brand-300',
+    },
+  };
+
+const FALLBACK_REASON_TITLE: Record<NonNullable<RagRouteEvent['fallback_reason']>, string> = {
+  timeout: '응답 지연으로 대체 경로 사용',
+  unavailable: '서비스 불가로 대체 경로 사용',
+  degraded: '서비스 저하로 대체 경로 사용',
+};
+
+export function RagRouteBadge({ route }: RagRouteBadgeProps) {
+  const styles = PATH_STYLES[route.path];
+  const fallbackLabel = route.fallback ? ' (폴백)' : '';
+  const titleAttr = route.fallback_reason ? FALLBACK_REASON_TITLE[route.fallback_reason] : undefined;
+  const ariaLabel = `RAG 경로: ${styles.label}${fallbackLabel}${titleAttr ? ` — ${titleAttr}` : ''}`;
+
+  return (
+    <span
+      role="status"
+      aria-label={ariaLabel}
+      title={titleAttr}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${styles.badge}`}
+    >
+      <span className={`h-1.5 w-1.5 rounded-full ${styles.dot}`} aria-hidden="true" />
+      {styles.label}
+      {route.fallback && (
+        <span className="text-amber-600">(폴백)</span>
+      )}
+    </span>
+  );
+}

--- a/components/chat/RagRouteBadge.tsx
+++ b/components/chat/RagRouteBadge.tsx
@@ -9,24 +9,26 @@ interface RagRouteBadgeProps {
   route: RagRouteEvent;
 }
 
-const PATH_STYLES: Record<'local' | 'hybrid' | 'regula', { dot: string; label: string; badge: string }> =
-  {
-    local: {
-      dot: 'bg-ink-400',
-      label: '고객 Runtime',
-      badge: 'bg-ink-50 text-ink-700 border-ink-150',
-    },
-    hybrid: {
-      dot: 'bg-brand-500',
-      label: '하이브리드',
-      badge: 'bg-brand-50 text-brand-700 border-brand-200',
-    },
-    regula: {
-      dot: 'bg-brand-700',
-      label: 'Regula',
-      badge: 'bg-brand-100 text-brand-800 border-brand-300',
-    },
-  };
+const PATH_STYLES: Record<
+  'local' | 'hybrid' | 'regula',
+  { dot: string; label: string; badge: string }
+> = {
+  local: {
+    dot: 'bg-ink-400',
+    label: '고객 Runtime',
+    badge: 'bg-ink-50 text-ink-700 border-ink-150',
+  },
+  hybrid: {
+    dot: 'bg-brand-500',
+    label: '하이브리드',
+    badge: 'bg-brand-50 text-brand-700 border-brand-200',
+  },
+  regula: {
+    dot: 'bg-brand-700',
+    label: 'Regula',
+    badge: 'bg-brand-100 text-brand-800 border-brand-300',
+  },
+};
 
 const FALLBACK_REASON_TITLE: Record<NonNullable<RagRouteEvent['fallback_reason']>, string> = {
   timeout: '응답 지연으로 대체 경로 사용',
@@ -37,21 +39,20 @@ const FALLBACK_REASON_TITLE: Record<NonNullable<RagRouteEvent['fallback_reason']
 export function RagRouteBadge({ route }: RagRouteBadgeProps) {
   const styles = PATH_STYLES[route.path];
   const fallbackLabel = route.fallback ? ' (폴백)' : '';
-  const titleAttr = route.fallback_reason ? FALLBACK_REASON_TITLE[route.fallback_reason] : undefined;
+  const titleAttr = route.fallback_reason
+    ? FALLBACK_REASON_TITLE[route.fallback_reason]
+    : undefined;
   const ariaLabel = `RAG 경로: ${styles.label}${fallbackLabel}${titleAttr ? ` — ${titleAttr}` : ''}`;
 
   return (
-    <span
-      role="status"
+    <output
       aria-label={ariaLabel}
       title={titleAttr}
       className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${styles.badge}`}
     >
       <span className={`h-1.5 w-1.5 rounded-full ${styles.dot}`} aria-hidden="true" />
       {styles.label}
-      {route.fallback && (
-        <span className="text-amber-600">(폴백)</span>
-      )}
-    </span>
+      {route.fallback && <span className="text-amber-600">(폴백)</span>}
+    </output>
   );
 }

--- a/hooks/useStreamingAnswer.ts
+++ b/hooks/useStreamingAnswer.ts
@@ -16,6 +16,7 @@ import type { ConsultRequest } from '../types/consult';
 import {
   type ConfidenceEvent,
   type MetaEvent,
+  type RagRouteEvent,
   type SourceItem,
   type StreamEvent,
   type TraceEvent,
@@ -37,6 +38,7 @@ export interface StreamingState {
     related?: string[];
     expertReviewRequired?: boolean;
     expertReviewReason?: string;
+    ragRoute?: RagRouteEvent;
   };
   error: string | null;
   duration_ms: number | null;
@@ -138,6 +140,10 @@ function applyEvent(state: StreamingState, ev: StreamEvent): StreamingState {
     case 'related':
       return { ...state, structured: { ...state.structured, related: ev.items } };
 
+    // Issue #200 — RAG routing path badge.
+    case 'rag_route':
+      return { ...state, structured: { ...state.structured, ragRoute: ev } };
+
     default:
       return state;
   }
@@ -151,6 +157,7 @@ export interface UseStreamingAnswerReturn {
   meta: MetaEvent | undefined;
   error: StreamingState['error'];
   duration_ms: StreamingState['duration_ms'];
+  ragRoute: RagRouteEvent | undefined;
   start: (input: ConsultRequest) => void;
   abort: () => void;
 }
@@ -253,6 +260,7 @@ export function useStreamingAnswer(): UseStreamingAnswerReturn {
     meta: state.structured.meta,
     error: state.error,
     duration_ms: state.duration_ms,
+    ragRoute: state.structured.ragRoute,
     start,
     abort,
   };

--- a/tests/unit/rag-route-badge.test.tsx
+++ b/tests/unit/rag-route-badge.test.tsx
@@ -1,7 +1,10 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+/** @vitest-environment jsdom */
+
+import '@testing-library/jest-dom';
 import { RagRouteBadge } from '@/components/chat/RagRouteBadge';
 import type { RagRouteEvent } from '@/types/streaming';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
 describe('RagRouteBadge', () => {
   it('renders local path label', () => {
@@ -23,7 +26,12 @@ describe('RagRouteBadge', () => {
   });
 
   it('shows fallback indicator when fallback=true', () => {
-    const route: RagRouteEvent = { type: 'rag_route', path: 'local', fallback: true, fallback_reason: 'timeout' };
+    const route: RagRouteEvent = {
+      type: 'rag_route',
+      path: 'local',
+      fallback: true,
+      fallback_reason: 'timeout',
+    };
     render(<RagRouteBadge route={route} />);
     const badge = screen.getByRole('status');
     expect(badge).toHaveTextContent('폴백');
@@ -33,7 +41,10 @@ describe('RagRouteBadge', () => {
   it('has aria-label with path name', () => {
     const route: RagRouteEvent = { type: 'rag_route', path: 'hybrid' };
     render(<RagRouteBadge route={route} />);
-    expect(screen.getByRole('status')).toHaveAttribute('aria-label', expect.stringContaining('하이브리드'));
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('하이브리드'),
+    );
   });
 
   it('no title when no fallback_reason', () => {

--- a/tests/unit/rag-route-badge.test.tsx
+++ b/tests/unit/rag-route-badge.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RagRouteBadge } from '@/components/chat/RagRouteBadge';
+import type { RagRouteEvent } from '@/types/streaming';
+
+describe('RagRouteBadge', () => {
+  it('renders local path label', () => {
+    const route: RagRouteEvent = { type: 'rag_route', path: 'local' };
+    render(<RagRouteBadge route={route} />);
+    expect(screen.getByRole('status')).toHaveTextContent('고객 Runtime');
+  });
+
+  it('renders hybrid path label', () => {
+    const route: RagRouteEvent = { type: 'rag_route', path: 'hybrid' };
+    render(<RagRouteBadge route={route} />);
+    expect(screen.getByRole('status')).toHaveTextContent('하이브리드');
+  });
+
+  it('renders regula path label', () => {
+    const route: RagRouteEvent = { type: 'rag_route', path: 'regula' };
+    render(<RagRouteBadge route={route} />);
+    expect(screen.getByRole('status')).toHaveTextContent('Regula');
+  });
+
+  it('shows fallback indicator when fallback=true', () => {
+    const route: RagRouteEvent = { type: 'rag_route', path: 'local', fallback: true, fallback_reason: 'timeout' };
+    render(<RagRouteBadge route={route} />);
+    const badge = screen.getByRole('status');
+    expect(badge).toHaveTextContent('폴백');
+    expect(badge).toHaveAttribute('title', '응답 지연으로 대체 경로 사용');
+  });
+
+  it('has aria-label with path name', () => {
+    const route: RagRouteEvent = { type: 'rag_route', path: 'hybrid' };
+    render(<RagRouteBadge route={route} />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', expect.stringContaining('하이브리드'));
+  });
+
+  it('no title when no fallback_reason', () => {
+    const route: RagRouteEvent = { type: 'rag_route', path: 'regula' };
+    render(<RagRouteBadge route={route} />);
+    expect(screen.getByRole('status')).not.toHaveAttribute('title');
+  });
+});

--- a/types/streaming.ts
+++ b/types/streaming.ts
@@ -115,7 +115,15 @@ export interface ErrorEvent {
   message: string;
 }
 
-// StreamEvent union — 12 types total (8 Phase 2 + 4 Phase 3 reserve).
+// Issue #200 — RAG routing source event (emitted by hybrid-router; undefined when local-only).
+export interface RagRouteEvent {
+  type: 'rag_route';
+  path: 'local' | 'hybrid' | 'regula';
+  fallback?: boolean;
+  fallback_reason?: 'timeout' | 'unavailable' | 'degraded';
+}
+
+// StreamEvent union — 13 types total (8 Phase 2 + 4 Phase 3 reserve + 1 Issue #200).
 export type StreamEvent =
   | MetaEvent
   | TraceEvent
@@ -128,7 +136,8 @@ export type StreamEvent =
   | RelatedEvent
   | ExpertReviewRequiredEvent
   | DoneEvent
-  | ErrorEvent;
+  | ErrorEvent
+  | RagRouteEvent;
 
 // Known event type values for runtime guard.
 const KNOWN_TYPES = new Set<string>([
@@ -144,6 +153,7 @@ const KNOWN_TYPES = new Set<string>([
   'expert_review_required',
   'done',
   'error',
+  'rag_route',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- `types/streaming.ts` — `RagRouteEvent` 추가 (rag_route 이벤트, `KNOWN_TYPES` 업데이트)
- `RagRouteBadge` 컴포넌트 신규: local/hybrid/regula 각 경로를 색상 dot + 라벨 pill로 표시, fallback 상태 amber 표기
- `useStreamingAnswer` — `rag_route` 케이스 추가, `ragRoute` 반환
- `AnswerBlock` — `ragRoute` prop 추가, meta row에 `<RagRouteBadge />` 렌더
- `ChatShell` — `ragRoute` 추출 및 `AnswerBlock` 전달
- 단위 테스트: `tests/unit/rag-route-badge.test.tsx` (6 케이스)

## Test plan

- [ ] CI vitest 통과 확인
- [ ] 로컬 런타임 경로 → `고객 Runtime` 회색 뱃지
- [ ] hybrid 경로 → `하이브리드` 브랜드 뱃지
- [ ] regula 경로 → `Regula` 진한 브랜드 뱃지
- [ ] fallback=true → 폴백 amber 텍스트 + title tooltip

Closes #200

🗿 MoAI <email@mo.ai.kr>