### PR TITLE
feat(hybrid): audit 페이지 hybrid-ra 상태·내보내기 UX (#201)

### DIFF
--- a/app/(app)/audit/page.tsx
+++ b/app/(app)/audit/page.tsx
@@ -6,6 +6,7 @@
 'use client';
 
 import { AuditorWatermark } from '@/components/audit/AuditorWatermark';
+import { HybridAuditStatus } from '@/components/audit/HybridAuditStatus';
 import { useCallback, useEffect, useState } from 'react';
 import { AuditPackageBuilder } from './AuditPackageBuilder';
 
@@ -80,6 +81,9 @@ export default function AuditPage() {
       </header>
 
       <AuditPackageBuilder />
+
+      {/* Issue #201 — Hybrid RA audit status and export entry point */}
+      <HybridAuditStatus />
 
       <form
         className="flex flex-wrap gap-3 rounded-lg border border-ink-150 bg-surface p-4"

--- a/app/(app)/audit/page.tsx
+++ b/app/(app)/audit/page.tsx
@@ -82,7 +82,7 @@ export default function AuditPage() {
 
       <AuditPackageBuilder />
 
-      {/* Issue #201 — Hybrid RA audit status and export entry point */}
+      {/* Issue 201 — Hybrid RA audit status and export entry point */}
       <HybridAuditStatus />
 
       <form

--- a/app/api/ra/hybrid/audit-export/route.ts
+++ b/app/api/ra/hybrid/audit-export/route.ts
@@ -1,0 +1,44 @@
+// @MX:NOTE BFF for hybrid audit export — proxies exportAudit() and returns download URL.
+// @MX:SPEC Issue #201
+export const runtime = 'nodejs';
+
+import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
+import { z } from 'zod';
+
+const ExportSchema = z.object({
+  from: z.string().min(1),
+  to: z.string().min(1),
+  format: z.enum(['csv', 'json']).optional(),
+});
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = (await request.json()) as unknown;
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = ExportSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: 'Invalid request', details: parsed.error.issues }, { status: 400 });
+  }
+
+  try {
+    const data = await createHybridRaClient().exportAudit(parsed.data);
+    return Response.json({ status: 'ok', export: data });
+  } catch (err) {
+    if (err instanceof HybridRaClientError && err.kind === 'unconfigured') {
+      return Response.json({ status: 'unconfigured' }, { status: 200 });
+    }
+    const e = err instanceof HybridRaClientError ? err : null;
+    return Response.json(
+      {
+        status: 'error',
+        message: e?.message ?? 'Unknown error',
+        kind: e?.kind ?? 'server_error',
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/ra/hybrid/audit-export/route.ts
+++ b/app/api/ra/hybrid/audit-export/route.ts
@@ -3,6 +3,7 @@
 export const runtime = 'nodejs';
 
 import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
 import { z } from 'zod';
 
 const ExportSchema = z.object({
@@ -11,7 +12,7 @@ const ExportSchema = z.object({
   format: z.enum(['csv', 'json']).optional(),
 });
 
-export async function POST(request: Request) {
+export const POST = withPermission('audit.package.generate', async (request) => {
   let body: unknown;
   try {
     body = (await request.json()) as unknown;
@@ -21,7 +22,10 @@ export async function POST(request: Request) {
 
   const parsed = ExportSchema.safeParse(body);
   if (!parsed.success) {
-    return Response.json({ error: 'Invalid request', details: parsed.error.issues }, { status: 400 });
+    return Response.json(
+      { error: 'Invalid request', details: parsed.error.issues },
+      { status: 400 },
+    );
   }
 
   try {
@@ -41,4 +45,4 @@ export async function POST(request: Request) {
       { status: 502 },
     );
   }
-}
+});

--- a/app/api/ra/hybrid/audit-status/route.ts
+++ b/app/api/ra/hybrid/audit-status/route.ts
@@ -1,0 +1,25 @@
+// @MX:NOTE BFF for hybrid audit health — proxies health() to hide internal endpoint.
+// @MX:SPEC Issue #201
+export const runtime = 'nodejs';
+
+import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
+
+export async function GET() {
+  try {
+    const data = await createHybridRaClient().health();
+    return Response.json({ status: 'ok', health: data });
+  } catch (err) {
+    if (err instanceof HybridRaClientError && err.kind === 'unconfigured') {
+      return Response.json({ status: 'unconfigured' });
+    }
+    const e = err instanceof HybridRaClientError ? err : null;
+    return Response.json(
+      {
+        status: 'error',
+        message: e?.message ?? 'Unknown error',
+        kind: e?.kind ?? 'server_error',
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/ra/hybrid/audit-status/route.ts
+++ b/app/api/ra/hybrid/audit-status/route.ts
@@ -3,8 +3,9 @@
 export const runtime = 'nodejs';
 
 import { HybridRaClientError, createHybridRaClient } from '@/lib/api/hybrid-ra-client';
+import { withPermission } from '@/lib/auth/with-permission';
 
-export async function GET() {
+export const GET = withPermission('audit.read', async () => {
   try {
     const data = await createHybridRaClient().health();
     return Response.json({ status: 'ok', health: data });
@@ -22,4 +23,4 @@ export async function GET() {
       { status: 502 },
     );
   }
-}
+});

--- a/components/audit/HybridAuditStatus.tsx
+++ b/components/audit/HybridAuditStatus.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+// @MX:NOTE HybridAuditStatus — shows hybrid-ra health and exposes audit export entry point.
+// @MX:SPEC Issue #201
+
+import { useEffect, useState } from 'react';
+
+interface HealthState {
+  status: 'loading' | 'unconfigured' | 'ok' | 'degraded' | 'unavailable' | 'error';
+  version?: string;
+}
+
+interface ExportState {
+  status: 'idle' | 'loading' | 'done' | 'error';
+  downloadUrl?: string;
+  expiresAt?: string;
+  recordCount?: number;
+  error?: string;
+}
+
+export function HybridAuditStatus() {
+  const [health, setHealth] = useState<HealthState>({ status: 'loading' });
+  const [exportOpen, setExportOpen] = useState(false);
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [format, setFormat] = useState<'csv' | 'json'>('csv');
+  const [exportState, setExportState] = useState<ExportState>({ status: 'idle' });
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch('/api/ra/hybrid/audit-status');
+        const data = (await res.json()) as { status: string; health?: { status: string; version?: string } };
+        if (data.status === 'unconfigured') {
+          setHealth({ status: 'unconfigured' });
+        } else if (data.status === 'ok' && data.health) {
+          setHealth({ status: data.health.status as HealthState['status'], version: data.health.version });
+        } else {
+          setHealth({ status: 'error' });
+        }
+      } catch {
+        setHealth({ status: 'error' });
+      }
+    })();
+  }, []);
+
+  const handleExport = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!fromDate || !toDate) return;
+    setExportState({ status: 'loading' });
+    try {
+      const res = await fetch('/api/ra/hybrid/audit-export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ from: fromDate, to: toDate, format }),
+      });
+      const data = (await res.json()) as {
+        status: string;
+        export?: { download_url: string; expires_at: string; record_count: number };
+        message?: string;
+      };
+      if (data.status === 'ok' && data.export) {
+        setExportState({
+          status: 'done',
+          downloadUrl: data.export.download_url,
+          expiresAt: data.export.expires_at,
+          recordCount: data.export.record_count,
+        });
+      } else {
+        setExportState({ status: 'error', error: data.message ?? '내보내기 실패' });
+      }
+    } catch {
+      setExportState({ status: 'error', error: '요청 실패. 다시 시도하세요.' });
+    }
+  };
+
+  if (health.status === 'loading') {
+    return (
+      <div className="animate-pulse rounded-lg border border-ink-150 bg-ink-50 p-4 text-sm text-ink-400">
+        Hybrid RA 상태 확인 중…
+      </div>
+    );
+  }
+
+  if (health.status === 'unconfigured') {
+    return (
+      <div className="rounded-lg border border-ink-150 bg-ink-50 p-4 text-sm text-ink-500">
+        Hybrid RA가 구성되지 않았습니다. Audit export는 Hybrid RA 연동 시 활성화됩니다.
+      </div>
+    );
+  }
+
+  const statusDot =
+    health.status === 'ok'
+      ? 'bg-success-500'
+      : health.status === 'degraded'
+        ? 'bg-amber-500'
+        : 'bg-danger-500';
+
+  const statusLabel =
+    health.status === 'ok' ? '정상' : health.status === 'degraded' ? '저하' : '불가';
+
+  return (
+    <div className="rounded-lg border border-ink-150 bg-surface p-4 text-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className={`h-2 w-2 rounded-full ${statusDot}`} aria-hidden="true" />
+          <span className="font-medium text-ink-900">Hybrid RA</span>
+          <span className="text-ink-500">{statusLabel}</span>
+          {health.version && <span className="text-ink-400">v{health.version}</span>}
+        </div>
+        {health.status === 'ok' && (
+          <button
+            type="button"
+            onClick={() => { setExportOpen((o) => !o); setExportState({ status: 'idle' }); }}
+            className="rounded border border-brand-300 px-3 py-1 text-xs text-brand-700 hover:bg-brand-50 transition-colors"
+          >
+            {exportOpen ? '닫기' : 'Audit 내보내기'}
+          </button>
+        )}
+      </div>
+
+      {health.status === 'degraded' && (
+        <p className="mt-2 text-xs text-amber-700">
+          Hybrid RA 서비스가 저하 상태입니다. Audit export 결과가 불완전할 수 있습니다.
+        </p>
+      )}
+
+      {health.status === 'unavailable' && (
+        <p className="mt-2 text-xs text-danger">
+          Hybrid RA 서비스에 연결할 수 없습니다. 관리자에게 문의하세요.
+        </p>
+      )}
+
+      {exportOpen && (
+        <form onSubmit={(e) => { void handleExport(e); }} className="mt-4 flex flex-col gap-3 border-t border-ink-100 pt-4">
+          <div className="flex flex-wrap gap-3">
+            <label className="flex flex-col text-xs text-ink-600">
+              시작일
+              <input
+                type="date"
+                value={fromDate}
+                onChange={(e) => setFromDate(e.target.value)}
+                required
+                className="mt-1 rounded border border-ink-150 px-2 py-1 text-sm"
+              />
+            </label>
+            <label className="flex flex-col text-xs text-ink-600">
+              종료일
+              <input
+                type="date"
+                value={toDate}
+                onChange={(e) => setToDate(e.target.value)}
+                required
+                className="mt-1 rounded border border-ink-150 px-2 py-1 text-sm"
+              />
+            </label>
+            <label className="flex flex-col text-xs text-ink-600">
+              형식
+              <select
+                value={format}
+                onChange={(e) => setFormat(e.target.value as 'csv' | 'json')}
+                className="mt-1 rounded border border-ink-150 px-2 py-1 text-sm"
+              >
+                <option value="csv">CSV</option>
+                <option value="json">JSON</option>
+              </select>
+            </label>
+          </div>
+
+          <button
+            type="submit"
+            disabled={exportState.status === 'loading'}
+            className="self-start rounded bg-brand-700 px-4 py-1 text-xs text-white disabled:opacity-50 hover:bg-brand-800 transition-colors"
+          >
+            {exportState.status === 'loading' ? '처리 중…' : '내보내기 시작'}
+          </button>
+
+          {exportState.status === 'done' && exportState.downloadUrl && (
+            <div className="rounded-lg border border-success-200 bg-success-50 p-3">
+              <p className="text-xs font-medium text-success-700">
+                내보내기 완료 ({exportState.recordCount?.toLocaleString()}건)
+              </p>
+              <a
+                href={exportState.downloadUrl}
+                download
+                className="mt-1 inline-block text-xs text-brand-700 underline hover:text-brand-900"
+              >
+                다운로드
+              </a>
+              {exportState.expiresAt && (
+                <p className="mt-1 text-xs text-ink-500">
+                  만료: {new Intl.DateTimeFormat('ko-KR', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(exportState.expiresAt))}
+                </p>
+              )}
+            </div>
+          )}
+
+          {exportState.status === 'error' && (
+            <p className="text-xs text-danger">{exportState.error}</p>
+          )}
+        </form>
+      )}
+    </div>
+  );
+}

--- a/components/audit/HybridAuditStatus.tsx
+++ b/components/audit/HybridAuditStatus.tsx
@@ -30,11 +30,17 @@ export function HybridAuditStatus() {
     void (async () => {
       try {
         const res = await fetch('/api/ra/hybrid/audit-status');
-        const data = (await res.json()) as { status: string; health?: { status: string; version?: string } };
+        const data = (await res.json()) as {
+          status: string;
+          health?: { status: string; version?: string };
+        };
         if (data.status === 'unconfigured') {
           setHealth({ status: 'unconfigured' });
         } else if (data.status === 'ok' && data.health) {
-          setHealth({ status: data.health.status as HealthState['status'], version: data.health.version });
+          setHealth({
+            status: data.health.status as HealthState['status'],
+            version: data.health.version,
+          });
         } else {
           setHealth({ status: 'error' });
         }
@@ -112,7 +118,10 @@ export function HybridAuditStatus() {
         {health.status === 'ok' && (
           <button
             type="button"
-            onClick={() => { setExportOpen((o) => !o); setExportState({ status: 'idle' }); }}
+            onClick={() => {
+              setExportOpen((o) => !o);
+              setExportState({ status: 'idle' });
+            }}
             className="rounded border border-brand-300 px-3 py-1 text-xs text-brand-700 hover:bg-brand-50 transition-colors"
           >
             {exportOpen ? '닫기' : 'Audit 내보내기'}
@@ -133,7 +142,12 @@ export function HybridAuditStatus() {
       )}
 
       {exportOpen && (
-        <form onSubmit={(e) => { void handleExport(e); }} className="mt-4 flex flex-col gap-3 border-t border-ink-100 pt-4">
+        <form
+          onSubmit={(e) => {
+            void handleExport(e);
+          }}
+          className="mt-4 flex flex-col gap-3 border-t border-ink-100 pt-4"
+        >
           <div className="flex flex-wrap gap-3">
             <label className="flex flex-col text-xs text-ink-600">
               시작일
@@ -190,7 +204,11 @@ export function HybridAuditStatus() {
               </a>
               {exportState.expiresAt && (
                 <p className="mt-1 text-xs text-ink-500">
-                  만료: {new Intl.DateTimeFormat('ko-KR', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(exportState.expiresAt))}
+                  만료:{' '}
+                  {new Intl.DateTimeFormat('ko-KR', {
+                    dateStyle: 'short',
+                    timeStyle: 'short',
+                  }).format(new Date(exportState.expiresAt))}
                 </p>
               )}
             </div>

--- a/tests/unit/hybrid-audit-export-route.test.ts
+++ b/tests/unit/hybrid-audit-export-route.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class HybridRaClientError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public endpoint: string,
+    public kind: string,
+  ) {
+    super(message);
+    this.name = 'HybridRaClientError';
+  }
+}
+
+const mockExportAudit = vi.fn();
+vi.mock('@/lib/api/hybrid-ra-client', () => ({
+  HybridRaClientError,
+  createHybridRaClient: () => ({ exportAudit: mockExportAudit }),
+}));
+
+const withPermissionMock = vi.fn(
+  (_action: string, handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>) =>
+    (req: Request, ctx: unknown) =>
+      handler(req, ctx, {
+        user: {
+          id: 'user-auditor-1',
+          role: 'auditor',
+          organizationId: 'org-1',
+        },
+      }),
+);
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: withPermissionMock,
+}));
+
+const { POST } = await import('@/app/api/ra/hybrid/audit-export/route');
+
+function makeReq(body: unknown): Request {
+  return new Request('https://example.com/api/ra/hybrid/audit-export', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/ra/hybrid/audit-export', () => {
+  beforeEach(() => {
+    mockExportAudit.mockReset();
+  });
+
+  it('is gated by audit package RBAC before proxying', () => {
+    expect(withPermissionMock).toHaveBeenCalledWith('audit.package.generate', expect.any(Function));
+  });
+
+  it('returns ok with export URL on success', async () => {
+    mockExportAudit.mockResolvedValueOnce({
+      export_id: 'exp-123',
+      download_url: 'https://storage.example.com/audit.csv',
+      expires_at: '2026-06-23T00:00:00Z',
+      record_count: 25,
+    });
+
+    const res = await POST(makeReq({ from: '2026-06-01', to: '2026-06-22', format: 'csv' }), {});
+    const data = (await res.json()) as { status: string; export: { download_url: string } };
+
+    expect(res.status).toBe(200);
+    expect(data.status).toBe('ok');
+    expect(data.export.download_url).toContain('audit.csv');
+    expect(mockExportAudit).toHaveBeenCalledWith({
+      from: '2026-06-01',
+      to: '2026-06-22',
+      format: 'csv',
+    });
+  });
+});

--- a/tests/unit/hybrid-audit-status-route.test.ts
+++ b/tests/unit/hybrid-audit-status-route.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+class HybridRaClientError extends Error {
+  constructor(public kind: string, message: string) {
+    super(message);
+    this.name = 'HybridRaClientError';
+  }
+}
+
+const mockHealth = vi.fn();
+vi.mock('@/lib/api/hybrid-ra-client', () => ({
+  HybridRaClientError,
+  createHybridRaClient: () => ({ health: mockHealth }),
+}));
+
+const { GET } = await import('@/app/api/ra/hybrid/audit-status/route');
+
+describe('GET /api/ra/hybrid/audit-status', () => {
+  it('returns unconfigured when hybrid-ra is not set up', async () => {
+    mockHealth.mockRejectedValueOnce(new HybridRaClientError('unconfigured', 'not configured'));
+    const res = await GET();
+    const data = await res.json() as { status: string };
+    expect(data.status).toBe('unconfigured');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns ok with health data on success', async () => {
+    mockHealth.mockResolvedValueOnce({ status: 'ok', version: '1.2.3' });
+    const res = await GET();
+    const data = await res.json() as { status: string; health: { status: string; version: string } };
+    expect(data.status).toBe('ok');
+    expect(data.health.version).toBe('1.2.3');
+  });
+
+  it('returns error with 502 on server_error kind', async () => {
+    mockHealth.mockRejectedValueOnce(new HybridRaClientError('server_error', 'internal error'));
+    const res = await GET();
+    const data = await res.json() as { status: string; kind: string };
+    expect(data.status).toBe('error');
+    expect(data.kind).toBe('server_error');
+    expect(res.status).toBe(502);
+  });
+
+  it('returns error with kind server_error on unexpected exception', async () => {
+    mockHealth.mockRejectedValueOnce(new Error('unexpected'));
+    const res = await GET();
+    const data = await res.json() as { status: string; kind: string };
+    expect(data.status).toBe('error');
+    expect(data.kind).toBe('server_error');
+  });
+});

--- a/tests/unit/hybrid-audit-status-route.test.ts
+++ b/tests/unit/hybrid-audit-status-route.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 class HybridRaClientError extends Error {
-  constructor(public kind: string, message: string) {
+  constructor(
+    public kind: string,
+    message: string,
+  ) {
     super(message);
     this.name = 'HybridRaClientError';
   }
@@ -13,29 +16,52 @@ vi.mock('@/lib/api/hybrid-ra-client', () => ({
   createHybridRaClient: () => ({ health: mockHealth }),
 }));
 
+const withPermissionMock = vi.fn(
+  (_action: string, handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>) =>
+    (req: Request, ctx: unknown) =>
+      handler(req, ctx, {
+        user: {
+          id: 'user-auditor-1',
+          role: 'auditor',
+          organizationId: 'org-1',
+        },
+      }),
+);
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: withPermissionMock,
+}));
+
 const { GET } = await import('@/app/api/ra/hybrid/audit-status/route');
 
 describe('GET /api/ra/hybrid/audit-status', () => {
+  it('is gated by audit read RBAC before proxying', () => {
+    expect(withPermissionMock).toHaveBeenCalledWith('audit.read', expect.any(Function));
+  });
+
   it('returns unconfigured when hybrid-ra is not set up', async () => {
     mockHealth.mockRejectedValueOnce(new HybridRaClientError('unconfigured', 'not configured'));
-    const res = await GET();
-    const data = await res.json() as { status: string };
+    const res = await GET(new Request('https://example.com/api/ra/hybrid/audit-status'), {});
+    const data = (await res.json()) as { status: string };
     expect(data.status).toBe('unconfigured');
     expect(res.status).toBe(200);
   });
 
   it('returns ok with health data on success', async () => {
     mockHealth.mockResolvedValueOnce({ status: 'ok', version: '1.2.3' });
-    const res = await GET();
-    const data = await res.json() as { status: string; health: { status: string; version: string } };
+    const res = await GET(new Request('https://example.com/api/ra/hybrid/audit-status'), {});
+    const data = (await res.json()) as {
+      status: string;
+      health: { status: string; version: string };
+    };
     expect(data.status).toBe('ok');
     expect(data.health.version).toBe('1.2.3');
   });
 
   it('returns error with 502 on server_error kind', async () => {
     mockHealth.mockRejectedValueOnce(new HybridRaClientError('server_error', 'internal error'));
-    const res = await GET();
-    const data = await res.json() as { status: string; kind: string };
+    const res = await GET(new Request('https://example.com/api/ra/hybrid/audit-status'), {});
+    const data = (await res.json()) as { status: string; kind: string };
     expect(data.status).toBe('error');
     expect(data.kind).toBe('server_error');
     expect(res.status).toBe(502);
@@ -43,8 +69,8 @@ describe('GET /api/ra/hybrid/audit-status', () => {
 
   it('returns error with kind server_error on unexpected exception', async () => {
     mockHealth.mockRejectedValueOnce(new Error('unexpected'));
-    const res = await GET();
-    const data = await res.json() as { status: string; kind: string };
+    const res = await GET(new Request('https://example.com/api/ra/hybrid/audit-status'), {});
+    const data = (await res.json()) as { status: string; kind: string };
     expect(data.status).toBe('error');
     expect(data.kind).toBe('server_error');
   });


### PR DESCRIPTION
## Summary

- BFF `GET /api/ra/hybrid/audit-status` — `health()` 프록시, unconfigured → HTTP 200
- BFF `POST /api/ra/hybrid/audit-export` — `exportAudit()` 프록시, Zod 입력 검증(from/to/format)
- `HybridAuditStatus` 컴포넌트: ok/degraded/unavailable/unconfigured 4개 상태 + 날짜범위·포맷 선택 내보내기 폼(ok 상태에서만 노출) + 다운로드 링크
- `app/(app)/audit/page.tsx` — `AuditPackageBuilder` 뒤에 `<HybridAuditStatus />` 삽입. 외부감사자(read-only) 흐름은 건드리지 않음
- 단위 테스트: `tests/unit/hybrid-audit-status-route.test.ts` (4 케이스)

## Test plan

- [ ] CI vitest 통과 확인
- [ ] unconfigured → 중립 회색 안내 카드, 내보내기 버튼 없음
- [ ] degraded → 상태 도트 amber + 경고 메시지, 내보내기 버튼 없음
- [ ] ok → 정상 도트 + `Audit 내보내기` 버튼 표시
- [ ] 내보내기 완료 → 다운로드 링크 + 만료일 표시
- [ ] 외부감사자 워터마크 등 기존 요소 정상 공존 확인

Closes #201

🗿 MoAI <email@mo.ai.kr>