### PR TITLE
docs(specs): 26개 SPEC-REGULA 일괄 작성 + README 대시보드 갱신

### DIFF
--- a/.moai/specs/SPEC-REGULA-ADOPTION-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-ADOPTION-001/spec.md
@@ -1,0 +1,147 @@
+---
+id: SPEC-REGULA-ADOPTION-001
+version: 1.0.0
+status: draft
+phase: wave4
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 38
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-BREADTH-001
+  - SPEC-REGULA-ENTERPRISE-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/frontend
+  - component/infra
+---
+
+# SPEC-REGULA-ADOPTION-001 — 사용자 온보딩·성과 KPI·피드백 루프
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #38 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+릴리즈/품질/고급 RA 기능이 모두 완료되면 제품은 강력해지지만, 6~20명 규모의 내부 사용자가 실제로 반복 사용하려면 온보딩, 역할별 첫 작업, 신뢰 피드백, 성과 지표가 필요하다. 기능이 존재하는 것과 사용자가 그 기능을 채택하는 것은 별개의 문제다.
+
+본 SPEC은 Regula의 실사용 채택률(adoption rate)과 개선 우선순위를 측정하기 위한 제품 운영(product-ops) 시스템을 정의한다. 핵심은 역할별 온보딩, 답변별 in-product 피드백, PII-safe KPI 대시보드, 주간 success review export 네 가지다.
+
+기존 onboarding은 브라우저 localStorage에 상태를 저장하므로 기기 간 동기화가 되지 않고 audit 추적이 불가능하다. 본 SPEC은 이를 user profile 기반 서버 상태로 승격하여 신뢰 가능한 채택 지표를 확보한다.
+
+피드백 루프는 단순 별점 수집이 아니라 reason taxonomy(citation missing, outdated source 등)로 구조화하여, #35 Knowledge Gap Ops 또는 #36 Review Ops의 실제 action으로 전환 가능하게 한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- 21 CFR Part 11 — onboarding 완료/스킵/재시작 및 feedback 전환은 audit trail로 기록되어야 한다 (electronic records).
+- 개인정보 보호 원칙 (data minimization) — KPI 및 analytics는 PII-safe aggregate만 저장하며 개인별 생산성 평가 목적으로 사용하지 않는다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- A. 역할별 온보딩: RA, Dev/QA, Exec, External 역할별 first task preset, localStorage → user profile 서버 상태 승격, onboarding 이벤트 audit/analytics 기록
+- B. In-Product Feedback: 답변별 useful/not useful + reason taxonomy 수집, #35/#36 action 전환
+- C. KPI Dashboard: WAU, answered-with-citation, unanswered rate, review turnaround, replay pass rate 등 PII-safe aggregate 지표
+- D. Success Review Export: 주간 내부 리뷰용 Markdown/CSV export
+
+### 1.4 Out of Scope
+
+- 외부 고객 과금/CRM 분석
+- 세션 리플레이 녹화 (screen recording)
+- 개인별 생산성 평가 (individual productivity scoring)
+- 외부 마케팅 analytics 연동
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-ADOPTION-001 | WHEN 사용자가 최초 로그인하면 THE SYSTEM SHALL 사용자 역할(RA/Dev-QA/Exec/External)에 맞는 onboarding flow를 표시해야 한다 | High |
+| REQ-ADOPTION-002 | THE SYSTEM SHALL onboarding 상태(완료/스킵/진행중)를 user profile 기반 서버 상태로 영속 저장해야 한다 | High |
+| REQ-ADOPTION-003 | WHEN onboarding이 완료/스킵/재시작되면 THE SYSTEM SHALL 해당 이벤트를 audit_logs와 analytics에 기록해야 한다 | High |
+| REQ-ADOPTION-004 | THE SYSTEM SHALL 각 역할별 first task preset을 제공하여 사용자가 첫 작업을 즉시 시작할 수 있게 해야 한다 | High |
+| REQ-ADOPTION-005 | WHEN 사용자가 답변에 대해 useful/not useful을 선택하면 THE SYSTEM SHALL 해당 피드백을 답변 ID와 함께 저장해야 한다 | High |
+| REQ-ADOPTION-006 | WHEN not useful 피드백이 제출되면 THE SYSTEM SHALL reason taxonomy(citation missing/outdated source/unclear answer/workflow too slow/needs expert review) 선택을 요청해야 한다 | High |
+| REQ-ADOPTION-007 | WHERE 피드백이 citation/source 관련일 경우 THE SYSTEM SHALL 해당 피드백을 #35 Knowledge Gap Ops action으로 전환 가능하게 해야 한다 | Medium |
+| REQ-ADOPTION-008 | WHERE 피드백이 expert review 관련일 경우 THE SYSTEM SHALL 해당 피드백을 #36 Review Ops action으로 전환 가능하게 해야 한다 | Medium |
+| REQ-ADOPTION-009 | THE SYSTEM SHALL KPI 대시보드에 WAU, answered-with-citation rate, unanswered rate, review turnaround, replay pass rate를 표시해야 한다 | High |
+| REQ-ADOPTION-010 | THE SYSTEM SHALL time-to-first-cited-answer, expert review SLA, knowledge gap resolution time 지표를 집계해야 한다 | Medium |
+| REQ-ADOPTION-011 | THE SYSTEM SHALL 모든 KPI 및 analytics 데이터를 PII-safe aggregate 형태로만 저장해야 한다 | High |
+| REQ-ADOPTION-012 | THE SYSTEM SHALL NOT 개인별 식별 가능한 생산성 점수를 저장하거나 표시해야 한다 | High |
+| REQ-ADOPTION-013 | WHEN 주간 success review export가 요청되면 THE SYSTEM SHALL Markdown 및 CSV 형식으로 unresolved gap, high-value topics, failing eval scenario를 묶어 생성해야 한다 | Medium |
+| REQ-ADOPTION-014 | IF KPI 대시보드 접근 권한이 없는 사용자가 요청하면 THEN THE SYSTEM SHALL 접근을 거부하고 audit_logs에 기록해야 한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | 최초 로그인 시 역할별 onboarding flow가 표시되고 first task preset이 제공됨 | E2E: 4개 역할 계정으로 로그인 후 각 preset 노출 확인 |
+| AC-02 | onboarding 상태가 user profile에 서버 저장되어 기기 변경 후에도 유지됨 | Integration: 상태 저장 후 다른 세션에서 조회 |
+| AC-03 | onboarding 완료/스킵/재시작 이벤트가 audit_logs에 기록됨 | DB 조회: audit_logs에 해당 action row 존재 확인 |
+| AC-04 | 답변별 feedback이 reason taxonomy와 함께 저장됨 | Integration: feedback 제출 후 DB row + reason 분류 검증 |
+| AC-05 | citation/expert 관련 feedback이 #35 또는 #36 action으로 전환됨 | Integration: 전환 API 호출 후 대상 큐에 항목 생성 확인 |
+| AC-06 | KPI 대시보드가 PII-safe aggregate 지표만 표시함 | 수동 QA + 코드 리뷰: 개인 식별자 미포함 검증 |
+| AC-07 | 권한 없는 사용자의 KPI 접근이 차단되고 audit에 기록됨 | E2E: External 계정으로 대시보드 접근 시 403 + audit row |
+| AC-08 | 주간 success review가 Markdown 및 CSV로 export됨 | Integration: export 실행 후 두 형식 파일 생성 및 내용 검증 |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/
+    api/
+      onboarding/route.ts          # onboarding 상태 저장/조회
+      feedback/route.ts            # 답변 피드백 수집
+      feedback/convert/route.ts    # #35/#36 action 전환
+      kpi/route.ts                 # KPI aggregate 조회
+      success-review/export/route.ts
+    (dashboard)/
+      onboarding/page.tsx          # 역할별 onboarding UI
+      kpi/page.tsx                 # KPI 대시보드
+  lib/
+    onboarding/role-presets.ts     # 역할별 first task preset 정의
+    feedback/taxonomy.ts           # reason taxonomy 상수
+    kpi/aggregator.ts              # PII-safe aggregate 계산
+    kpi/success-review.ts          # Markdown/CSV export
+  db/
+    schema/onboarding.ts
+    schema/feedback.ts
+    schema/kpi-snapshots.ts
+```
+
+### 4.2 DB Schema
+
+- `user_onboarding`: user_id (FK), role, status (completed/skipped/in_progress), completed_steps (jsonb), updated_at
+- `answer_feedback`: id, answer_id (FK), user_id (FK), useful (boolean), reason_code (enum: citation_missing/outdated_source/unclear_answer/workflow_too_slow/needs_expert_review), comment (text, nullable), converted_to (enum: knowledge_gap/review_ops/null), created_at
+- `kpi_snapshots`: id, period_start, period_end, metric_key, metric_value (numeric), aggregate_only (boolean, default true), created_at
+- `audit_logs` (기존): onboarding 및 feedback 전환 이벤트 추가 기록
+
+### 4.3 API Endpoints
+
+- `GET/PUT /api/onboarding` — 역할별 onboarding 상태 조회/갱신
+- `POST /api/feedback` — 답변 피드백 제출 (useful + reason_code)
+- `POST /api/feedback/convert` — #35 Knowledge Gap 또는 #36 Review Ops로 전환
+- `GET /api/kpi` — PII-safe aggregate KPI 조회 (RBAC: RA/Exec 한정)
+- `POST /api/success-review/export` — Markdown/CSV export 생성
+
+### 4.4 의존성
+
+- 선행: SPEC-REGULA-FOUNDATION-001 (auth, audit_logs, user profile), SPEC-REGULA-BREADTH-001, SPEC-REGULA-ENTERPRISE-001
+- 연계: #35 Knowledge Gap Ops, #36 Review Ops (feedback 전환 대상)
+- 기술: Next.js 15 App Router, Auth.js v5 (역할/RBAC), Drizzle ORM, PostgreSQL

--- a/.moai/specs/SPEC-REGULA-BATCH-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-BATCH-001/spec.md
@@ -1,0 +1,133 @@
+---
+id: SPEC-REGULA-BATCH-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 43
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-ENTERPRISE-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-BATCH-001 — 배치 질의 모드 (사전 미팅 준비·대량 규제 Q&A)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #43 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+RA 팀은 반복적으로 대량의 규제 질의를 한꺼번에 처리해야 한다. 대표적인 시나리오는 FDA Pre-Submission Meeting 준비를 위한 20~50개 질의응답 작성, EU MDR Technical File 검토를 위한 100개 항목 체크리스트 일괄 확인, 규제기관 감사 준비를 위한 기 제출 답변의 현행 규제 적합성 재검토, RA 신입 교육용 기본 규제 지식 Q&A 일괄 생성이다.
+
+현재 Regula는 한 번에 한 질문씩만 처리한다. 이를 개별로 입력하면 20~50회의 반복 작업이 필요하여 비효율적이다. 본 SPEC은 CSV/Excel/TSV 업로드 또는 인라인 입력을 통해 다수의 질문을 한 번에 받아 병렬 RAG 처리하고, 결과를 DOCX/Excel/PDF로 export하는 배치 질의 모드를 구현한다.
+
+배치 처리는 질문 1건을 1 job으로 큐잉하여 독립 처리 및 실패 격리를 보장하며, 중간 실패 시 완료된 부분 결과를 보존하고 재개 가능하도록 한다. 신뢰도가 낮은 답변은 자동 플래그하여 expert review로 연결한다.
+
+본 기능은 기존 DocIngest 인프라(Cloudflare Queue 또는 Inngest)를 재활용하며, RBAC 기반 배치 접근 권한을 적용한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA: Pre-Submission Program (Q-Submission), Pre-Sub Meeting 양식
+- EU MDR: Regulation (EU) 2017/745, Technical File / Technical Documentation
+- PMDA: 사전 상담 (consultation)
+- MFDS: Q&A 양식
+- 모든 배치 처리는 audit log 기록 및 citation 포함을 요구한다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- A. 배치 입력 인터페이스: CSV/Excel/TSV 업로드, 인라인 텍스트 편집기, 템플릿 선택(FDA Pre-Sub, EU MDR TechFile, PMDA 사전 상담, MFDS Q&A), 최대 100건 제한
+- B. 배치 처리 엔진: 병렬 RAG 처리(concurrency 10), citation 포함 답변 생성, 신뢰도 < 0.7 자동 플래그, SSE 실시간 진행 업데이트, 부분 실패 복구
+- C. 배치 결과 export: DOCX(질문-답변, citation 각주, 신뢰도), Excel(질문/답변/신뢰도/citation/review 컬럼), PDF(Pre-Sub Meeting 양식), batch audit log 기록
+- D. 배치 히스토리: 완료된 배치 세션 저장 및 재활용, 동일 질문 배치의 이전 버전 비교(규제 개정 전/후 답변 변화 추적)
+
+### 1.4 Out of Scope
+
+- 실시간 협업 배치 편집 (#25 Co-editing 소관)
+- 외부 고객 API (내부 사용자 전용)
+- AI 기반 질문 자동 생성
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-BATCH-001 | WHEN a user uploads a CSV/Excel/TSV file of questions THE SYSTEM SHALL parse the questions into a batch job list. | High |
+| REQ-BATCH-002 | WHEN a user enters questions in the inline editor THE SYSTEM SHALL accept line-delimited questions as a batch. | High |
+| REQ-BATCH-003 | WHEN a user selects a template THE SYSTEM SHALL apply the corresponding format (FDA Pre-Sub, EU MDR TechFile, PMDA 사전 상담, MFDS Q&A). | Medium |
+| REQ-BATCH-004 | IF a batch exceeds 100 questions THEN THE SYSTEM SHALL split it into separate processing batches. | High |
+| REQ-BATCH-005 | WHEN a batch is processed THE SYSTEM SHALL run RAG in parallel with a concurrency limit of 10. | High |
+| REQ-BATCH-006 | WHEN each question is answered THE SYSTEM SHALL include citations in the answer. | High |
+| REQ-BATCH-007 | IF an answer's confidence score is below 0.7 THEN THE SYSTEM SHALL automatically flag it and recommend expert review. | High |
+| REQ-BATCH-008 | WHILE a batch is processing THE SYSTEM SHALL emit SSE updates indicating N/M completed. | High |
+| REQ-BATCH-009 | IF a question job fails mid-batch THEN THE SYSTEM SHALL preserve completed partial results and allow the batch to resume. | High |
+| REQ-BATCH-010 | WHEN a batch completes THE SYSTEM SHALL support export to DOCX, Excel, and PDF formats. | High |
+| REQ-BATCH-011 | WHEN a batch session is recorded THE SYSTEM SHALL write a batch audit log entry (batch_id, question count, confidence distribution, expert flag count). | High |
+| REQ-BATCH-012 | WHEN a batch completes THE SYSTEM SHALL save the session for later reuse in batch history. | Medium |
+| REQ-BATCH-013 | WHEN a user compares two versions of the same question batch THE SYSTEM SHALL show answer changes before/after regulatory revisions. | Low |
+| REQ-BATCH-014 | WHILE a user lacks the required RBAC permission for batch access THE SYSTEM SHALL deny the batch operation. | High |
+| REQ-BATCH-015 | WHEN 100 questions are processed THE SYSTEM SHALL complete within 5 minutes. | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | CSV 업로드 → 배치 RAG 처리 → DOCX/Excel/PDF export가 동작한다. | Test |
+| AC-02 | 처리 중 실시간 진행 상황(N/M)이 SSE로 표시된다. | Test |
+| AC-03 | 신뢰도 낮은 답변이 자동 플래그되고 expert review로 연결된다. | Test |
+| AC-04 | 100건 처리 기준 완료 시간이 5분 이내이다. | Test |
+| AC-05 | 배치 세션이 audit_logs에 일괄 기록된다. | Test |
+| AC-06 | 중간 실패 시 완료된 부분 결과가 보존된다. | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `app/(workflows)/batch/page.tsx` — 배치 질의 진입 UI (업로드/인라인/템플릿 선택)
+- `app/api/batch/route.ts` — 배치 생성 API
+- `app/api/batch/[id]/stream/route.ts` — SSE 진행 상황 스트림
+- `lib/batch/parser.ts` — CSV/Excel/TSV 파서
+- `lib/batch/queue.ts` — 큐 단위 job 처리 (Cloudflare Queue / Inngest)
+- `lib/batch/aggregator.ts` — Redis/KV 결과 집계 및 병합
+- `lib/batch/export.ts` — DOCX/Excel/PDF export
+
+### 4.2 DB Schema
+
+- `batch_sessions` (신규): batch_id, user_id, question_count, status, confidence_distribution, expert_flag_count, created_at
+- `batch_questions` (신규): batch_id, question, answer, confidence, citations JSON, review_required, status
+- `audit_logs` (기존): 배치 세션 일괄 기록
+
+### 4.3 API Endpoints
+
+- `POST /api/batch` — 배치 생성 (입력: 질문 목록 또는 파일)
+- `GET /api/batch/[id]/stream` — SSE 진행 상황
+- `GET /api/batch/[id]/export?format=docx|xlsx|pdf` — 결과 export
+- `GET /api/batch/history` — 배치 히스토리 조회
+
+### 4.4 의존성
+
+- SPEC-REGULA-CHAT-001 (RAG core)
+- SPEC-REGULA-ENTERPRISE-001 (RBAC, 배치 접근 권한)
+- #35 Knowledge Gap Ops (답변 불가 → gap 자동 등록)
+- #36 Review Ops (expert review 연결)
+- DocIngest 인프라 (Cloudflare Queue / Inngest), Redis/KV

--- a/.moai/specs/SPEC-REGULA-CAPA-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CAPA-001/spec.md
@@ -1,0 +1,150 @@
+---
+id: SPEC-REGULA-CAPA-001
+version: 1.0.0
+status: draft
+phase: wave5
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 68
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-RISK-001
+  - SPEC-REGULA-CHANGE-CONTROL-001
+  - SPEC-REGULA-ESIG-001
+  - SPEC-REGULA-PMS-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+---
+
+# SPEC-REGULA-CAPA-001 — 불만·CAPA 폐루프 관리 (Complaint→Vigilance→Risk→DHF 연결)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #68 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+#61 Vigilance는 규제 보고 대상 유해사례를 다루지만, 모든 고객 불만·품질 이슈가 즉시 MDR(Medical Device Reporting)/MDV 보고 대상은 아니다. 의료기기 운영에서는 complaint intake, investigation, root cause, CAPA(Corrective and Preventive Action), effectiveness check가 QMS와 DHF, Risk, PMS를 연결하는 핵심 폐루프이다.
+
+본 SPEC은 불만 접수부터 CAPA 완료, 효과성 확인, DHF/Risk/PMS 반영까지 하나의 추적 가능한 워크플로우로 관리한다. complaint intake 구조화 폼, reportability assessment(#61 Vigilance 연결), root cause analysis(5 Whys, Fishbone), corrective/preventive action 분리 관리, CAPA owner·due date·effectiveness check 관리, 반복 불만 trend detection(#53 PMS 연결)을 포함한다.
+
+CAPA 결과는 #46 Risk, #54 Change Control, #64 DHF에 자동 연결되고, QMS 시스템(#57)과 양방향 상태 동기화하며, 모든 단계에 전자서명 및 audit_logs를 기록한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA 21 CFR 820.100: Corrective and Preventive Action (CAPA)
+- FDA 21 CFR 820.198: Complaint Files
+- FDA 21 CFR 803: Medical Device Reporting (reportability)
+- EU MDR (2017/745) Article 87-92: Vigilance 및 보고
+- ISO 13485:2016 §8.5: 개선 (CAPA)
+- ISO 14971: Risk Management 연계
+- 21 CFR Part 11: 전자서명·audit trail
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- complaint intake 구조화 폼
+- reportability assessment 결과를 #61 Vigilance와 연결
+- root cause analysis(5 Whys, Fishbone) 작성 지원
+- corrective action / preventive action 분리 관리
+- CAPA owner, due date, effectiveness check 관리
+- 반복 불만 trend detection 및 #53 PMS 연결
+- CAPA 결과를 #46 Risk, #54 Change Control, #64 DHF에 자동 연결
+- QMS 시스템(#57)과 양방향 상태 동기화
+- 모든 단계 전자서명 및 audit_logs 기록
+
+### 1.4 Out of Scope
+
+- 실제 규제기관 MDR/MDV 전자 제출 (#61 Vigilance 범위)
+- 외부 QMS 시스템 자체 구현 (상태 동기화 인터페이스만 담당)
+- 자동 root cause AI 판정 (작성 지원만, 판단은 사용자/expert)
+- complaint 고객 접점 채널(이메일/콜센터) 통합
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-CAPA-001 | THE SYSTEM SHALL complaint intake를 구조화된 폼으로 접수·저장한다 | High |
+| REQ-CAPA-002 | WHEN complaint가 접수되면 THE SYSTEM SHALL reportability assessment를 수행하고 결과를 #61 Vigilance와 연결한다 | High |
+| REQ-CAPA-003 | WHEN 사용자가 root cause analysis를 수행하면 THE SYSTEM SHALL 5 Whys 및 Fishbone 작성을 지원한다 | High |
+| REQ-CAPA-004 | THE SYSTEM SHALL corrective action과 preventive action을 분리하여 관리한다 | High |
+| REQ-CAPA-005 | THE SYSTEM SHALL 각 CAPA에 owner, due date, effectiveness check를 할당·추적한다 | High |
+| REQ-CAPA-006 | WHEN effectiveness check 기한이 도래하면 THE SYSTEM SHALL 담당자에게 알림을 전송한다 | High |
+| REQ-CAPA-007 | WHEN 반복 불만 트렌드가 감지되면 THE SYSTEM SHALL #53 PMS와 연결한다 | High |
+| REQ-CAPA-008 | WHEN CAPA가 완료되면 THE SYSTEM SHALL 결과를 #46 Risk, #54 Change Control, #64 DHF에 자동 연결한다 | High |
+| REQ-CAPA-009 | THE SYSTEM SHALL QMS 시스템(#57)과 CAPA 상태를 양방향 동기화한다 | High |
+| REQ-CAPA-010 | WHEN 각 CAPA 단계가 전환되면 THE SYSTEM SHALL 전자서명을 요구하고 audit_logs에 기록한다 | High |
+| REQ-CAPA-011 | IF reportable 사건인데 Vigilance 연결이 누락되면 THEN THE SYSTEM SHALL CAPA close를 차단한다 | High |
+| REQ-CAPA-012 | IF 권한 없는 사용자가 CAPA 상태 전이를 시도하면 THEN THE SYSTEM SHALL 접근을 거부한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | complaint → reportability → CAPA 분기 E2E 통과 | E2E test |
+| AC-02 | CAPA effectiveness check 기한 알림 동작 | integration test (스케줄러) |
+| AC-03 | CAPA와 risk/DHF/change control 링크 누락 0건 | integration test |
+| AC-04 | 전자서명 및 감사 로그 100% 기록 | audit log 검증 |
+| AC-05 | QMS export/import 상태 동기화 지원 | integration test |
+| AC-06 | 반복 불만 trend detection → PMS 연결 | integration test |
+| AC-07 | reportable인데 Vigilance 미연결 시 close 차단 | negative test |
+| AC-08 | 권한 없는 상태 전이 거부됨 | RBAC negative test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+app/(app)/capa/                      # CAPA 폐루프 워크벤치 UI
+lib/capa/
+  intake.ts                          # complaint 구조화 접수
+  reportability.ts                   # reportability assessment + Vigilance 연결
+  root-cause.ts                      # 5 Whys / Fishbone
+  effectiveness.ts                   # effectiveness check 스케줄·알림
+  trend-detector.ts                  # 반복 불만 트렌드 → PMS
+  qms-sync.ts                        # QMS 양방향 동기화
+lib/db/schema/capa.ts
+```
+
+### 4.2 DB Schema
+
+- `complaints` 테이블: project_id FK, intake_data, reportability_status, vigilance_ref
+- `capa_records` 테이블: complaint_id FK, type(corrective|preventive), owner, due_date, status, effectiveness_status
+- `capa_root_causes` 테이블: capa_id FK, method(5whys|fishbone), analysis_data
+- `capa_links` 테이블: capa_id FK, target_type(risk|change_control|dhf|pms), target_id
+- `audit_logs` 재사용 (전자서명 메타데이터 포함)
+
+### 4.3 API Endpoints
+
+- `POST /api/capa/complaints` — complaint intake
+- `POST /api/capa/complaints/[id]/reportability` — assessment + Vigilance 연결
+- `POST /api/capa/records` — CAPA 생성 (corrective/preventive)
+- `POST /api/capa/records/[id]/root-cause` — RCA 작성
+- `POST /api/capa/records/[id]/effectiveness` — effectiveness check
+- `POST /api/capa/records/[id]/close` — reportability·링크 검증 후 전자서명
+- `GET/POST /api/capa/qms-sync` — QMS 양방향 동기화
+
+### 4.4 의존성
+
+- #46 Risk (CAPA 후 risk 재평가)
+- #53 PMS/PMCF (반복 불만 및 postmarket trend 반영)
+- #54 Change Control (CAPA 기반 설계 변경 평가)
+- #57 QMS Integration (외부 QMS 상태 동기화)
+- #61 Vigilance (보고 대상 사건 분기)
+- #64 DHF (설계 이력 반영)
+- SPEC-REGULA-ESIG-001 (전자서명)

