### PR TITLE
Fix weekly digest cron filtering and retries

### DIFF
--- a/lib/inngest/__tests__/weekly-digest.test.ts
+++ b/lib/inngest/__tests__/weekly-digest.test.ts
@@ -2,6 +2,7 @@
 // Regression coverage for manual digest replay targeting.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DigestPayload } from '../../digest/digest-generator';
 
 const ormMocks = vi.hoisted(() => ({
   and: vi.fn((...clauses: unknown[]) => ({ clauses, op: 'and' })),
@@ -20,7 +21,7 @@ vi.mock('drizzle-orm', async (importOriginal) => {
 });
 
 import { orgDigestPreferences } from '../../db/schema';
-import { buildDigestPreferencesPredicate } from '../digest/weekly-digest';
+import { buildDigestPreferencesPredicate, processDigestPreference } from '../digest/weekly-digest';
 
 describe('buildDigestPreferencesPredicate', () => {
   beforeEach(() => {
@@ -47,16 +48,48 @@ describe('buildDigestPreferencesPredicate', () => {
     });
   });
 
-  it('keeps scheduled cron runs scoped to enabled preferences only', () => {
+  it('keeps scheduled cron runs scoped to weekly preferences only', () => {
     const predicate = buildDigestPreferencesPredicate({});
 
-    expect(ormMocks.eq).not.toHaveBeenCalled();
+    expect(ormMocks.eq).toHaveBeenCalledWith(orgDigestPreferences.frequency, 'weekly');
     expect(ormMocks.and).not.toHaveBeenCalled();
-    expect(ormMocks.ne).toHaveBeenCalledWith(orgDigestPreferences.frequency, 'disabled');
+    expect(ormMocks.ne).not.toHaveBeenCalled();
     expect(predicate).toEqual({
       left: orgDigestPreferences.frequency,
-      op: 'ne',
-      right: 'disabled',
+      op: 'eq',
+      right: 'weekly',
     });
+  });
+});
+
+describe('processDigestPreference', () => {
+  const payload = { week_id: '2026-W25' } as DigestPayload;
+
+  it('throws when digest email delivery returns false so Inngest can retry the step', async () => {
+    const errorLogger = vi.fn();
+    const generateWeeklyDigest = vi.fn().mockResolvedValue(payload);
+    const sendDigestEmail = vi.fn().mockResolvedValue(false);
+
+    await expect(
+      processDigestPreference({
+        generateWeeklyDigest,
+        logger: { error: errorLogger },
+        pref: {
+          orgId: '00000000-0000-0000-0000-000000000001',
+          recipientEmails: ['ra@example.com'],
+        },
+        sendDigestEmail,
+        weekId: '2026-W25',
+      }),
+    ).rejects.toThrow('Digest email send failed for org 00000000-0000-0000-0000-000000000001');
+
+    expect(generateWeeklyDigest).toHaveBeenCalledWith(
+      '00000000-0000-0000-0000-000000000001',
+      '2026-W25',
+    );
+    expect(sendDigestEmail).toHaveBeenCalledWith('00000000-0000-0000-0000-000000000001', payload, [
+      'ra@example.com',
+    ]);
+    expect(errorLogger).toHaveBeenCalled();
   });
 });

--- a/lib/inngest/digest/weekly-digest.ts
+++ b/lib/inngest/digest/weekly-digest.ts
@@ -1,18 +1,55 @@
 // @MX:SPEC SPEC-REGULA-DIGEST-001 (Phase 2 — Inngest cron wiring)
-// Weekly regulatory intelligence digest: enumerates orgs with frequency != disabled,
+// Weekly regulatory intelligence digest: enumerates weekly org preferences,
 // generates the payload, and dispatches email via the digest sender.
 
 import { and, eq, ne } from 'drizzle-orm';
 import { orgDigestPreferences } from '../../db/schema';
+import type { DigestPayload } from '../../digest/digest-generator';
 import { INNGEST_EVENTS, inngest } from '../client';
 
 type DigestWeeklyTriggerData = { orgId?: string; weekId?: string };
+type DigestPreference = Pick<typeof orgDigestPreferences.$inferSelect, 'orgId' | 'recipientEmails'>;
+type DigestLogger = { error: (message: string, err?: unknown) => void };
 
 export function buildDigestPreferencesPredicate(data: DigestWeeklyTriggerData) {
-  const enabledPreference = ne(orgDigestPreferences.frequency, 'disabled');
   return data.orgId
-    ? and(eq(orgDigestPreferences.orgId, data.orgId), enabledPreference)
-    : enabledPreference;
+    ? and(
+        eq(orgDigestPreferences.orgId, data.orgId),
+        ne(orgDigestPreferences.frequency, 'disabled'),
+      )
+    : eq(orgDigestPreferences.frequency, 'weekly');
+}
+
+export async function processDigestPreference({
+  generateWeeklyDigest,
+  logger,
+  pref,
+  sendDigestEmail,
+  weekId,
+}: {
+  generateWeeklyDigest: (orgId: string, weekId?: string) => Promise<DigestPayload>;
+  logger: DigestLogger;
+  pref: DigestPreference;
+  sendDigestEmail: (
+    orgId: string,
+    payload: DigestPayload,
+    recipientEmails: string[],
+  ) => Promise<boolean>;
+  weekId?: string;
+}): Promise<1> {
+  try {
+    const payload = await generateWeeklyDigest(pref.orgId, weekId);
+    if (pref.recipientEmails.length > 0) {
+      const sent = await sendDigestEmail(pref.orgId, payload, pref.recipientEmails);
+      if (!sent) {
+        throw new Error(`Digest email send failed for org ${pref.orgId}`);
+      }
+    }
+    return 1;
+  } catch (err) {
+    logger.error(`[digest-cron] Failed for org ${pref.orgId}:`, err);
+    throw err;
+  }
 }
 
 /** Cron schedule: every Monday at 00:00 UTC. Orgs apply their own tz offset. */
@@ -46,18 +83,15 @@ export const weeklyDigestFn = inngest.createFunction(
 
     let processed = 0;
     for (const pref of prefs) {
-      const count = await step.run(`digest-org-${pref.orgId}`, async () => {
-        try {
-          const payload = await generateWeeklyDigest(pref.orgId, data.weekId);
-          if (pref.recipientEmails.length > 0) {
-            await sendDigestEmail(pref.orgId, payload, pref.recipientEmails);
-          }
-          return 1;
-        } catch (err) {
-          logger.error(`[digest-cron] Failed for org ${pref.orgId}:`, err);
-          return 0;
-        }
-      });
+      const count = await step.run(`digest-org-${pref.orgId}`, () =>
+        processDigestPreference({
+          generateWeeklyDigest,
+          logger,
+          pref,
+          sendDigestEmail,
+          weekId: data.weekId,
+        }),
+      );
       processed += count;
     }
 


### PR DESCRIPTION
## Summary
- Restrict scheduled weekly digest cron selection to weekly preferences only
- Treat false email delivery results as per-org step failures so Inngest can retry
- Add regression tests for cron filtering and failed send retry behavior

## Tests
- pnpm vitest run lib/inngest/__tests__/weekly-digest.test.ts
- pnpm typecheck
- pnpm lint