--- a/.moai/specs/SPEC-REGULA-CHANGE-CONTROL-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CHANGE-CONTROL-001/spec.md
@@ -1,0 +1,151 @@
+---
+id: SPEC-REGULA-CHANGE-CONTROL-001
+version: 1.0.0
+status: draft
+phase: wave4
+priority: Medium
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 54
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-WORKFLOWS-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+---
+
+# SPEC-REGULA-CHANGE-CONTROL-001 — 설계 변경 규제 영향 자동 평가기 (Change Control RA Impact)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #54 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+의료기기 개발 과정에서 설계 변경(design change)은 불가피하다. 그러나 모든 설계 변경이 규제적 영향을 가지며, 잘못된 평가는 새로운 허가 신청 누락 → 무허가 기기 판매 → 리콜·행정제재로 이어진다. 변경 영향 평가는 RA 전문가의 가장 반복적이고 시간 소모적인 업무 중 하나다.
+
+현재 규제 영향 평가는 RA 전문가의 경험에 전적으로 의존한다. FDA 21 CFR 807.81(a)(3), EU MDR Article 120(3), MFDS 기준 등 다중 관할권의 변경 평가 기준이 서로 다르며, 각 시장별로 새 허가 신청 필요 여부 판단 로직이 상이하다.
+
+본 SPEC은 설계 변경을 구조화 입력으로 받아 각 시장별 규제 영향을 자동 평가한다. 변경 유형(design, material, manufacturing_process, software, labeling, intended_use)을 분류하고, 관할권별로 "새 허가 필요 / 변경 신고 / 내부 기록만 / 해당 없음"을 판단하며, 각 판단에 규제 문서 citation을 강제한다. 평가 결과는 PDF 보고서로 내보내어 기존 DHF/변경 관리 시스템에 첨부할 수 있다.
+
+자동 평가는 잘못된 자동 판단을 막기 위해 expert review gate와 연계되며, ISO 14971(#46) 위험 재평가와 연동된다. 이를 통해 설계 변경 규제 평가 오류로 인한 리콜·행정제재 위험을 제거한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+| 관할권 | 평가 기준 |
+|--------|----------|
+| FDA | 21 CFR 807.81(a)(3), FDA Modifications Guidance 2019 (When to Submit a 510(k)) |
+| EU MDR | Article 120(3), MDCG 2020-3 (significant changes) |
+| MFDS | 의료기기법 제12조 변경 허가/신고 기준 |
+| NMPA | 중국 변경 등록 기준 |
+| PMDA | 일본 일부변경 승인 기준 |
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- `workflow_type` enum에 `change_control_assessment` 추가
+- 변경 사항 구조화 입력 폼: 변경 유형, 설명, 영향 범위
+- 변경 유형 분류: design, material, manufacturing_process, software, labeling, intended_use
+- 관할권별 AI 평가: 새 허가 필요 / 변경 신고 / 내부 기록만 / 해당 없음 (+ 근거)
+- 근거 citation 강제: 각 판단에 규제 문서 출처 필수
+- 변경 영향 평가 보고서 PDF 내보내기
+- ISO 14971(#46) 위험 재평가 연계
+
+### 1.4 Out of Scope
+
+- 실제 변경 허가/신고 외부 제출 자동화
+- 변경 관리 시스템(eDHF/QMS) 양방향 동기화
+- 전자서명 full validation
+- 본 SPEC에 명시되지 않은 추가 관할권 평가 로직
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-CHANGE-CONTROL-001 | THE SYSTEM SHALL include change_control_assessment as a value in the workflow_type enum | High |
+| REQ-CHANGE-CONTROL-002 | THE SYSTEM SHALL provide a structured change input form capturing change type, description, and impact scope | High |
+| REQ-CHANGE-CONTROL-003 | WHEN a change is submitted THE SYSTEM SHALL classify it as one of design, material, manufacturing_process, software, labeling, or intended_use | High |
+| REQ-CHANGE-CONTROL-004 | WHEN a change is assessed THE SYSTEM SHALL produce a per-jurisdiction verdict of new submission required, change notification, internal record only, or not applicable | High |
+| REQ-CHANGE-CONTROL-005 | THE SYSTEM SHALL evaluate against FDA, EU MDR, MFDS, NMPA, and PMDA criteria for the project's target markets | High |
+| REQ-CHANGE-CONTROL-006 | IF an assessment verdict lacks a regulatory document citation THEN THE SYSTEM SHALL reject the verdict and require a citation | High |
+| REQ-CHANGE-CONTROL-007 | THE SYSTEM SHALL export the change impact assessment as a PDF report attachable to a DHF or change management system | Medium |
+| REQ-CHANGE-CONTROL-008 | WHEN a change assessment is created THE SYSTEM SHALL link it to an ISO 14971 (#46) risk re-evaluation | Medium |
+| REQ-CHANGE-CONTROL-009 | WHEN the AI produces a verdict THE SYSTEM SHALL route it through an expert review gate before it is treated as final | High |
+| REQ-CHANGE-CONTROL-010 | WHEN a workflow run completes THE SYSTEM SHALL record model, prompt, and template version metadata enabling rollback | Medium |
+| REQ-CHANGE-CONTROL-011 | WHILE a verdict is unreviewed THE SYSTEM SHALL display it as provisional and exclude it from final export | High |
+| REQ-CHANGE-CONTROL-012 | WHEN a change assessment is recorded THE SYSTEM SHALL write an audit_logs entry with actor, timestamp, and inputs | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | 사용자가 변경 유형·설명·영향 범위를 구조화 입력할 수 있다 | Review |
+| AC-02 | 변경이 6개 유형 중 하나로 분류된다 | Test |
+| AC-03 | 각 target market에 대해 4단계 verdict(+근거)가 생성된다 | Test |
+| AC-04 | citation 없는 verdict는 거부된다 (citation 강제) | Test |
+| AC-05 | 변경 영향 평가 보고서가 PDF로 export된다 | Test |
+| AC-06 | ISO 14971(#46) 위험 재평가 연계가 생성된다 | Test |
+| AC-07 | AI verdict가 expert review 전에는 provisional로 표시되고 export에서 제외된다 | Test |
+| AC-08 | 모든 평가가 audit_logs에 기록되고 model/prompt version metadata가 남는다 | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/
+    (dashboard)/change-control/
+      page.tsx                  # 변경 입력 폼
+      [assessmentId]/page.tsx   # 관할권별 verdict, citation, 위험 연계
+    api/change-control/
+      route.ts                  # assessment 생성 (workflow 실행)
+      [assessmentId]/export/route.ts  # PDF 보고서
+  lib/change-control/
+    classify.ts                 # 변경 유형 분류
+    jurisdictions/
+      fda.ts                    # 21 CFR 807.81(a)(3) 로직
+      eu-mdr.ts                 # Article 120(3), MDCG 2020-3
+      mfds.ts                   # 의료기기법 제12조
+      nmpa.ts                   # 중국 변경 등록
+      pmda.ts                   # 일본 일부변경
+    verdict.ts                  # citation 강제 검증
+  workflows/change-control-assessment.ts  # Workflows runtime 재사용
+  db/schema/change-control.ts
+```
+
+### 4.2 DB Schema
+
+- `change_assessments`: id, project_id, change_type, description, impact_scope, status (provisional|reviewed|final), model_version, prompt_version, created_at
+- `change_verdicts`: id, assessment_id, jurisdiction, verdict (new_submission|change_notification|internal_record|not_applicable), rationale, created_at
+- `change_verdict_citations`: id, verdict_id, source_section_id, excerpt (NOT NULL — citation 강제)
+- `change_risk_links`: id, assessment_id, risk_item_id (#46 연계)
+- audit_logs 재사용 — assessment 생성/verdict/review 기록
+
+### 4.3 API Endpoints
+
+- `POST /api/change-control` — 구조화 입력 → workflow 실행 → 관할권별 verdict
+- `GET /api/change-control/{id}` — verdict + citation + risk link 조회
+- `POST /api/change-control/{id}/export` — PDF 보고서 (reviewed 상태 검증)
+- review 경로는 #36 Review Ops 게이트 재사용
+
+### 4.4 의존성
+
+- SPEC-REGULA-FOUNDATION-001 (projects, target_markets, source_sections, citations, audit_logs)
+- SPEC-REGULA-WORKFLOWS-001 (Cloudflare Workflows runtime 재사용, workflow_type enum)
+- #46 ISO 14971 Risk Management (위험 재평가 연계)
+- #36 Review Ops (expert review gate — verdict 확정)

--- a/.moai/specs/SPEC-REGULA-CLASSIFY-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CLASSIFY-001/spec.md
@@ -1,0 +1,141 @@
+---
+id: SPEC-REGULA-CLASSIFY-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 59
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-BREADTH-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-CLASSIFY-001 — 의료기기 분류 자동화 마법사 (FDA/EU/MFDS/NMPA/PMDA 통합)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #59 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+모든 규제 제출의 출발점은 의료기기 분류다. 510(k)/PMA/CE/국내허가 중 어느 경로를 밟을지, 제출 비용이 얼마나 들지, 어떤 표준이 적용되는지는 전부 분류에서 결정된다. 현재 Regula는 510(k) 초안기(#22), CER 빌더(#23), PCCP 작성기(#24) 등 제출 도구는 갖추었지만, 그 제출이 필요한지·어떤 제출인지를 결정하는 분류 단계가 빠져 있다.
+
+Regula가 end-to-end RA 플랫폼이 되려면 Classification Wizard가 모든 워크플로우의 진입점이 되어야 한다. 사용자가 기기 용도·작동 원리·환자 접촉 여부 등을 입력하면 FDA/EU MDR/MFDS/NMPA/PMDA 5개 관할권의 분류 결과와 규제 경로를 자동 산출한다.
+
+분류 엔진은 규칙 기반 분류 트리(FDA Product Code DB, EU MDR Annex VIII 규칙 트리, MFDS/NMPA/PMDA 분류 코드 맵)에 RAG 보조를 결합한다. Haiku intent parser로 기기 특성을 추출한 뒤 각 관할권 분류 엔진을 거쳐 결과를 집계하고 ComparisonTable, Timeline, Citations 블록으로 렌더링한다.
+
+분류 결과는 predicate search(#22), CER builder(#23), strategy generator(#40), standards mapping(SPEC-REGULA-STANDARDS-001), SaMD path(SPEC-REGULA-SAMD-001) 등 후속 워크플로우의 입력으로 연계된다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA: 21 CFR 862-892 (Device Classification), Class I/II/III, Product Code, Regulation Number, 510(k)/PMA/De Novo/Exempt 경로
+- EU MDR: Regulation (EU) 2017/745 Annex VIII Rules 1-22, Class I/IIa/IIb/III, MDR/IVDR 구분, Notified Body 선정
+- MFDS: 의료기기 품목 및 품목별 등급에 관한 규정 (1~4등급)
+- NMPA: 의료기기 등급 분류 (1~3등급)
+- PMDA: PMD Act 클래스 I~IV
+- AI/ML SaMD: SPEC-REGULA-SAMD-001 연계
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 분류 입력 파라미터: intended use 자연어 입력, 신체 접촉 여부(비접촉/외부접촉/내부접촉/이식형), 기기 유형(능동/비능동, SW/HW), AI/ML 구성 요소 여부
+- FDA 분류 엔진: Class I/II/III + Exempt/510(k)/PMA 경로 결정, Product Code + Regulation Number 산출, De Novo 경로 식별, predicate 초기 목록 제시
+- EU MDR 분류 엔진: Class I/IIa/IIb/III (Annex VIII Rules 1-22), MDR/IVDR 구분, Notified Body 필요 여부
+- MFDS/NMPA/PMDA 분류 엔진: 한국·중국·일본 분류 등급 산출, 동등 경로 식별
+- 분류 결과 보고서: 5개 관할권 비교표, 예상 타임라인, 핵심 표준 목록, 추정 제출 비용 범위
+
+### 1.4 Out of Scope
+
+- 실제 외부 기관 제출 (SPEC-REGULA-EXTERNAL-001 소관)
+- SaMD 세부 경로 분기 (SPEC-REGULA-SAMD-001 소관)
+- 표준 개정 추적 (SPEC-REGULA-STANDARDS-001 소관, 본 SPEC은 표준 목록 연계만)
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-CLASSIFY-001 | WHEN a user submits an intended-use description in natural language THE SYSTEM SHALL extract device characteristics via the Haiku intent parser. | High |
+| REQ-CLASSIFY-002 | WHEN a user specifies body contact THE SYSTEM SHALL accept one of (non-contact / surface-contact / internal-contact / implantable) as a classification parameter. | High |
+| REQ-CLASSIFY-003 | WHEN a user specifies device type THE SYSTEM SHALL capture active/non-active and software/hardware attributes. | High |
+| REQ-CLASSIFY-004 | IF the device contains an AI/ML component THEN THE SYSTEM SHALL route the SaMD path branch to SPEC-REGULA-SAMD-001. | High |
+| REQ-CLASSIFY-005 | WHEN FDA classification runs THE SYSTEM SHALL determine Class I/II/III plus the Exempt/510(k)/PMA path. | High |
+| REQ-CLASSIFY-006 | WHEN FDA classification runs THE SYSTEM SHALL produce the Product Code and Regulation Number (21 CFR §). | High |
+| REQ-CLASSIFY-007 | WHEN FDA classification runs THE SYSTEM SHALL identify any applicable De Novo path. | Medium |
+| REQ-CLASSIFY-008 | WHEN FDA classification produces a result THE SYSTEM SHALL present an initial predicate device list and link to #22 Predicate Search. | Medium |
+| REQ-CLASSIFY-009 | WHEN EU MDR classification runs THE SYSTEM SHALL classify Class I/IIa/IIb/III by applying Annex VIII Rules 1-22. | High |
+| REQ-CLASSIFY-010 | WHEN EU MDR classification runs THE SYSTEM SHALL distinguish MDR from IVDR. | Medium |
+| REQ-CLASSIFY-011 | WHEN EU MDR classification runs THE SYSTEM SHALL determine whether Notified Body selection is required. | High |
+| REQ-CLASSIFY-012 | WHEN MFDS/NMPA/PMDA classification runs THE SYSTEM SHALL produce the Korea/China/Japan classification grades. | High |
+| REQ-CLASSIFY-013 | WHEN MFDS/NMPA/PMDA classification runs THE SYSTEM SHALL identify each jurisdiction's equivalent path (등가심사, 비교 인증). | Medium |
+| REQ-CLASSIFY-014 | WHEN classification completes THE SYSTEM SHALL render a 5-jurisdiction comparison table using the ComparisonTable block. | High |
+| REQ-CLASSIFY-015 | WHEN classification completes THE SYSTEM SHALL render an expected regulatory timeline using the Timeline block. | Medium |
+| REQ-CLASSIFY-016 | WHEN classification completes THE SYSTEM SHALL list applicable core standards and link to SPEC-REGULA-STANDARDS-001. | Medium |
+| REQ-CLASSIFY-017 | WHEN classification completes THE SYSTEM SHALL include citations to the classification basis documents. | High |
+| REQ-CLASSIFY-018 | WHEN classification completes THE SYSTEM SHALL automatically link the result to the Submission Lifecycle (#37). | Medium |
+| REQ-CLASSIFY-019 | WHEN a user requests 5-jurisdiction classification THE SYSTEM SHALL return a response within 3 seconds. | High |
+| REQ-CLASSIFY-020 | WHEN classification results are produced THE SYSTEM SHALL persist them to the device_classifications table. | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | FDA 분류 정확도가 테스트 기기 셋 기준 90% 이상이다. | Test |
+| AC-02 | 5개 관할권 동시 분류 응답이 3초 이내이다. | Test |
+| AC-03 | 분류 근거 문서 citation이 포함된다. | Test / Review |
+| AC-04 | 분류 결과가 Submission Lifecycle (#37)로 자동 연계된다. | Test |
+| AC-05 | EU MDR 분류가 Annex VIII Rules 1-22를 적용하여 Class I/IIa/IIb/III를 산출한다. | Test |
+| AC-06 | AI/ML 구성 기기는 SaMD 경로 분기(SPEC-REGULA-SAMD-001)로 라우팅된다. | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `app/(workflows)/classify/page.tsx` — 분류 마법사 진입 UI
+- `app/api/classify/route.ts` — 분류 세션 API
+- `lib/classify/intent-parser.ts` — Haiku intent parser (기기 특성 추출)
+- `lib/classify/engines/fda.ts` — FDA 분류 엔진 (Product Code DB)
+- `lib/classify/engines/eu-mdr.ts` — EU MDR Annex VIII 규칙 트리
+- `lib/classify/engines/mfds-nmpa-pmda.ts` — 분류 코드 맵
+- `lib/classify/aggregator.ts` — 결과 집계 → ComparisonTable/Timeline/Citations
+
+### 4.2 DB Schema
+
+- `device_classifications` (신규): 분류 결과 저장 (intended_use, parameters JSON, fda_result, eu_result, mfds_result, nmpa_result, pmda_result, citations JSON)
+- `classification_rules` (신규): 관할권별 분류 규칙 (버전 관리)
+- `product_code_index` (신규): FDA Product Code 인덱스 (CDRH 데이터)
+
+### 4.3 API Endpoints
+
+- `POST /api/classify` — 분류 세션 생성 (입력: device description + parameters)
+- `GET /api/classify/[id]` — 분류 결과 조회
+- `GET /api/classify/[id]/export` — 분류 보고서 export
+
+### 4.4 의존성
+
+- #22 Predicate Search (분류 결과 → predicate 검색 진입점)
+- #23 CER Builder (EU 분류 결과 → CER 범위 결정)
+- #40 Strategy Generator (분류 결과 → 전략 생성 입력)
+- SPEC-REGULA-STANDARDS-001 (분류 결과 → 적용 표준 매핑)
+- SPEC-REGULA-SAMD-001 (AI/ML 구성 → SaMD 경로 분기)
+- #37 Submission Lifecycle (자동 연계)
+- FDA CDRH Product Code DB, EU MDR Annex VIII 규칙 데이터

--- a/.moai/specs/SPEC-REGULA-CLINICAL-INVESTIGATION-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CLINICAL-INVESTIGATION-001/spec.md
@@ -1,0 +1,148 @@
+---
+id: SPEC-REGULA-CLINICAL-INVESTIGATION-001
+version: 1.0.0
+status: draft
+phase: wave5
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 69
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-REGULA-CER-001
+  - SPEC-REGULA-PMS-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-CLINICAL-INVESTIGATION-001 — 임상시험·임상조사 계획기 (FDA IDE·EU MDR Clinical Investigation·IRB 패키지)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #69 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+#23 CER와 #60 Clinical Literature는 기존 임상 근거 수집과 보고서 작성을 다룬다. 그러나 임상 근거가 부족할 때 필요한 FDA IDE(Investigational Device Exemption), EU MDR Clinical Investigation, IRB/EC(Institutional Review Board / Ethics Committee) 제출 패키지 생성은 별도 범위이다.
+
+본 SPEC은 임상 근거 갭을 바탕으로 임상시험·임상조사 필요 여부를 판단하고, 관할권별 제출·승인·운영 패키지를 생성한다. CER/문헌 근거 갭 기반 clinical investigation 필요성 평가, FDA IDE 필요 여부 결정 트리, EU MDR Article 62 및 Annex XV 임상조사 체크리스트, IRB/EC 제출 문서 패키지 초안 생성을 포함한다.
+
+protocol synopsis, endpoint, inclusion/exclusion criteria 작성 지원, risk/benefit rationale 및 informed consent 초안 생성, investigator brochure 및 monitoring plan 템플릿, study milestone·deviation·adverse event 연결을 제공하며, 결과 데이터를 CER(#23), PMS(#53), DHF(#64)에 반영한다. 각 판단에는 regulatory basis citation을 포함한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA 21 CFR 812: Investigational Device Exemptions (IDE)
+- FDA 21 CFR 50: Protection of Human Subjects (informed consent)
+- FDA 21 CFR 56: Institutional Review Boards
+- EU MDR (2017/745) Article 62-82, Annex XV: Clinical Investigations
+- ISO 14155: 임상조사 Good Clinical Practice
+- Declaration of Helsinki: 임상 윤리 원칙
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- CER/문헌 근거 갭 기반 clinical investigation 필요성 평가
+- FDA IDE 필요 여부 결정 트리
+- EU MDR Article 62 및 Annex XV 임상조사 체크리스트
+- IRB/EC 제출 문서 패키지 초안 생성
+- protocol synopsis, endpoint, inclusion/exclusion criteria 작성 지원
+- risk/benefit rationale 및 informed consent 초안 생성
+- investigator brochure 및 monitoring plan 템플릿
+- study milestone, deviation, adverse event 연결
+- 결과 데이터를 CER(#23), PMS(#53), DHF(#64)에 반영
+
+### 1.4 Out of Scope
+
+- 실제 IRB/EC 또는 규제기관 직접 제출
+- EDC(Electronic Data Capture) / CTMS 임상 데이터 수집 시스템 구현
+- 환자 모집·스크리닝 운영
+- 임상시험 통계 분석 자체 수행
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-CLININV-001 | WHEN CER/문헌 근거 갭이 입력되면 THE SYSTEM SHALL clinical investigation 필요성 평가 결과를 생성한다 | High |
+| REQ-CLININV-002 | WHEN 사용자가 FDA IDE 경로를 평가하면 THE SYSTEM SHALL IDE 필요 여부 결정 트리를 제공한다 | High |
+| REQ-CLININV-003 | WHEN 사용자가 EU MDR 임상조사를 평가하면 THE SYSTEM SHALL Article 62 및 Annex XV 체크리스트를 제공한다 | High |
+| REQ-CLININV-004 | THE SYSTEM SHALL IRB/EC 제출 문서 패키지 초안을 생성한다 | High |
+| REQ-CLININV-005 | WHEN 사용자가 protocol을 작성하면 THE SYSTEM SHALL protocol synopsis, endpoint, inclusion/exclusion criteria 작성을 지원한다 | High |
+| REQ-CLININV-006 | THE SYSTEM SHALL risk/benefit rationale 및 informed consent 초안을 생성한다 | High |
+| REQ-CLININV-007 | THE SYSTEM SHALL investigator brochure 및 monitoring plan 템플릿을 제공한다 | High |
+| REQ-CLININV-008 | THE SYSTEM SHALL study milestone, deviation, adverse event를 연결·추적한다 | High |
+| REQ-CLININV-009 | WHEN study 결과가 확정되면 THE SYSTEM SHALL 결과 데이터를 CER(#23), PMS(#53), DHF(#64)에 반영한다 | High |
+| REQ-CLININV-010 | THE SYSTEM SHALL IDE/임상조사 경로 판단의 근거 citation을 포함하도록 강제한다 | High |
+| REQ-CLININV-011 | THE SYSTEM SHALL 임상조사 승인/진행 상태 대시보드를 제공한다 | Medium |
+| REQ-CLININV-012 | IF expert signoff 없이 임상조사 판단을 close하려 하면 THEN THE SYSTEM SHALL 차단한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | CER gap → clinical investigation recommendation 생성 | integration test |
+| AC-02 | FDA IDE / EU MDR Clinical Investigation 경로 판단 근거 citation 포함 | eval assertion (citation coverage) |
+| AC-03 | IRB/EC 패키지 초안 생성 | integration test |
+| AC-04 | study result가 CER와 DHF traceability에 연결 | integration test |
+| AC-05 | 임상조사 승인/진행 상태 대시보드 제공 | E2E test |
+| AC-06 | protocol synopsis/endpoint/criteria 작성 지원 동작 | unit/integration test |
+| AC-07 | expert signoff 없이 close 차단 | negative test |
+| AC-08 | adverse event ↔ Vigilance/study milestone 연결 | integration test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+app/(app)/clinical-investigation/    # 임상조사 계획기 UI
+lib/clinical-investigation/
+  gap-assessment.ts                  # CER/문헌 갭 → 필요성 평가
+  ide-decision-tree.ts               # FDA IDE 결정 트리
+  eu-checklist.ts                    # Article 62 / Annex XV
+  irb-package.ts                     # IRB/EC 패키지 초안
+  protocol-builder.ts                # synopsis/endpoint/criteria
+  consent-generator.ts               # informed consent 초안
+lib/db/schema/clinical-investigation.ts
+```
+
+### 4.2 DB Schema
+
+- `clinical_investigations` 테이블: project_id FK, pathway(fda_ide|eu_mdr), necessity_status, approval_status
+- `ci_protocols` 테이블: investigation_id FK, synopsis, endpoints, inclusion_criteria, exclusion_criteria
+- `ci_documents` 테이블: investigation_id FK, doc_type(irb_package|consent|brochure|monitoring_plan), content, review_status
+- `ci_events` 테이블: investigation_id FK, type(milestone|deviation|adverse_event), data
+- `ci_links` 테이블: investigation_id FK, target_type(cer|pms|dhf), target_id
+
+### 4.3 API Endpoints
+
+- `POST /api/clinical-investigation/assess` — 갭 기반 필요성 평가
+- `POST /api/clinical-investigation/[id]/ide-decision` — IDE 결정 트리
+- `GET /api/clinical-investigation/[id]/eu-checklist`
+- `POST /api/clinical-investigation/[id]/protocol`
+- `POST /api/clinical-investigation/[id]/irb-package`
+- `POST /api/clinical-investigation/[id]/events` — milestone/deviation/AE
+- `POST /api/clinical-investigation/[id]/close` — expert signoff 검증
+
+### 4.4 의존성
+
+- #23 CER (임상평가보고서 입력 및 결과 반영)
+- #53 PMS/PMCF (시판 후 임상 추적과 연결)
+- #60 Clinical Literature (임상 근거 갭 판단)
+- #61 Vigilance (시험 중 adverse event 연결)
+- #64 DHF (임상 검증 증거 연결)
+- #65 eSubmit (IDE/clinical investigation 제출 패키지 포함)

--- a/.moai/specs/SPEC-REGULA-CORPUS-LICENSE-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-LICENSE-001/spec.md
@@ -1,0 +1,140 @@
+---
+id: SPEC-REGULA-CORPUS-LICENSE-001
+version: 1.0.0
+status: draft
+phase: system
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 72
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-RELEASE-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/infra
+---
+
+# SPEC-REGULA-CORPUS-LICENSE-001 — 코퍼스 라이선스·사용권 관리 (규제문서·표준·논문 수집 권한 검증)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #72 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula는 규제 문서, 표준, 논문, 사내 SOP를 대규모로 수집한다. #48 Source Governance는 출처 권위도·버전·유효일을 다루지만, 라이선스·구독·사용권·재배포 권한은 별도 통제가 필요하다.
+
+특히 ISO/IEC/ASTM 표준 전문, 유료 DB, 논문 전문은 무단 ingestion 또는 재배포 시 법적 리스크가 크다. 표준 전문을 entitlement 없이 embedding하거나 답변에 재배포하면 라이선스 위반이 된다. 논문도 abstract-only 정책과 전문 사용권을 구분해야 한다.
+
+본 SPEC은 각 source의 수집·embedding·검색·요약·export 사용 권한을 명시하고, 권한 없는 자료는 ingestion과 답변 생성을 차단한다. 사용권 검증 gate는 ingestion 이전 단계에 위치하여 무권한 자료가 corpus에 진입하는 것을 원천 차단한다.
+
+license expiry 또는 entitlement revoke 시에는 해당 source가 corpus search에서 즉시 제외되며, 답변·export 산출물에는 source별 사용 제한 문구가 자동 포함된다. 모든 권한 변경 내역은 audit_logs에 기록되어 #48 Source Governance의 authority/version metadata와 통합된다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- 저작권법 / 표준 라이선스 (ISO/IEC/ASTM copyright) — 표준 전문의 무단 저장·재배포 금지.
+- 데이터베이스 구독 약관 (PubMed/Embase entitlement) — abstract-only vs full-text 사용권 구분.
+- 영업비밀 보호 — 사내 SOP/제출 문서의 confidentiality/trade secret 권한 관리.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- source별 license_type, entitlement, permitted_use, expiry_date 저장
+- ingestion 전 사용권 검증 gate
+- ISO/IEC/ASTM 등 유료 표준 전문 entitlement 없으면 전문 저장 금지
+- PubMed/Embase 논문 전문 사용권 및 abstract-only 정책 구분
+- 사내 SOP/제출 문서의 confidentiality/trade secret 권한 관리
+- 답변·export 시 source별 사용 제한 문구 자동 포함
+- license expiry/entitlement revoke 시 corpus search 차단
+- #48 Source Governance와 authority/version metadata 통합
+
+### 1.4 Out of Scope
+
+- 라이선스 자동 구매/갱신 결제 처리
+- 외부 라이선스 제공자 API 직접 연동 (수동 entitlement 입력 우선)
+- DRM(Digital Rights Management) 기술적 암호화
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-CORPUSLIC-001 | THE SYSTEM SHALL 각 source에 license_type, entitlement, permitted_use, expiry_date를 저장해야 한다 | High |
+| REQ-CORPUSLIC-002 | WHEN 문서 ingestion이 요청되면 THE SYSTEM SHALL ingestion 이전에 사용권 검증 gate를 실행해야 한다 | High |
+| REQ-CORPUSLIC-003 | IF license metadata가 없는 source가 ingestion되려 하면 THEN THE SYSTEM SHALL ingestion을 차단해야 한다 | High |
+| REQ-CORPUSLIC-004 | IF ISO/IEC/ASTM 유료 표준 전문이 entitlement 없이 저장되려 하면 THEN THE SYSTEM SHALL 전문 저장 및 embedding을 차단해야 한다 | High |
+| REQ-CORPUSLIC-005 | THE SYSTEM SHALL PubMed/Embase 논문에 대해 full-text 사용권과 abstract-only 정책을 구분하여 적용해야 한다 | High |
+| REQ-CORPUSLIC-006 | THE SYSTEM SHALL 사내 SOP/제출 문서의 confidentiality 및 trade secret 권한을 관리해야 한다 | High |
+| REQ-CORPUSLIC-007 | WHEN 답변 또는 export가 생성되면 THE SYSTEM SHALL source별 사용 제한 문구를 자동 포함해야 한다 | High |
+| REQ-CORPUSLIC-008 | IF source의 license가 만료되거나 entitlement가 revoke되면 THEN THE SYSTEM SHALL 해당 source를 corpus search 결과에서 제외해야 한다 | High |
+| REQ-CORPUSLIC-009 | THE SYSTEM SHALL source license/entitlement 정보를 #48 Source Governance의 authority/version metadata와 통합해야 한다 | High |
+| REQ-CORPUSLIC-010 | WHEN 권한 정보가 변경되면 THE SYSTEM SHALL 변경 내역을 audit_logs에 기록해야 한다 | High |
+| REQ-CORPUSLIC-011 | WHEN export 패키지가 생성되면 THE SYSTEM SHALL 포함된 모든 source의 export 권한을 검증해야 한다 | High |
+| REQ-CORPUSLIC-012 | IF 권한 없는 사용자가 license 설정을 변경하려 하면 THEN THE SYSTEM SHALL 거부하고 audit_logs에 기록해야 한다 | High |
+| REQ-CORPUSLIC-013 | WHILE source가 abstract-only 정책일 동안 THE SYSTEM SHALL 전문 검색/요약을 차단하고 abstract만 노출해야 한다 | High |
+| REQ-CORPUSLIC-014 | THE SYSTEM SHALL license expiry 임박 source에 대해 관리자에게 사전 경고를 제공해야 한다 | Medium |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | license metadata 없는 source의 ingestion이 차단됨 | Integration: metadata 누락 source ingestion 시도 시 거부 |
+| AC-02 | 유료 표준 전문의 무권한 저장·embedding이 차단됨 | Integration: ISO 표준 entitlement 없이 ingestion 시 block |
+| AC-03 | source expiry 시 검색 결과에서 제외됨 | Integration: expiry 설정 후 corpus search에서 미노출 |
+| AC-04 | export 산출물에 사용권 제한 문구가 포함됨 | E2E: export 생성 후 제한 문구 텍스트 검증 |
+| AC-05 | 권한 변경 내역이 audit_logs에 100% 기록됨 | DB 조회: 모든 license 변경에 대응하는 audit row |
+| AC-06 | abstract-only source가 전문 검색/요약을 차단함 | Integration: abstract-only source 전문 요청 시 abstract만 반환 |
+| AC-07 | 권한 없는 사용자의 license 설정 변경이 차단됨 | E2E: 무권한 계정 license 수정 시 403 + audit row |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/api/corpus-license/
+    source-license/route.ts        # license metadata CRUD
+    ingestion-gate/route.ts        # ingestion 전 사용권 검증
+    entitlement/route.ts           # entitlement 관리/revoke
+  lib/corpus-license/
+    license-gate.ts                # ingestion 사용권 검증 게이트
+    permitted-use.ts               # permitted_use 정책 평가
+    usage-notice.ts                # 답변/export 사용 제한 문구 생성
+    expiry-checker.ts              # expiry/revoke 시 search 제외
+  lib/ingest/                      # #10 DocIngest 연동 지점
+  db/schema/
+    source-license.ts
+    entitlement.ts
+```
+
+### 4.2 DB Schema
+
+- `source_license`: id, source_id (FK to source governance), license_type (enum: standard_paid/journal/internal_sop/open), entitlement_ref, permitted_use (jsonb: ingest/embed/search/summarize/export), full_text_allowed (boolean), abstract_only (boolean), confidentiality_level (enum: public/internal/trade_secret), expiry_date (date, nullable), created_at
+- `entitlement`: id, source_license_id (FK), status (enum: active/revoked/expired), granted_by (FK), granted_at, revoked_at (nullable)
+- `audit_logs` (기존): license/entitlement 변경, 차단 이벤트 기록
+
+### 4.3 API Endpoints
+
+- `POST/GET/PUT /api/corpus-license/source-license` — license metadata 관리 (RBAC gate)
+- `POST /api/corpus-license/ingestion-gate` — ingestion 전 사용권 검증 (#10 연동)
+- `POST /api/corpus-license/entitlement` — entitlement grant/revoke
+- corpus search/answer/export 경로에 license-gate 및 usage-notice 미들웨어 적용
+
+### 4.4 의존성
+
+- 선행: SPEC-REGULA-FOUNDATION-001 (auth/RBAC/audit), SPEC-REGULA-RELEASE-001
+- 연계: #10 DocIngest (수집 전 권한 검증), #48 Source Governance (메타데이터 통합), #60 Clinical Literature (논문 사용권), #62 Standards (ISO/IEC/ASTM entitlement), #65 eSubmit (export 권한)
+- 기술: Next.js 15, Drizzle ORM, PostgreSQL + pgvector (embedding gate), ingestion pipeline 연동

--- a/.moai/specs/SPEC-REGULA-CROSSMARKET-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CROSSMARKET-001/spec.md
@@ -1,0 +1,131 @@
+---
+id: SPEC-REGULA-CROSSMARKET-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 42
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-BREADTH-001
+  - SPEC-REGULA-STRATEGY-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-CROSSMARKET-001 — 멀티 관할권 갭 분석기 (기존 허가 → 신규 시장 진출 요건)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #42 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+의료기기 RA 업무에서 멀티-관할권 진출은 매우 일반적인 시나리오다. 그러나 현재 Regula는 각 관할권에 대해 독립적으로만 답변할 뿐, "이미 A 시장에서 허가를 받았을 때, B 시장 진출에 추가로 필요한 것은 무엇인가"를 분석하지 못한다.
+
+RA 팀이 실제로 마주하는 질문은 다음과 같다. "FDA 510(k) 클리어런스를 받았다. EU CE mark를 위해 추가로 무엇이 필요한가?", "MFDS 허가가 있다. 미국 진출 시 510(k)가 필요한가, De Novo인가?", "EU MDR CER을 작성했다. PMDA 승인에 이 임상 데이터를 재활용할 수 있는가?"
+
+이 갭 분석은 현재 수동으로 4~6주가 소요된다. 본 SPEC은 기존 허가 현황을 입력받아 목표 관할권 진출에 필요한 추가 요건과 재활용 가능 항목을 자동으로 분석하여 갭 분석 보고서를 생성한다.
+
+본 기능은 전략 생성기(#40)의 상위 레벨 통합에서 활용되며, 5 corpus retriever, predicate search, CER builder, submission lifecycle 데이터를 결합한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA: 510(k)/PMA 클리어런스 데이터, 21 CFR Part 807/814
+- EU MDR: Regulation (EU) 2017/745, CE marking, CER (Clinical Evaluation Report), PMCF
+- MFDS: 의료기기법 품목허가
+- PMDA: PMD Act 승인, bridging study 요건
+- NMPA: 의료기기 등록
+- 데이터 공용: 관할권 간 임상 데이터 재활용 범위, 기술문서 공용 섹션
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- A. 기존 허가 인식: 사용자 입력 또는 프로젝트 정보에서 보유 허가 현황 파악 (FDA 510(k)/PMA, EU MDR CE, MFDS 품목허가, PMDA 승인, NMPA 등록)
+- B. 갭 분석 엔진: 기존 허가 → 목표 관할권 갭 분석 (추가 임상 데이터, 현지화 요건, 현지 대리인/법인, 기술문서 추가 항목, 규제 경로 차이) 및 재활용 가능 항목 식별
+- C. 갭 우선순위 및 경로 최적화: 갭 항목별 난이도/기간 예측, 의존성 고려한 해소 순서 제안
+- D. 갭 분석 보고서: Markdown + DOCX export, 관할권별 갭 요약 테이블, 재활용 항목 하이라이트, 항목별 citation
+
+### 1.4 Out of Scope
+
+- 실제 외부 기관 제출 대행
+- 현지 법인 설립 컨설팅
+- 관세/수입 인증 (CE marking 이외 국가별 수입 허가)
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-CROSSMARKET-001 | WHEN a user inputs current approval status THE SYSTEM SHALL recognize the held approvals (FDA 510(k)/PMA, EU MDR CE, MFDS 품목허가, PMDA 승인, NMPA 등록). | High |
+| REQ-CROSSMARKET-002 | WHERE project information is available THE SYSTEM SHALL auto-detect held approvals from the project context. | Medium |
+| REQ-CROSSMARKET-003 | WHEN a user specifies a target jurisdiction THE SYSTEM SHALL perform a gap analysis from the held approvals to the target jurisdiction. | High |
+| REQ-CROSSMARKET-004 | WHEN gap analysis runs THE SYSTEM SHALL categorize gap items by type (additional clinical data, localization, local representative/entity, additional technical documentation, regulatory path differences). | High |
+| REQ-CROSSMARKET-005 | WHEN gap analysis runs THE SYSTEM SHALL identify reusable items including shared clinical data scope and shared technical documentation sections. | High |
+| REQ-CROSSMARKET-006 | WHEN gap items are produced THE SYSTEM SHALL estimate difficulty (High/Medium/Low) and duration for each gap item. | Medium |
+| REQ-CROSSMARKET-007 | WHEN gap items are produced THE SYSTEM SHALL propose an optimal resolution order considering dependencies between items. | Medium |
+| REQ-CROSSMARKET-008 | WHEN a gap analysis report is generated THE SYSTEM SHALL produce a per-jurisdiction gap summary table (item, current state, required state, gap type). | High |
+| REQ-CROSSMARKET-009 | WHEN a gap analysis report is generated THE SYSTEM SHALL highlight reusable items distinctly from additionally required items. | High |
+| REQ-CROSSMARKET-010 | WHEN any gap item is reported THE SYSTEM SHALL include a regulatory basis citation with a source link. | High |
+| REQ-CROSSMARKET-011 | WHEN a gap analysis report is generated THE SYSTEM SHALL support export to Markdown and DOCX formats. | High |
+| REQ-CROSSMARKET-012 | IF a high-risk gap is detected THEN THE SYSTEM SHALL automatically flag it for expert review. | High |
+| REQ-CROSSMARKET-013 | WHEN retrieval is performed THE SYSTEM SHALL query the 5-corpus retrievers to source jurisdiction-specific requirements. | High |
+| REQ-CROSSMARKET-014 | WHEN a gap analysis session completes THE SYSTEM SHALL record an audit log entry with session metadata. | High |
+| REQ-CROSSMARKET-015 | WHILE a user lacks the required role for gap analysis THE SYSTEM SHALL deny access and return an authorization error. | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | 기존 허가 현황 + 목표 관할권 입력 시 갭 분석 보고서가 생성된다. | Test |
+| AC-02 | 재활용 가능 항목과 추가 필요 항목이 명확히 구분된다. | Test / Review |
+| AC-03 | 각 갭 항목에 규제 근거 citation(출처 링크)이 포함된다. | Test |
+| AC-04 | DOCX 보고서가 export된다. | Test |
+| AC-05 | 고위험 갭이 자동으로 expert review 플래그된다. | Test |
+| AC-06 | promptfoo eval 시나리오 FDA→EU MDR, MFDS→FDA, EU MDR→PMDA 3가지가 통과한다. | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `app/(workflows)/crossmarket/page.tsx` — 갭 분석기 진입 UI
+- `app/api/crossmarket/route.ts` — 갭 분석 세션 API (SSE)
+- `lib/crossmarket/approval-recognizer.ts` — 기존 허가 인식
+- `lib/crossmarket/gap-engine.ts` — 갭 분석 엔진
+- `lib/crossmarket/path-optimizer.ts` — 갭 우선순위 및 경로 최적화
+- `lib/crossmarket/report-builder.ts` — Markdown/DOCX 보고서 생성
+
+### 4.2 DB Schema
+
+- `crossmarket_analyses` (신규): 갭 분석 세션 결과 저장 (held_approvals, target_jurisdiction, gap_items JSON, confidence_score, expert_review_required)
+- `audit_logs` (기존): 세션 metadata 기록
+
+### 4.3 API Endpoints
+
+- `POST /api/crossmarket` — 갭 분석 세션 생성 (입력: held approvals + target jurisdiction), SSE 응답
+- `GET /api/crossmarket/[id]/export?format=md|docx` — 보고서 export
+
+### 4.4 의존성
+
+- SPEC-REGULA-BREADTH-001 (5 corpus retrieval)
+- #22 Predicate Search (FDA 경로 근거)
+- #23 CER Builder (EU MDR 경로 근거)
+- #40 Regulatory Strategy Generator (전략 레벨 통합)
+- #37 Submission Lifecycle (기존 허가 데이터)

--- a/.moai/specs/SPEC-REGULA-CYBERDEVICE-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CYBERDEVICE-001/spec.md
@@ -1,0 +1,149 @@
+---
+id: SPEC-REGULA-CYBERDEVICE-001
+version: 1.0.0
+status: draft
+phase: wave5
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 67
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-RELEASE-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/security
+  - component/infra
+---
+
+# SPEC-REGULA-CYBERDEVICE-001 — 의료기기 사이버보안·SBOM 제출 증거 (FDA Cybersecurity·EU MDR GSPR 대응)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #67 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula 자체 보안과 배포 보안은 기존 Release/Cloudflare/Validation 이슈가 다루지만, 고객 의료기기 제품의 사이버보안 제출 증거는 별도 영역이다. Regula가 생성/관리하는 것은 Regula의 보안이 아니라 고객 의료기기 제품의 제출용 사이버보안 증거 패키지다.
+
+연결형 의료기기(connected device)와 SaMD(Software as a Medical Device)는 FDA Premarket Cybersecurity Guidance, EU MDR GSPR, IEC 81001-5-1, SBOM 요구사항을 제출 자료에 포함해야 한다. 이 증거는 제품 아키텍처, threat model, SBOM, 취약점 관리, 보안 업데이트 계획을 구조화하여 제출 가능한 형태로 묶여야 한다.
+
+본 SPEC은 제품별 사이버보안 위험을 구조화하고, SBOM을 입력/검증/버전 관리하며, CVE 영향 분석과 secure update 계획을 생성하고, 이를 SaMD(#63)/DHF(#64)/Submission(#65) 산출물과 연결한다.
+
+보안 취약점 변경은 #54 Change Control 및 #46 Risk 재평가와 연계하여 residual cybersecurity risk를 ISO 14971 risk item으로 연결한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA Premarket Cybersecurity Guidance (2023) — threat model, SBOM, vulnerability management, secure update 제출 요구.
+- EU MDR GSPR Annex I §17.2 / §17.4 — IT 환경 보안 및 최소 보안 요구사항.
+- IEC 81001-5-1 — health software 보안 lifecycle.
+- ISO 14971 — cybersecurity residual risk를 risk management item으로 연결.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 제품 아키텍처 기반 threat model 생성 및 FDA cybersecurity section 체크리스트 자동 작성
+- SBOM 입력/검증/버전 관리 및 버전 diff
+- known exploited vulnerabilities 및 CVE 영향 분석
+- secure update / patch / end-of-support 계획 생성
+- EU MDR GSPR 17.2/17.4 및 IEC 81001-5-1 매핑
+- penetration test, vulnerability scan, residual risk evidence 연결
+- SaMD(#63)/DHF(#64)/Submission(#65) 산출물 연결, #54/#46 재평가 연계
+
+### 1.4 Out of Scope
+
+- Regula 플랫폼 자체 인프라 보안 (기존 Release/Cloudflare 이슈 담당)
+- 실제 penetration test 수행 (외부 결과 evidence 연결만 담당)
+- 고객 의료기기 firmware 직접 분석
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-CYBERDEVICE-001 | THE SYSTEM SHALL 제품 아키텍처 입력을 기반으로 threat model을 생성해야 한다 | High |
+| REQ-CYBERDEVICE-002 | THE SYSTEM SHALL FDA cybersecurity section 체크리스트를 자동 생성하고 커버리지를 추적해야 한다 | High |
+| REQ-CYBERDEVICE-003 | WHEN SBOM이 입력되면 THE SYSTEM SHALL 형식(SPDX/CycloneDX)을 검증하고 저장해야 한다 | High |
+| REQ-CYBERDEVICE-004 | THE SYSTEM SHALL SBOM 버전 간 diff를 제공하여 구성요소 변경을 추적해야 한다 | High |
+| REQ-CYBERDEVICE-005 | THE SYSTEM SHALL known exploited vulnerabilities(KEV) 및 CVE 영향 분석을 수행해야 한다 | High |
+| REQ-CYBERDEVICE-006 | WHEN CVE가 식별되면 THE SYSTEM SHALL 해당 CVE를 영향받는 제품 구성요소와 연결해야 한다 | High |
+| REQ-CYBERDEVICE-007 | THE SYSTEM SHALL secure update, patch, end-of-support 계획을 생성하고 관리해야 한다 | High |
+| REQ-CYBERDEVICE-008 | THE SYSTEM SHALL threat model 항목을 EU MDR GSPR 17.2/17.4 및 IEC 81001-5-1 요구사항에 매핑해야 한다 | High |
+| REQ-CYBERDEVICE-009 | THE SYSTEM SHALL penetration test, vulnerability scan, residual risk evidence를 연결해야 한다 | Medium |
+| REQ-CYBERDEVICE-010 | THE SYSTEM SHALL residual cybersecurity risk를 ISO 14971 risk item(#46)으로 연결해야 한다 | High |
+| REQ-CYBERDEVICE-011 | WHEN 보안 취약점이 변경되면 THE SYSTEM SHALL #54 Change Control 및 #46 Risk 재평가를 트리거해야 한다 | High |
+| REQ-CYBERDEVICE-012 | THE SYSTEM SHALL cybersecurity evidence bundle을 SaMD(#63)/DHF(#64)/Submission(#65) 산출물과 연결해야 한다 | High |
+| REQ-CYBERDEVICE-013 | IF entitlement 없는 사용자가 cybersecurity evidence에 접근하면 THEN THE SYSTEM SHALL 접근을 차단하고 audit_logs에 기록해야 한다 | High |
+| REQ-CYBERDEVICE-014 | WHEN 제출 패키지가 생성되면 THE SYSTEM SHALL cybersecurity evidence bundle을 포함해야 한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | SBOM import/export 및 버전 diff가 동작함 | Integration: SBOM 2개 버전 입력 후 diff 결과 검증 |
+| AC-02 | FDA cybersecurity checklist 100% 항목이 커버됨 | checklist 커버리지 리포트 확인 |
+| AC-03 | CVE 영향 분석 결과가 제품 구성요소와 연결됨 | Integration: CVE 입력 후 영향 구성요소 매핑 검증 |
+| AC-04 | residual cybersecurity risk가 ISO 14971 risk item으로 연결됨 | DB 조회: cybersecurity risk → risk_item FK 검증 |
+| AC-05 | 제출 패키지에 cybersecurity evidence bundle이 포함됨 | E2E: submission export 후 bundle 포함 확인 |
+| AC-06 | threat model이 GSPR 17.2/17.4 및 IEC 81001-5-1에 매핑됨 | 매핑 테이블 완전성 검증 |
+| AC-07 | 권한 없는 evidence 접근이 차단되고 audit에 기록됨 | E2E: 무권한 계정 접근 시 403 + audit row |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/api/cyberdevice/
+    threat-model/route.ts
+    sbom/route.ts
+    sbom/diff/route.ts
+    cve-analysis/route.ts
+    update-plan/route.ts
+    evidence-bundle/route.ts
+  lib/cyberdevice/
+    threat-model-generator.ts
+    sbom-parser.ts          # SPDX/CycloneDX 파싱·검증
+    cve-mapper.ts           # CVE/KEV → 구성요소 연결
+    gspr-mapping.ts         # GSPR 17.2/17.4, IEC 81001-5-1 매핑
+    checklist.ts            # FDA cybersecurity checklist
+  db/schema/
+    threat-model.ts
+    sbom.ts
+    cve-impact.ts
+    cyber-evidence.ts
+```
+
+### 4.2 DB Schema
+
+- `threat_model`: id, product_id, architecture_input (jsonb), threats (jsonb), gspr_mapping (jsonb), created_at
+- `sbom`: id, product_id, format (enum: spdx/cyclonedx), version, components (jsonb), validated (boolean), created_at
+- `cve_impact`: id, cve_id, kev_flag (boolean), affected_component_id (FK to sbom component), severity, mitigation (text), risk_item_id (FK, nullable), created_at
+- `cyber_evidence_bundle`: id, product_id, threat_model_id (FK), sbom_id (FK), pentest_artifact_path, update_plan (jsonb), linked_samd_id (FK), linked_dhf_id (FK), linked_submission_id (FK), created_at
+- `audit_logs` (기존): evidence 접근 기록
+
+### 4.3 API Endpoints
+
+- `POST /api/cyberdevice/threat-model` — 아키텍처 기반 threat model 생성
+- `POST/GET /api/cyberdevice/sbom`, `GET /api/cyberdevice/sbom/diff` — SBOM 관리/diff
+- `POST /api/cyberdevice/cve-analysis` — CVE/KEV 영향 분석
+- `POST /api/cyberdevice/update-plan` — secure update/end-of-support 계획
+- `POST /api/cyberdevice/evidence-bundle` — 제출용 evidence bundle 생성
+
+### 4.4 의존성
+
+- 선행: SPEC-REGULA-FOUNDATION-001 (auth/RBAC/audit), SPEC-REGULA-RELEASE-001
+- 연계: #46 Risk (ISO 14971 residual risk), #49 Validation, #54 Change Control, #63 SaMD, #64 DHF, #65 eSubmit
+- 기술: Next.js 15, Drizzle ORM, PostgreSQL, SPDX/CycloneDX SBOM 파서, CVE/KEV 데이터 소스 연동

--- a/.moai/specs/SPEC-REGULA-KNOWLEDGE-GAP-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-KNOWLEDGE-GAP-001/spec.md
@@ -1,0 +1,143 @@
+---
+id: SPEC-REGULA-KNOWLEDGE-GAP-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 35
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-REGULA-RELEASE-HARDENING-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/rag
+  - component/ops
+---
+
+# SPEC-REGULA-KNOWLEDGE-GAP-001 — 미답변 자동 이슈화 및 지식베이스 보강 루프
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #35 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula는 질의응답, 문서 ingestion, 워크플로우, Predicate/CER/PCCP 작성까지 갖춘 내부 RA(Regulatory Affairs) 운영 시스템을 지향한다. 그러나 현재 시스템은 사용자가 질문을 하고 답을 받는 단방향 도구에 머물러 있으며, 답변하지 못한 질문이 시스템 개선으로 환류되는 폐쇄 루프가 존재하지 않는다.
+
+제품 철학에 명시된 핵심 가치는 "미답변 → Issue → 지식베이스 보강 → 재답변 가능"이라는 지속 개선 루프이다. 현장의 RA 담당자가 던지는 질문은 그 자체로 지식베이스의 빈틈을 드러내는 가장 가치 있는 신호이다. 이 신호를 자동으로 포착하여 추적 가능한 작업 항목으로 전환하지 못하면, 같은 미답변이 반복되고 RA 팀의 신뢰가 저하된다.
+
+본 SPEC은 Regula가 단순 답변 도구가 아니라, 현장 질문을 통해 지식베이스를 지속 보강하는 운영 시스템이 되도록 만드는 후속 SPEC이다. 미답변 감지, GitHub Issue 자동 등록, RA 분류 워크플로우, 일일 Digest, 폐쇄 루프 검증의 5개 축을 구현한다.
+
+미답변 후보 저장 시 사용자 질문 원문에 포함될 수 있는 PII 및 영업비밀을 redaction하여, 규제 도메인의 기밀성 요구를 충족하면서도 추적 가능성을 확보한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- 의료기기 품질경영시스템(ISO 13485) 및 21 CFR Part 820은 문서화된 정보의 통제와 지속적 개선(CAPA) 프로세스를 요구한다. 미답변 루프는 지식베이스에 대한 CAPA의 디지털 구현체로 볼 수 있다.
+- 21 CFR Part 11(전자기록·전자서명)에 따라 미답변 감지, 분류, 해결 이벤트는 변조 불가능한 audit trail로 기록되어야 한다.
+- 질문 원문 저장 시 PII/영업비밀 redaction은 개인정보보호법 및 영업비밀 보호 의무를 충족하기 위한 필수 통제이다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 미답변 감지: confidence threshold 미달, citation coverage 미달, 검색 결과 0건, 정책상 답변 불가 조건을 `knowledge_gap` 후보로 기록
+- PII/영업비밀 redaction 후 질문 저장 및 `unanswered_queue` 테이블 관리
+- 중복 질문 클러스터링 및 기존 GitHub Issue append
+- GitHub Issue 자동 등록 (라벨, 본문 메타데이터 포함)
+- RA 분류 워크플로우 (4개 분류 카테고리 + audit 기록 + handoff 템플릿)
+- 매일 08:00 일일 Digest 생성 및 알림
+- 폐쇄 루프 검증: 지식베이스 보강 후 replay test로 resolved 처리
+- `expert_review_required`와 `knowledge_gap_required` 플래그 분리
+
+### 1.4 Out of Scope
+
+- 외부 고객용 support ticketing 시스템
+- Slack/Jira 양방향 동기화
+- 자동 규정 해석 생성 (RA 전문가 판단 대체 금지)
+- redaction 알고리즘 자체의 신규 개발 (기존 redaction 유틸리티 재사용 전제)
+
+---
+
+## §2 Requirements (EARS Format)
+
+### REQ-KNOWLEDGE-GAP: 미답변 감지·이슈화·분류·검증
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-KNOWLEDGE-GAP-001 | WHEN 답변 생성 결과의 confidence가 설정된 threshold 미달이거나 citation coverage가 미달이거나 검색 결과가 0건이거나 정책상 답변 불가일 때 THE SYSTEM SHALL 해당 질의를 `knowledge_gap` 후보로 기록한다 | High |
+| REQ-KNOWLEDGE-GAP-002 | WHEN 미답변 후보를 저장할 때 THE SYSTEM SHALL 사용자 질문 원문에 PII 및 영업비밀 redaction을 적용한 후 저장하고 redaction hash를 함께 기록한다 | High |
+| REQ-KNOWLEDGE-GAP-003 | THE SYSTEM SHALL `expert_review_required`와 `knowledge_gap_required` 플래그를 분리하여 관리한다 | High |
+| REQ-KNOWLEDGE-GAP-004 | WHEN 미답변 후보가 기록될 때 THE SYSTEM SHALL `unanswered_queue` 테이블에 항목을 생성한다 | High |
+| REQ-KNOWLEDGE-GAP-005 | WHEN 새 미답변 후보가 기존 미답변과 의미상 동일/유사하게 클러스터링될 때 THE SYSTEM SHALL 새 GitHub Issue를 만들지 않고 기존 이슈에 append한다 | High |
+| REQ-KNOWLEDGE-GAP-006 | WHEN 신규 미답변 클러스터가 GitHub Issue로 등록될 때 THE SYSTEM SHALL 이슈 본문에 질문 요약, 실패 원인, 누락 출처 후보, 관련 conversation/message id, redaction hash를 포함한다 | High |
+| REQ-KNOWLEDGE-GAP-007 | WHEN GitHub Issue를 등록할 때 THE SYSTEM SHALL `knowledge-gap`, `ra-auto`, `needs-classification` 라벨을 부여한다 | Medium |
+| REQ-KNOWLEDGE-GAP-008 | WHERE RA 담당자가 분류 워크플로우를 사용할 때 THE SYSTEM SHALL `ra-project 지식 누락`, `MD-process SOP 누락`, `외부 규제 원문 필요`, `제품 버그` 중 하나로 분류하는 UI/API를 제공한다 | High |
+| REQ-KNOWLEDGE-GAP-009 | WHEN RA 담당자가 미답변을 분류할 때 THE SYSTEM SHALL 분류 결과를 audit_logs에 기록한다 | High |
+| REQ-KNOWLEDGE-GAP-010 | WHERE 분류 완료된 미답변이 담당 저장소/문서 소스로 handoff될 때 THE SYSTEM SHALL handoff용 Markdown 템플릿을 제공한다 | Medium |
+| REQ-KNOWLEDGE-GAP-011 | WHEN 매일 08:00이 도래할 때 THE SYSTEM SHALL 전날 미답변 요약 Digest(이메일/알림)를 생성한다 | High |
+| REQ-KNOWLEDGE-GAP-012 | WHERE 일일 Digest가 생성될 때 THE SYSTEM SHALL 반복 미답변 top topics, 긴급도, 미처리 SLA를 표시한다 | Medium |
+| REQ-KNOWLEDGE-GAP-013 | IF Digest 발송이 실패하면 THEN THE SYSTEM SHALL 발송 실패 사실을 audit_logs에 기록한다 | High |
+| REQ-KNOWLEDGE-GAP-014 | WHEN 관련 문서 ingestion이 완료될 때 THE SYSTEM SHALL 동일/유사 질문에 대한 replay test를 생성한다 | High |
+| REQ-KNOWLEDGE-GAP-015 | IF replay test가 citation 포함 답변으로 통과하면 THEN THE SYSTEM SHALL 해당 queue item을 resolved 처리하고 GitHub Issue에 근거 문서와 replay 결과를 댓글로 기록한다 | High |
+| REQ-KNOWLEDGE-GAP-016 | THE SYSTEM SHALL 미답변 생성, 분류, digest, resolved 이벤트를 모두 audit_logs에 기록한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | confidence/citation/검색0건/정책불가 4개 조건 각각에 대해 미답변 후보가 `unanswered_queue`에 자동 생성된다 | Test |
+| AC-02 | PII/영업비밀이 포함된 질문이 redaction된 형태로만 저장되고 redaction hash가 기록된다 | Test |
+| AC-03 | 의미상 유사한 미답변 2건이 별도 이슈가 아닌 동일 GitHub Issue에 묶인다 | Test |
+| AC-04 | RA 분류 UI/API가 4개 카테고리로 분류를 수행하고 결과가 audit_logs에 남는다 | Test / Review |
+| AC-05 | 매일 08:00 스케줄러가 전날 미답변 Digest를 생성하고, 발송 실패 시 audit_logs에 기록한다 | Test |
+| AC-06 | 관련 문서 ingestion 후 replay test가 citation 포함 답변으로 통과하면 queue item과 GitHub Issue가 resolved 처리된다 | Test |
+| AC-07 | 생성/분류/digest/resolved 4종 이벤트가 모두 audit_logs에서 조회된다 | Test |
+| AC-08 | 권한 없는 사용자가 분류 API를 호출하면 거부되고 audit_logs에 거부 기록이 남는다 | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `lib/db/schema/unanswered-queue.ts` — 미답변 큐 스키마
+- `lib/knowledge-gap/detector.ts` — 미답변 감지 로직 (confidence/citation/검색/정책)
+- `lib/knowledge-gap/redaction.ts` — PII/영업비밀 redaction 래퍼 (기존 유틸 재사용)
+- `lib/knowledge-gap/clustering.ts` — 중복 질문 클러스터링
+- `lib/knowledge-gap/github-issue.ts` — GitHub Issue 등록/append
+- `lib/knowledge-gap/digest.ts` — 일일 Digest 생성
+- `lib/knowledge-gap/replay.ts` — 폐쇄 루프 replay test 생성/검증
+- `app/api/knowledge-gap/classify/route.ts` — RA 분류 API
+- `app/(app)/knowledge-gap/page.tsx` — RA 분류 워크플로우 UI
+- `templates/knowledge-gap-handoff.md` — handoff Markdown 템플릿
+
+### 4.2 DB Schema
+
+- 신규 테이블 `unanswered_queue`: id, org_id, conversation_id, message_id, redacted_question, redaction_hash, gap_reason(enum: low_confidence/low_citation/no_results/policy_blocked), cluster_id, github_issue_number, classification(enum), status(enum: open/classified/resolved), created_at, resolved_at
+- 신규 플래그 컬럼: messages 테이블에 `knowledge_gap_required` boolean 추가 (기존 `expert_review_required`와 분리)
+- audit_logs 활용: 신규 action 값 `knowledge_gap_created`, `knowledge_gap_classified`, `knowledge_gap_digest_sent`, `knowledge_gap_resolved`
+
+### 4.3 API Endpoints
+
+- `POST /api/knowledge-gap/classify` — RA 담당자 분류 (RBAC: ra-lead/admin)
+- `GET /api/knowledge-gap/queue` — 미답변 큐 조회
+- `POST /api/knowledge-gap/replay/:queueId` — replay test 실행
+- 내부 cron: 매일 08:00 digest 작업
+
+### 4.4 의존성
+
+- 외부: GitHub API (이슈 생성/append/댓글), 이메일/알림 채널, 스케줄러(cron)
+- 기존 SPEC: SPEC-REGULA-FOUNDATION-001(audit_logs, RBAC), SPEC-REGULA-CHAT-001(conversation/message), SPEC-REGULA-DOCINGEST-001(ingestion 완료 이벤트), SPEC-REGULA-RELEASE-HARDENING-001
+- 보완 관계: SPEC-REGULA-KNOWLEDGE-PROMO-001(#50, 우수답변 승격 — 미답변과 반대 방향), SPEC-REGULA-SOURCE-GOVERNANCE-001(#48, source 변경 시 gap 영향 표시)

--- a/.moai/specs/SPEC-REGULA-KNOWLEDGE-PROMO-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-KNOWLEDGE-PROMO-001/spec.md
@@ -1,0 +1,139 @@
+---
+id: SPEC-REGULA-KNOWLEDGE-PROMO-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 50
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-KNOWLEDGE-GAP-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/rag
+  - component/frontend
+---
+
+# SPEC-REGULA-KNOWLEDGE-PROMO-001 — 대화 시맨틱 검색 & 우수 답변 팀 지식 승격
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #50 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Phase 1-9 완료 후 Regula는 수천 건의 규제 Q&A 대화를 축적하게 된다. 그러나 현재 구조에서는 이 대화들이 사용자 개인 히스토리에만 머물며, 팀 전체의 집단 지성으로 승화되지 않는다. 예를 들어 RA Lead가 1년 전 작성한 완벽한 FDA 510(k) 실질동등성(substantial equivalence) 답변이 있어도, 다른 팀원은 같은 질문을 다시 던지고 처음부터 답을 만들어야 한다.
+
+이는 조직 차원에서 중대한 지식 낭비이다. 기관 고유의 사내 판례(precedent)가 누적되지 못하면, 동일 질문에 대해 팀원마다 다른 답을 받게 되어 규제 당국 대응 시 일관성이 깨질 위험이 있다.
+
+본 SPEC은 전체 조직 대화에 대한 시맨틱 검색(키워드 + 의미 기반)을 지원하고, RA Lead/Admin이 우수 답변을 팀 지식 라이브러리로 승격할 수 있게 하며, 승격된 답변을 RAG 검색 시 우선 표시 및 citation으로 활용하도록 만든다. 이를 통해 기관 고유의 사내 판례가 누적되어 답변 품질이 지속적으로 향상된다.
+
+승격은 권한이 통제되어야 한다. ra-lead/admin만 승격할 수 있고, 모든 멤버가 열람할 수 있으며, 승격 행위는 감사 로그로 추적된다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- 규제 당국 대응의 일관성(consistency)은 ISO 13485 품질 시스템의 핵심 원칙이다. 승격된 사내 판례는 동일 입장 유지를 위한 통제된 지식 자산이 된다.
+- 21 CFR Part 11에 따라 지식 승격(promotion) 행위는 누가·언제·무엇을 승격했는지 감사 가능해야 한다.
+- 승격된 답변이 RAG citation으로 활용될 때, 그 출처(원본 message)가 추적 가능해야 규제 제출물의 근거 추적성(traceability)을 만족한다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 조직 전체 대화에 대한 full-text + 시맨틱 검색 API
+- 답변 승격 UI (메시지 단위 / 대화 단위 승격 버튼)
+- 승격된 답변 전용 테이블 (`promoted_answers`)
+- RAG 파이프라인에 promoted_answers retriever 추가 (내부 문서보다 높은 가중치)
+- 지식 라이브러리 뷰 (Personal Library 페이지 확장)
+- 승격 감사 로그
+- RBAC: ra-lead/admin만 승격 가능, 전 멤버 열람 가능
+
+### 1.4 Out of Scope
+
+- 외부 조직 간 지식 공유
+- 승격 답변의 자동 만료/재검증 (별도 후속 SPEC, #48 source governance와 연계 검토)
+- 승격 답변에 대한 협업 편집 (SPEC-REGULA-COEDIT-001 영역)
+- 승격 우선순위 자동 학습 (RLHF #56 영역)
+
+---
+
+## §2 Requirements (EARS Format)
+
+### REQ-KNOWLEDGE-PROMO: 시맨틱 검색·승격·RAG 통합·RBAC
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-KNOWLEDGE-PROMO-001 | THE SYSTEM SHALL 조직 전체 대화에 대한 full-text 검색 API를 제공한다 | High |
+| REQ-KNOWLEDGE-PROMO-002 | THE SYSTEM SHALL 조직 전체 대화에 대한 시맨틱(의미 기반) 검색 API를 제공한다 | High |
+| REQ-KNOWLEDGE-PROMO-003 | WHEN 사용자가 검색을 수행할 때 THE SYSTEM SHALL 자신의 org 범위 내 대화만 결과로 반환한다 | High |
+| REQ-KNOWLEDGE-PROMO-004 | WHERE 사용자가 메시지 단위로 승격을 요청할 때 THE SYSTEM SHALL 해당 메시지를 승격 대상으로 처리하는 UI를 제공한다 | High |
+| REQ-KNOWLEDGE-PROMO-005 | WHERE 사용자가 대화 단위로 승격을 요청할 때 THE SYSTEM SHALL 해당 대화를 승격 대상으로 처리하는 UI를 제공한다 | Medium |
+| REQ-KNOWLEDGE-PROMO-006 | WHEN 답변이 승격될 때 THE SYSTEM SHALL `promoted_answers` 테이블에 id, orgId, sourceMessageId, title, tags, promotedBy, promotedAt를 기록한다 | High |
+| REQ-KNOWLEDGE-PROMO-007 | IF 승격을 요청한 사용자의 역할이 ra-lead 또는 admin이 아니면 THEN THE SYSTEM SHALL 승격을 거부한다 | High |
+| REQ-KNOWLEDGE-PROMO-008 | THE SYSTEM SHALL org의 전 멤버가 승격된 답변을 열람할 수 있도록 허용한다 | High |
+| REQ-KNOWLEDGE-PROMO-009 | WHEN RAG 검색을 수행할 때 THE SYSTEM SHALL promoted_answers retriever를 포함하여 검색한다 | High |
+| REQ-KNOWLEDGE-PROMO-010 | WHERE promoted answer가 검색될 때 THE SYSTEM SHALL 내부 문서보다 높은 가중치를 부여한다 | High |
+| REQ-KNOWLEDGE-PROMO-011 | WHEN promoted answer가 citation으로 사용될 때 THE SYSTEM SHALL 원본 sourceMessageId로 추적 가능한 citation을 생성한다 | High |
+| REQ-KNOWLEDGE-PROMO-012 | THE SYSTEM SHALL 지식 라이브러리 뷰에서 승격된 답변 목록을 title/tags로 탐색 가능하게 표시한다 | Medium |
+| REQ-KNOWLEDGE-PROMO-013 | WHEN 답변이 승격될 때 THE SYSTEM SHALL audit_logs에 승격 action(누가·무엇을·언제)을 기록한다 | High |
+| REQ-KNOWLEDGE-PROMO-014 | WHEN 승격이 취소(unpromote)될 때 THE SYSTEM SHALL audit_logs에 취소 action을 기록하고 RAG 검색에서 제외한다 | Medium |
+| REQ-KNOWLEDGE-PROMO-015 | THE SYSTEM SHALL 승격 시 부여한 tags로 promoted_answers를 필터링하는 기능을 제공한다 | Low |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | full-text 검색과 시맨틱 검색 API가 org 범위 내 대화를 반환하고, 타 org 대화는 노출되지 않는다 | Test |
+| AC-02 | ra-lead/admin이 메시지 단위 및 대화 단위로 답변을 승격하면 promoted_answers에 레코드가 생성된다 | Test |
+| AC-03 | ra-lead/admin이 아닌 멤버가 승격을 시도하면 거부되고 audit_logs에 기록된다 | Test |
+| AC-04 | 승격된 답변이 RAG 검색에서 내부 문서보다 높은 가중치로 우선 표시된다 | Test |
+| AC-05 | 승격된 답변이 citation으로 사용될 때 원본 sourceMessageId로 추적된다 | Test |
+| AC-06 | 전 멤버가 지식 라이브러리 뷰에서 승격된 답변을 열람할 수 있다 | Test / Review |
+| AC-07 | 승격/취소 action이 audit_logs에 기록된다 | Test |
+| AC-08 | unpromote된 답변이 RAG 검색 결과에서 제외된다 | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `lib/db/schema/promoted-answers.ts` — 승격 답변 스키마
+- `lib/knowledge-promo/semantic-search.ts` — full-text + 시맨틱 검색 (pgvector)
+- `lib/knowledge-promo/promote.ts` — 메시지/대화 승격 로직 + RBAC 검증
+- `lib/rag/retrievers/promoted-answers-retriever.ts` — RAG 가중치 retriever
+- `app/api/knowledge-promo/search/route.ts` — 조직 대화 검색 API
+- `app/api/knowledge-promo/promote/route.ts` — 승격/취소 API
+- `components/answer-block/promote-button.tsx` — 승격 UI 버튼
+- `app/(app)/library/page.tsx` — 지식 라이브러리 뷰 (Personal Library 확장)
+
+### 4.2 DB Schema
+
+- 신규 테이블 `promoted_answers`: id, org_id, source_message_id, title, tags(array), promoted_by, promoted_at, status(enum: active/unpromoted)
+- 대화/메시지 검색용 pgvector 인덱스 (기존 임베딩 활용 또는 신규 임베딩 컬럼)
+- audit_logs 활용: 신규 action `answer_promoted`, `answer_unpromoted`
+
+### 4.3 API Endpoints
+
+- `GET /api/knowledge-promo/search?q=&mode=fulltext|semantic` — 조직 대화 검색
+- `POST /api/knowledge-promo/promote` — 승격 (RBAC: ra-lead/admin)
+- `DELETE /api/knowledge-promo/promote/:id` — 승격 취소 (RBAC: ra-lead/admin)
+- `GET /api/knowledge-promo/library` — 지식 라이브러리 목록
+
+### 4.4 의존성
+
+- 외부 라이브러리: pgvector (시맨틱 검색), Drizzle ORM
+- 기존 SPEC: SPEC-REGULA-FOUNDATION-001(RBAC, audit_logs), SPEC-REGULA-CHAT-001(conversation/message, RAG 파이프라인), SPEC-REGULA-PERSONAL-LIB-001(library 뷰 확장)
+- 외부 이슈 의존: #34 Quality Elevation(코퍼스 시드 후 적용)
+- 보완 관계: SPEC-REGULA-KNOWLEDGE-GAP-001(#35, 미답변 이슈화 ↔ 우수답변 승격), SPEC-REGULA-RLHF-001(#56, high-rated → 승격 후보 제안)

--- a/.moai/specs/SPEC-REGULA-LABELING-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-LABELING-001/spec.md
@@ -1,0 +1,146 @@
+---
+id: SPEC-REGULA-LABELING-001
+version: 1.0.0
+status: draft
+phase: wave5
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 66
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-REGULA-CHANGE-CONTROL-001
+  - SPEC-REGULA-TRACEABILITY-001
+  - SPEC-REGULA-CROSSMARKET-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-LABELING-001 — 라벨링·IFU·클레임 검토 워크벤치 (표시문구·사용목적·번역 일관성 관리)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #66 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula가 분류, CER, PCCP, DHF, 전자 제출까지 지원해도 실제 제품 출시 전에는 라벨링, IFU(Instructions for Use), intended use, indication, 광고성 claim 검토가 별도 병목으로 남는다. 라벨링 변경은 #54 Change Control과도 연결되지만, 라벨·IFU 문구 자체를 작성·검토·번역·승인하는 전용 워크벤치는 없다.
+
+본 SPEC은 의료기기 라벨, IFU, intended use, indication, 마케팅 claim을 관할권별(FDA, EU MDR, MFDS, PMDA, NMPA) 규제 기준에 맞춰 작성·검토·승인하고, 제출 패키지(#65)와 변경통제(#54)에 연결하는 워크벤치를 정의한다.
+
+핵심 통제는 claim 문구마다 근거 citation 연결을 강제하고, unsupported·comparative·superiority claim을 자동 경고하며, 번역본 간 의미 차이를 검출해 RA 승인 게이트를 거치도록 하는 것이다. 모든 승인·수정·export 이벤트는 audit_logs에 기록한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA 21 CFR 801: Labeling (의료기기 라벨링 요구사항)
+- FDA 21 CFR 807.87: 510(k) 라벨링 제출
+- EU MDR (2017/745) Annex I Chapter III: 라벨 및 IFU 정보 요구사항
+- MFDS 의료기기법 표시·기재 기준
+- PMDA / NMPA 라벨링 표시사항 기준
+- 21 CFR Part 11: 전자 서명·audit trail
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 라벨링/IFU 문서 구조화 작성기
+- intended use / indication / contraindication / warning / precaution 섹션 관리
+- FDA, EU MDR, MFDS, PMDA, NMPA 관할권별 필수 표시사항 체크
+- claim 문구와 근거 citation 연결
+- unsupported, comparative, superiority claim 자동 경고
+- 번역본 간 의미 차이 검출 및 RA 승인 게이트
+- 라벨링 변경 시 #54 Change Control 자동 연계
+- 최종 승인본을 #65 전자 제출 패키지에 포함
+- 모든 승인·수정·export 이벤트 audit_logs 기록
+
+### 1.4 Out of Scope
+
+- 인쇄용 라벨 아트워크/그래픽 디자인 편집
+- UDI(Unique Device Identification) 바코드 생성 (별도 범위)
+- 자동 기계 번역 엔진 자체 구현 (검출·게이트만 담당)
+- 광고 심의 외부 기관 직접 제출
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-LABEL-001 | THE SYSTEM SHALL 라벨링/IFU 문서를 구조화된 섹션(intended use, indication, contraindication, warning, precaution)으로 작성·관리한다 | High |
+| REQ-LABEL-002 | WHEN 사용자가 관할권을 선택하면 THE SYSTEM SHALL FDA/EU MDR/MFDS/PMDA/NMPA별 필수 표시사항 체크리스트를 제공한다 | High |
+| REQ-LABEL-003 | WHEN 사용자가 claim 문구를 입력하면 THE SYSTEM SHALL 해당 claim과 근거 citation을 연결하도록 요구한다 | High |
+| REQ-LABEL-004 | IF claim이 근거 citation 없이 입력되면 THEN THE SYSTEM SHALL expert review required 상태로 표시하고 경고한다 | High |
+| REQ-LABEL-005 | WHEN comparative 또는 superiority claim이 감지되면 THE SYSTEM SHALL 자동 경고를 표시한다 | High |
+| REQ-LABEL-006 | IF unsupported claim이 존재하면 THEN THE SYSTEM SHALL export를 제한한다 | High |
+| REQ-LABEL-007 | WHEN 번역본이 등록되면 THE SYSTEM SHALL 원본과 번역본 간 의미 차이를 검출하고 RA 승인 게이트를 적용한다 | High |
+| REQ-LABEL-008 | WHEN 라벨링 변경이 발생하면 THE SYSTEM SHALL #54 Change Control 항목을 자동 생성하거나 연결한다 | High |
+| REQ-LABEL-009 | WHEN 라벨이 최종 승인되면 THE SYSTEM SHALL 승인본을 #65 전자 제출 패키지에 포함한다 | High |
+| REQ-LABEL-010 | WHEN 승인·수정·export 이벤트가 발생하면 THE SYSTEM SHALL audit_logs에 기록한다 | High |
+| REQ-LABEL-011 | THE SYSTEM SHALL 관할권별 필수 표시사항 체크리스트를 100% 커버한다 | High |
+| REQ-LABEL-012 | IF 권한 없는 사용자가 라벨 승인을 시도하면 THEN THE SYSTEM SHALL 접근을 거부한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | FDA/EU/MFDS 필수 라벨링 항목 체크리스트 100% 커버 | unit test (항목 매핑) |
+| AC-02 | claim마다 근거 citation 또는 expert review required 상태 강제 | integration test |
+| AC-03 | unsupported claim 0건으로 export 제한 동작 | negative test |
+| AC-04 | comparative/superiority claim 자동 경고 표시 | unit test |
+| AC-05 | 한/영 라벨 의미 차이 검출 및 승인 로그 기록 | integration test |
+| AC-06 | 라벨링 변경 → Change Control 자동 생성 또는 연결 | E2E test |
+| AC-07 | 승인본이 전자 제출 패키지에 포함됨 | integration test |
+| AC-08 | 권한 없는 승인 시도 거부됨 | RBAC negative test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+app/(app)/labeling/                  # 라벨링 워크벤치 UI
+lib/labeling/
+  section-builder.ts                 # 구조화 섹션 작성기
+  claim-validator.ts                 # claim ↔ citation, unsupported/comparative 경고
+  jurisdiction-checklist.ts          # 관할권별 필수 표시사항
+  translation-diff.ts                # 번역본 의미 차이 검출
+lib/db/schema/labeling.ts
+```
+
+### 4.2 DB Schema
+
+- `labeling_documents` 테이블: project_id FK, jurisdiction, status, review_status
+- `labeling_sections` 테이블: document_id FK, section_type, content, locale
+- `labeling_claims` 테이블: section_id FK, claim_text, citation_ref, claim_type(supported|comparative|superiority|unsupported)
+- `labeling_translations` 테이블: section_id FK, source_locale, target_locale, semantic_diff_status, approval_status
+- `audit_logs` 재사용
+
+### 4.3 API Endpoints
+
+- `POST /api/labeling/documents` — 문서 생성
+- `POST /api/labeling/documents/[id]/claims` — claim 입력·검증
+- `GET /api/labeling/documents/[id]/checklist?jurisdiction=` — 관할권 체크리스트
+- `POST /api/labeling/documents/[id]/translations` — 번역본 등록·diff
+- `POST /api/labeling/documents/[id]/approve` — RA 승인 게이트
+- `POST /api/labeling/documents/[id]/export` — unsupported claim 0건일 때만 허용
+
+### 4.4 의존성
+
+- #40 Strategy (시장별 claim 전략 입력)
+- #42 Crossmarket (관할권별 라벨링 갭 분석)
+- #47 Traceability (claim ↔ evidence 연결)
+- #54 Change Control (라벨링 변경 영향 평가)
+- #65 eSubmit (제출 패키지 포함)
+- #64 DHF (설계 산출물 및 변경 이력 연결)

--- a/.moai/specs/SPEC-REGULA-MODEL-GOVERNANCE-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-MODEL-GOVERNANCE-001/spec.md
@@ -1,0 +1,147 @@
+---
+id: SPEC-REGULA-MODEL-GOVERNANCE-001
+version: 1.0.0
+status: draft
+phase: system
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 71
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-RELEASE-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/infra
+---
+
+# SPEC-REGULA-MODEL-GOVERNANCE-001 — LLM·프롬프트·템플릿 변경통제 (모델 버전 검증·승인·롤백)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #71 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula는 LLM, prompt, structured template, retrieval 설정에 따라 규제 문서 품질이 달라진다. #49 Validation과 #56 RLHF가 품질을 다루지만, 모델·프롬프트·템플릿 자체의 변경통제와 승인·롤백 체계는 별도 관리가 필요하다.
+
+규제 문서 생성 제품에서는 모델 또는 prompt 변경이 기능 변경과 동일한 품질 리스크가 된다. 동일한 질문이라도 prompt가 바뀌면 citation 누락, hallucination, 잘못된 규제 해석으로 이어질 수 있다. 따라서 승인된 조합(approved combination)만 production에서 사용되어야 한다.
+
+본 SPEC은 LLM provider, model version, prompt, template, eval set, retriever 설정 변경을 통제한다. 변경은 변경 요청 → eval run → expert approval → rollout 워크플로우를 거치며, 실패 시 이전 승인 버전으로 즉시 rollback한다.
+
+모든 production answer에는 model/prompt/template version audit metadata가 기록되어 어떤 조합이 어떤 답변을 생성했는지 추적 가능하다. #56 RLHF 개선안은 승인 전 production에 반영되지 않는다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- 21 CFR Part 11 — model/prompt 변경 승인 및 audit trail은 electronic record로 기록.
+- GAMP 5 / ISO 13485 §4.1.6 — 소프트웨어 구성요소 변경통제 및 검증 재실행.
+- ISO 14971 — 모델 변경에 따른 품질 리스크 평가.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- prompt/template registry 및 immutable versioning
+- model provider/model id/version pinning
+- retrieval config 변경 이력 관리
+- 변경 요청 → eval run → expert approval → rollout 워크플로우
+- 실패 시 이전 승인 버전 즉시 rollback
+- production answer에 model/prompt/template version audit metadata 기록
+- promptfoo eval threshold 및 regression suite를 release gate로 연결
+- 승인되지 않은 prompt/model 조합 사용 시 runtime block
+
+### 1.4 Out of Scope
+
+- LLM 자체 fine-tuning 또는 training 파이프라인
+- prompt 자동 생성/최적화 알고리즘
+- RLHF 데이터 수집 로직 (#56 담당, 본 SPEC은 승인 게이트만 제공)
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-MODELGOV-001 | THE SYSTEM SHALL prompt 및 template을 registry에 immutable version으로 저장해야 한다 | High |
+| REQ-MODELGOV-002 | THE SYSTEM SHALL model provider, model id, model version을 pinning하여 관리해야 한다 | High |
+| REQ-MODELGOV-003 | THE SYSTEM SHALL retrieval config 변경 이력을 버전 단위로 관리해야 한다 | High |
+| REQ-MODELGOV-004 | WHEN 변경 요청이 제출되면 THE SYSTEM SHALL eval run → expert approval → rollout 워크플로우를 강제해야 한다 | High |
+| REQ-MODELGOV-005 | IF eval이 통과되지 않으면 THEN THE SYSTEM SHALL 해당 조합의 production 사용을 차단해야 한다 | High |
+| REQ-MODELGOV-006 | WHEN rollback이 요청되면 THE SYSTEM SHALL 직전 승인 조합으로 즉시 복구해야 한다 | High |
+| REQ-MODELGOV-007 | THE SYSTEM SHALL 모든 production answer에 model/prompt/template version audit metadata를 기록해야 한다 | High |
+| REQ-MODELGOV-008 | IF 승인되지 않은 prompt/model 조합이 런타임에 사용되려 하면 THEN THE SYSTEM SHALL 실행을 차단해야 한다 | High |
+| REQ-MODELGOV-009 | WHERE #56 RLHF 개선안이 존재하면 THE SYSTEM SHALL 해당 개선안을 승인 전 pending_review 상태로만 저장하고 production 반영을 금지해야 한다 | High |
+| REQ-MODELGOV-010 | THE SYSTEM SHALL promptfoo eval threshold 및 regression suite를 release gate에 연결해야 한다 | High |
+| REQ-MODELGOV-011 | IF promptfoo regression threshold가 미달이면 THEN THE SYSTEM SHALL release gate를 실패 처리해야 한다 | High |
+| REQ-MODELGOV-012 | THE SYSTEM SHALL 변경 승인 시 승인자, 타임스탬프, eval 결과 링크를 audit_logs에 기록해야 한다 | High |
+| REQ-MODELGOV-013 | WHEN 승인된 조합이 rollout되면 THE SYSTEM SHALL 활성 조합(active combination)을 단일하게 유지해야 한다 | Medium |
+| REQ-MODELGOV-014 | IF 권한 없는 사용자가 변경 승인을 시도하면 THEN THE SYSTEM SHALL 거부하고 audit_logs에 기록해야 한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | 모든 LLM 응답에 model/prompt/template version audit metadata가 기록됨 | Integration: answer 생성 후 metadata 필드 검증 |
+| AC-02 | prompt 변경 시 eval 통과 전 production 사용이 차단됨 | Integration: eval 미통과 조합 사용 시도 시 block |
+| AC-03 | rollback 명령으로 직전 승인 조합이 복구됨 | Integration: rollback 후 active combination 이전 버전 확인 |
+| AC-04 | promptfoo regression threshold 미달 시 release gate가 실패함 | CI: threshold 미달 시나리오에서 gate fail |
+| AC-05 | RLHF 개선안이 pending_review 상태로만 저장됨 | DB 조회: RLHF 제안 status=pending_review 확인 |
+| AC-06 | 승인되지 않은 조합 런타임 사용이 차단됨 | Integration: unapproved 조합 호출 시 runtime block |
+| AC-07 | 변경 승인이 승인자/타임스탬프/eval 링크로 audit에 기록됨 | DB 조회: audit_logs approval row 검증 |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/api/model-governance/
+    prompt-registry/route.ts
+    model-pinning/route.ts
+    change-request/route.ts
+    approve/route.ts
+    rollback/route.ts
+  lib/model-governance/
+    registry.ts            # immutable prompt/template version 관리
+    combination-resolver.ts # active approved combination 조회/검증
+    runtime-guard.ts       # 미승인 조합 runtime block
+    eval-gate.ts           # promptfoo threshold 연동
+    audit-metadata.ts      # answer version metadata 부착
+  db/schema/
+    prompt-registry.ts
+    model-pin.ts
+    change-request.ts
+    approved-combination.ts
+```
+
+### 4.2 DB Schema
+
+- `prompt_registry`: id, kind (enum: prompt/template), content_hash, content (text), version, immutable (boolean default true), created_at
+- `model_pin`: id, provider, model_id, model_version, retrieval_config (jsonb), created_at
+- `change_request`: id, prompt_id (FK), model_pin_id (FK), eval_run_id, eval_status (enum: pending/passed/failed), approval_status (enum: pending_review/approved/rejected), approver_id (FK, nullable), created_at
+- `approved_combination`: id, prompt_id (FK), model_pin_id (FK), active (boolean), approved_at, superseded_by (FK, nullable)
+- `audit_logs` (기존): answer version metadata, 승인/rollback 이벤트
+
+### 4.3 API Endpoints
+
+- `POST/GET /api/model-governance/prompt-registry` — prompt/template 등록 (immutable)
+- `POST /api/model-governance/change-request` — 변경 요청 + eval run 트리거
+- `POST /api/model-governance/approve` — expert approval (RBAC gate)
+- `POST /api/model-governance/rollback` — 직전 승인 조합 복구
+- runtime-guard middleware — answer 생성 경로에서 active combination 검증
+
+### 4.4 의존성
+
+- 선행: SPEC-REGULA-FOUNDATION-001 (auth/RBAC/audit), SPEC-REGULA-RELEASE-001 (release gate)
+- 연계: #39 Workflows LLM executor (생성 파이프라인), #49 Validation, #56 RLHF (승인 게이트), #48 Source Governance, #32 Release Gate
+- 기술: Next.js 15, Drizzle ORM, PostgreSQL, promptfoo eval 연동, CI release gate

--- a/.moai/specs/SPEC-REGULA-PMS-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-PMS-001/spec.md
@@ -1,0 +1,140 @@
+---
+id: SPEC-REGULA-PMS-001
+version: 1.0.0
+status: draft
+phase: wave5
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 53
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-REGULA-CER-001
+  - SPEC-REGULA-RISK-001
+  - SPEC-REGULA-BREADTH-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-PMS-001 — EU MDR 출시 후 임상 감시 (PMS 보고서 & PMCF 계획 생성기)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #53 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+EU MDR (2017/745) Article 83-86은 모든 CE 마킹 의료기기에 대해 출시 후 임상 감시(Post-Market Surveillance, PMS)를 의무화한다. Class IIa 이상 기기는 추가로 PMCF(Post-Market Clinical Follow-up) 계획 및 보고서가 필요하다.
+
+현재 Regula의 워크플로우(Phase 9)는 허가 전 문서(510k, CER 초안, PCCP)에 집중되어 있으나, 허가 후 PMS/PMCF 사이클은 지원하지 않는다. 이는 EU 시장 제품의 연간 RA 업무 중 가장 시간 소모적인 부분이다.
+
+EU MDR 전환 기간(2026-2028) 동안 수천 개 기기의 재인증 수요가 폭발할 것으로 예상되며, PMS/PMCF 자동화는 CE 마킹 기업의 핵심 페인포인트이다. 본 SPEC은 PMS 보고서(PMSR) 구조화 자동 작성, PMCF 계획 템플릿 생성 및 AI 지원 작성, PMCF 평가 보고서 초안 생성을 다루며, 기존 CER 데이터(#23) 및 임상 데이터와 연계한다.
+
+complaint/vigilance 데이터 입력 통합(수동 또는 파일 업로드)과 의심 심각한 부작용(SUSAR)·트렌드 리포팅 섹션 템플릿을 제공하고, EU MDR Article 83-86 자동 컴플라이언스 체크를 수행한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- EU MDR (2017/745) Article 83-86: Post-Market Surveillance 시스템·PMS 계획·PMSR
+- EU MDR Annex III: 기술 문서 중 PMS 문서
+- EU MDR Annex XIV Part B: PMCF 요구사항
+- MDCG 2022-21: PMSR 가이던스
+- 21 CFR Part 11: 전자 기록·서명, audit trail
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- `workflow_type` enum에 `pms_report`, `pmcf_plan`, `pmcf_evaluation` 추가
+- PMS 보고서 AI 워크플로우(MDCG 2022-21 기반 섹션 구조)
+- PMCF 계획 빌더(Annex XIV Part B 체크리스트 + AI 작성 지원)
+- SUSAR 및 트렌드 리포팅 섹션 템플릿
+- complaint/vigilance 데이터 입력 통합
+- 기존 CER 문서(#23) 자동 연계 (같은 프로젝트 내)
+- EU MDR Article 83-86 자동 컴플라이언스 체크
+
+### 1.4 Out of Scope
+
+- 실시간 외부 vigilance 데이터베이스(EUDAMED) API 연동
+- 규제기관 직접 제출
+- 미국 PMS(21 CFR 822 Postmarket Surveillance) 처리 (별도 범위)
+- CAPA 폐루프 관리 (SPEC-REGULA-CAPA-001)
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-PMS-001 | THE SYSTEM SHALL `workflow_type` enum에 `pms_report`, `pmcf_plan`, `pmcf_evaluation`을 추가한다 | High |
+| REQ-PMS-002 | WHEN 사용자가 PMS 보고서 워크플로우를 실행하면 THE SYSTEM SHALL MDCG 2022-21 가이던스 기반 섹션 구조를 자동 생성한다 | High |
+| REQ-PMS-003 | WHEN 사용자가 PMCF 계획을 작성하면 THE SYSTEM SHALL EU MDR Annex XIV Part B 요구사항 체크리스트를 제공하고 AI 작성을 지원한다 | High |
+| REQ-PMS-004 | WHEN 같은 프로젝트에 CER 문서(#23)가 존재하면 THE SYSTEM SHALL PMS/PMCF 문서에 CER 데이터를 자동 연계한다 | High |
+| REQ-PMS-005 | THE SYSTEM SHALL SUSAR 및 트렌드 리포팅 섹션 템플릿을 제공한다 | High |
+| REQ-PMS-006 | WHEN 사용자가 complaint/vigilance 데이터를 입력하거나 파일을 업로드하면 THE SYSTEM SHALL 해당 데이터를 PMS 보고서 입력으로 통합한다 | High |
+| REQ-PMS-007 | WHEN PMS 문서가 생성되면 THE SYSTEM SHALL EU MDR Article 83-86 컴플라이언스 체크 결과를 표시한다 | High |
+| REQ-PMS-008 | THE SYSTEM SHALL 모든 PMS/PMCF 판단의 근거 citation이 실제 claim을 지지하도록 강제한다 | High |
+| REQ-PMS-009 | IF PMS/PMCF draft에 expert review가 완료되지 않았다면 THEN THE SYSTEM SHALL export 또는 close를 차단한다 | High |
+| REQ-PMS-010 | WHEN reportability·심각도·follow-up 상태가 전이되면 THE SYSTEM SHALL audit_logs에 기록한다 | High |
+| REQ-PMS-011 | WHEN PMCF 평가 보고서를 생성하면 THE SYSTEM SHALL PMCF 계획 대비 수집된 임상 데이터 평가 초안을 작성한다 | Medium |
+| REQ-PMS-012 | IF 외부 파일 업로드가 실패하거나 형식이 잘못되면 THEN THE SYSTEM SHALL 명확한 오류를 반환한다 | Medium |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | `workflow_type` enum에 3개 신규 타입 존재 | schema/migration 검토 |
+| AC-02 | PMS 보고서가 MDCG 2022-21 섹션 구조로 생성됨 | integration test + 섹션 매핑 검증 |
+| AC-03 | PMCF 계획에 Annex XIV Part B 체크리스트 100% 포함 | unit test (체크리스트 항목 수) |
+| AC-04 | 같은 프로젝트 CER 데이터가 PMS 문서에 자동 연계됨 | integration test |
+| AC-05 | complaint/vigilance 데이터 입력·업로드 통합 동작 | E2E test |
+| AC-06 | Article 83-86 컴플라이언스 체크 결과 표시 | E2E test |
+| AC-07 | expert review 없이 close 시도 시 차단됨 | negative test |
+| AC-08 | 상태 전이 audit_logs 100% 기록 | audit log 검증 |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+lib/workflows/
+  pms-report/executor.ts
+  pmcf-plan/executor.ts
+  pmcf-evaluation/executor.ts
+  _shared/compliance-check.ts       # Article 83-86 체크
+app/(app)/pms/                       # PMS 워크벤치 UI
+lib/db/schema/pms.ts                 # complaint/vigilance 입력 테이블
+```
+
+### 4.2 DB Schema
+
+- `workflow_type` enum 확장: `pms_report`, `pmcf_plan`, `pmcf_evaluation`
+- `pms_inputs` 테이블: complaint/vigilance 데이터 (project_id FK, source, severity, susar_flag, trend_category)
+- `pms_documents` 테이블: 생성된 PMSR/PMCF 문서 (cer_ref FK, compliance_status, review_status)
+- `audit_logs` 재사용: 상태 전이 기록
+
+### 4.3 API Endpoints
+
+- `POST /api/workflows/pms-report/run`
+- `POST /api/workflows/pmcf-plan/run`
+- `POST /api/workflows/pmcf-evaluation/run`
+- `POST /api/pms/inputs` — complaint/vigilance 입력·업로드
+- `GET /api/pms/[projectId]/compliance` — Article 83-86 체크 결과
+
+### 4.4 의존성
+
+- #23 CER Builder (완료 후 연계)
+- #46 ISO 14971 Risk Management (위험 데이터 공유)
+- SPEC-REGULA-BREADTH-001 (projects 테이블)

--- a/.moai/specs/SPEC-REGULA-PROJECT-MEMORY-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-PROJECT-MEMORY-001/spec.md
@@ -1,0 +1,136 @@
+---
+id: SPEC-REGULA-PROJECT-MEMORY-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 51
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-BREADTH-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/rag
+  - component/frontend
+---
+
+# SPEC-REGULA-PROJECT-MEMORY-001 — 프로젝트 지속 컨텍스트 메모리 (의사결정 누적 & 크로스 세션 기억)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #51 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+현재 Regula의 대화(conversation)는 각각 독립적이다. 같은 프로젝트 내에서도 이전 세션에서 결정한 디바이스 분류(device classification)나 목표 시장(target market) 전략을 새 대화에서 AI가 기억하지 못한다. 사용자는 매 대화마다 동일한 컨텍스트를 반복 입력해야 하며, 이는 비효율을 넘어 규제 일관성을 위협한다.
+
+의료기기 개발 프로젝트는 수년에 걸쳐 진행된다. 디바이스 분류, 목표 시장, 심사 전략, predicate device 같은 핵심 의사결정은 프로젝트 수명 전반에 걸쳐 일관되게 유지되어야 한다. 프로젝트 범위의 누적 컨텍스트는 단순 편의 기능이 아니라 규제 일관성의 핵심이다.
+
+본 SPEC은 프로젝트 단위로 RA 의사결정 메모리를 누적하고, 새 대화 시작 시 프로젝트 컨텍스트를 자동 주입하며, RA Lead가 프로젝트 메모리를 명시적으로 편집/검토할 수 있게 하고, 메모리 변경 이력을 감사 목적으로 추적하도록 만든다.
+
+AI는 대화에서 의사결정을 감지하면 메모리 업데이트를 제안하되, 자동 확정이 아닌 사용자 검토를 거치도록 설계한다. 이는 잘못된 자동 판단이 프로젝트 컨텍스트를 오염시키는 것을 방지한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- 규제 제출물의 일관성은 ISO 13485 및 design control(21 CFR 820.30)의 요구이다. 디바이스 분류, 위험 등급(risk class), predicate device 결정은 프로젝트 전반에서 일관되게 유지되어야 한다.
+- 21 CFR Part 11에 따라 프로젝트 메모리의 생성·수정·무효화 이력은 감사 가능해야 한다.
+- 팀원 교체 시 컨텍스트 유실은 규제 일관성 리스크이며, 본 SPEC의 메모리 누적이 이를 완화한다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 프로젝트 단위 RA 의사결정 메모리 누적 (`project_memory` 테이블)
+- memoryType enum: device_classification, target_markets, submission_strategy, predicate_device, risk_class, custom
+- 새 대화 시작 시 project memory 자동 주입 (시스템 프롬프트 앞부분)
+- AI 의사결정 감지 시 메모리 업데이트 제안
+- 프로젝트 메모리 관리 UI (편집/검토)
+- 감사 로그: memory_created, memory_updated, memory_invalidated
+
+### 1.4 Out of Scope
+
+- 프로젝트 간 메모리 공유/상속
+- 메모리 자동 확정 (사용자 검토 없는 자동 적용 금지)
+- 메모리 충돌 자동 해소 (충돌 시 사용자 판단에 위임)
+- 외부 PLM/QMS 시스템과의 메모리 동기화
+
+---
+
+## §2 Requirements (EARS Format)
+
+### REQ-PROJECT-MEMORY: 메모리 누적·주입·편집·감사
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-PROJECT-MEMORY-001 | THE SYSTEM SHALL `project_memory` 테이블에 id, projectId, memoryType, key, value, sourceConversationId, createdBy, validFrom, validUntil를 관리한다 | High |
+| REQ-PROJECT-MEMORY-002 | THE SYSTEM SHALL memoryType을 device_classification, target_markets, submission_strategy, predicate_device, risk_class, custom enum으로 제한한다 | High |
+| REQ-PROJECT-MEMORY-003 | WHEN 새 대화가 시작될 때 THE SYSTEM SHALL 해당 프로젝트의 유효한(validFrom~validUntil 범위 내) project memory를 시스템 프롬프트 앞부분에 자동 주입한다 | High |
+| REQ-PROJECT-MEMORY-004 | WHEN AI가 대화에서 의사결정을 감지할 때 THE SYSTEM SHALL 메모리 업데이트를 제안한다 | High |
+| REQ-PROJECT-MEMORY-005 | THE SYSTEM SHALL AI가 제안한 메모리 업데이트를 사용자 검토 없이 자동 확정하지 않는다 | High |
+| REQ-PROJECT-MEMORY-006 | WHERE RA Lead가 프로젝트 메모리 관리 UI를 사용할 때 THE SYSTEM SHALL 메모리 항목의 편집/검토 기능을 제공한다 | High |
+| REQ-PROJECT-MEMORY-007 | WHEN 메모리가 생성될 때 THE SYSTEM SHALL audit_logs에 memory_created 이벤트를 기록한다 | High |
+| REQ-PROJECT-MEMORY-008 | WHEN 메모리가 수정될 때 THE SYSTEM SHALL audit_logs에 memory_updated 이벤트를 기록한다 | High |
+| REQ-PROJECT-MEMORY-009 | WHEN 메모리가 무효화(invalidate)될 때 THE SYSTEM SHALL validUntil을 설정하고 audit_logs에 memory_invalidated 이벤트를 기록한다 | High |
+| REQ-PROJECT-MEMORY-010 | WHEN 메모리를 주입할 때 THE SYSTEM SHALL validUntil이 만료된 메모리를 주입 대상에서 제외한다 | High |
+| REQ-PROJECT-MEMORY-011 | IF 메모리 편집을 요청한 사용자의 권한이 부족하면 THEN THE SYSTEM SHALL 편집을 거부하고 audit_logs에 기록한다 | High |
+| REQ-PROJECT-MEMORY-012 | WHERE 동일 projectId 및 동일 key의 메모리가 갱신될 때 THE SYSTEM SHALL 기존 메모리를 무효화하고 새 메모리를 생성하여 변경 이력을 보존한다 | Medium |
+| REQ-PROJECT-MEMORY-013 | THE SYSTEM SHALL sourceConversationId를 통해 메모리의 출처 대화를 추적 가능하게 한다 | Medium |
+| REQ-PROJECT-MEMORY-014 | WHEN 사용자가 AI 제안 메모리를 승인할 때 THE SYSTEM SHALL 해당 메모리를 project_memory에 반영하고 createdBy를 기록한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | project_memory 테이블이 6종 memoryType으로 메모리를 저장하고 조회한다 | Test |
+| AC-02 | 새 대화 시작 시 해당 프로젝트의 유효한 메모리가 시스템 프롬프트에 자동 주입된다 | Test |
+| AC-03 | AI가 대화에서 디바이스 분류 결정을 감지하면 메모리 업데이트를 제안하되 자동 확정하지 않는다 | Test |
+| AC-04 | RA Lead가 메모리 관리 UI에서 메모리를 편집/검토할 수 있다 | Test / Review |
+| AC-05 | memory_created/updated/invalidated 이벤트가 audit_logs에 기록된다 | Test |
+| AC-06 | validUntil이 만료된 메모리가 주입 대상에서 제외된다 | Test |
+| AC-07 | 동일 key 메모리 갱신 시 기존 메모리가 무효화되고 변경 이력이 보존된다 | Test |
+| AC-08 | 권한 없는 사용자의 메모리 편집이 거부되고 audit_logs에 기록된다 | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `lib/db/schema/project-memory.ts` — 프로젝트 메모리 스키마
+- `lib/project-memory/injector.ts` — 시스템 프롬프트 메모리 주입기
+- `lib/project-memory/extractor.ts` — AI 의사결정 감지 및 메모리 제안
+- `lib/project-memory/manager.ts` — 메모리 생성/수정/무효화 + 이력 보존
+- `app/api/project-memory/route.ts` — 메모리 CRUD API
+- `app/api/project-memory/suggest/route.ts` — AI 제안 승인 API
+- `app/(app)/projects/[id]/memory/page.tsx` — 프로젝트 메모리 관리 UI
+
+### 4.2 DB Schema
+
+- 신규 테이블 `project_memory`: id, project_id, memory_type(enum: device_classification/target_markets/submission_strategy/predicate_device/risk_class/custom), key, value, source_conversation_id, created_by, valid_from, valid_until
+- 인덱스: (project_id, key, valid_until) — 유효 메모리 조회 최적화
+- audit_logs 활용: 신규 action `memory_created`, `memory_updated`, `memory_invalidated`
+
+### 4.3 API Endpoints
+
+- `GET /api/project-memory?projectId=` — 프로젝트 유효 메모리 조회
+- `POST /api/project-memory` — 메모리 생성 (RBAC: ra-lead)
+- `PATCH /api/project-memory/:id` — 메모리 수정 (RBAC: ra-lead)
+- `DELETE /api/project-memory/:id` — 메모리 무효화 (RBAC: ra-lead)
+- `POST /api/project-memory/suggest/approve` — AI 제안 승인
+
+### 4.4 의존성
+
+- 기존 SPEC: SPEC-REGULA-BREADTH-001(projects 테이블 — 완료), SPEC-REGULA-FOUNDATION-001(audit_logs, RBAC), SPEC-REGULA-CHAT-001(conversation, 시스템 프롬프트 파이프라인)
+- 외부 이슈 보완 관계: #47 Evidence Traceability(메모리 출처 추적)
+- 외부: LLM(의사결정 감지/추출)

--- a/.moai/specs/SPEC-REGULA-REIMBURSEMENT-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-REIMBURSEMENT-001/spec.md
@@ -1,0 +1,148 @@
+---
+id: SPEC-REGULA-REIMBURSEMENT-001
+version: 1.0.0
+status: draft
+phase: wave5
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 70
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-REGULA-CER-001
+  - SPEC-REGULA-CLASSIFY-001
+  - SPEC-REGULA-ROI-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-REIMBURSEMENT-001 — 보험·상환 경로 분석기 (CPT/HCPCS·DRG·수가·시장접근 근거 생성)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #70 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula가 인허가 경로와 제출 패키지를 완성해도 실제 사업 성과는 상환·수가·시장접근 전략에 크게 좌우된다. #55 ROI는 내부 효율을 측정하지만, 제품 자체의 CPT/HCPCS/DRG, HIRA(심평원)/NHIS, EU HTA(Health Technology Assessment) 등 상환 경로 판단은 다루지 않는다.
+
+본 SPEC은 의료기기 제품 설명과 시장 전략을 기반으로 관할권별 보험·상환 가능성, 필요 근거, 코딩 경로, 시장접근 리스크를 분석한다. 미국 CPT/HCPCS/ICD-10/DRG 후보 매핑, CMS coverage pathway 및 payer evidence requirement 요약, 한국 심평원/NHIS 급여·비급여 경로 체크리스트, EU 주요 시장 HTA evidence requirement 요약을 포함한다.
+
+임상·경제성 근거 갭 분석을 수행하고 CER(#23), Clinical Literature(#60), PMS(#53) 근거를 재사용하며, 시장별 reimbursement readiness score를 제공하고 상환 전략 메모 및 executive summary export를 지원한다. ROI dashboard와 시장접근 지표를 연결한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- CMS National/Local Coverage Determination (NCD/LCD)
+- AMA CPT / HCPCS Level II 코딩 체계
+- CMS MS-DRG (Diagnosis Related Groups)
+- 한국 건강보험심사평가원(HIRA) 요양급여·신의료기술평가
+- 국민건강보험공단(NHIS) 급여 기준
+- EU HTA Regulation (EU) 2021/2282 (Joint Clinical Assessment)
+
+> 참고: 본 SPEC은 코딩·급여 경로 후보를 분석·제안하며, 규제 인허가가 아닌 시장접근 의사결정 지원 도구이다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 미국 CPT/HCPCS/ICD-10/DRG 후보 매핑
+- CMS coverage pathway 및 payer evidence requirement 요약
+- 한국 심평원/NHIS 급여·비급여 경로 체크리스트
+- EU 주요 시장 HTA evidence requirement 요약
+- 임상·경제성 근거 갭 분석
+- CER(#23), Clinical Literature(#60), PMS(#53) 근거 재사용
+- 시장별 reimbursement readiness score 제공
+- 상환 전략 메모 및 executive summary export
+
+### 1.4 Out of Scope
+
+- 실제 payer/보험사 청구 제출 또는 협상 자동화
+- 정확한 수가 금액 산정 또는 가격 책정
+- 코딩 확정 판정 (후보 제안만, 확정은 전문가)
+- 실시간 외부 코딩 데이터베이스 API 연동
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-REIMBURSE-001 | WHEN 제품 설명이 입력되면 THE SYSTEM SHALL 미국 CPT/HCPCS/ICD-10/DRG 후보를 매핑한다 | High |
+| REQ-REIMBURSE-002 | THE SYSTEM SHALL CMS coverage pathway 및 payer evidence requirement를 요약한다 | High |
+| REQ-REIMBURSE-003 | THE SYSTEM SHALL 한국 심평원/NHIS 급여·비급여 경로 체크리스트를 제공한다 | High |
+| REQ-REIMBURSE-004 | THE SYSTEM SHALL EU 주요 시장 HTA evidence requirement를 요약한다 | High |
+| REQ-REIMBURSE-005 | WHEN 분석이 실행되면 THE SYSTEM SHALL 임상 근거와 경제성 근거 갭을 분석한다 | High |
+| REQ-REIMBURSE-006 | WHEN 같은 프로젝트에 CER/Clinical Literature/PMS 근거가 존재하면 THE SYSTEM SHALL 해당 근거를 재사용한다 | High |
+| REQ-REIMBURSE-007 | THE SYSTEM SHALL 시장별 reimbursement readiness score를 산출한다 | High |
+| REQ-REIMBURSE-008 | THE SYSTEM SHALL 상환 전략 메모 및 executive summary를 export한다 | High |
+| REQ-REIMBURSE-009 | THE SYSTEM SHALL 임상 근거와 경제성 근거를 구분하여 표시한다 | High |
+| REQ-REIMBURSE-010 | WHEN 코딩/급여 경로 후보가 제안되면 THE SYSTEM SHALL 판단 근거 citation을 포함한다 | High |
+| REQ-REIMBURSE-011 | THE SYSTEM SHALL ROI dashboard(#55)와 시장접근 지표를 연결한다 | Medium |
+| REQ-REIMBURSE-012 | IF 코딩 후보가 자동 확정되려 하면 THEN THE SYSTEM SHALL 명시적 사용자 선택 또는 expert review gate를 적용한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | US/KR/EU 상환 경로 후보 생성 | integration test |
+| AC-02 | reimbursement evidence gap report 생성 | integration test |
+| AC-03 | 임상 근거와 경제성 근거를 구분해 표시 | unit test |
+| AC-04 | executive summary export 지원 | E2E test |
+| AC-05 | ROI dashboard와 시장접근 지표 연결 | integration test |
+| AC-06 | CPT/HCPCS/DRG 후보 매핑 동작 | unit test |
+| AC-07 | 코딩 후보 자동 확정 방지(사용자 선택/expert gate) | negative test |
+| AC-08 | 코딩/급여 판단에 citation 포함 | eval assertion |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+app/(app)/reimbursement/             # 상환 경로 분석기 UI
+lib/reimbursement/
+  us-coding-mapper.ts                # CPT/HCPCS/ICD-10/DRG 후보
+  cms-pathway.ts                     # CMS coverage + payer evidence
+  kr-pathway.ts                      # 심평원/NHIS 체크리스트
+  eu-hta.ts                          # EU HTA evidence
+  gap-analyzer.ts                    # 임상·경제성 근거 갭
+  readiness-score.ts                 # 시장별 readiness score
+lib/db/schema/reimbursement.ts
+```
+
+### 4.2 DB Schema
+
+- `reimbursement_analyses` 테이블: project_id FK, jurisdiction(us|kr|eu), readiness_score, review_status
+- `reimbursement_codes` 테이블: analysis_id FK, code_system(cpt|hcpcs|icd10|drg), code_candidate, citation_ref, confirmation_status
+- `reimbursement_gaps` 테이블: analysis_id FK, evidence_type(clinical|economic), gap_description, source_ref
+- `audit_logs` 재사용 (export·확정 이벤트)
+
+### 4.3 API Endpoints
+
+- `POST /api/reimbursement/analyze` — 관할권별 경로 분석
+- `GET /api/reimbursement/[id]/codes` — 코딩 후보 조회
+- `POST /api/reimbursement/[id]/codes/confirm` — 사용자 선택/expert gate
+- `GET /api/reimbursement/[id]/gaps` — 근거 갭 리포트
+- `GET /api/reimbursement/[id]/readiness` — readiness score
+- `POST /api/reimbursement/[id]/export` — executive summary export
+
+### 4.4 의존성
+
+- #40 Strategy (규제 전략과 시장접근 전략 연결)
+- #55 ROI (사업 가치 산정 연결)
+- #59 Classification (제품 분류 입력 재사용)
+- #60 Clinical Literature (임상·경제성 근거 입력)
+- #65 eSubmit (인허가 후 시장 진입 패키지 연결)
+- #23 CER, #53 PMS (근거 재사용)

--- a/.moai/specs/SPEC-REGULA-REVIEW-OPS-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-REVIEW-OPS-001/spec.md
@@ -1,0 +1,142 @@
+---
+id: SPEC-REGULA-REVIEW-OPS-001
+version: 1.0.0
+status: draft
+phase: wave4
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 36
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-WORKFLOWS-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+---
+
+# SPEC-REGULA-REVIEW-OPS-001 — 전문가 검토 SLA·승인 워크벤치·증거 패키지
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #36 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+기존 구현과 선행 이슈들은 expert review flag, queue, approval 흐름을 이미 포함하고 있다. 그러나 단순 큐 구조만으로는 RA 리드가 실제 검토 업무를 SLA 기반으로 운영하기 어렵다. 플래그된 답변과 생성된 제출 초안이 적시에 판정되지 않으면 규제 리스크가 누적되며, 검토 근거가 구조화되지 않으면 동일한 결함이 반복된다.
+
+본 SPEC은 단순 큐를 넘어 RA 검토자가 실제 검토 업무를 운영할 수 있는 워크벤치를 정의한다. 검토자는 플래그된 답변과 제출 초안을 SLA 기한 안에서 우선순위에 따라 판정하고, Evidence Packet을 통해 검토 근거를 한 화면에서 확인하며, 승인/반려 결과를 audit 가능한 품질 데이터로 축적한다.
+
+검토 결정(approve / request changes / reject / knowledge gap)은 모두 reviewer 신원, timestamp, 사유와 함께 audit_logs에 기록되어야 하며, 승인되지 않은 산출물은 downstream export에서 서버 측으로 차단된다. 또한 반복 반려 사유와 결함 카테고리를 집계하여 Knowledge Gap Ops(#35)로 넘길 수 있는 action을 자동 생성한다.
+
+이를 통해 Regula는 답변 생성기를 넘어 audit-ready RA 검토 운영 도구로 발전한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA 21 CFR Part 820 (Quality System Regulation) — design review 및 record 통제
+- ISO 13485:2016 §7.3 (Design and Development Review), §4.2.4 (Control of Records)
+- ISO/IEC 62304 (소프트웨어 라이프사이클 검토 근거)
+- 검토 결정 audit trail은 21 CFR Part 11 record integrity 원칙을 준수 (단, 전자서명 full validation은 범위 외)
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- SLA 기반 검토 운영: review item priority 산정(high-risk keyword, confidence, submission impact, due date), SLA 상태(on-track / due-soon / overdue), reviewer assignment·reassignment·escalation audit
+- Evidence Packet: 검토 대상 답변/초안, citation list, source excerpts, confidence rationale, related regulatory updates를 한 화면에 묶어 제공. draft diff 비교, citation mismatch·stale source·missing source 태깅
+- 승인/반려 결정: approve / request changes / reject / mark as knowledge gap, 모든 결정의 audit 기록
+- 검토 품질 데이터: 반복 반려 사유 통계, 모델/프롬프트/코퍼스별 defect category 집계, Knowledge Gap Ops handoff action 생성
+
+### 1.4 Out of Scope
+
+- 전자서명 Part 11 full validation package
+- 외부 reviewer portal
+- 다기관 reviewer marketplace
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-REVIEW-OPS-001 | WHEN a flagged answer or submission draft enters the review queue THE SYSTEM SHALL compute a review priority from high-risk keyword, confidence, submission impact, and due date | High |
+| REQ-REVIEW-OPS-002 | WHEN a review item is displayed THE SYSTEM SHALL show its SLA status as one of on-track, due-soon, or overdue | High |
+| REQ-REVIEW-OPS-003 | THE SYSTEM SHALL allow a RA reviewer to sort and filter the review queue by SLA status, priority, and product | High |
+| REQ-REVIEW-OPS-004 | WHEN a reviewer is assigned, reassigned, or escalated THE SYSTEM SHALL record the action in audit_logs with reviewer identity and timestamp | High |
+| REQ-REVIEW-OPS-005 | WHEN a review item is opened THE SYSTEM SHALL render an Evidence Packet containing the target answer/draft, citation list, source excerpts, confidence rationale, and related regulatory updates | High |
+| REQ-REVIEW-OPS-006 | WHERE a user-edited draft differs from the original generated draft THE SYSTEM SHALL display a diff between the two versions | Medium |
+| REQ-REVIEW-OPS-007 | THE SYSTEM SHALL allow a reviewer to tag citation mismatch, stale source, and missing source on a review item | Medium |
+| REQ-REVIEW-OPS-008 | WHEN a reviewer submits a decision THE SYSTEM SHALL accept one of approve, request changes, reject, or mark as knowledge gap | High |
+| REQ-REVIEW-OPS-009 | WHEN a review decision is recorded THE SYSTEM SHALL persist audit_logs entry, reviewer identity, timestamp, and reason as mandatory fields | High |
+| REQ-REVIEW-OPS-010 | IF an answer or draft has not been approved THEN THE SYSTEM SHALL block its export at the server side and mark it not reviewable | High |
+| REQ-REVIEW-OPS-011 | WHEN review decisions accumulate THE SYSTEM SHALL aggregate repeated rejection reasons and defect categories by model, prompt, and corpus | Medium |
+| REQ-REVIEW-OPS-012 | WHEN a review item is marked as knowledge gap THE SYSTEM SHALL generate a handoff action targeting Knowledge Gap Ops (#35) | Medium |
+| REQ-REVIEW-OPS-013 | IF a non-reviewer role attempts to record a review decision THEN THE SYSTEM SHALL deny the action and log the unauthorized attempt | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | RA reviewer가 SLA 기준(on-track/due-soon/overdue)으로 queue를 정렬·필터링할 수 있다 | Test / Review |
+| AC-02 | 각 review item에 Evidence Packet(답변/초안, citation, source excerpt, confidence rationale, regulatory updates)이 표시된다 | Review |
+| AC-03 | approve/request changes/reject/knowledge gap 전환이 reviewer identity·timestamp·reason과 함께 audit_logs에 저장된다 | Test |
+| AC-04 | 승인되지 않은 산출물의 export가 서버 측에서 차단된다 (클라이언트 우회 불가) | Test |
+| AC-05 | 반복 결함 통계(반려 사유·defect category)가 dashboard 또는 admin view에 노출된다 | Review |
+| AC-06 | knowledge gap 결정 시 #35 handoff action이 생성된다 | Test |
+| AC-07 | 권한 없는 역할의 검토 결정 시도가 거부되고 audit에 기록된다 | Test |
+| AC-08 | reviewer assignment/reassignment/escalation이 audit trail에 남는다 | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/
+    (dashboard)/review/
+      page.tsx                # review queue 워크벤치 (SLA 정렬·필터)
+      [reviewId]/page.tsx     # Evidence Packet + 결정 UI
+    api/review/
+      route.ts                # queue 조회 (priority, SLA 계산)
+      [reviewId]/decision/route.ts  # 결정 기록 + audit
+      [reviewId]/assign/route.ts    # assignment/escalation
+  lib/review/
+    sla.ts                    # priority·SLA 상태 산정
+    evidence-packet.ts        # Evidence Packet 조립
+    defect-stats.ts           # 반복 결함 집계
+  db/schema/review.ts         # review_items, review_decisions, review_tags
+```
+
+### 4.2 DB Schema
+
+- `review_items`: id, target_type (answer|draft), target_id, priority_score, sla_status, due_at, assigned_reviewer_id, status, created_at
+- `review_decisions`: id, review_item_id, reviewer_id, decision (approve|request_changes|reject|knowledge_gap), reason, created_at
+- `review_tags`: id, review_item_id, tag_type (citation_mismatch|stale_source|missing_source), citation_ref, created_by
+- `review_assignments`: id, review_item_id, reviewer_id, action (assign|reassign|escalate), actor_id, created_at
+- audit_logs는 기존 테이블 재사용 — 모든 결정/할당/태깅 이벤트 기록
+
+### 4.3 API Endpoints
+
+- `GET /api/review` — SLA·priority 정렬, jurisdiction/product/sla_status 필터
+- `GET /api/review/{reviewId}` — Evidence Packet 반환
+- `POST /api/review/{reviewId}/decision` — 결정 기록 (RBAC: reviewer/ra-lead), audit 강제
+- `POST /api/review/{reviewId}/assign` — assignment/reassign/escalate
+- `POST /api/review/{reviewId}/tags` — citation/source 태깅
+- export 경로(SUBMISSION-LIFECYCLE)는 `reviewed=true` 서버 검증 추가
+
+### 4.4 의존성
+
+- SPEC-REGULA-FOUNDATION-001 (audit_logs, RBAC, source/citation 모델)
+- SPEC-REGULA-WORKFLOWS-001 (draft 생성 산출물, workflow_runs)
+- #23 CER Builder, #24 PCCP Builder (검토 대상 draft 공급)
+- #35 Knowledge Gap Ops (handoff 대상)

--- a/.moai/specs/SPEC-REGULA-RLHF-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-RLHF-001/spec.md
@@ -1,0 +1,145 @@
+---
+id: SPEC-REGULA-RLHF-001
+version: 1.0.0
+status: draft
+phase: wave4
+priority: Medium
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 56
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-BREADTH-001
+  - SPEC-REGULA-KNOWLEDGE-GAP-001
+  - SPEC-REGULA-KNOWLEDGE-PROMO-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/rag
+  - component/frontend
+---
+
+# SPEC-REGULA-RLHF-001 — 사용자 피드백 기반 RAG 품질 연속 개선 (Answer Quality RLHF Loop)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #56 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+현재 Regula의 RAG 품질 평가는 오프라인 eval harness(promptfoo)에만 의존한다. 실제 사용자가 만족하거나 불만족하는 답변 패턴이 시스템 개선에 반영되지 않는다. 오프라인 eval은 사전에 정의된 시나리오만 측정하므로, 실제 현장에서 RA 전문가가 어떤 답변을 신뢰하고 어떤 답변을 거부하는지는 포착하지 못한다.
+
+의료기기 규제 도메인은 매우 전문적이어서 오프라인 eval만으로는 실제 사용 품질을 충분히 측정할 수 없다. RA 전문가의 인라인 피드백이 가장 가치 있는 품질 신호이다. 엄지 위/아래 평가와 상세 품질 태그(citation 누락, 답변 불완전, 관할권 불일치 등)는 RAG 파이프라인 개선을 위한 직접적이고 도메인 특화된 데이터를 제공한다.
+
+본 SPEC은 인라인 답변 평가를 수집하고, 저품질 답변을 자동 플래그하여 knowledge gap 이슈화(#35 연계)하며, 피드백 데이터로 retrieval 가중치를 조정(retrieval re-ranking)하고, 고품질 답변을 자동 프로모션 후보로 제안(#50 연계)하는 RLHF 루프를 구현한다.
+
+피드백 이벤트는 Langfuse에 전송되어 LLM trace 품질 추적과 연결되며, 질문 유형별·코퍼스별 품질 히트맵 대시보드로 가시화된다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- 지속적 개선(continuous improvement)은 ISO 13485의 핵심 요구이다. 사용자 피드백 루프는 RAG 품질에 대한 CAPA 입력 신호로 기능한다.
+- retrieval 가중치 조정 및 모델/프롬프트 변경은 버전 메타데이터와 rollback 가능성을 보장해야 규제 환경에서 변경 통제(change control)를 만족한다.
+- 피드백 수집 시 confidence/citation/expert-review 조건이 재가중치 적용 후에도 유지되어야 RA claim의 신뢰성이 보존된다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 인라인 답변 평가 (엄지 위/아래 + 품질 태그 + 선택적 텍스트)
+- `answer_feedback` 테이블 및 qualityTags enum
+- AnswerBlock 피드백 UI
+- 피드백 집계 파이프라인 (평균 점수, 하락 추이 감지)
+- Low-rated 답변 자동 Knowledge Gap 이슈 생성 (#35 연계)
+- High-rated 답변 자동 지식 승격 후보 제안 (#50 연계)
+- 피드백 기반 retrieval 재가중치 (source_sections.feedback_score)
+- Langfuse 피드백 이벤트 전송
+- 피드백 분석 대시보드 (품질 히트맵)
+
+### 1.4 Out of Scope
+
+- 모델 fine-tuning / 가중치 직접 학습 (retrieval re-ranking에 한정)
+- 외부 사용자 대상 피드백 수집
+- 피드백 기반 답변 자동 재생성 (제안만, 자동 적용 금지)
+- 익명 피드백 (userId 추적 필수)
+
+---
+
+## §2 Requirements (EARS Format)
+
+### REQ-RLHF: 피드백 수집·집계·재가중치·연계
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-RLHF-001 | THE SYSTEM SHALL `answer_feedback` 테이블에 id, messageId, userId, rating(enum: up/down), qualityTags(array), comment, createdAt를 관리한다 | High |
+| REQ-RLHF-002 | THE SYSTEM SHALL qualityTags를 citation_missing, citation_wrong, answer_incomplete, answer_wrong, outdated_info, jurisdiction_mismatch, helpful, excellent enum으로 제한한다 | High |
+| REQ-RLHF-003 | WHERE 사용자가 AnswerBlock을 볼 때 THE SYSTEM SHALL 엄지 아이콘, 태그 선택, 선택적 텍스트 입력 피드백 UI를 제공한다 | High |
+| REQ-RLHF-004 | WHEN 사용자가 답변에 피드백을 제출할 때 THE SYSTEM SHALL userId와 함께 answer_feedback에 기록한다 | High |
+| REQ-RLHF-005 | THE SYSTEM SHALL 답변별 평균 피드백 점수를 집계한다 | High |
+| REQ-RLHF-006 | WHEN 피드백 점수가 하락 추이를 보일 때 THE SYSTEM SHALL 하락 추이를 감지하여 표시한다 | Medium |
+| REQ-RLHF-007 | IF 답변이 low-rated로 판정되면 THEN THE SYSTEM SHALL 자동으로 Knowledge Gap 이슈(#35)를 생성한다 | High |
+| REQ-RLHF-008 | IF 답변이 high-rated로 판정되면 THEN THE SYSTEM SHALL 자동으로 지식 승격 후보(#50)로 제안한다 | High |
+| REQ-RLHF-009 | THE SYSTEM SHALL source_sections에 feedback_score 컬럼을 추가하고 피드백에 따라 갱신한다 | High |
+| REQ-RLHF-010 | WHEN RAG retrieval을 수행할 때 THE SYSTEM SHALL feedback_score를 retrieval 재가중치(re-ranking)에 반영한다 | High |
+| REQ-RLHF-011 | WHEN 피드백 이벤트가 발생할 때 THE SYSTEM SHALL Langfuse에 피드백 이벤트를 전송한다 | Medium |
+| REQ-RLHF-012 | THE SYSTEM SHALL 질문 유형별·코퍼스별 품질 히트맵 대시보드를 제공한다 | Medium |
+| REQ-RLHF-013 | WHEN retrieval 재가중치 또는 모델/프롬프트가 변경될 때 THE SYSTEM SHALL version metadata를 기록하고 rollback 가능하게 한다 | High |
+| REQ-RLHF-014 | WHERE retrieval 재가중치가 적용된 후 THE SYSTEM SHALL confidence, citation, expert-review 조건이 유지되는지 검증한다 | High |
+| REQ-RLHF-015 | THE SYSTEM SHALL high-rated 답변의 승격을 자동 확정하지 않고 후보 제안에 한정한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | AnswerBlock에서 엄지 위/아래 + 품질 태그 + 텍스트 피드백이 answer_feedback에 userId와 함께 저장된다 | Test |
+| AC-02 | qualityTags enum 8종이 검증되고 enum 외 값은 거부된다 | Test |
+| AC-03 | low-rated 답변이 자동으로 Knowledge Gap 이슈(#35)를 생성한다 | Test |
+| AC-04 | high-rated 답변이 자동으로 지식 승격 후보(#50)로 제안되되 자동 확정되지 않는다 | Test |
+| AC-05 | feedback_score가 source_sections에 반영되고 retrieval re-ranking에 영향을 준다 | Test |
+| AC-06 | retrieval 재가중치 변경 시 version metadata가 기록되고 rollback이 가능하다 | Test |
+| AC-07 | 재가중치 적용 후에도 confidence/citation/expert-review 조건이 유지된다 | Test |
+| AC-08 | 피드백 이벤트가 Langfuse에 전송되고, 품질 히트맵 대시보드가 질문 유형별·코퍼스별로 표시된다 | Test / Review |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `lib/db/schema/answer-feedback.ts` — 피드백 스키마
+- `lib/rlhf/feedback-aggregator.ts` — 답변별 평균 점수, 하락 추이 감지
+- `lib/rlhf/reranker.ts` — feedback_score 기반 retrieval 재가중치
+- `lib/rlhf/gap-promo-bridge.ts` — #35/#50 연계 자동 제안
+- `lib/rlhf/langfuse-emitter.ts` — Langfuse 이벤트 전송
+- `lib/rlhf/version-tracker.ts` — 재가중치/프롬프트 version metadata + rollback
+- `components/answer-block/feedback-control.tsx` — 피드백 UI
+- `app/api/rlhf/feedback/route.ts` — 피드백 제출 API
+- `app/(app)/quality/heatmap/page.tsx` — 품질 히트맵 대시보드
+
+### 4.2 DB Schema
+
+- 신규 테이블 `answer_feedback`: id, message_id, user_id, rating(enum: up/down), quality_tags(array enum), comment, created_at
+- 기존 테이블 확장: source_sections에 feedback_score(numeric) 컬럼 추가
+- retrieval 버전 추적용 metadata 테이블 또는 컬럼 (re-ranking version, prompt version, rollback ref)
+- audit_logs 활용: 신규 action `feedback_submitted`, `reranking_applied`, `reranking_rolled_back`
+
+### 4.3 API Endpoints
+
+- `POST /api/rlhf/feedback` — 답변 피드백 제출
+- `GET /api/rlhf/heatmap` — 품질 히트맵 데이터
+- `GET /api/rlhf/feedback/aggregate?messageId=` — 답변별 집계
+- 내부: re-ranking 적용 시 retrieval 파이프라인 훅, Langfuse SDK 전송
+
+### 4.4 의존성
+
+- 외부 라이브러리: Langfuse SDK (LLM trace 품질 추적), pgvector (retrieval)
+- 기존 SPEC: SPEC-REGULA-FOUNDATION-001(audit_logs, RBAC), SPEC-REGULA-CHAT-001(messages, AnswerBlock, RAG retrieval), SPEC-REGULA-BREADTH-001(messages 테이블, AnswerBlock 컴포넌트)
+- 연계 SPEC: SPEC-REGULA-KNOWLEDGE-GAP-001(#35, low-rated → gap 이슈화), SPEC-REGULA-KNOWLEDGE-PROMO-001(#50, high-rated → 승격 후보)
+- 기존: promptfoo eval harness (오프라인 eval과 온라인 피드백 병행)

--- a/.moai/specs/SPEC-REGULA-ROI-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-ROI-001/spec.md
@@ -1,0 +1,146 @@
+---
+id: SPEC-REGULA-ROI-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: Medium
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 55
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-WORKFLOWS-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+---
+
+# SPEC-REGULA-ROI-001 — 비즈니스 가치 대시보드: RA 업무 효율화 ROI 정량화
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #55 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula 도입 후 RA 팀의 실질적 효율화를 측정하고 경영진에게 증명하는 수단이 없다. SaaS 갱신 결정과 추가 도입 확대(enterprise upsell)는 ROI 증명에 달려 있다. 정량적 가치를 제시하지 못하면 도입 효과가 체감으로만 남고, 예산 의사결정에서 우선순위가 밀린다.
+
+현재 Adoption Analytics(#38)는 사용자 온보딩/참여 지표를 다루지만, 비용 절감·시간 절약의 재무적 가치는 측정하지 않는다. 즉 "얼마나 많이 쓰는가"는 알 수 있어도 "그래서 얼마를 아꼈는가"는 알 수 없다.
+
+본 SPEC은 AI 어시스트 답변의 시간 절약을 추정하고(질문 유형별 평균 답변 시간 기준), 전문가 검토 감소율(AI 자신감 향상 추이)을 측정하며, 문서 초안 생성 시간을 수동 작성 시간과 비교한다. 경영진/RA 디렉터용 ROI 리포트를 자동 생성하고, 조직 도입 전후 벤치마크를 제시한다.
+
+ROI 뷰는 민감한 비즈니스 데이터이므로 RBAC로 admin/ra-lead만 접근하도록 제한한다. 월간 ROI 리포트는 조직 로고를 포함한 PDF로 내보낼 수 있다. 시간 절약 추정은 추정 모델이므로 산출 근거(베이스라인, 가정)를 명시하여 과대평가를 방지한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+본 SPEC은 직접적인 규제 산출물이 아닌 운영 분석 도구이므로 외부 규제 표준의 직접 적용 대상은 아니다. 다만 다음을 준수한다:
+
+- ROI 지표 산출에 사용되는 워크플로우/검토 데이터 접근은 audit_logs에 기록 (내부 통제)
+- ROI 뷰 접근은 RBAC(admin/ra-lead)로 제한 (데이터 최소 노출 원칙)
+- 추정 모델의 가정과 베이스라인을 리포트에 명시 (투명성, 오도 방지)
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 시간 절약 추정 모델: 질문 복잡도(토큰 수, 인용 수)별 베이스라인 설정
+- 워크플로우 실행 시간 추적 (시작 → 완료)
+- Expert Review 비율 추이 (AI 신뢰도 향상 측정)
+- ROI 대시보드 뷰 (/dashboard 확장 또는 신규 /dashboard/roi)
+- 월간 ROI 리포트 PDF 내보내기 (조직 로고 포함)
+- 비교 벤치마크: 조직 도입 전후 지표 (온보딩 시 기준선 설정)
+- RBAC: admin/ra-lead만 ROI 뷰 접근
+
+### 1.4 Out of Scope
+
+- 실제 인건비/환율 기반 금액 정산 (시간 절약을 화폐로 환산하는 회계 처리)
+- 외부 BI 도구(Tableau, Looker 등) 연동
+- 사용자 개인별 생산성 평가/감시
+- #38 Adoption Analytics가 이미 다루는 온보딩/참여 지표
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-ROI-001 | THE SYSTEM SHALL define a time-saving estimation model with baselines indexed by question complexity (token count, citation count) | High |
+| REQ-ROI-002 | WHEN a workflow run starts and completes THE SYSTEM SHALL record its start and completion timestamps | High |
+| REQ-ROI-003 | THE SYSTEM SHALL compute estimated time saved per answer by comparing against the complexity baseline | High |
+| REQ-ROI-004 | THE SYSTEM SHALL track the expert review deflection rate as the trend of high-confidence AI responses over time | High |
+| REQ-ROI-005 | THE SYSTEM SHALL compute draft generation time versus a manual authoring baseline for 510(k) and CER drafts | Medium |
+| REQ-ROI-006 | THE SYSTEM SHALL provide an ROI dashboard view at /dashboard/roi | High |
+| REQ-ROI-007 | THE SYSTEM SHALL export a monthly ROI report as a PDF including the organization logo | Medium |
+| REQ-ROI-008 | WHEN an organization is onboarded THE SYSTEM SHALL allow a pre-adoption baseline to be set for before/after comparison | Medium |
+| REQ-ROI-009 | IF a user without admin or ra-lead role requests the ROI view THEN THE SYSTEM SHALL deny access | High |
+| REQ-ROI-010 | THE SYSTEM SHALL compute knowledge reuse rate as the citation count of promoted answers (#50) | Medium |
+| REQ-ROI-011 | THE SYSTEM SHALL compute corpus coverage improvement from the knowledge gap reduction rate (#35) | Medium |
+| REQ-ROI-012 | WHEN an ROI report is generated THE SYSTEM SHALL state the estimation model assumptions and baselines used | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | 질문 복잡도별 베이스라인 기반 시간 절약 추정이 산출된다 | Test |
+| AC-02 | 워크플로우 실행 시간(시작→완료)이 추적된다 | Test |
+| AC-03 | Expert Review 비율 추이가 시계열로 표시된다 | Review |
+| AC-04 | /dashboard/roi 뷰가 제공된다 | Review |
+| AC-05 | 월간 ROI 리포트가 조직 로고를 포함한 PDF로 export된다 | Test |
+| AC-06 | admin/ra-lead 외 역할은 ROI 뷰 접근이 차단된다 | Test |
+| AC-07 | 도입 전후 벤치마크 비교가 표시된다 | Review |
+| AC-08 | ROI 리포트에 추정 모델의 가정·베이스라인이 명시된다 | Review |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/
+    (dashboard)/dashboard/roi/
+      page.tsx                  # ROI 대시보드 (RBAC: admin/ra-lead)
+    api/roi/
+      route.ts                  # ROI 지표 집계
+      report/route.ts           # 월간 PDF 리포트
+      baseline/route.ts         # 도입 전 베이스라인 설정
+  lib/roi/
+    time-saving.ts              # 복잡도별 시간 절약 추정 모델
+    deflection.ts               # expert review deflection 추이
+    reuse.ts                    # knowledge reuse, corpus coverage
+    report-pdf.ts               # 로고 포함 PDF
+  db/schema/roi.ts
+```
+
+### 4.2 DB Schema
+
+- `roi_baselines`: id, org_id, question_complexity_band, baseline_minutes, set_at, set_by
+- `workflow_run_durations`: id, workflow_run_id, started_at, completed_at, complexity_band, estimated_saved_minutes
+- `roi_snapshots`: id, org_id, period (month), questions_per_hour, deflection_rate, completion_time_avg, reuse_rate, coverage_improvement, created_at
+- 기존 테이블 재사용: workflow_runs(시간), expert_reviews(deflection), promoted_answers #50(reuse), knowledge_gaps #35(coverage)
+- audit_logs 재사용 — ROI 데이터 접근 기록
+
+### 4.3 API Endpoints
+
+- `GET /api/roi` — 집계 지표 (RBAC: admin/ra-lead 서버 검증)
+- `POST /api/roi/baseline` — 도입 전 베이스라인 설정
+- `GET /api/roi/report?period=YYYY-MM` — 월간 PDF 리포트 (로고 포함)
+- 모든 ROI 경로에 admin/ra-lead RBAC 미들웨어 적용
+
+### 4.4 의존성
+
+- SPEC-REGULA-FOUNDATION-001 (org, RBAC, audit_logs, 조직 로고)
+- SPEC-REGULA-WORKFLOWS-001 (workflow_runs 실행 시간)
+- #38 Adoption Analytics (보완 관계 — 참여 vs 비즈니스 가치)
+- #37 Submission Lifecycle (510k/CER 워크플로우 완료 시간)
+- #50 Knowledge Promotion (knowledge reuse 메트릭)
+- #35 Knowledge Gap Ops (corpus coverage improvement)

--- a/.moai/specs/SPEC-REGULA-SOURCE-GOVERNANCE-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-SOURCE-GOVERNANCE-001/spec.md
@@ -1,0 +1,139 @@
+---
+id: SPEC-REGULA-SOURCE-GOVERNANCE-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 48
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-REGULA-KNOWLEDGE-GAP-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/rag
+  - component/governance
+---
+
+# SPEC-REGULA-SOURCE-GOVERNANCE-001 — 규제·SOP 출처 권위도·버전·유효일·폐기 상태 관리
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #48 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Delta Sync(#45)가 코퍼스를 최신화하더라도, RA 업무에서는 단순 최신화만으로는 충분하지 않다. RA 답변과 제출 문서는 유효한 출처, 올바른 버전, 적용 가능한 관할권(jurisdiction), 폐기되지 않은 문서를 근거로 삼아야 한다. 최신 문서라도 권위도가 낮거나, 이미 superseded된 버전이거나, 적용 관할권이 다르면 RA 산출물의 근거로 부적합하다.
+
+규제 기관 공식 문서, 조화된 표준(harmonized standard), 내부 SOP, 과거 제출물, 공개 데이터베이스, 2차 참고자료는 서로 권위도가 다르다. 동일한 주제에 대해 여러 출처가 검색될 때, 시스템은 권위도가 높고 유효한 출처를 우선해야 하며 폐기된 출처를 근거로 삼아서는 안 된다.
+
+본 SPEC은 Regula의 모든 RAG/워크플로우 산출물이 출처 품질 정책을 통과하도록 만드는 source governance SPEC이다. Source Authority Model, Retrieval Policy Gate, Source Review Workflow, Governance Dashboard의 4개 축을 구현하여 출처의 권위도·버전·유효일·폐기 상태를 통제한다.
+
+특히 draft 작성 및 export 단계에서 stale source citation을 차단하여, 규제 제출물이 유효하지 않은 근거로 작성되는 것을 원천 방지한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- ISO 13485 및 21 CFR Part 820의 문서 통제(Document Control) 요구사항은 유효 버전 관리, 폐기 문서 식별, 승인 상태 관리를 의무화한다. 본 SPEC의 source authority/version/sunset 관리가 이를 디지털로 구현한다.
+- RA 제출물은 적용 관할권의 현행 규제(예: FDA 21 CFR, EU MDR, 식약처 고시)를 근거로 해야 하며, superseded된 규정 인용은 제출 거부 사유가 될 수 있다.
+- 내부 SOP는 승인된(approved) 상태이고 담당 부서(owner department)가 명시되어야 품질 시스템 근거로 인정된다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- Source Authority Model: 6단계 권위 등급 + jurisdiction/effective_date/sunset_date/superseded_by/owner/review_cycle 필드 관리
+- 내부 SOP의 owner department 및 approval status 필수화
+- Retrieval Policy Gate: 권위 우선 검색, superseded 기본 제외, stale citation 차단, 저권위 출처 시 expert review
+- Source Review Workflow: pending_review 상태, 변경 영향 표시, periodic review 알림
+- Governance Dashboard: approved/pending/stale/superseded count, review due 목록, stale citation 포함 산출물 목록
+- Delta Sync(#45) 결과와 source governance 상태 연동
+
+### 1.4 Out of Scope
+
+- 유료 표준 원문 자동 구매/라이선스 관리
+- 외부 QMS(Quality Management System) master data 동기화
+- 법무 검토 워크플로우
+- 출처 권위 등급의 자동 추론 (RA owner가 명시적으로 설정하는 것을 전제)
+
+---
+
+## §2 Requirements (EARS Format)
+
+### REQ-SOURCE-GOV: 권위 모델·검색 정책·리뷰·대시보드
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-SOURCE-GOV-001 | THE SYSTEM SHALL 각 source에 대해 authority 등급(regulator official, harmonized standard, internal SOP, prior submission, public database, secondary reference)을 저장한다 | High |
+| REQ-SOURCE-GOV-002 | THE SYSTEM SHALL 각 source에 jurisdiction, effective_date, sunset_date, superseded_by, owner, review_cycle 필드를 관리한다 | High |
+| REQ-SOURCE-GOV-003 | WHERE source가 internal SOP일 때 THE SYSTEM SHALL owner department와 approval status를 필수로 요구한다 | High |
+| REQ-SOURCE-GOV-004 | WHEN 검색을 수행할 때 THE SYSTEM SHALL regulator official과 internal approved SOP를 우선 순위로 검색한다 | High |
+| REQ-SOURCE-GOV-005 | WHEN 일반 질의를 검색할 때 THE SYSTEM SHALL superseded source를 기본 검색 대상에서 제외한다 | High |
+| REQ-SOURCE-GOV-006 | WHERE 질의가 historical question으로 명시될 때 THE SYSTEM SHALL superseded source 검색을 허용한다 | Medium |
+| REQ-SOURCE-GOV-007 | WHEN draft 작성 또는 export 단계가 진행될 때 THE SYSTEM SHALL stale source citation을 차단한다 | High |
+| REQ-SOURCE-GOV-008 | IF 검색 결과가 authority 등급이 낮은 출처만 포함하면 THEN THE SYSTEM SHALL expert review required로 표시한다 | High |
+| REQ-SOURCE-GOV-009 | WHEN 새 source가 ingestion될 때 THE SYSTEM SHALL RA owner approval 전까지 해당 source를 `pending_review` 상태로 둔다 | High |
+| REQ-SOURCE-GOV-010 | WHEN source가 변경될 때 THE SYSTEM SHALL 관련 knowledge gap, eval scenario, submission package에 영향을 표시한다 | High |
+| REQ-SOURCE-GOV-011 | WHEN source의 review_cycle 기한이 도래할 때 THE SYSTEM SHALL source owner에게 periodic review 알림을 발송한다 | Medium |
+| REQ-SOURCE-GOV-012 | THE SYSTEM SHALL governance dashboard에서 corpus별 approved/pending/stale/superseded count를 표시한다 | High |
+| REQ-SOURCE-GOV-013 | THE SYSTEM SHALL 30일 내 review due인 source 목록을 dashboard에 표시한다 | Medium |
+| REQ-SOURCE-GOV-014 | THE SYSTEM SHALL stale citation이 포함된 answer/draft/package 목록을 dashboard에 표시한다 | High |
+| REQ-SOURCE-GOV-015 | WHEN source approval workflow가 진행될 때 THE SYSTEM SHALL 승인/반려 이벤트를 audit_logs에 기록한다 | High |
+| REQ-SOURCE-GOV-016 | WHEN #45 delta sync가 완료될 때 THE SYSTEM SHALL sync 결과에 따라 source governance 상태(effective_date, supersession 등)를 갱신한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | source authority 등급, effective_date, sunset_date, superseded_by 상태가 저장되고 조회된다 | Test |
+| AC-02 | superseded source가 일반 검색에서 제외되고, historical question일 때만 포함된다 | Test |
+| AC-03 | stale citation을 포함한 draft/export 시도가 차단되고 사유가 사용자에게 표시된다 | Test |
+| AC-04 | internal SOP가 owner department/approval status 없이 ingestion되면 pending_review로 강제되고 검색에서 제외된다 | Test |
+| AC-05 | source approval/반려 이벤트가 audit_logs에 기록된다 | Test |
+| AC-06 | governance dashboard가 corpus별 approved/pending/stale/superseded count와 30일 내 review due 목록을 표시한다 | Test / Review |
+| AC-07 | #45 delta sync 완료 후 source governance 상태가 갱신된다 | Test |
+| AC-08 | 저권위 출처만 검색된 답변에 expert review required 플래그가 부여된다 | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `lib/db/schema/source-governance.ts` — source authority/version 스키마
+- `lib/source-governance/authority-model.ts` — 권위 등급 정의 및 평가
+- `lib/source-governance/retrieval-gate.ts` — 검색 정책 게이트 (우선순위, superseded 제외, stale 차단)
+- `lib/source-governance/review-workflow.ts` — pending_review 상태 관리, 영향 표시
+- `lib/source-governance/review-notifier.ts` — periodic review 알림
+- `app/api/source-governance/approve/route.ts` — source 승인 API
+- `app/(app)/governance/page.tsx` — Governance Dashboard UI
+- `lib/source-governance/delta-sync-hook.ts` — #45 delta sync 연동
+
+### 4.2 DB Schema
+
+- 신규/확장 테이블 `sources` (또는 기존 source 테이블 확장): authority_grade(enum), jurisdiction, effective_date, sunset_date, superseded_by(self-ref), owner, owner_department, approval_status(enum: pending_review/approved/rejected), review_cycle, last_reviewed_at
+- citation/source_sections 연결 테이블에 source governance 상태 참조 추가
+- audit_logs 활용: 신규 action `source_approved`, `source_rejected`, `source_review_due`, `source_superseded`
+
+### 4.3 API Endpoints
+
+- `POST /api/source-governance/approve` — source 승인/반려 (RBAC: ra-owner/admin)
+- `GET /api/source-governance/dashboard` — governance dashboard 데이터
+- `GET /api/source-governance/review-due` — review due source 목록
+- retrieval 파이프라인 내부 통합: Retrieval Policy Gate 미들웨어
+
+### 4.4 의존성
+
+- 기존 SPEC: SPEC-REGULA-FOUNDATION-001(audit_logs, RBAC), SPEC-REGULA-DOCINGEST-001(ingestion 시 source 등록), SPEC-REGULA-CHAT-001(retrieval/citation), SPEC-REGULA-KNOWLEDGE-GAP-001(#35, source 변경 시 knowledge gap 영향)
+- 외부 이슈 의존: #45 Delta Sync(governance 상태 갱신 트리거), #47 Traceability(submission package 영향)
+- 외부: 알림 채널(periodic review)

--- a/.moai/specs/SPEC-REGULA-STANDARDS-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-STANDARDS-001/spec.md
@@ -1,0 +1,148 @@
+---
+id: SPEC-REGULA-STANDARDS-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 62
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-CLASSIFY-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-STANDARDS-001 — 조화 표준 적용성 & 개정 추적기 (ISO/IEC/EN/ASTM 자동 매핑)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #62 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+규제 인허가의 핵심 증거는 조화 표준(Harmonized Standards) 준수다. CE 마킹은 EU 조화 표준(EN 60601, EN ISO 10993 등), FDA 510(k)는 Recognized Consensus Standards(ISO, ASTM 등) 준수를 통해 적합성 추정(Presumption of Conformity)을 받는다.
+
+현재 Regula의 Regulatory Radar(Phase 10)는 FDA Federal Register, EU Official Journal, MFDS 공고 등 규제 기관 변경을 모니터링하지만, ISO/IEC/EN/ASTM 등 표준 기구의 개정은 추적하지 않는다. 그 결과 의료기기 회사는 "우리 기기에 어떤 표준이 적용되나?"를 수작업으로 수십 시간 조사하거나, IEC 60601-1-2 개정을 놓쳐 갱신 비용이 발생하거나, EU OJ 표준 개정 게재 후 유예기간을 놓쳐 비준수 제품을 출시하는 위험에 직면한다.
+
+본 SPEC은 기기 분류 및 특성을 기반으로 적용 표준을 자동 매핑하고, 표준 기구(ISO, IEC, CEN, ASTM) 개정을 실시간 추적하여 영향 포트폴리오를 알린다. 표준 매핑 엔진은 분류 결과(SPEC-REGULA-CLASSIFY-001)를 입력받아 규칙 기반 + RAG 보조로 적용 표준 목록을 생성하며, cron 기반 표준 데이터베이스 모니터링이 개정을 감지하면 영향 분석과 알림 파이프라인을 거쳐 Regulatory Radar 및 Notifications Hub(#52)에 통합된다.
+
+전환 기간(Transition Period) 및 철회일(Withdrawal Date)에 대해 D-12개월, D-6개월, D-3개월 단계 알림을 제공하여 비준수 위험을 사전에 차단한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA: Recognized Consensus Standards Database (Section 514(c) of FD&C Act), Presumption of Conformity
+- EU: Harmonized Standards (Official Journal Series C), Presumption of Conformity under MDR
+- 전기안전: IEC 60601 시리즈
+- 생체적합성: ISO 10993 시리즈
+- 소프트웨어: IEC 62304, IEC 62366
+- 무균/멸균: ISO 11135, ISO 13485
+- 위험관리: ISO 14971
+- 포장: ISO 11607
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 표준 적용성 매핑: 분류 결과 → 적용 표준 목록 자동 생성, FDA Recognized Consensus Standards / EU Harmonized Standards 연동, 기기 특성별 표준 매핑
+- 표준 데이터베이스 구축: ISO Online Browsing Platform 크롤러, IEC Webstore 메타데이터, ASTM Compass API, CEN OpenStandards 연동, 버전 이력 및 대체 관계 관리
+- 표준 개정 알림 시스템: cron 기반 개정 감지, EU OJ 게재 → 전환 기간 자동 계산, 영향 제품 자동 식별, D-12/6/3개월 알림
+- 표준 갭 분석: 현재 인증 표준 버전 vs 최신 버전 비교, 개정 사항 요약, 업데이트 필요 검증 항목 목록
+- FDA 510(k) 인정 표준 체크: 인용 표준의 FDA 인정 여부 실시간 확인, 철회된 표준 경고, 대체 인정 표준 제안
+
+### 1.4 Out of Scope
+
+- 기기 분류 자체 (SPEC-REGULA-CLASSIFY-001 소관, 본 SPEC은 분류 결과 입력만)
+- ISO 14971 위험관리 워크플로우 (#46 소관, 본 SPEC은 표준 준수 체크 연계만)
+- 알림 채널 인프라 구축 (#52 Notifications Hub 소관, 본 SPEC은 알림 발행만)
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-STANDARDS-001 | WHEN a device classification result is provided THE SYSTEM SHALL automatically generate a list of applicable standards. | High |
+| REQ-STANDARDS-002 | WHEN applicable standards are generated THE SYSTEM SHALL integrate the FDA Recognized Consensus Standards Database. | High |
+| REQ-STANDARDS-003 | WHEN applicable standards are generated THE SYSTEM SHALL integrate EU Harmonized Standards from the Official Journal. | High |
+| REQ-STANDARDS-004 | WHEN a device has electrical-safety characteristics THE SYSTEM SHALL map the IEC 60601 series. | Medium |
+| REQ-STANDARDS-005 | WHEN a device has biocompatibility characteristics THE SYSTEM SHALL map the ISO 10993 series. | Medium |
+| REQ-STANDARDS-006 | WHEN a device contains software THE SYSTEM SHALL map IEC 62304 and IEC 62366. | Medium |
+| REQ-STANDARDS-007 | WHEN the standards database is built THE SYSTEM SHALL crawl ISO Online Browsing Platform, IEC Webstore, ASTM Compass API, and CEN OpenStandards. | High |
+| REQ-STANDARDS-008 | WHEN standards metadata is stored THE SYSTEM SHALL manage version history and supersession relationships. | High |
+| REQ-STANDARDS-009 | WHILE cron monitoring is active THE SYSTEM SHALL detect revisions to applicable standards. | High |
+| REQ-STANDARDS-010 | WHEN a standard is published in the EU OJ THE SYSTEM SHALL automatically calculate the transition period. | High |
+| REQ-STANDARDS-011 | WHEN a standard revision is detected THE SYSTEM SHALL automatically identify the affected products. | High |
+| REQ-STANDARDS-012 | WHEN a withdrawal date approaches THE SYSTEM SHALL send alerts at D-12 months, D-6 months, and D-3 months. | High |
+| REQ-STANDARDS-013 | WHEN gap analysis runs THE SYSTEM SHALL compare the current certified standard version against the latest version. | High |
+| REQ-STANDARDS-014 | WHEN a revision is summarized THE SYSTEM SHALL describe what changed and why it matters, and list verification items needing update. | Medium |
+| REQ-STANDARDS-015 | WHEN a standard is cited for a 510(k) submission THE SYSTEM SHALL verify its FDA recognition status in real time. | High |
+| REQ-STANDARDS-016 | IF a cited standard's FDA recognition has been withdrawn THEN THE SYSTEM SHALL warn the user and propose an alternative recognized standard. | High |
+| REQ-STANDARDS-017 | WHEN a standard revision alert is produced THE SYSTEM SHALL integrate it into the Regulatory Radar dashboard. | Medium |
+| REQ-STANDARDS-018 | WHEN a standard revision alert is produced THE SYSTEM SHALL publish it to the Notifications Hub (#52) for email/Slack delivery. | Medium |
+| REQ-STANDARDS-019 | WHEN a device classification is provided THE SYSTEM SHALL produce the applicable standards list within 5 seconds. | High |
+| REQ-STANDARDS-020 | WHEN a standard revision is detected THE SYSTEM SHALL emit an alert within 24 hours. | High |
+| REQ-STANDARDS-021 | WHEN any applicable-standard result is returned THE SYSTEM SHALL include a citation to the source standards database entry. | High |
+| REQ-STANDARDS-022 | WHILE a user lacks the required role for standards tracking THE SYSTEM SHALL deny access and return an authorization error. | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | FDA Recognized Standards Database가 완전 연동되어 6,000개 이상 표준을 포함한다. | Test |
+| AC-02 | EU Harmonized Standards OJ 크롤러가 자동 업데이트된다. | Test |
+| AC-03 | 기기 분류 → 적용 표준 목록 생성이 5초 이내이다. | Test |
+| AC-04 | 표준 개정 감지 → 알림이 24시간 이내에 발행된다. | Test |
+| AC-05 | 전환 기간 만료 D-6개월 자동 경고가 발생한다. | Test |
+| AC-06 | 인용 표준의 FDA 인정 철회 시 경고와 대체 표준 제안이 표시된다. | Test / Review |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `app/(workflows)/standards/page.tsx` — 표준 매핑 및 추적 UI
+- `app/api/standards/applicability/route.ts` — 적용 표준 매핑 API
+- `app/api/standards/check/route.ts` — FDA 인정 상태 실시간 체크 API
+- `lib/standards/mapping-engine.ts` — 표준 매핑 엔진 (규칙 기반 + RAG 보조)
+- `lib/standards/crawlers/` — ISO/IEC/CEN/ASTM 크롤러
+- `lib/standards/revision-detector.ts` — 개정 감지 (cron)
+- `lib/standards/transition-calculator.ts` — 전환 기간 자동 계산
+- `lib/standards/impact-analyzer.ts` — 영향 제품 식별 및 분석
+- `lib/standards/alert-pipeline.ts` — 알림 파이프라인 (Radar / Notifications Hub 통합)
+
+### 4.2 DB Schema
+
+- `standards_catalog` (신규): 표준 메타데이터 (번호, 제목, 버전, 상태)
+- `standards_applicability` (신규): 기기 유형별 적용 표준 매핑
+- `standards_updates` (신규): 개정 이력 및 영향 분석
+- `product_standards_compliance` (신규): 제품별 표준 준수 상태
+
+### 4.3 API Endpoints
+
+- `POST /api/standards/applicability` — 분류 결과 → 적용 표준 목록 생성
+- `GET /api/standards/check?standard={id}` — FDA 인정 상태 실시간 체크
+- `GET /api/standards/[id]/gap` — 표준 갭 분석 (현재 버전 vs 최신)
+- `POST /api/standards/cron/detect` — cron 트리거 개정 감지 (내부)
+
+### 4.4 의존성
+
+- SPEC-REGULA-CLASSIFY-001 (기기 분류 결과 → 표준 매핑 입력)
+- Phase 10 Regulatory Radar (표준 개정 알림 통합)
+- #46 ISO 14971 Risk (위험관리 표준 준수 체크 연계)
+- #37 Submission Lifecycle (인용 표준 FDA 인정 상태 실시간 체크)
+- #52 Notifications Hub (표준 개정 알림 채널)
+- 외부: FDA Recognized Consensus Standards DB, EU OJ Series C, ISO/IEC/CEN/ASTM 표준 카탈로그

--- a/.moai/specs/SPEC-REGULA-STRATEGY-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-STRATEGY-001/spec.md
@@ -1,0 +1,144 @@
+---
+id: SPEC-REGULA-STRATEGY-001
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 40
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-CHAT-001
+  - SPEC-REGULA-BREADTH-001
+  - SPEC-REGULA-WORKFLOWS-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-STRATEGY-001 — 멀티 관할권 규제 전략 생성기 (Killer Feature)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #40 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+현재 Regula는 "어떤 규제가 어떻게 적용되는가"에 답한다. 그러나 RA(Regulatory Affairs) 책임자가 실제로 가장 필요로 하는 것은 단순한 질의응답이 아니라 전략 합성(strategy synthesis)이다. 즉 "이 기기(예: 임플란트형 심장 모니터, AI 지원 ECG)에 대해 FDA, EU MDR, MFDS, PMDA에서 어떤 경로로 어떤 순서로 진행해야 하는가? 총 소요 기간, 필요 임상 데이터, 주요 리스크는 무엇인가?"에 대한 통합 답변이다.
+
+이 기능은 Regula를 경쟁사와 차별화하는 킬러 기능(killer feature)이다. 단일 RAG 질의로는 해결할 수 없으며, RAG + 5개 corpus + predicate DB + 규제 분류 체계 + 임상 요건 매트릭스를 결합해야 가능하다.
+
+전략 합성은 기기 규제 분류 분석, 관할권별 최적 규제 경로 추천, 임상 데이터 갭 분석, 그리고 전략 보고서 생성으로 구성된다. 또한 보고서 생성 이후에도 RA 책임자가 후속 질의(follow-up)를 통해 시나리오를 탐색할 수 있어야 한다.
+
+본 기능은 기존 chat 컴포넌트, predicate search engine, CER builder, 5 corpus retriever, workflow framework를 통합하는 상위 레벨 워크플로우다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA: 21 CFR Part 807 (510(k)), Part 814 (PMA), De Novo classification (513(f)(2)), Exempt 분류
+- EU MDR: Regulation (EU) 2017/745 Annex VIII (Rules 1-22), Article 61 (Clinical evaluation)
+- MFDS: 의료기기법 등급분류(1~4등급), GMP 인증 및 품목 허가
+- PMDA: 의료기기 클래스 I~IV 분류 (PMD Act)
+- NMPA: 의료기기 등급 분류 (1~3등급)
+- AI/ML SaMD: FDA 2019 AI/ML SaMD Action Plan, EU MDR Article 61 적용
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- A. 기기 규제 분류 분석: FDA/EU MDR/MFDS/PMDA/NMPA 5개 관할권 분류 + AI/ML SaMD 해당 여부 판정
+- B. 규제 경로 추천: 관할권별 최적 경로 추천 및 선택 근거(predicate availability, classification basis, clinical data sufficiency) 제시, 병렬 진행 가능 여부 분석
+- C. 임상 데이터 갭 분석: 보유 데이터 vs 요구 데이터 비교, 공용 가능 데이터 식별, 추가 수집 필요 데이터 유형/규모 산출
+- D. 전략 보고서 생성: 관할권별 타임라인 예측(±30% 불확실성 표시), 마일스톤/의사결정 포인트, 리스크 매트릭스, 우선순위 경로 제안, citation 명시
+- E. 대화형 세션: 보고서 생성 후 follow-up 질의 지원, 각 턴마다 citation 유지
+
+### 1.4 Out of Scope
+
+- 실제 외부 기관 제출 (SPEC-REGULA-EXTERNAL-001 소관)
+- 특허/IP 분석
+- 보험/수가(reimbursement) 전략
+- 외부 고객 대상 API 제공
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-STRATEGY-001 | WHEN a user submits a device description with current clinical/technical data summary THE SYSTEM SHALL return classification analysis for all 5 jurisdictions (FDA/EU MDR/MFDS/PMDA/NMPA). | High |
+| REQ-STRATEGY-002 | WHEN classification analysis runs THE SYSTEM SHALL determine whether the device qualifies as AI/ML SaMD and apply the corresponding regulatory path branch. | High |
+| REQ-STRATEGY-003 | WHEN a jurisdiction is analyzed THE SYSTEM SHALL recommend the optimal regulatory path (FDA: 510(k)/De Novo/PMA/Exempt; EU: Self-cert/Notified Body; MFDS: GMP+품목허가). | High |
+| REQ-STRATEGY-004 | WHEN a path is recommended THE SYSTEM SHALL provide selection rationale citing predicate availability, classification basis, and clinical data sufficiency. | High |
+| REQ-STRATEGY-005 | WHEN strategy synthesis runs THE SYSTEM SHALL analyze whether multiple jurisdiction submissions can proceed in parallel. | Medium |
+| REQ-STRATEGY-006 | WHEN clinical gap analysis runs THE SYSTEM SHALL compare currently held data against each jurisdiction's required data and produce a gap list. | High |
+| REQ-STRATEGY-007 | WHEN clinical gap analysis runs THE SYSTEM SHALL identify reusable data across jurisdictions (e.g., FDA 510(k) clinical data reuse for EU MDR PMCF). | Medium |
+| REQ-STRATEGY-008 | WHEN a strategy report is generated THE SYSTEM SHALL include per-jurisdiction timeline predictions with ±30% uncertainty indicators. | High |
+| REQ-STRATEGY-009 | WHEN a strategy report is generated THE SYSTEM SHALL include a risk matrix (High/Medium/Low × each jurisdiction). | High |
+| REQ-STRATEGY-010 | WHEN a strategy report is generated THE SYSTEM SHALL propose a priority path (fast market entry vs broad coverage). | Medium |
+| REQ-STRATEGY-011 | WHEN a strategy report is generated THE SYSTEM SHALL support export to DOCX and PDF formats. | High |
+| REQ-STRATEGY-012 | IF the synthesis confidence score is below 0.8 THEN THE SYSTEM SHALL flag the report as requiring expert review. | High |
+| REQ-STRATEGY-013 | WHEN a user submits a follow-up question after report generation THE SYSTEM SHALL respond using the existing chat component while preserving the strategy session context. | High |
+| REQ-STRATEGY-014 | WHEN any answer or report section is produced THE SYSTEM SHALL maintain citations referencing classification basis and guidance documents. | High |
+| REQ-STRATEGY-015 | WHEN retrieval is performed THE SYSTEM SHALL query FDA, EU MDR, MFDS, and PMDA corpora in parallel using per-corpus retrievers. | High |
+| REQ-STRATEGY-016 | WHEN a strategy session completes THE SYSTEM SHALL persist the session to the workflow_runs table. | High |
+| REQ-STRATEGY-017 | WHEN structured output is rendered THE SYSTEM SHALL emit Phase C SSE blocks (ComparisonTable, Checklist, Timeline, Callout). | Medium |
+| REQ-STRATEGY-018 | IF a corpus retriever fails or times out THEN THE SYSTEM SHALL surface the failure and continue with available jurisdiction results rather than aborting the whole session. | High |
+| REQ-STRATEGY-019 | WHEN a strategy session is created THE SYSTEM SHALL record an audit log entry with session metadata and confidence distribution. | High |
+| REQ-STRATEGY-020 | WHILE a user lacks the required role for strategy generation THE SYSTEM SHALL deny access and return an authorization error. | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | 기기 설명 입력 시 5개 관할권 분류 분석이 반환된다. | Test |
+| AC-02 | 각 관할권별 최적 규제 경로가 citation과 함께 추천된다. | Test |
+| AC-03 | 임상 데이터 갭 분석 섹션이 생성되며 재활용 가능 항목과 추가 필요 항목을 구분한다. | Test / Review |
+| AC-04 | 전략 보고서가 DOCX 및 PDF로 export된다. | Test |
+| AC-05 | 신뢰도 < 0.8인 경우 expert review 필요 표시가 나타난다. | Test |
+| AC-06 | 보고서 생성 후 follow-up 대화 세션이 기존 chat 컴포넌트로 동작하며 citation을 유지한다. | Test / Review |
+| AC-07 | promptfoo eval 시나리오 Class II wearable, Class III implant, AI/ML SaMD 각 1건 이상 통과한다. | Test |
+| AC-08 | corpus retriever 실패 시에도 부분 결과가 보존되고 실패가 명시된다. | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+- `app/(workflows)/strategy/page.tsx` — 전략 생성기 진입 UI
+- `app/api/strategy/route.ts` — 전략 세션 생성 API (SSE)
+- `lib/strategy/synthesis.ts` — multi-jurisdiction synthesis (Sonnet, 긴 컨텍스트)
+- `lib/strategy/classification-analyzer.ts` — 5 관할권 분류 분석
+- `lib/strategy/path-recommender.ts` — 규제 경로 추천 엔진
+- `lib/strategy/clinical-gap-analyzer.ts` — 임상 데이터 갭 분석
+- `lib/strategy/report-builder.ts` — DOCX/PDF 보고서 생성
+- `lib/strategy/retrievers.ts` — per-corpus 병렬 retriever (FDA/EU MDR/MFDS/PMDA)
+
+### 4.2 DB Schema
+
+- `workflow_runs` (기존 테이블 재활용): 전략 세션 저장. 컬럼 추가 검토 — `workflow_type='strategy'`, `confidence_score`, `expert_review_required`
+- `audit_logs` (기존): 전략 세션 metadata 기록
+
+### 4.3 API Endpoints
+
+- `POST /api/strategy` — 전략 세션 생성 (입력: device description + clinical/technical data summary), SSE 스트림 응답
+- `POST /api/strategy/[id]/followup` — follow-up 대화 질의
+- `GET /api/strategy/[id]/export?format=docx|pdf` — 보고서 export
+
+### 4.4 의존성
+
+- #22 Predicate Search Engine (FDA 510(k) 경로 근거)
+- #23 CER Builder (EU MDR 경로 근거)
+- SPEC-REGULA-BREADTH-001 (5 corpus retriever)
+- SPEC-REGULA-WORKFLOWS-001 (workflow framework)
+- #39 WORKFLOWS-LLM-002 (workflow executor infra)
+- Sonnet 모델 (multi-jurisdiction synthesis, 긴 컨텍스트)

--- a/.moai/specs/SPEC-REGULA-SUBMISSION-LIFECYCLE-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-SUBMISSION-LIFECYCLE-001/spec.md
@@ -1,0 +1,149 @@
+---
+id: SPEC-REGULA-SUBMISSION-LIFECYCLE-001
+version: 1.0.0
+status: draft
+phase: wave4
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 37
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-WORKFLOWS-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+---
+
+# SPEC-REGULA-SUBMISSION-LIFECYCLE-001 — 510(k)·CER·PCCP 산출물 패키징·검증·추적
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #37 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Predicate Search(#22), CER Builder(#23), PCCP Builder(#24)가 완료되면 Regula는 핵심 규제 산출물을 생성할 수 있다. 그러나 실제 RA 업무에서는 산출물 생성이 끝이 아니다. 생성된 초안을 제출 패키지로 구성하고, readiness를 검증하며, 버전을 추적하고, 승인 상태를 관리하는 운영 단계가 필요하다.
+
+본 SPEC은 개별 작성기들을 하나의 제출 라이프사이클로 묶는다. product/project 단위로 submission package를 생성하고, 각 산출물(draft, source evidence, checklist, reviewer approval, export artifact)을 package item으로 연결한다. Readiness Validator는 필수 섹션 누락, citation 미연결, unreviewed draft, stale regulatory update, unresolved knowledge gap을 검사하여 blocking/non-blocking finding으로 분리한다.
+
+모든 export는 package version, artifact hash, reviewer approval snapshot과 함께 immutable audit trail을 생성하며, 이전 버전과의 변경 diff를 제공한다. 상태는 draft → review → approved → exported → submitted_external_manual → archived로 전이되며, 외부 제출은 수동 evidence upload와 receipt number 기록으로 추적한다.
+
+이를 통해 Regula는 문서 생성기를 넘어 제출 준비 운영 도구로 발전한다. 단, 실제 외부 제출 API(FDA ESG/eSTAR, EUDAMED) 연동은 범위 외이다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA 510(k): 21 CFR 807 Subpart E, eCopy/eSTAR readiness checklist (실제 ESG 제출은 범위 외)
+- EU MDR CER: Annex XIV, MEDDEV 2.7/1 Rev 4 stage completeness
+- AI/ML PCCP: FDA Predetermined Change Control Plan guidance
+- ISO 13485:2016 §4.2.5 (Control of Documents), §7.3.10 (Design and Development Files)
+- audit trail은 21 CFR Part 11 record integrity 원칙 준수 (전자서명 full validation은 범위 외)
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- Submission Package 모델: product/project 단위 package, type(FDA 510(k), EU MDR CER, AI/ML PCCP, internal review packet), package item(draft, source evidence, checklist, reviewer approval, export artifact)
+- Readiness Validator: 필수 섹션·citation·review·stale source·knowledge gap 검사, blocking/non-blocking 분리, FDA eSTAR / EU Annex XIV completeness 검사
+- Versioning & Audit: package version, artifact hash, reviewer approval snapshot, export별 immutable audit trail, 버전 diff
+- Status Tracking: 상태 전이, manual submission evidence upload, external submission ID / receipt number 기록
+
+### 1.4 Out of Scope
+
+- FDA ESG/eSTAR 실제 mTLS 제출
+- EU EUDAMED machine submission
+- 공인기관 포털 자동 업로드
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-SUBMISSION-001 | WHEN a user creates a submission package THE SYSTEM SHALL associate it with a product or project and a package type (FDA 510(k), EU MDR CER, AI/ML PCCP, internal review packet) | High |
+| REQ-SUBMISSION-002 | THE SYSTEM SHALL allow generated drafts from #22, #23, and #24 to be linked as package items | High |
+| REQ-SUBMISSION-003 | WHEN a package item is added THE SYSTEM SHALL record its type as one of draft, source evidence, checklist, reviewer approval, or export artifact | High |
+| REQ-SUBMISSION-004 | WHEN readiness validation runs THE SYSTEM SHALL detect missing required sections, unlinked citations, unreviewed drafts, stale regulatory updates, and unresolved knowledge gaps | High |
+| REQ-SUBMISSION-005 | THE SYSTEM SHALL classify each readiness finding as blocking or non-blocking | High |
+| REQ-SUBMISSION-006 | WHERE the package type is FDA 510(k) THE SYSTEM SHALL validate against an eCopy/eSTAR readiness checklist | Medium |
+| REQ-SUBMISSION-007 | WHERE the package type is EU MDR CER THE SYSTEM SHALL validate Annex XIV / MEDDEV stage completeness | Medium |
+| REQ-SUBMISSION-008 | IF a package contains any unreviewed or unresolved blocking item THEN THE SYSTEM SHALL block export | High |
+| REQ-SUBMISSION-009 | WHEN a package is exported THE SYSTEM SHALL record the export artifact hash and reviewer approval snapshot in audit_logs | High |
+| REQ-SUBMISSION-010 | WHEN a new package version is created THE SYSTEM SHALL display a diff against the previous version | Medium |
+| REQ-SUBMISSION-011 | THE SYSTEM SHALL transition package status through draft, review, approved, exported, submitted_external_manual, and archived | High |
+| REQ-SUBMISSION-012 | WHEN external submission occurs THE SYSTEM SHALL allow manual upload of submission evidence and recording of an external submission ID or portal receipt number | Medium |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | 프로젝트에서 submission package를 생성하고 type을 지정할 수 있다 | Test / Review |
+| AC-02 | #22/#23/#24 산출물을 package item으로 연결할 수 있다 | Test |
+| AC-03 | readiness validator가 blocking/non-blocking finding을 분리한다 | Test |
+| AC-04 | unreviewed 또는 unresolved blocking item이 있으면 export가 서버 측에서 차단된다 | Test |
+| AC-05 | export artifact hash와 reviewer snapshot이 audit_logs에 기록된다 | Test |
+| AC-06 | manual submission receipt를 저장하고 상태를 전이할 수 있다 | Test / Review |
+| AC-07 | 이전 버전과의 변경 diff가 표시된다 | Review |
+| AC-08 | FDA 510(k) / EU MDR CER 각각의 completeness 검사가 동작한다 | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/
+    (dashboard)/submissions/
+      page.tsx                  # package 목록
+      [packageId]/page.tsx      # package detail, readiness, status
+      [packageId]/diff/page.tsx # 버전 diff
+    api/submissions/
+      route.ts                  # package 생성/조회
+      [packageId]/items/route.ts    # package item 연결
+      [packageId]/readiness/route.ts # validator 실행
+      [packageId]/export/route.ts    # export + hash + audit
+      [packageId]/status/route.ts    # 상태 전이 + manual receipt
+  lib/submissions/
+    readiness/
+      fda-510k.ts               # eSTAR checklist
+      eu-mdr-cer.ts             # Annex XIV completeness
+      validator.ts              # blocking/non-blocking 분류
+    versioning.ts               # version diff, snapshot
+    artifact-hash.ts            # export hash
+  db/schema/submissions.ts
+```
+
+### 4.2 DB Schema
+
+- `submission_packages`: id, project_id, package_type, status, current_version, created_at
+- `submission_package_items`: id, package_id, item_type, source_ref (draft/evidence/checklist/approval/artifact id), created_at
+- `submission_package_versions`: id, package_id, version, artifact_hash, reviewer_snapshot (jsonb), exported_at
+- `readiness_findings`: id, package_id, finding_type, severity (blocking|non_blocking), detail, created_at
+- `external_submissions`: id, package_id, external_id, receipt_number, evidence_file_ref, recorded_by, recorded_at
+- audit_logs 재사용 — export·status 전이·version 기록
+
+### 4.3 API Endpoints
+
+- `POST /api/submissions` — package 생성
+- `POST /api/submissions/{id}/items` — 산출물 연결
+- `POST /api/submissions/{id}/readiness` — validator 실행, finding 반환
+- `POST /api/submissions/{id}/export` — readiness 통과 검증 후 export, hash·snapshot·audit
+- `POST /api/submissions/{id}/status` — 상태 전이, manual receipt 기록
+- `GET /api/submissions/{id}/diff?from=&to=` — 버전 diff
+
+### 4.4 의존성
+
+- SPEC-REGULA-FOUNDATION-001 (project, audit_logs, RBAC, source/citation)
+- SPEC-REGULA-WORKFLOWS-001 (draft 생성 산출물)
+- #22 Predicate Search, #23 CER Builder, #24 PCCP Builder (package item 공급)
+- #36 Review Ops (reviewed=true 게이트, reviewer approval snapshot)

--- a/.moai/specs/SPEC-REGULA-TRACEABILITY-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-TRACEABILITY-001/spec.md
@@ -1,0 +1,146 @@
+---
+id: SPEC-REGULA-TRACEABILITY-001
+version: 1.0.0
+status: draft
+phase: wave4
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 47
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-WORKFLOWS-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/backend
+---
+
+# SPEC-REGULA-TRACEABILITY-001 — 규제 근거·위험·요구사항·초안·검토·제출 추적 매트릭스
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #47 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+선행 이슈들(#22~#46)이 완료되면 Regula는 질의응답, 문서 ingestion, 규제 전략, Predicate/CER/PCCP, 위험관리, 영향 추적, 제출 패키징까지 수행한다. 남은 핵심 공백은 모든 결론과 산출물이 어떤 근거에서 왔고, 어떤 검토와 제출 상태로 이어졌는지 한 번에 추적하는 evidence graph이다.
+
+의료기기 RA 업무에서 최종 유용성은 답변 생성 능력보다 추적성(traceability)에 의해 결정된다. 규제 당국과 공인기관은 "이 결론의 근거는 무엇이며, 누가 검토했고, 어느 제출에 포함되었는가"를 요구한다. 근거가 끊기거나 stale source가 산출물에 남아 있으면 제출 자체가 거부될 수 있다.
+
+본 SPEC은 source_sections, citations, messages, workflow_runs, expert_reviews, submission_packages, risk_items를 연결하는 traceability graph를 생성한다. 각 노드는 source authority, version, effective date, reviewer, artifact hash를 포함하고, 각 edge는 derived_from, cites, reviewed_by, exported_in, mitigates, satisfies 관계로 구분된다. Traceability Matrix UI는 요구사항·규제 요구사항·위험 항목·제출 섹션을 행으로, 근거 출처·생성 답변·reviewer decision·export artifact·open gap을 열로 제시한다.
+
+source가 superseded되면 연결된 산출물과 제출 패키지에 stale flag가 전파되며, 모든 traceability 변경은 audit_logs에 기록된다. 이를 통해 Regula는 문서 생성기가 아니라 audit-ready RA operating system이 된다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA 21 CFR Part 820 (Design History File, traceability)
+- ISO 13485:2016 §7.3 (Design and Development traceability), §4.2.4 (Control of Records)
+- ISO 14971:2019 (risk-to-control traceability)
+- EU MDR Annex II (Technical Documentation traceability)
+- IEC 62304 (요구사항-설계-검증 traceability)
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- Evidence Graph 모델: source_sections·citations·messages·workflow_runs·expert_reviews·submission_packages·risk_items를 연결, 노드 메타데이터(authority, version, effective date, reviewer, artifact hash), edge 관계(derived_from, cites, reviewed_by, exported_in, mitigates, satisfies)
+- Traceability Matrix UI: 요구사항/규제/위험/제출 섹션(행) × 근거/답변/reviewer decision/export/gap(열), jurisdiction·product·package·risk level·stale source 필터
+- 산출물별 근거 패키지: 답변·CER 섹션·PCCP 컴포넌트·510(k) 섹션·위험 항목에서 evidence packet 열람, citation 누락·stale·unresolved review 표시, PDF/Markdown export
+- 감사 및 회귀 검증: edge 변경 audit, source supersession 시 stale flag 전파, replay/eval 시나리오가 edge 검증
+
+### 1.4 Out of Scope
+
+- 외부 QMS 전용 시스템 양방향 동기화
+- 전자서명 full validation
+- 제출 포털 자동 업로드
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-TRACEABILITY-001 | WHEN an answer or draft is generated from sources THE SYSTEM SHALL persist a graph edge linking source, answer/draft, review, and export artifact | High |
+| REQ-TRACEABILITY-002 | THE SYSTEM SHALL store each graph node with source authority, version, effective date, reviewer, and artifact hash | High |
+| REQ-TRACEABILITY-003 | THE SYSTEM SHALL distinguish edge relationships as derived_from, cites, reviewed_by, exported_in, mitigates, or satisfies | High |
+| REQ-TRACEABILITY-004 | THE SYSTEM SHALL provide a per-project traceability matrix UI with requirements, regulatory requirements, risk items, and submission sections as rows | High |
+| REQ-TRACEABILITY-005 | THE SYSTEM SHALL allow the traceability matrix to be filtered by jurisdiction, product, package, risk level, and stale-source status | Medium |
+| REQ-TRACEABILITY-006 | WHEN the matrix is displayed THE SYSTEM SHALL flag missing citations, stale sources, and unresolved reviews | High |
+| REQ-TRACEABILITY-007 | WHEN a user opens a deliverable THE SYSTEM SHALL present an evidence packet for the answer, CER section, PCCP component, 510(k) section, or risk item | High |
+| REQ-TRACEABILITY-008 | THE SYSTEM SHALL export an evidence packet to PDF or Markdown | Medium |
+| REQ-TRACEABILITY-009 | WHEN a source is superseded THE SYSTEM SHALL propagate a stale flag to all linked deliverables and submission packages | High |
+| REQ-TRACEABILITY-010 | WHEN a traceability edge is created, modified, or deleted THE SYSTEM SHALL record the change in audit_logs | High |
+| REQ-TRACEABILITY-011 | WHEN a replay or eval scenario runs THE SYSTEM SHALL verify the integrity of traceability edges | Medium |
+| REQ-TRACEABILITY-012 | IF a deliverable has no linked source THEN THE SYSTEM SHALL mark it as an open evidence gap in the matrix | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | source → answer/draft → review → export artifact 관계가 graph로 저장된다 | Test |
+| AC-02 | 프로젝트별 traceability matrix UI가 제공되고 필터가 동작한다 | Review |
+| AC-03 | citation 누락·stale source·unresolved review가 matrix에서 표시된다 | Test / Review |
+| AC-04 | evidence packet PDF/Markdown export가 가능하다 | Test |
+| AC-05 | source supersession 시 영향받는 산출물이 stale로 표시된다 | Test |
+| AC-06 | 모든 traceability 변경이 audit_logs에 남는다 | Test |
+| AC-07 | replay/eval 시나리오가 traceability edge를 검증한다 | Test |
+| AC-08 | source 미연결 산출물이 open evidence gap으로 표시된다 | Test |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/
+    (dashboard)/traceability/
+      page.tsx                  # matrix UI (rows × columns, filters)
+      [deliverableId]/page.tsx  # evidence packet 열람
+    api/traceability/
+      route.ts                  # matrix 조회
+      edges/route.ts            # edge 생성/변경 (audit)
+      [deliverableId]/packet/route.ts  # evidence packet
+      [deliverableId]/export/route.ts  # PDF/Markdown export
+  lib/traceability/
+    graph.ts                    # 노드/엣지 모델, 조회
+    stale-propagation.ts        # supersession 전파
+    evidence-packet.ts          # packet 조립
+    matrix.ts                   # 행/열 집계, gap 검출
+  db/schema/traceability.ts
+```
+
+### 4.2 DB Schema
+
+- `evidence_nodes`: id, node_type (source_section|citation|message|workflow_run|expert_review|submission_package|risk_item), ref_id, authority, version, effective_date, reviewer_id, artifact_hash
+- `evidence_edges`: id, from_node_id, to_node_id, relation (derived_from|cites|reviewed_by|exported_in|mitigates|satisfies), created_at
+- `stale_flags`: id, node_id, reason (superseded_source), propagated_from, created_at
+- audit_logs 재사용 — edge create/modify/delete 기록
+- pgvector source 모델(FOUNDATION) 재사용 — source authority/version 참조
+
+### 4.3 API Endpoints
+
+- `GET /api/traceability?projectId=` — matrix rows/columns + filters
+- `POST /api/traceability/edges` — edge 생성/변경 (RBAC, audit)
+- `GET /api/traceability/{deliverableId}/packet` — evidence packet
+- `GET /api/traceability/{deliverableId}/export?format=pdf|md` — packet export
+- supersession 이벤트는 source ingestion(FOUNDATION) 훅에서 stale propagation 트리거
+
+### 4.4 의존성
+
+- SPEC-REGULA-FOUNDATION-001 (source_sections, citations, messages, audit_logs, pgvector)
+- SPEC-REGULA-WORKFLOWS-001 (workflow_runs, draft 산출물)
+- #35 Knowledge Gap Ops (open gap 연동)
+- #36 Review Ops (expert_reviews, reviewed_by edge)
+- #37 Submission Lifecycle (submission_packages, exported_in edge)
+- #41 Impact Tracker (regulatory update supersession)
+- #46 ISO 14971 Risk (risk_items, mitigates edge)

--- a/.moai/specs/SPEC-REGULA-VALIDATION-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-001/spec.md
@@ -1,0 +1,144 @@
+---
+id: SPEC-REGULA-VALIDATION-001
+version: 1.0.0
+status: draft
+phase: system
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 49
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-RELEASE-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/infra
+---
+
+# SPEC-REGULA-VALIDATION-001 — Regula 자체 검증 패키지 (IQ/OQ/PQ·변경통제·릴리즈 증거)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #49 기반. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula가 RA 의사결정, 제출 초안, 위험관리, 검토 승인에 사용된다면 Regula 자체도 검증 가능한(validated) 업무 시스템이어야 한다. 기능 이슈들은 제품 기능을 완성하지만, 운영 관점에서는 릴리즈마다 무엇이 검증됐고 어떤 제한 조건으로 사용 가능한지를 증거로 남겨야 한다.
+
+본 SPEC은 내부용 CSV-lite 수준의 IQ/OQ/PQ(Installation/Operational/Performance Qualification) 기반 Regula system validation package를 정의한다. 이는 외부 인증 대행이나 FDA 제출용 소프트웨어 validation이 아니라, 내부 거버넌스를 위한 검증 증거 체계다.
+
+검증 증거는 사람이 수기로 정리하는 것이 아니라 commit SHA, CI run, test command, artifact path를 자동 수집하여 신뢰 가능한 release validation report로 묶는다.
+
+변경통제(change control)는 source policy, prompt, model, schema, retrieval, export, review workflow 변경의 영향을 평가하고, high-impact change에는 validation rerun을 강제한다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- GAMP 5 / CSV (Computerized System Validation) — IQ/OQ/PQ 단계별 검증 증거 체계.
+- 21 CFR Part 11 — validation sign-off는 electronic record로 audit_logs에 기록되어야 한다.
+- ISO 13485 §4.1.6 — 소프트웨어 validation 및 변경통제 요구.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- A. Intended Use & Validation Scope: intended/prohibited use, human review boundary 문서화, 기능별 validation criticality 분류
+- B. IQ/OQ/PQ Evidence: 환경/dependency/migration/config/secret 검증(IQ), core function requirement test(OQ), 대표 RA 시나리오 E2E evidence(PQ)
+- C. Change Control: 릴리즈별 변경 영향 평가, high-impact change validation rerun, exception/residual risk 기록
+- D. Release Validation Report: 릴리즈 결과 연결, traceability/source governance/review ops 상태 포함, final sign-off checklist
+
+### 1.4 Out of Scope
+
+- 외부 인증기관 검증 대행
+- SOC 2 / ISO 27001 full certification
+- FDA 제출용 소프트웨어 validation 패키지
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-VALIDATION-001 | THE SYSTEM SHALL Regula의 intended use, prohibited use, human review boundary를 문서로 관리해야 한다 | High |
+| REQ-VALIDATION-002 | THE SYSTEM SHALL 각 기능(chat/RAG/workflow draft/review/submission package/risk management)에 validation criticality 등급을 분류해야 한다 | High |
+| REQ-VALIDATION-003 | WHEN IQ가 실행되면 THE SYSTEM SHALL 환경, dependency, migration, config, secret presence를 검증하고 결과를 기록해야 한다 | High |
+| REQ-VALIDATION-004 | WHEN OQ가 실행되면 THE SYSTEM SHALL core function requirement test 결과를 evidence bundle로 묶어야 한다 | High |
+| REQ-VALIDATION-005 | WHEN PQ가 실행되면 THE SYSTEM SHALL 대표 RA 시나리오의 end-to-end evidence를 묶어야 한다 | High |
+| REQ-VALIDATION-006 | THE SYSTEM SHALL 각 evidence에 commit SHA, CI run ID, test command, artifact path를 포함해야 한다 | High |
+| REQ-VALIDATION-007 | WHEN 릴리즈가 준비되면 THE SYSTEM SHALL source policy/prompt/model/schema/retrieval/export/review workflow 변경 영향 평가를 생성해야 한다 | High |
+| REQ-VALIDATION-008 | IF 변경이 high-impact로 분류되면 THEN THE SYSTEM SHALL validation rerun을 필수 조건으로 강제해야 한다 | High |
+| REQ-VALIDATION-009 | THE SYSTEM SHALL validation exception과 residual risk를 기록해야 한다 | Medium |
+| REQ-VALIDATION-010 | THE SYSTEM SHALL release validation report에 release/traceability/source governance/review ops 상태를 연결해야 한다 | High |
+| REQ-VALIDATION-011 | WHEN release validation report가 export되면 THE SYSTEM SHALL Markdown 및 PDF 형식으로 생성해야 한다 | Medium |
+| REQ-VALIDATION-012 | WHEN validation이 sign-off되면 THE SYSTEM SHALL 승인자, 타임스탬프를 audit_logs에 기록해야 한다 | High |
+| REQ-VALIDATION-013 | IF final sign-off checklist 항목이 미충족이면 THEN THE SYSTEM SHALL release sign-off를 차단해야 한다 | High |
+| REQ-VALIDATION-014 | THE SYSTEM SHALL CI/test/eval 결과를 validation report에 자동으로 링크해야 한다 | High |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | intended use / prohibited use 문서가 생성되고 버전 관리됨 | 문서 존재 + git history 확인 |
+| AC-02 | IQ/OQ/PQ evidence template과 자동 수집 스크립트가 동작함 | 스크립트 실행 후 evidence bundle 생성 확인 |
+| AC-03 | CI/test/eval 결과가 validation report에 링크됨 | report 내 CI run ID/artifact path 검증 |
+| AC-04 | prompt/model/source/schema 변경 시 impact assessment가 생성됨 | 변경 시뮬레이션 후 assessment 문서 자동 생성 |
+| AC-05 | release validation report가 Markdown 및 PDF로 export됨 | export 실행 후 두 형식 파일 생성 검증 |
+| AC-06 | validation sign-off가 audit_logs에 승인자/타임스탬프로 기록됨 | DB 조회: audit_logs sign-off row 확인 |
+| AC-07 | final sign-off checklist 미충족 시 release가 차단됨 | Integration: 미충족 상태에서 sign-off 시도 시 거부 |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+src/
+  app/api/
+    validation/iq/route.ts
+    validation/oq/route.ts
+    validation/pq/route.ts
+    validation/impact-assessment/route.ts
+    validation/report/export/route.ts
+    validation/signoff/route.ts
+  lib/
+    validation/criticality.ts        # 기능별 criticality 분류
+    validation/evidence-collector.ts # commit SHA/CI run/artifact 수집
+    validation/change-control.ts     # 변경 영향 평가
+    validation/report-builder.ts     # Markdown/PDF report 생성
+  db/schema/
+    validation-evidence.ts
+    change-control.ts
+    validation-signoff.ts
+scripts/
+  collect-validation-evidence.ts     # CI 연동 자동 수집
+docs/validation/
+  intended-use.md
+```
+
+### 4.2 DB Schema
+
+- `validation_evidence`: id, qualification_type (enum: IQ/OQ/PQ), commit_sha, ci_run_id, test_command, artifact_path, result (enum: pass/fail/skip), created_at
+- `change_control`: id, release_id, change_axis (enum: source_policy/prompt/model/schema/retrieval/export/review_workflow), impact_level (enum: low/medium/high), rerun_required (boolean), residual_risk (text), exception_note (text, nullable), created_at
+- `validation_signoff`: id, release_id, checklist_state (jsonb), approver_id (FK), signed_at, report_artifact_path
+- `audit_logs` (기존): sign-off 이벤트 기록
+
+### 4.3 API Endpoints
+
+- `POST /api/validation/iq|oq|pq` — qualification 실행 및 evidence 수집
+- `POST /api/validation/impact-assessment` — 변경 영향 평가 생성
+- `POST /api/validation/report/export` — Markdown/PDF report export
+- `POST /api/validation/signoff` — final sign-off (checklist gate 적용)
+
+### 4.4 의존성
+
+- 선행: SPEC-REGULA-FOUNDATION-001 (audit_logs, RBAC), SPEC-REGULA-RELEASE-001 (release scope SSoT)
+- 연계: #31~#34 Release, #47 Traceability, #48 Source Governance, #36 Review Ops
+- 기술: Next.js 15, Drizzle ORM, PostgreSQL, CI (GitHub Actions) 연동, promptfoo eval 결과 연결

--- a/.moai/specs/SPEC-REGULA-WORKFLOWS-LLM-002/spec.md
+++ b/.moai/specs/SPEC-REGULA-WORKFLOWS-LLM-002/spec.md
@@ -1,0 +1,140 @@
+---
+id: SPEC-REGULA-WORKFLOWS-LLM-002
+version: 1.0.0
+status: draft
+phase: wave3
+priority: High
+created: 2026-06-22
+updated: 2026-06-22
+author: manager-spec (batch-2026-06-22)
+issue_number: 39
+depends_on:
+  - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-REGULA-WORKFLOWS-001
+  - SPEC-REGULA-PREDICATE-001
+  - SPEC-REGULA-CER-001
+  - SPEC-REGULA-PCCP-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/rag
+---
+
+# SPEC-REGULA-WORKFLOWS-LLM-002 — 워크플로우 LLM 실제 구현 (510(k)·감사대응·적응증영향 executor)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #39 기반. SPEC-REGULA-WORKFLOWS-001(stub)의 mock executor를 실제 LLM 구현으로 승격. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+Regula의 핵심 가치 제안은 "규제 문서 초안을 AI로 자동 생성한다"이다. 그러나 현재 `lib/workflows/*/executor.ts`의 세 개 executor(`submission-drafter`, `audit-response`, `indication-impact`)는 전체가 mock 구현으로, `_mock: true` 플래그가 붙은 고정 응답을 반환한다. 이로 인해 Predicate Search(#22), CER Builder(#23), PCCP Builder(#24)의 산출물이 실제 문서 생성으로 이어지지 못하고 데모 수준에 머물러 있다.
+
+#33 Release Hardening은 워크플로우 실제 LLM 구현을 명시적으로 "범위 외"로 연기하면서 본 SPEC(SPEC-REGULA-WORKFLOWS-LLM-002)을 후속 작업으로 지정했다. SPEC-REGULA-WORKFLOWS-001은 executor 인터페이스 계약과 SSE streaming 계약을 정의한 stub SPEC이며, 본 SPEC은 그 계약을 유지한 채 실제 LLM 호출을 채워 넣는다.
+
+510(k) Submission Drafter는 FDA 510(k) eCopy 구조(커버레터, 목차, 기기 설명, 용도, 기술 특성, 성능 데이터)에 따라 Predicate 데이터를 입력받아 section-by-section streaming draft를 생성해야 한다. Audit Response Drafter는 FDA Form 483 / Warning Letter / EU MDR notified body 지적 사항에 대해 regulatory basis + corrective action + timeline 3-part 구조의 대응 초안을 생성한다. Indication Impact Analyzer는 적응증 변경 입력에 대해 substantial equivalence 재평가, EU MDR classification 변경, 임상 데이터 추가 필요 여부의 규제 영향 체인을 분석한다.
+
+세 executor 공통으로 citation 강제(규제 원문 + predicate/CER 데이터 인용)와 expert review gate(review 없이 export 차단)가 의료기기 규제 안전성의 핵심 통제이다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+- FDA 510(k) Program Guidance (2014) 및 eCopy Program Guidance (2023): eCopy 구조·형식 준수
+- 21 CFR 807 Subpart E: Premarket Notification 510(k) 요구사항
+- FDA Form 483 / Warning Letter 대응 프로세스 (21 CFR 820 QSR)
+- EU MDR (2017/745) Article 52, Annex II/III: 적합성 평가 및 기술 문서
+- 21 CFR Part 11: 전자 기록·서명, audit trail 무결성
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+- 세 executor의 mock 제거 및 실제 Sonnet 기반 streaming LLM 구현
+- FDA 510(k) eCopy 섹션 구조 기반 draft 생성
+- 감사 지적 사항별 3-part 대응 초안 생성 (hybrid retrieval: 사내 SOP + 규제 corpus)
+- 적응증 영향 체인 분석 (3개 판단 축)
+- 공통 인프라: SSE streaming chain, audit_logs 이벤트, citation enforcement
+- promptfoo eval 시나리오 6건 이상 (각 executor × 2)
+
+### 1.4 Out of Scope
+
+- EU eCTD / FDA eSTAR 실제 mTLS 제출 (SPEC-REGULA-EXTERNAL-001)
+- 제출 포털 자동 업로드
+- 실시간 FDA CDRH 피드백 통합
+- 새로운 워크플로우 타입 추가 (PMS/CAPA 등은 별도 SPEC)
+
+---
+
+## §2 Requirements (EARS Format)
+
+| ID | EARS Statement | Priority |
+|----|---------------|----------|
+| REQ-WFLLM-001 | WHEN 사용자가 510(k) Submission Drafter를 실행하면 THE SYSTEM SHALL Predicate Search 결과를 입력으로 받아 FDA eCopy 6개 섹션의 실제 LLM draft를 생성한다 | High |
+| REQ-WFLLM-002 | WHILE draft가 생성되는 동안 THE SYSTEM SHALL 기존 SSE 계약에 따라 section-by-section streaming으로 응답을 전송한다 | High |
+| REQ-WFLLM-003 | WHEN audit-response executor가 지적 사항을 입력받으면 THE SYSTEM SHALL regulatory basis + corrective action + timeline 3-part 구조의 대응 초안을 생성한다 | High |
+| REQ-WFLLM-004 | WHEN audit-response가 컨텍스트를 수집하면 THE SYSTEM SHALL 사내 SOP corpus와 관련 규제 corpus를 동시에 hybrid retrieval로 검색한다 | High |
+| REQ-WFLLM-005 | WHEN indication-impact executor가 적응증 변경을 입력받으면 THE SYSTEM SHALL 510(k) substantial equivalence 재평가, EU MDR classification 변경, 임상 데이터 추가 필요 여부를 각각 판단한다 | High |
+| REQ-WFLLM-006 | THE SYSTEM SHALL 모든 draft 섹션의 citation coverage가 80% 이상이 되도록 규제 출처 인용을 강제한다 | High |
+| REQ-WFLLM-007 | IF draft에 expert review가 완료되지 않았다면 THEN THE SYSTEM SHALL export를 차단한다 | High |
+| REQ-WFLLM-008 | WHEN executor가 LLM을 호출하면 THE SYSTEM SHALL `workflow.llm_call`, `workflow.draft_version`, `workflow.expert_flagged` 이벤트를 audit_logs에 기록한다 | High |
+| REQ-WFLLM-009 | THE SYSTEM SHALL 세 executor의 응답에서 `_mock: true` 플래그를 제거한다 | High |
+| REQ-WFLLM-010 | IF LLM 호출이 실패하거나 timeout/rate limit에 도달하면 THEN THE SYSTEM SHALL 명확한 오류를 반환하고 부분 draft를 저장한다 | High |
+| REQ-WFLLM-011 | THE SYSTEM SHALL 510(k) draft가 FDA 2023 eCopy guidance 형식을 준수하는지 검증한다 | Medium |
+| REQ-WFLLM-012 | WHEN 세 executor 구현이 완료되면 THE SYSTEM SHALL `/workflows` UI의 Beta 배지를 제거한다 | Medium |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|-------------|
+| AC-01 | `lib/workflows/submission-drafter/executor.ts`에 `_mock: true` 없음 | grep + unit test |
+| AC-02 | `lib/workflows/audit-response/executor.ts`에 `_mock: true` 없음 | grep + unit test |
+| AC-03 | `lib/workflows/indication-impact/executor.ts`에 `_mock: true` 없음 | grep + unit test |
+| AC-04 | 각 executor가 streaming SSE로 실제 LLM 응답 반환 | integration test (SSE 수신 검증) |
+| AC-05 | 모든 draft 섹션 citation coverage ≥ 80% | promptfoo eval assertion |
+| AC-06 | expert review 없이 export 시도 시 차단됨 | E2E negative test |
+| AC-07 | `pnpm eval:ci` 워크플로우 시나리오 80% 이상 통과 | CI eval run |
+| AC-08 | promptfoo 시나리오 6건 이상 (executor × 2) 존재 | eval config 검토 |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 파일 구조
+
+```
+lib/workflows/
+  submission-drafter/executor.ts   # FDA 510(k) eCopy 섹션 streaming draft
+  audit-response/executor.ts        # 3-part 대응 초안 + hybrid retrieval
+  indication-impact/executor.ts     # 적응증 영향 체인 3축 분석
+  _shared/
+    streaming-chain.ts              # Sonnet streaming chain 공통 구성
+    citation-enforcer.ts            # citation coverage 검증
+    review-gate.ts                  # expert review export 차단
+evals/workflows/                    # promptfoo 시나리오 6건+
+```
+
+### 4.2 DB Schema
+
+기존 `workflows`, `workflow_runs`, `audit_logs` 테이블 재사용. `workflow_runs`에 `draft_version`, `citation_coverage`, `review_status`(pending|approved|rejected) 컬럼이 없다면 추가. `_mock` 관련 메타데이터 컬럼 제거 또는 deprecate.
+
+### 4.3 API Endpoints
+
+기존 SSE 계약 유지:
+- `POST /api/workflows/[type]/run` — executor 실행, SSE streaming 응답
+- `GET /api/workflows/runs/[id]` — draft 버전·citation·review 상태 조회
+- `POST /api/workflows/runs/[id]/export` — review_status=approved일 때만 허용
+
+### 4.4 의존성
+
+- #22 Predicate Search Engine (510k drafter input)
+- #23 CER Builder (audit-response context)
+- #24 PCCP Builder (indication impact context)
+- SPEC-REGULA-WORKFLOWS-001 (executor interface contract)
+- #33 Release Hardening (mock → beta 플래그 제거 후 진행)
+- Anthropic Sonnet (streaming LLM), pgvector hybrid retrieval

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 ---
 
-## 구현 현황 대시보드 (2026-06-21 KST 기준)
+## 구현 현황 대시보드 (2026-06-23 KST 기준)
 
 상세 점검 기록: [`docs/implementation-status.md`](docs/implementation-status.md)
 
-### 최신 main 상태 (2026-06-21)
+### 최신 main 상태 (2026-06-23)
 
 현재 `main`은 PR #218(Gate 0 SPEC 승격)까지 반영된 상태입니다. Wave 5 규제 준수 축(ESIG #88 / Export Hub #87 / Auditor View #92) 완성에 이어 개인 RA 라이브러리(#86), 규제 캘린더(#44), 코퍼스 증분 동기화(#45)가 머지되었고, QA 게이트 프레임워크가 정비되어 **Gate 0~5 SPEC 6개가 모두 Active**로 승격되었습니다(#212 Gate 1-5, #217 Gate 5 SSoT 정합, #218 Gate 0). 2026-06-21 기준 main의 `CI`, `Security Scan`, `E2E Tests`, `Deploy`가 모두 통과했습니다.
 
@@ -45,6 +45,56 @@
 | 로컬 단위 테스트 | PASS | `pnpm test`: 2,766 passed / 7 skipped |
 | 권한 매트릭스 | PASS | `audit.read`, `audit.package.generate`, `signature.sign` 포함 — auditor role은 `additionalRoles` 경유로만 audit endpoint 접근 |
 | AuditAction enum | PASS | `signature.applied`, `signature.revoked`, `audit.denied`, `audit.package.generated` 포함 |
+
+### 신규 SPEC Batch (2026-06-22) — Wave 3/4/5·시스템 26개 스펙 일괄 작성
+
+2026-06-22에 `manager-spec` 배치 작업으로 **26개 `SPEC-REGULA-*`** 가 신규 작성되었습니다 (모두 `status: draft`, 기존 이슈 #35~#72에 1:1 매핑). 각 SPEC은 `.moai/specs/SPEC-REGULA-*/spec.md`에 위치하며, 멀티 관할권 규제 전략(STRATEGY #40, 킬러 기능)을 필두로 채택·검증·PMS·거버넌스 축이 한 번에 정의되었습니다. 구현 진행은 각 SPEC의 이슈에서 추적합니다.
+
+**Wave 3 — 전략·분류·지식 루프 (11개)**
+
+| SPEC | 이슈 | 제목 |
+|---|---|---|
+| `SPEC-REGULA-BATCH-001` | #43 | 배치 질의 모드 (사전 미팅 준비·대량 규제 Q&A) |
+| `SPEC-REGULA-CLASSIFY-001` | #59 | 의료기기 분류 자동화 마법사 (FDA/EU/MFDS/NMPA/PMDA 통합) |
+| `SPEC-REGULA-CROSSMARKET-001` | #42 | 멀티 관할권 갭 분석기 (기존 허가 → 신규 시장 진출 요건) |
+| `SPEC-REGULA-KNOWLEDGE-GAP-001` | #35 | 미답변 자동 이슈화 및 지식베이스 보강 루프 |
+| `SPEC-REGULA-KNOWLEDGE-PROMO-001` | #50 | 대화 시맨틱 검색 & 우수 답변 팀 지식 승격 |
+| `SPEC-REGULA-PROJECT-MEMORY-001` | #51 | 프로젝트 지속 컨텍스트 메모리 (의사결정 누적 & 크로스 세션 기억) |
+| `SPEC-REGULA-ROI-001` | #55 | 비즈니스 가치 대시보드: RA 업무 효율화 ROI 정량화 |
+| `SPEC-REGULA-SOURCE-GOVERNANCE-001` | #48 | 규제·SOP 출처 권위도·버전·유효일·폐기 상태 관리 |
+| `SPEC-REGULA-STANDARDS-001` | #62 | 조화 표준 적용성 & 개정 추적기 (ISO/IEC/EN/ASTM 자동 매핑) |
+| `SPEC-REGULA-STRATEGY-001` | #40 | 멀티 관할권 규제 전략 생성기 (Killer Feature) |
+| `SPEC-REGULA-WORKFLOWS-LLM-002` | #39 | 워크플로우 LLM 실제 구현 (510(k)·감사대응·적응증영향 executor) |
+
+**Wave 4 — 온보딩·변경통제·검토·추적 (6개)**
+
+| SPEC | 이슈 | 제목 |
+|---|---|---|
+| `SPEC-REGULA-ADOPTION-001` | #38 | 사용자 온보딩·성과 KPI·피드백 루프 |
+| `SPEC-REGULA-CHANGE-CONTROL-001` | #54 | 설계 변경 규제 영향 자동 평가기 (Change Control RA Impact) |
+| `SPEC-REGULA-REVIEW-OPS-001` | #36 | 전문가 검토 SLA·승인 워크벤치·증거 패키지 |
+| `SPEC-REGULA-RLHF-001` | #56 | 사용자 피드백 기반 RAG 품질 연속 개선 (Answer Quality RLHF Loop) |
+| `SPEC-REGULA-SUBMISSION-LIFECYCLE-001` | #37 | 510(k)·CER·PCCP 산출물 패키징·검증·추적 |
+| `SPEC-REGULA-TRACEABILITY-001` | #47 | 규제 근거·위험·요구사항·초안·검토·제출 추적 매트릭스 |
+
+**Wave 5 — PMS·CAPA·사이버·라벨링·임상·보험 (6개)**
+
+| SPEC | 이슈 | 제목 |
+|---|---|---|
+| `SPEC-REGULA-CAPA-001` | #68 | 불만·CAPA 폐루프 관리 (Complaint→Vigilance→Risk→DHF 연결) |
+| `SPEC-REGULA-CLINICAL-INVESTIGATION-001` | #69 | 임상시험·임상조사 계획기 (FDA IDE·EU MDR Clinical Investigation·IRB 패키지) |
+| `SPEC-REGULA-CYBERDEVICE-001` | #67 | 의료기기 사이버보안·SBOM 제출 증거 (FDA Cybersecurity·EU MDR GSPR 대응) |
+| `SPEC-REGULA-LABELING-001` | #66 | 라벨링·IFU·클레임 검토 워크벤치 (표시문구·사용목적·번역 일관성 관리) |
+| `SPEC-REGULA-PMS-001` | #53 | EU MDR 출시 후 임상 감시 (PMS 보고서 & PMCF 계획 생성기) |
+| `SPEC-REGULA-REIMBURSEMENT-001` | #70 | 보험·상환 경로 분석기 (CPT/HCPCS·DRG·수가·시장접근 근거 생성) |
+
+**시스템 — 검증·코퍼스 라이선스·모델 거버넌스 (3개)**
+
+| SPEC | 이슈 | 제목 |
+|---|---|---|
+| `SPEC-REGULA-CORPUS-LICENSE-001` | #72 | 코퍼스 라이선스·사용권 관리 (규제문서·표준·논문 수집 권한 검증) |
+| `SPEC-REGULA-MODEL-GOVERNANCE-001` | #71 | LLM·프롬프트·템플릿 변경통제 (모델 버전 검증·승인·롤백) |
+| `SPEC-REGULA-VALIDATION-001` | #49 | Regula 자체 검증 패키지 (IQ/OQ/PQ·변경통제·릴리즈 증거) |
 
 ### 21 CFR Part 11 Electronic Signature 완료 — Issue #88 / PR #204
 


### PR DESCRIPTION
## 개요

2026-06-22 `manager-spec` 배치 작업으로 **Wave 3/4/5·시스템 26개 `SPEC-REGULA-*`** 를 신규 작성했습니다 (`status: draft`, 기존 이슈 #35~#72에 1:1 매핑). README 구현 현황 대시보드를 2026-06-23 기준으로 갱신하고 26개 SPEC 카탈로그 섹션을 추가했습니다.

## 변경 내용

- 26개 신규 `.moai/specs/SPEC-REGULA-*/spec.md` (frontmatter: id/version/status/phase/issue_number/depends_on)
- `README.md` 대시보드 날짜 갱신(06-21 → 06-23) + 신규 SPEC Batch 카탈로그 섹션(Wave별 그룹)

## SPEC 카탈로그 (26개)

**Wave 3 — 전략·분류·지식 루프 (11개)**

| SPEC | 이슈 | 제목 |
|---|---|---|
| `SPEC-REGULA-BATCH-001` | #43 | 배치 질의 모드 (사전 미팅 준비·대량 규제 Q&A) |
| `SPEC-REGULA-CLASSIFY-001` | #59 | 의료기기 분류 자동화 마법사 (FDA/EU/MFDS/NMPA/PMDA 통합) |
| `SPEC-REGULA-CROSSMARKET-001` | #42 | 멀티 관할권 갭 분석기 (기존 허가 → 신규 시장 진출 요건) |
| `SPEC-REGULA-KNOWLEDGE-GAP-001` | #35 | 미답변 자동 이슈화 및 지식베이스 보강 루프 |
| `SPEC-REGULA-KNOWLEDGE-PROMO-001` | #50 | 대화 시맨틱 검색 & 우수 답변 팀 지식 승격 |
| `SPEC-REGULA-PROJECT-MEMORY-001` | #51 | 프로젝트 지속 컨텍스트 메모리 (의사결정 누적 & 크로스 세션 기억) |
| `SPEC-REGULA-ROI-001` | #55 | 비즈니스 가치 대시보드: RA 업무 효율화 ROI 정량화 |
| `SPEC-REGULA-SOURCE-GOVERNANCE-001` | #48 | 규제·SOP 출처 권위도·버전·유효일·폐기 상태 관리 |
| `SPEC-REGULA-STANDARDS-001` | #62 | 조화 표준 적용성 & 개정 추적기 (ISO/IEC/EN/ASTM 자동 매핑) |
| `SPEC-REGULA-STRATEGY-001` | #40 | 멀티 관할권 규제 전략 생성기 (Killer Feature) |
| `SPEC-REGULA-WORKFLOWS-LLM-002` | #39 | 워크플로우 LLM 실제 구현 (510(k)·감사대응·적응증영향 executor) |

**Wave 4 — 온보딩·변경통제·검토·추적 (6개)**

| SPEC | 이슈 | 제목 |
|---|---|---|
| `SPEC-REGULA-ADOPTION-001` | #38 | 사용자 온보딩·성과 KPI·피드백 루프 |
| `SPEC-REGULA-CHANGE-CONTROL-001` | #54 | 설계 변경 규제 영향 자동 평가기 (Change Control RA Impact) |
| `SPEC-REGULA-REVIEW-OPS-001` | #36 | 전문가 검토 SLA·승인 워크벤치·증거 패키지 |
| `SPEC-REGULA-RLHF-001` | #56 | 사용자 피드백 기반 RAG 품질 연속 개선 (Answer Quality RLHF Loop) |
| `SPEC-REGULA-SUBMISSION-LIFECYCLE-001` | #37 | 510(k)·CER·PCCP 산출물 패키징·검증·추적 |
| `SPEC-REGULA-TRACEABILITY-001` | #47 | 규제 근거·위험·요구사항·초안·검토·제출 추적 매트릭스 |

**Wave 5 — PMS·CAPA·사이버·라벨링·임상·보험 (6개)**

| SPEC | 이슈 | 제목 |
|---|---|---|
| `SPEC-REGULA-CAPA-001` | #68 | 불만·CAPA 폐루프 관리 (Complaint→Vigilance→Risk→DHF 연결) |
| `SPEC-REGULA-CLINICAL-INVESTIGATION-001` | #69 | 임상시험·임상조사 계획기 (FDA IDE·EU MDR Clinical Investigation·IRB 패키지) |
| `SPEC-REGULA-CYBERDEVICE-001` | #67 | 의료기기 사이버보안·SBOM 제출 증거 (FDA Cybersecurity·EU MDR GSPR 대응) |
| `SPEC-REGULA-LABELING-001` | #66 | 라벨링·IFU·클레임 검토 워크벤치 (표시문구·사용목적·번역 일관성 관리) |
| `SPEC-REGULA-PMS-001` | #53 | EU MDR 출시 후 임상 감시 (PMS 보고서 & PMCF 계획 생성기) |
| `SPEC-REGULA-REIMBURSEMENT-001` | #70 | 보험·상환 경로 분석기 (CPT/HCPCS·DRG·수가·시장접근 근거 생성) |

**시스템 — 검증·코퍼스 라이선스·모델 거버넌스 (3개)**

| SPEC | 이슈 | 제목 |
|---|---|---|
| `SPEC-REGULA-CORPUS-LICENSE-001` | #72 | 코퍼스 라이선스·사용권 관리 (규제문서·표준·논문 수집 권한 검증) |
| `SPEC-REGULA-MODEL-GOVERNANCE-001` | #71 | LLM·프롬프트·템플릿 변경통제 (모델 버전 검증·승인·롤백) |
| `SPEC-REGULA-VALIDATION-001` | #49 | Regula 자체 검증 패키지 (IQ/OQ/PQ·변경통제·릴리즈 증거) |

## 검증

- 27 files changed, +3784/-2 (26 spec.md + README)
- 모든 SPEC frontmatter 정합, 이슈 매핑 1:1 (26개)
- 깨끗한 단일 커밋 (digest 픽스 PR #232 머지 후 main 기반)

## 다음 단계

각 SPEC은 `status: draft` 이므로 annotation cycle 후 `/moai run SPEC-XXX` 로 구현 진행 가능합니다.

---
🗿 MoAI <email@mo.ai.kr>
