### PR TITLE
feat(labeling): SPEC-REGULA-LABELING-001 라벨링·IFU·클레임 검토 워크벤치 (#66)

### DIFF
--- a/.moai/specs/SPEC-REGULA-LABELING-001/tasks.md
+++ b/.moai/specs/SPEC-REGULA-LABELING-001/tasks.md
@@ -1,0 +1,284 @@
+# SPEC-REGULA-LABELING-001 — 구현 태스크 분해
+
+> **브랜치**: `feat/issue-66` (base `5ec86c5`)
+> **SPEC**: `.moai/specs/SPEC-REGULA-LABELING-001/spec.md`
+> **참조 모델**: SPEC-REGULA-CHANGE-CONTROL-001 (#54, 머지됨), SPEC-REGULA-CLASSIFY-001 (#59), SPEC-REGULA-TRACEABILITY-001 (#47)
+> **방법론**: TDD (RED-GREEN_REFACTOR), Brownfield Enhancement 적용
+
+---
+
+## 검증된 베이스라인 (직접 grep으로 확인)
+
+| 항목 | 현재 값 | 출처 |
+|------|---------|------|
+| `workflow_type` pgEnum | **14** 값 | `lib/db/schema.ts:318` |
+| `audit_action` pgEnum | **133** 값 | `lib/db/schema.ts:115` (마이그레이션 ALTER TYPE 누적 106 + 사전 선언 27) |
+| `PermissionAction` union | **45** 값 (실제 액션) | `lib/auth/permissions.ts:8` (`none`, `project`, `user` 등 비액션 3개 제외 시 42~45) |
+| 다음 migration 번호 | **0072** | `migrations/0071_change_control.sql` 최신 |
+| `lib/labeling/` | **미구현** (신규 생성) | `find` 결과 empty |
+| `app/(app)/labeling/` | **미구현** (신규 생성) | `find` 결과 empty |
+| Change Control `ChangeType.labeling` | **이미 존재** | `lib/change-control/types.ts:10`, `lib/change-control/classify.ts:51` |
+
+---
+
+## Phase 1 — DB 스키마 및 마이그레이션 (REQ-LABEL-001, 010, 011, 012)
+
+### Task 1.1: migration 0072 — 라벨링 테이블 및 enum 확장
+- [ ] `migrations/0072_labeling.sql` 작성
+- [ ] **workflow_type 확장**: `'labeling'` 추가 (14 → **15**)
+- [ ] **audit_action 확장** (6개 추가, 133 → **139**):
+  - `label.document_created`
+  - `label.claim_validated`
+  - `label.claim_citation_rejected` (citation 없는 claim expert-review 강제 시)
+  - `label.translation_diff_detected`
+  - `label.approved`
+  - `label.export_blocked` (unsupported claim 존재 시)
+- [ ] `labeling_documents` 테이블 (project_id FK, jurisdiction, status, review_status, org_id, RLS)
+- [ ] `labeling_sections` 테이블 (document_id FK, section_type, content, locale)
+- [ ] `labeling_claims` 테이블 (section_id FK, claim_text, claim_type, citation_ref)
+- [ ] `labeling_claim_citations` 테이블 (claim_id FK, source, section, excerpt — change_verdict_citations 패턴 재사용)
+- [ ] `labeling_translations` 테이블 (section_id FK, source_locale, target_locale, semantic_diff_status, approval_status)
+- [ ] RLS 정책 (tenant_isolation, change_assessments 패턴 복제)
+- [ ] 인덱스 (project_id, org_id, document_id)
+- [ ] `lib/db/schema.ts` pgEnum 확장 (workflowTypeEnum, auditActionEnum)
+- [ ] Drizzle 테이블 정의 추가 (`labelingDocuments`, `labelingSections`, `labelingClaims`, `labelingClaimCitations`, `labelingTranslations`)
+- **매핑**: REQ-LABEL-001, REQ-LABEL-010, REQ-LABEL-011 | AC-01
+
+### Task 1.2: PermissionAction 확장
+- [ ] `lib/auth/permissions.ts`에 라벨링 권한 추가:
+  - `label.create` — 문서 생성/편집
+  - `label.view` — 조회
+  - `label.approve` — RA 승인 게이트 (REQ-LABEL-012)
+  - `label.export` — export (unsupported claim 0건 시만)
+- [ ] `PERMISSIONS` 레코드에 PermissionSpec 추가 (roles 매핑: RA Lead/Tech Writer만 approve)
+- **매핑**: REQ-LABEL-012 | AC-08
+
+---
+
+## Phase 2 — 도메인 로직 (lib/labeling/)
+
+### Task 2.1: section-builder.ts — 구조화 섹션 작성기
+- [ ] `lib/labeling/section-builder.ts` — 섹션 타입 정의 및 빌더
+- [ ] `SectionType` union: `intended_use | indication | contraindication | warning | precaution`
+- [ ] 섹션 CRUD (traceability/graph.ts upsertNode 패턴 참조)
+- **매핑**: REQ-LABEL-001 | AC-01
+
+### Task 2.2: jurisdiction-checklist.ts — 관할권별 필수 표시사항
+- [ ] `lib/labeling/jurisdiction-checklist.ts`
+- [ ] `Jurisdiction` union 재사용: `'FDA' | 'EU_MDR' | 'MFDS' | 'NMPA' | 'PMDA'` (change-control/types.ts와 동일)
+- [ ] `REQUIRED_LABEL_ELEMENTS: Record<Jurisdiction, LabelElement[]>` — 각 관할권 필수 항목 매핑
+- [ ] FDA: 21 CFR 801 기반 (device name, manufacturer, intended use, warnings, Rx/OTC 등)
+- [ ] EU MDR: Annex I Chapter III 기반 (UDI, CE 마크, IFU 제공 등)
+- [ ] MFDS: 의료기기법 표시기재 기준
+- [ ] PMDA/NMPA: 각국 라벨링 기준
+- [ ] `evaluateChecklist(document, jurisdiction)` — 누락 항목 감지, 100% 커버리지 반환
+- [ ] 단위 테스트: 각 관할권별 필수 항목 100% 매핑 검증
+- **매핑**: REQ-LABEL-002, REQ-LABEL-011 | AC-01
+
+### Task 2.3: claim-validator.ts — claim ↔ citation 검증
+- [ ] `lib/labeling/claim-validator.ts`
+- [ ] `ClaimType` union: `supported | comparative | superiority | unsupported`
+- [ ] `validateClaimCitations(claim, citations)` — classify/validate.ts `validateCitations` 패턴 재사용
+  - citation이 없거나 매칭 실패 시 → `expert_review_required` 상태, 경고
+  - identifierMatches 로직 재사용 (normalizeId, token-set overlap)
+- [ ] `detectUnsupportedClaim(claim, citations)` — citation 미연결 claim 감지
+- **매핑**: REQ-LABEL-003, REQ-LABEL-004 | AC-02
+
+### Task 2.4: comparable-detector.ts — comparative/superiority 자동 감지
+- [ ] `lib/labeling/comparable-detector.ts`
+- [ ] 키워드 휴리스틱 (MVP):
+  - comparative: `compared to`, `compared with`, `in comparison`, `versus`, `vs.`, `비교`
+  - superiority: `superior`, `better than`, `more effective`, `outperforms`, `faster than`, `우수`, `더 효과`
+  - safety/effectiveness 주장: `safe`, `effective`, `safety`, `안전`, `효과`
+- [ ] `detectComparativeClaim(claimText): { isComparative: boolean; isSuperiority: boolean; matchedKeywords: string[] }`
+- [ ] 감지 시 자동 경고 플래그 반환 (UI에서 경고 표시)
+- [ ] 단위 테스트: 오탐/미탐 시나리오 (REQ-LABEL-005)
+- **매핑**: REQ-LABEL-005 | AC-04
+
+### Task 2.5: translation-diff.ts — 번역 의미 차이 검출
+- [ ] `lib/labeling/translation-diff.ts`
+- [ ] **MVP 접근법 결정**: 휴리스틱 + 옵션 LLM 하이브리드
+  - Phase 1 (MVP): 휴리스틱 — 키워드 매핑 테이블 (경고/금기 용어 사전), 숫자/단위 불일치 감지, 섹션 구조 diff
+  - Phase 2 (선택): LLM 기반 의미 diff — `createHybridRaFetch` stub 패턴 재사용 (createHybridRaFetch가 endpoint 반환 시만 활성, 미설정 시 휴리스틱 fallback)
+- [ ] `detectSemanticDiff(sourceText, sourceLocale, targetText, targetLocale): SemanticDiffResult`
+- [ ] `SemanticDiffStatus`: `match | minor_diff | major_diff | review_required`
+- [ ] RA 승인 게이트 연동: `major_diff` 시 승인 required
+- **매핑**: REQ-LABEL-007 | AC-05
+- **결정 근거**: 번역 LLM은 오탐/비용 트레이드오프. MVP는 휴리스틱으로 핵심 규제 용어(금기, 경고, 적응증) 불일치만 잡고, LLM은 선택적 하이브리드로. 이유: (1) CER/PCCT의 createHybridRaFetch 패턴이 이미 stub-optional 검증됨, (2) 핵심 의료기기 용어는 사전 매핑이 정확도 높음
+
+### Task 2.6: change-control-link.ts — #54 Change Control 연결
+- [ ] `lib/labeling/change-control-link.ts`
+- [ ] **재사용**: `lib/change-control/classify.ts` `classifyChangeType`이 이미 `'labeling'` 감기 (classify.ts:51 확인)
+- [ ] `linkLabelingChangeToChangeControl(documentId, changeDescription)`:
+  - 기존 `change_assessments` 테이블에 `change_type='labeling'` 행 생성 (또는 기존 assessment에 link)
+  - `change-control/engine.ts` assessChange 호출 시 `changeType: 'labeling'` 전달
+- [ ] **이미 구현된 인프라 재사용** (L-002 준수): ChangeType union에 labeling 이미 있음, jurisdiction DEFAULT_VERDICT_HINT에 labeling 매핑 이미 있음 (jurisdictions.ts:62)
+- [ ] 라벨링 변경 발생 시 자동 호출 훅
+- **매핑**: REQ-LABEL-008 | AC-06
+
+### Task 2.7: export-gate.ts — unsupported claim export 제한
+- [ ] `lib/labeling/export-gate.ts`
+- [ ] **재사용**: PMS export gating 패턴 (0070_pms_export_gating.sql, `pms.report_export_denied`)
+- [ ] `canExportLabelingDocument(documentId): { allowed: boolean; blockingClaims: string[] }`
+  - unsupported claim 0건 확인
+  - 미확인 expert-review-required claim이 있으면 차단
+- [ ] 차단 시 `label.export_blocked` audit 기록, 403 반환
+- [ ] 승인 시 `label.document_approved` audit, export 허용
+- **매핑**: REQ-LABEL-006, REQ-LABEL-010 | AC-03
+
+---
+
+## Phase 3 — API 라우트 (app/api/labeling/)
+
+### Task 3.1: POST /api/labeling/documents — 문서 생성
+- [ ] `app/api/labeling/documents/route.ts`
+- [ ] `withPermission('label.create', ...)` 래핑
+- [ ] Zod 스키마 검증 (projectId, jurisdiction)
+- [ ] `assertProjectOrgAccess` IDOR 방어 (PMS/change-control 패턴)
+- [ ] `label.document_created` audit 기록
+- **매핑**: REQ-LABEL-001, REQ-LABEL-010 | AC-01
+
+### Task 3.2: POST /api/labeling/documents/[id]/claims — claim 입력·검증
+- [ ] `app/api/labeling/documents/[id]/claims/route.ts`
+- [ ] claim-validator + comparable-detector 호출
+- [ ] citation 없으면 `expert_review_required` 상태로 저장, 경고 반환
+- [ ] `label.claim_validated` 또는 `label.claim_citation_rejected` audit
+- **매핑**: REQ-LABEL-003, REQ-LABEL-004, REQ-LABEL-005 | AC-02, AC-04
+
+### Task 3.3: GET /api/labeling/documents/[id]/checklist — 관할권 체크리스트
+- [ ] `app/api/labeling/documents/[id]/checklist/route.ts`
+- [ ] `?jurisdiction=FDA|EU_MDR|MFDS|PMDA|NMPA` 쿼리 파라미터
+- [ ] `evaluateChecklist` 호출, 누락 항목 + 커버리지 % 반환
+- **매핑**: REQ-LABEL-002, REQ-LABEL-011 | AC-01
+
+### Task 3.4: POST /api/labeling/documents/[id]/translations — 번역 등록·diff
+- [ ] `app/api/labeling/documents/[id]/translations/route.ts`
+- [ ] `detectSemanticDiff` 호출
+- [ ] `major_diff` 시 승인 대기 상태 전환
+- [ ] `label.translation_diff_detected` audit (diff 감지 시)
+- **매핑**: REQ-LABEL-007 | AC-05
+
+### Task 3.5: POST /api/labeling/documents/[id]/approve — RA 승인 게이트
+- [ ] `app/api/labeling/documents/[id]/approve/route.ts`
+- [ ] `withPermission('label.approve', ...)` — RA Lead 전용 (REQ-LABEL-012)
+- [ ] 승인 전제조건: unsupported claim 0건, 번역 diff 해결, 체크리스트 100%
+- [ ] `label.approved` audit
+- [ ] #65 eSubmit 포워드 훅 호출 (인터페이스만, 미구현 시 no-op + 로그)
+- **매핑**: REQ-LABEL-006, REQ-LABEL-009, REQ-LABEL-012 | AC-03, AC-07, AC-08
+
+### Task 3.6: POST /api/labeling/documents/[id]/export — 내보내기
+- [ ] `app/api/labeling/documents/[id]/export/route.ts`
+- [ ] `withPermission('label.export', ...)`
+- [ ] `canExportLabelingDocument` 게이트 — unsupported claim 0건만 허용
+- [ ] 차단 시 403 + `label.export_blocked` audit
+- [ ] 허용 시 export-hub `register(new LabelingExporter())` 패턴으로 출력
+- **매핑**: REQ-LABEL-006, REQ-LABEL-010 | AC-03
+
+---
+
+## Phase 4 — UI (app/(app)/labeling/)
+
+### Task 4.1: 라벨링 워크벤치 메인 페이지
+- [ ] `app/(app)/labeling/page.tsx` — 문서 목록
+- [ ] `app/(app)/labeling/[documentId]/page.tsx` — 문서 편집기
+- [ ] 섹션별 탭 UI (intended_use, indication, contraindication, warning, precaution)
+- [ ] 관할권 선택 드롭다운 (체크리스트 실시간 표시)
+- **매핑**: REQ-LABEL-001, REQ-LABEL-002 | AC-01
+
+### Task 4.2: claim 입력 및 검증 UI
+- [ ] `app/(app)/labeling/[documentId]/claims/page.tsx` 또는 인라인 컴포넌트
+- [ ] claim 입력 시 실시간 citation 연결 프롬프트
+- [ ] citation 없으면 경고 배지 (expert review required)
+- [ ] comparative/superiority 자동 감지 시 경고 표시
+- [ ] i18n 적용 (ko/en)
+- **매핑**: REQ-LABEL-003, REQ-LABEL-004, REQ-LABEL-005 | AC-02, AC-04
+
+### Task 4.3: 번역 diff 및 승인 UI
+- [ ] 번역 등록 패널
+- [ ] 의미 차이 시각화 (major_diff 하이라이트)
+- [ ] RA 승인 버튼 (권한 게이트)
+- **매핑**: REQ-LABEL-007, REQ-LABEL-012 | AC-05, AC-08
+
+---
+
+## Phase 5 — 통합 및 외부 의존성 훅
+
+### Task 5.1: #65 eSubmit 포워드 훅 (인터페이스만)
+- [ ] `lib/labeling/esubmit-bridge.ts`
+- [ ] 승인 완료 시 `lib/esubmit/validators.ts` `validateSubmissionPackage` 호출하여 라벨링 섹션 추가
+- [ ] **미구현 의존성 처리 (L-002/L-004 준수)**: eSubmit 패키지 생성 로직이 미구현이므로, 인터페이스/타입 정의만 + no-op stub. follow-up 이슈 권고.
+- **매핑**: REQ-LABEL-009 | AC-07
+- **DEFERRED**: #65 eSubmit 실제 패키지 생성은 #65 구현 후 활성화
+
+### Task 5.2: #47 Traceability claim↔evidence 연결
+- [ ] `lib/labeling/traceability-integration.ts`
+- [ ] `lib/traceability/graph.ts` `upsertNode`로 claim 노드 생성
+- [ ] claim의 citation을 evidence edge로 연결 (traceability/verify-edges.ts 패턴)
+- [ ] **이미 구현된 인프라 재사용** (L-002 준수): traceability 모듈 완성됨
+- **매핑**: REQ-LABEL-003 (claim ↔ citation 연결의 evidence 그래프 통합)
+
+### Task 5.3: 감사 로깅 통합
+- [ ] 모든 API 라우트에 `writeAudit` 호출 확인
+- [ ] audit_action 6개 신규 값 매핑 검증
+- **매핑**: REQ-LABEL-010 | 전체 AC
+
+---
+
+## Phase 6 — 품질 게이트
+
+### Task 6.1: 단위 테스트
+- [ ] `lib/labeling/__tests__/section-builder.test.ts`
+- [ ] `lib/labeling/__tests__/jurisdiction-checklist.test.ts` — 각 관할권 100% 커버리지 (AC-01)
+- [ ] `lib/labeling/__tests__/claim-validator.test.ts` — citation 없는 claim expert-review 강제 (AC-02)
+- [ ] `lib/labeling/__tests__/comparable-detector.test.ts` — comparative/superiority 감지 (AC-04)
+- [ ] `lib/labeling/__tests__/translation-diff.test.ts` — 의미 차이 검출 (AC-05)
+- [ ] `lib/labeling/__tests__/export-gate.test.ts` — unsupported claim export 제한 (AC-03)
+
+### Task 6.2: 통합/E2E 테스트
+- [ ] 라벨링 변경 → change-control 자동 생성 E2E (AC-06)
+- [ ] 권한 없는 승인 시도 RBAC negative test (AC-08)
+- [ ] 승인본 eSubmit 패키지 포함 integration test (AC-07, stub 환경)
+
+### Task 6.3: RBAC 및 보안 검증
+- [ ] 모든 라우트 `withPermission` 적용 확인
+- [ ] RLS 정책 적용 확인 (tenant_isolation_labeling_*)
+- [ ] IDOR 방어 (assertProjectOrgAccess) 확인
+
+---
+
+## 위험 및 DEFERRED 항목
+
+| 항목 | 상태 | 대응 |
+|------|------|------|
+| #65 eSubmit 실제 패키지 생성 | **DEFERRED** | 인터페이스/stub만 구현, follow-up 이슈 권고 |
+| #40 Strategy 시장별 claim 전략 | **DEFERRED** | 입력 인터페이스만, 실제 데이터 도착 시 활성화 |
+| #42 Crossmarket 관할권 갭 분석 | **DEFERRED** | 체크리스트 갭 분석은 자체 구현, crossmarket 연동은 훅만 |
+| #64 DHF 설계 산출물 연결 | **DEFERRED** | 링크 인터페이스만, DHF 구현 후 활성화 |
+| 번역 LLM 의미 diff | **MVP** | 휴리스틱 우선, LLM 하이브리드는 선택적 |
+| comparable 키워드 오탐/미탐 | **리스크** | 키워드 사전 지속 보완, RA 검수 게이트로 보완 |
+
+---
+
+## 수행 순서 (의존성 기반)
+
+1. **Task 1.1, 1.2** (DB/권한) → 모든 것의 기반
+2. **Task 2.1~2.7** (도메인 로직) → 병렬 가능 일부 존재 (2.3은 2.4 독립, 2.6은 2.1 이후)
+3. **Task 3.1~3.6** (API) → Task 2 완료 후
+4. **Task 4.1~4.3** (UI) → Task 3 API 완료 후
+5. **Task 5.1~5.3** (통합) → Task 3과 병렬 가능
+6. **Task 6.1~6.3** (품질) → 각 Phase 완료 시점에 TDD로 함께
+
+---
+
+## AC 매핑 요약
+
+| AC | 태스크 | 검증 방법 |
+|----|--------|-----------|
+| AC-01 | 1.1, 2.1, 2.2, 3.3, 4.1 | 단위 테스트 (관할권별 필수 항목 매핑) |
+| AC-02 | 2.3, 3.2, 4.2 | 통합 테스트 (citation 없는 claim expert-review 강제) |
+| AC-03 | 2.7, 3.5, 3.6 | negative 테스트 (unsupported claim 0건 export) |
+| AC-04 | 2.4, 3.2, 4.2 | 단위 테스트 (comparative/superiority 감지) |
+| AC-05 | 2.5, 3.4, 4.3 | 통합 테스트 (한/영 의미 차이 검출) |
+| AC-06 | 2.6, 5.2 | E2E (라벨링 변경 → change-control 생성) |
+| AC-07 | 5.1, 3.5 | 통합 테스트 (eSubmit 패키지 포함, stub 환경) |
+| AC-08 | 1.2, 3.5, 6.3 | RBAC negative 테스트 (권한 없는 승인 거부) |

--- a/app/(app)/labeling/[documentId]/_components/LabelingWorkbench.tsx
+++ b/app/(app)/labeling/[documentId]/_components/LabelingWorkbench.tsx
@@ -1,0 +1,959 @@
+'use client';
+
+// @MX:NOTE [AUTO] LabelingWorkbench — section tabs + checklist + claims + translations + gates.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001~007, REQ-009, REQ-012, AC-01/02/03/04/05/08)
+//
+// Client island handling all labeling mutations: section content (read-only view
+// of pre-created 5 sections), jurisdiction checklist (GET), claim input + citation
+// linking + comparative/expert-review warnings (POST claims), translation diff
+// (POST translations), RA-lead approval gate (POST approve), export gate with
+// unsupported-claim 403 handling (POST export). Mirrors the AssessmentView
+// client-island pattern (RSC shell pre-fetches, island handles mutations).
+//
+// #65 eSubmit stub disclosure: the approve response carries `esubmitForwarded:
+// false` until #65 ships. We surface this as an explicit "eSubmit 연동: Beta"
+// label next to the approve action (QA requirement: beta state must be visible).
+
+import {
+  ComparableClaimBadge,
+  ExpertReviewRequiredBadge,
+} from '@/components/labeling/ClaimWarningBadges';
+import { LabelingStatusBadge } from '@/components/labeling/LabelingStatusBadge';
+import {
+  type ChecklistEvaluationResponse,
+  type CreateClaimResponse,
+  type CreateTranslationResponse,
+  type LabelingDocumentDetailResponse,
+  approveDocument,
+  createClaim,
+  createTranslation,
+  exportDocument,
+  fetchChecklist,
+} from '@/lib/labeling/api-client';
+import { ALL_LABELING_JURISDICTIONS } from '@/lib/labeling/jurisdiction-checklist';
+import { SECTION_TYPE_LABELS } from '@/lib/labeling/section-builder';
+import type { LabelingJurisdiction, LabelingSectionType } from '@/lib/labeling/types';
+import { AlertTriangle, CheckCircle2, FileDown, Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+interface LabelingWorkbenchProps {
+  documentId: string;
+  initial: LabelingDocumentDetailResponse;
+  /** ra-member+ can edit (create claims/translations). */
+  canEdit: boolean;
+  /** ra-lead only can approve (REQ-012). */
+  canApprove: boolean;
+  /** ra-lead only can export (label.export mirrors label.approve). */
+  canExport: boolean;
+}
+
+type TabId = 'sections' | 'checklist' | 'claims' | 'translations';
+
+const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+  { id: 'sections', label: '섹션' },
+  { id: 'checklist', label: '관할권 체크리스트' },
+  { id: 'claims', label: 'Claim 검증' },
+  { id: 'translations', label: '번역 diff' },
+] as const;
+
+const JURISDICTION_LABEL: Readonly<Record<LabelingJurisdiction, string>> = {
+  FDA: 'FDA',
+  EU_MDR: 'EU MDR',
+  MFDS: 'MFDS',
+  NMPA: 'NMPA',
+  PMDA: 'PMDA',
+};
+
+export function LabelingWorkbench({
+  documentId,
+  initial,
+  canEdit,
+  canApprove,
+  canExport,
+}: LabelingWorkbenchProps) {
+  const [detail, setDetail] = useState<LabelingDocumentDetailResponse>(initial);
+  const [activeTab, setActiveTab] = useState<TabId>('sections');
+  const [checklist, setChecklist] = useState<ChecklistEvaluationResponse | null>(null);
+  const [checklistLoading, setChecklistLoading] = useState(false);
+  const [checklistError, setChecklistError] = useState<string | null>(null);
+  const [selectedJurisdiction, setSelectedJurisdiction] = useState<LabelingJurisdiction>(
+    initial.document.jurisdiction,
+  );
+
+  const [approveError, setApproveError] = useState<string | null>(null);
+  const [approveNotice, setApproveNotice] = useState<string | null>(null);
+  const [approving, setApproving] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportNotice, setExportNotice] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  const isApproved = detail.document.status === 'approved';
+
+  // REQ-002/011: fetch checklist whenever jurisdiction or document changes.
+  const loadChecklist = useCallback(
+    async (jurisdiction: LabelingJurisdiction) => {
+      setChecklistLoading(true);
+      setChecklistError(null);
+      try {
+        const evalResult = await fetchChecklist(documentId, jurisdiction);
+        setChecklist(evalResult);
+      } catch (err) {
+        setChecklistError(err instanceof Error ? err.message : '체크리스트 조회 실패');
+        setChecklist(null);
+      } finally {
+        setChecklistLoading(false);
+      }
+    },
+    [documentId],
+  );
+
+  useEffect(() => {
+    void loadChecklist(selectedJurisdiction);
+  }, [loadChecklist, selectedJurisdiction]);
+
+  const handleApprove = useCallback(async () => {
+    if (!canApprove || isApproved) return;
+    setApproving(true);
+    setApproveError(null);
+    setApproveNotice(null);
+    try {
+      const result = await approveDocument(documentId);
+      // Optimistic state transition — REQ-012 approval flips status.
+      setDetail((prev) => ({
+        ...prev,
+        document: { ...prev.document, status: 'approved' },
+      }));
+      // #65 eSubmit stub disclosure — forwarded:false is expected until #65 ships.
+      const esubmitNote = result.esubmitForwarded
+        ? '승인본이 eSubmit 패키지로 전달되었습니다.'
+        : 'eSubmit 연동: #65 구현 후 활성화 예정 (Beta — 현재는 전달되지 않습니다).';
+      setApproveNotice(`라벨링 문서가 승인되었습니다. ${esubmitNote}`);
+    } catch (err) {
+      setApproveError(err instanceof Error ? err.message : '승인 실패');
+    } finally {
+      setApproving(false);
+    }
+  }, [canApprove, documentId, isApproved]);
+
+  const handleExport = useCallback(async () => {
+    if (!canExport) return;
+    setExporting(true);
+    setExportError(null);
+    setExportNotice(null);
+    try {
+      const report = await exportDocument(documentId);
+      // MVP: download the canonical JSON (mirrors change-control export pattern).
+      // Phase 6+ may wire a richer exporter via the export-hub.
+      const blob = new Blob([JSON.stringify(report, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `labeling-${documentId}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setExportNotice('라벨링 문서를 내보냈습니다. (Beta: 정형 JSON 보고서로 제공됩니다.)');
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : 'export 실패');
+    } finally {
+      setExporting(false);
+    }
+  }, [canExport, documentId]);
+
+  const sectionsById = useMemo(() => {
+    const map = new Map<LabelingSectionType, (typeof detail.sections)[number]>();
+    for (const s of detail.sections) {
+      map.set(s.sectionType, s);
+    }
+    return map;
+  }, [detail.sections]);
+
+  return (
+    <div className="flex flex-col gap-6" data-testid="labeling-workbench">
+      {/* Header: status + metadata */}
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <h1 className="font-serif text-2xl text-brand-800" data-testid="labeling-product-name">
+              {detail.document.productName}
+            </h1>
+            <LabelingStatusBadge status={detail.document.status} />
+          </div>
+          <p className="text-xs text-ink-500">
+            문서 ID: <span className="font-mono">{documentId}</span> · 관할권:{' '}
+            {JURISDICTION_LABEL[detail.document.jurisdiction]}
+          </p>
+        </div>
+
+        {/* Action bar: approve (REQ-012) + export (REQ-006) */}
+        <div className="flex flex-wrap items-center gap-2">
+          {canApprove && !isApproved && (
+            <button
+              type="button"
+              onClick={handleApprove}
+              disabled={approving}
+              className="inline-flex items-center gap-1.5 rounded-md bg-brand-800 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="labeling-approve-btn"
+              aria-busy={approving}
+            >
+              {approving ? (
+                <Loader2 aria-hidden="true" size={14} className="animate-spin" />
+              ) : (
+                <CheckCircle2 aria-hidden="true" size={14} />
+              )}
+              승인 (RA Lead)
+              <span className="ml-1 rounded-xs bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800">
+                eSubmit Beta
+              </span>
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={!canExport || exporting}
+            className="inline-flex items-center gap-1.5 rounded-md border border-ink-300 bg-surface px-4 py-2 text-sm font-medium text-ink-700 hover:bg-ink-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="labeling-export-btn"
+            aria-busy={exporting}
+            aria-disabled={!canExport}
+            title={
+              canExport
+                ? '라벨링 문서 내보내기 (미해결 claim 존재 시 차단)'
+                : 'export 권한이 필요합니다 (label.export — RA Lead)'
+            }
+          >
+            {exporting ? (
+              <Loader2 aria-hidden="true" size={14} className="animate-spin" />
+            ) : (
+              <FileDown aria-hidden="true" size={14} />
+            )}
+            내보내기
+          </button>
+        </div>
+      </header>
+
+      {/* REQ-006 export-gate banner: shown when not yet approved. */}
+      {!isApproved && (
+        <div
+          className="flex items-start gap-2 rounded-md border border-amber-400/40 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          role="alert"
+          data-testid="labeling-draft-banner"
+        >
+          <AlertTriangle aria-hidden="true" size={16} className="mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium">승인 대기 중 (Draft)</p>
+            <p className="mt-0.5 text-xs">
+              모든 claim의 citation이 확인되고, 체크리스트가 100% 충족되어야 RA Lead 승인이
+              가능합니다. 미해결(unsupported/expert-review-required) claim이 존재하면 export가
+              차단됩니다 (REQ-004, REQ-006).
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Error / notice surfaces */}
+      {approveError && (
+        <p
+          className="rounded-xs border border-danger/30 bg-danger-bg px-3 py-2 text-sm text-danger"
+          role="alert"
+          data-testid="labeling-approve-error"
+        >
+          {approveError}
+        </p>
+      )}
+      {approveNotice && (
+        <output
+          className="block rounded-xs border border-success/30 bg-success-bg px-3 py-2 text-sm text-success"
+          data-testid="labeling-approve-notice"
+        >
+          {approveNotice}
+        </output>
+      )}
+      {exportError && (
+        <p
+          className="rounded-xs border border-danger/30 bg-danger-bg px-3 py-2 text-sm text-danger"
+          role="alert"
+          data-testid="labeling-export-error"
+        >
+          {exportError}
+        </p>
+      )}
+      {exportNotice && (
+        <output
+          className="block rounded-xs border border-success/30 bg-success-bg px-3 py-2 text-sm text-success"
+          data-testid="labeling-export-notice"
+        >
+          {exportNotice}
+        </output>
+      )}
+
+      {/* Tabs */}
+      <div
+        role="tablist"
+        aria-label="라벨링 워크벤치 섹션"
+        className="flex flex-wrap gap-1 border-b border-ink-200"
+      >
+        {TABS.map((tab) => {
+          const selected = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              aria-controls={`labeling-panel-${tab.id}`}
+              id={`labeling-tab-${tab.id}`}
+              onClick={() => setActiveTab(tab.id)}
+              className={[
+                'rounded-t-md px-4 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2',
+                selected
+                  ? 'border-x border-t border-ink-200 bg-surface text-brand-800 -mb-px'
+                  : 'text-ink-600 hover:text-ink-800',
+              ].join(' ')}
+              data-testid={`labeling-tab-${tab.id}`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab panels */}
+      {activeTab === 'sections' && (
+        <SectionListPanel sections={detail.sections} sectionsById={sectionsById} />
+      )}
+      {activeTab === 'checklist' && (
+        <ChecklistPanel
+          jurisdiction={selectedJurisdiction}
+          onSelectJurisdiction={setSelectedJurisdiction}
+          checklist={checklist}
+          loading={checklistLoading}
+          error={checklistError}
+        />
+      )}
+      {activeTab === 'claims' && (
+        <ClaimsPanel documentId={documentId} sectionsById={sectionsById} canEdit={canEdit} />
+      )}
+      {activeTab === 'translations' && (
+        <TranslationsPanel documentId={documentId} sectionsById={sectionsById} canEdit={canEdit} />
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------- Sections tab ------------------------------ */
+
+interface SectionListPanelProps {
+  sections: LabelingDocumentDetailResponse['sections'];
+  sectionsById: Map<LabelingSectionType, LabelingDocumentDetailResponse['sections'][number]>;
+}
+
+function SectionListPanel({ sections }: SectionListPanelProps) {
+  return (
+    <section
+      id="labeling-panel-sections"
+      role="tabpanel"
+      aria-labelledby="labeling-tab-sections"
+      className="flex flex-col gap-4"
+      data-testid="labeling-sections-panel"
+    >
+      <h2 className="font-serif text-xl text-brand-700">구조화 섹션 (REQ-001)</h2>
+      <p className="text-sm text-ink-600">
+        라벨링 문서는 intended use·indication·contraindication·warning·precaution 5개 섹션으로
+        구성됩니다. 각 섹션의 내용은 체크리스트 커버리지 산정에 사용됩니다.
+      </p>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {sections.map((s) => (
+          <article
+            key={s.id}
+            className="rounded-md border border-ink-200 bg-surface p-4"
+            data-testid={`labeling-section-${s.sectionType}`}
+          >
+            <h3 className="mb-2 text-sm font-semibold text-brand-700">
+              {SECTION_TYPE_LABELS[s.sectionType]}
+              <span className="ml-2 text-xs font-normal text-ink-500">({s.locale})</span>
+            </h3>
+            {s.content.trim().length > 0 ? (
+              <p className="whitespace-pre-wrap text-sm text-ink-700">{s.content}</p>
+            ) : (
+              <p className="text-xs italic text-ink-400">내용이 아직 입력되지 않았습니다.</p>
+            )}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ------------------------------- Checklist tab ----------------------------- */
+
+interface ChecklistPanelProps {
+  jurisdiction: LabelingJurisdiction;
+  onSelectJurisdiction: (j: LabelingJurisdiction) => void;
+  checklist: ChecklistEvaluationResponse | null;
+  loading: boolean;
+  error: string | null;
+}
+
+function ChecklistPanel({
+  jurisdiction,
+  onSelectJurisdiction,
+  checklist,
+  loading,
+  error,
+}: ChecklistPanelProps) {
+  return (
+    <section
+      id="labeling-panel-checklist"
+      role="tabpanel"
+      aria-labelledby="labeling-tab-checklist"
+      className="flex flex-col gap-4"
+      data-testid="labeling-checklist-panel"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <h2 className="font-serif text-xl text-brand-700">관할권 필수 표시사항 (REQ-002/011)</h2>
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="labeling-checklist-jurisdiction"
+            className="text-xs font-medium text-ink-600"
+          >
+            관할권 전환
+          </label>
+          <select
+            id="labeling-checklist-jurisdiction"
+            value={jurisdiction}
+            onChange={(e) => onSelectJurisdiction(e.target.value as LabelingJurisdiction)}
+            className="rounded-md border border-ink-200 bg-surface px-3 py-1.5 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+            data-testid="labeling-checklist-jurisdiction-select"
+          >
+            {ALL_LABELING_JURISDICTIONS.map((j) => (
+              <option key={j} value={j}>
+                {JURISDICTION_LABEL[j]}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {loading && (
+        <p className="text-sm text-ink-500" data-testid="labeling-checklist-loading">
+          체크리스트 계산 중…
+        </p>
+      )}
+      {error && (
+        <p
+          className="rounded-xs border border-danger/30 bg-danger-bg px-3 py-2 text-sm text-danger"
+          role="alert"
+        >
+          {error}
+        </p>
+      )}
+      {checklist && !loading && <ChecklistResult evaluation={checklist} />}
+    </section>
+  );
+}
+
+function ChecklistResult({ evaluation }: { evaluation: ChecklistEvaluationResponse }) {
+  const isComplete = evaluation.coveragePercent >= 100;
+  return (
+    <div className="flex flex-col gap-4" data-testid="labeling-checklist-result">
+      {/* Coverage meter */}
+      <div
+        className="rounded-md border border-ink-200 bg-ink-50/60 px-4 py-3"
+        data-testid="labeling-checklist-coverage"
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-ink-700">커버리지</span>
+          <span
+            className={`font-mono text-lg font-semibold ${
+              isComplete ? 'text-success' : 'text-amber-700'
+            }`}
+          >
+            {evaluation.coveragePercent}%
+          </span>
+        </div>
+        <p className="mt-1 text-xs text-ink-500">
+          {evaluation.satisfied} / {evaluation.total} 항목 충족
+          {!isComplete && ' — 100% 달성 시 승인 가능 (REQ-011)'}
+        </p>
+      </div>
+
+      {/* Missing elements */}
+      {evaluation.missing.length > 0 ? (
+        <div>
+          <h3 className="mb-2 text-sm font-semibold text-danger">누락된 필수 항목</h3>
+          <ul className="flex flex-col gap-2" data-testid="labeling-checklist-missing">
+            {evaluation.missing.map((m) => (
+              <li
+                key={m.id}
+                className="rounded-md border border-amber-400/40 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+              >
+                <span className="font-medium">{m.title}</span>
+                {m.ref && <span className="ml-2 text-xs text-amber-700">({m.ref})</span>}
+                {m.sectionType && (
+                  <span className="ml-2 text-xs text-amber-700">
+                    → {SECTION_TYPE_LABELS[m.sectionType]} 섹션 입력 필요
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <div
+          className="flex items-center gap-2 rounded-md border border-success/30 bg-success-bg px-4 py-3 text-sm text-success"
+          data-testid="labeling-checklist-complete"
+          aria-label="체크리스트 100% 완료"
+        >
+          <CheckCircle2 aria-hidden="true" size={16} />
+          모든 필수 표시사항이 충족되었습니다 (100%).
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* -------------------------------- Claims tab ------------------------------ */
+
+interface ClaimsPanelProps {
+  documentId: string;
+  sectionsById: Map<LabelingSectionType, LabelingDocumentDetailResponse['sections'][number]>;
+  canEdit: boolean;
+}
+
+function ClaimsPanel({ documentId, sectionsById, canEdit }: ClaimsPanelProps) {
+  // Track claims created in this session (the list endpoint is out of scope;
+  // we surface each created claim's validation result inline).
+  const [results, setResults] = useState<CreateClaimResponse[]>([]);
+  const [sectionId, setSectionId] = useState<string>(sectionsById.get('intended_use')?.id ?? '');
+  const [claimText, setClaimText] = useState('');
+  const [citations, setCitations] = useState<string>(''); // textarea: one citation per line as `source|excerpt`
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(async () => {
+    if (!canEdit) return;
+    if (!sectionId || !claimText.trim()) {
+      setError('섹션과 claim 문구를 입력하세요.');
+      return;
+    }
+    // Parse citations: each non-empty line as "source|excerpt" (or "source|section|excerpt").
+    const parsedCitations = citations
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => {
+        const parts = line.split('|').map((p) => p.trim());
+        if (parts.length >= 3) {
+          return { source: parts[0] ?? '', section: parts[1], excerpt: parts[2] ?? '' };
+        }
+        if (parts.length === 2) {
+          return { source: parts[0] ?? '', excerpt: parts[1] ?? '' };
+        }
+        return { source: parts[0] ?? '', excerpt: parts[0] ?? '' };
+      });
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await createClaim(documentId, {
+        sectionId,
+        claimText: claimText.trim(),
+        citations: parsedCitations,
+      });
+      setResults((prev) => [result, ...prev]);
+      setClaimText('');
+      setCitations('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'claim 생성 실패');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canEdit, documentId, sectionId, claimText, citations]);
+
+  return (
+    <section
+      id="labeling-panel-claims"
+      role="tabpanel"
+      aria-labelledby="labeling-tab-claims"
+      className="flex flex-col gap-4"
+      data-testid="labeling-claims-panel"
+    >
+      <h2 className="font-serif text-xl text-brand-700">Claim 입력·검증 (REQ-003/004/005)</h2>
+      <p className="text-sm text-ink-600">
+        모든 claim은 근거 citation 연결이 권장됩니다. citation 없이 입력하면{' '}
+        <strong>전문가 검토 필요</strong> 배지가 자동 부여되며(REQ-004), 비교·우월성 표현 감지 시
+        경고가 표시됩니다(REQ-005).
+      </p>
+
+      <div className="rounded-md border border-ink-200 bg-surface p-4">
+        <div className="mb-3 flex flex-col gap-1.5">
+          <label htmlFor="label-claim-section" className="text-sm font-medium text-ink-700">
+            대상 섹션
+          </label>
+          <select
+            id="label-claim-section"
+            value={sectionId}
+            onChange={(e) => setSectionId(e.target.value)}
+            disabled={!canEdit}
+            className="rounded-md border border-ink-200 bg-surface px-3 py-2 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-60"
+            data-testid="label-claim-section-select"
+          >
+            {[...sectionsById.values()].map((s) => (
+              <option key={s.id} value={s.id}>
+                {SECTION_TYPE_LABELS[s.sectionType]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="mb-3 flex flex-col gap-1.5">
+          <label htmlFor="label-claim-text" className="text-sm font-medium text-ink-700">
+            Claim 문구
+          </label>
+          <textarea
+            id="label-claim-text"
+            value={claimText}
+            onChange={(e) => setClaimText(e.target.value)}
+            disabled={!canEdit}
+            maxLength={8000}
+            rows={3}
+            placeholder="예: 본 기기는 기존 대비 30% 빠른 혈류 복원을 지원합니다."
+            className="rounded-md border border-ink-200 bg-surface px-3 py-2 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-60"
+            data-testid="label-claim-text-input"
+          />
+        </div>
+
+        <div className="mb-3 flex flex-col gap-1.5">
+          <label htmlFor="label-claim-citations" className="text-sm font-medium text-ink-700">
+            근거 citation (한 줄에 하나 — 형식: <code>출처|발췌</code> 또는{' '}
+            <code>출처|섹션|발췌</code>)
+          </label>
+          <textarea
+            id="label-claim-citations"
+            value={citations}
+            onChange={(e) => setCitations(e.target.value)}
+            disabled={!canEdit}
+            rows={3}
+            placeholder={
+              '예: 21 CFR 801.109(b)(1)|적응증 명시 필요\nClinical Report 2024-03|30% 향상 데이터'
+            }
+            className="rounded-md border border-ink-200 bg-surface px-3 py-2 font-mono text-xs text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-60"
+            data-testid="label-claim-citations-input"
+          />
+          <p className="text-xs text-ink-500">
+            빈 줄은 무시됩니다. citation 없이 제출 시 자동으로 expert-review-required 상태가 됩니다.
+          </p>
+        </div>
+
+        {error && (
+          <p
+            className="mb-3 rounded-xs border border-danger/30 bg-danger-bg px-3 py-2 text-sm text-danger"
+            role="alert"
+            data-testid="label-claim-error"
+          >
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canEdit || submitting}
+            className="inline-flex items-center gap-2 rounded-md bg-brand-800 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="label-claim-submit"
+            aria-busy={submitting}
+          >
+            {submitting ? (
+              <Loader2 aria-hidden="true" size={14} className="animate-spin" />
+            ) : (
+              <CheckCircle2 aria-hidden="true" size={14} />
+            )}
+            claim 검증
+          </button>
+        </div>
+      </div>
+
+      {/* Results */}
+      {results.length > 0 && (
+        <div className="flex flex-col gap-3" data-testid="labeling-claims-results">
+          <h3 className="text-sm font-semibold text-ink-700">이번 세션에서 검증한 claim</h3>
+          {results.map((r, idx) => (
+            <article
+              key={r.claimId}
+              className="rounded-md border border-ink-200 bg-surface p-4"
+              data-testid={`labeling-claim-result-${idx}`}
+            >
+              <div className="mb-2 flex flex-wrap items-center gap-2">
+                <span className="rounded-xs bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700">
+                  {r.claimType}
+                </span>
+                {r.expertReviewRequired && <ExpertReviewRequiredBadge />}
+                <ComparableClaimBadge
+                  isSuperiority={r.isSuperiority}
+                  isComparative={r.isComparative}
+                  matchedKeywords={r.matchedKeywords}
+                />
+              </div>
+              <p className="text-xs text-ink-500">
+                근거 citation: {r.groundedCitationCount}건
+                {r.rejectedCitationCount > 0 && (
+                  <span className="text-danger"> (거부: {r.rejectedCitationCount}건)</span>
+                )}
+                {' · '}
+                <span className="font-mono">{r.claimId.slice(0, 8)}</span>
+              </p>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/* ----------------------------- Translations tab --------------------------- */
+
+interface TranslationsPanelProps {
+  documentId: string;
+  sectionsById: Map<LabelingSectionType, LabelingDocumentDetailResponse['sections'][number]>;
+  canEdit: boolean;
+}
+
+function TranslationsPanel({ documentId, sectionsById, canEdit }: TranslationsPanelProps) {
+  const [results, setResults] = useState<CreateTranslationResponse[]>([]);
+  const [sectionId, setSectionId] = useState<string>(sectionsById.get('intended_use')?.id ?? '');
+  const [sourceLocale, setSourceLocale] = useState('ko');
+  const [targetLocale, setTargetLocale] = useState('en');
+  const [targetText, setTargetText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const sourceText = useMemo(() => {
+    const entry = [...sectionsById.values()].find((s) => s.id === sectionId);
+    return entry?.content ?? '';
+  }, [sectionsById, sectionId]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!canEdit) return;
+    if (!sectionId || !targetText.trim()) {
+      setError('섹션과 번역문을 입력하세요.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await createTranslation(documentId, {
+        sectionId,
+        sourceLocale,
+        targetLocale,
+        targetText: targetText.trim(),
+      });
+      setResults((prev) => [result, ...prev]);
+      setTargetText('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '번역 등록 실패');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canEdit, documentId, sectionId, sourceLocale, targetLocale, targetText]);
+
+  return (
+    <section
+      id="labeling-panel-translations"
+      role="tabpanel"
+      aria-labelledby="labeling-tab-translations"
+      className="flex flex-col gap-4"
+      data-testid="labeling-translations-panel"
+    >
+      <h2 className="font-serif text-xl text-brand-700">번역 의미 diff (REQ-007)</h2>
+      <p className="text-sm text-ink-600">
+        원본과 번역문 간 의미 차이를 휴리스틱으로 검출합니다. <code>major_diff</code> 감지 시 RA
+        승인 게이트가 강제됩니다.
+      </p>
+
+      <div className="rounded-md border border-ink-200 bg-surface p-4">
+        <div className="mb-3 flex flex-col gap-1.5">
+          <label htmlFor="label-translation-section" className="text-sm font-medium text-ink-700">
+            대상 섹션
+          </label>
+          <select
+            id="label-translation-section"
+            value={sectionId}
+            onChange={(e) => setSectionId(e.target.value)}
+            disabled={!canEdit}
+            className="rounded-md border border-ink-200 bg-surface px-3 py-2 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-60"
+            data-testid="label-translation-section-select"
+          >
+            {[...sectionsById.values()].map((s) => (
+              <option key={s.id} value={s.id}>
+                {SECTION_TYPE_LABELS[s.sectionType]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="mb-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="label-translation-source-locale"
+              className="text-xs font-medium text-ink-600"
+            >
+              원본 로케일
+            </label>
+            <input
+              id="label-translation-source-locale"
+              type="text"
+              value={sourceLocale}
+              onChange={(e) => setSourceLocale(e.target.value)}
+              disabled={!canEdit}
+              maxLength={16}
+              className="rounded-md border border-ink-200 bg-surface px-3 py-1.5 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-60"
+              data-testid="label-translation-source-locale"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="label-translation-target-locale"
+              className="text-xs font-medium text-ink-600"
+            >
+              대상 로케일
+            </label>
+            <input
+              id="label-translation-target-locale"
+              type="text"
+              value={targetLocale}
+              onChange={(e) => setTargetLocale(e.target.value)}
+              disabled={!canEdit}
+              maxLength={16}
+              className="rounded-md border border-ink-200 bg-surface px-3 py-1.5 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-60"
+              data-testid="label-translation-target-locale"
+            />
+          </div>
+        </div>
+
+        {/* Source preview */}
+        {sourceText.trim().length > 0 && (
+          <div className="mb-3">
+            <p className="mb-1 text-xs font-medium text-ink-500">원본 섹션 내용</p>
+            <p className="max-h-32 overflow-y-auto whitespace-pre-wrap rounded-xs bg-ink-50 p-2 text-xs text-ink-700">
+              {sourceText}
+            </p>
+          </div>
+        )}
+
+        <div className="mb-3 flex flex-col gap-1.5">
+          <label
+            htmlFor="label-translation-target-text"
+            className="text-sm font-medium text-ink-700"
+          >
+            번역문
+          </label>
+          <textarea
+            id="label-translation-target-text"
+            value={targetText}
+            onChange={(e) => setTargetText(e.target.value)}
+            disabled={!canEdit}
+            maxLength={20000}
+            rows={4}
+            placeholder="번역된 섹션 내용을 입력하세요"
+            className="rounded-md border border-ink-200 bg-surface px-3 py-2 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-60"
+            data-testid="label-translation-target-input"
+          />
+        </div>
+
+        {error && (
+          <p
+            className="mb-3 rounded-xs border border-danger/30 bg-danger-bg px-3 py-2 text-sm text-danger"
+            role="alert"
+            data-testid="label-translation-error"
+          >
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canEdit || submitting}
+            className="inline-flex items-center gap-2 rounded-md bg-brand-800 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="label-translation-submit"
+            aria-busy={submitting}
+          >
+            {submitting ? (
+              <Loader2 aria-hidden="true" size={14} className="animate-spin" />
+            ) : (
+              <CheckCircle2 aria-hidden="true" size={14} />
+            )}
+            번역 diff 실행
+          </button>
+        </div>
+      </div>
+
+      {/* Diff results */}
+      {results.length > 0 && (
+        <div className="flex flex-col gap-3" data-testid="labeling-translation-results">
+          <h3 className="text-sm font-semibold text-ink-700">이번 세션의 번역 diff 결과</h3>
+          {results.map((r, idx) => (
+            <TranslationDiffCard key={r.translationId} result={r} index={idx} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TranslationDiffCard({
+  result,
+  index,
+}: {
+  result: CreateTranslationResponse;
+  index: number;
+}) {
+  const isMajor = result.diffStatus === 'major_diff' || result.diffStatus === 'review_required';
+  const statusLabel: Record<typeof result.diffStatus, string> = {
+    match: '일치 (Match)',
+    minor_diff: '경미한 차이 (Minor)',
+    major_diff: '주요 차이 (Major)',
+    review_required: '검토 필요 (Review Required)',
+  };
+  return (
+    <article
+      className={`rounded-md border p-4 ${
+        isMajor ? 'border-amber-400/50 bg-amber-50' : 'border-ink-200 bg-surface'
+      }`}
+      data-testid={`labeling-translation-result-${index}`}
+    >
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <span
+          className={`rounded-xs px-2 py-0.5 text-xs font-medium ${
+            isMajor ? 'bg-amber-100 text-amber-800' : 'bg-success-bg text-success'
+          }`}
+        >
+          {statusLabel[result.diffStatus]}
+        </span>
+        {isMajor && (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-800">
+            <AlertTriangle aria-hidden="true" size={12} />
+            RA 승인 게이트 강제
+          </span>
+        )}
+        <span className="font-mono text-xs text-ink-500">{result.translationId.slice(0, 8)}</span>
+      </div>
+      {result.details.length > 0 ? (
+        <ul className="flex flex-col gap-1 text-xs text-ink-700">
+          {result.details.map((d, i) => (
+            <li key={`${d.type}-${i}`}>
+              <span className="font-mono text-ink-500">[{d.type}]</span> {d.description}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-ink-500">감지된 의미 차이가 없습니다.</p>
+      )}
+    </article>
+  );
+}

--- a/app/(app)/labeling/[documentId]/page.tsx
+++ b/app/(app)/labeling/[documentId]/page.tsx
@@ -1,0 +1,119 @@
+// @MX:NOTE [AUTO] Labeling document detail page — workbench shell (REQ-001~012).
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001, REQ-002, REQ-006, REQ-012, AC-01/03/08)
+//
+// Server Component shell: resolves role + fetches the document (org-scoped)
+// via the internal API. Passes the full detail to LabelingWorkbench (client
+// island) which renders the section tabs + checklist + claim input + translation
+// diff + approval/export gates. Mirrors the CC assessment detail RSC pattern.
+
+import { auth } from '@/lib/auth';
+import { type Role, hasRole } from '@/lib/auth/rbac';
+import type { LabelingDocumentDetailResponse } from '@/lib/labeling/api-client';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { LabelingWorkbench } from './_components/LabelingWorkbench';
+
+export const metadata: Metadata = {
+  title: '라벨링 문서 — Regula',
+  description: '라벨링·IFU·claim 검토 워크벤치 (SPEC-REGULA-LABELING-001)',
+  robots: { index: false, follow: false },
+};
+
+type LabelingDocumentPageProps = {
+  params: Promise<{ documentId: string }>;
+};
+
+export default async function LabelingDocumentPage({ params }: LabelingDocumentPageProps) {
+  const { documentId } = await params;
+
+  let role: Role | undefined;
+  let orgId: string | undefined;
+  let sessionHeaders: Record<string, string> | undefined;
+  try {
+    const session = await auth();
+    const user = session?.user as
+      | { role?: string; organizationId?: string; accessToken?: string }
+      | undefined;
+    role = user?.role as Role | undefined;
+    orgId = user?.organizationId;
+    if (user?.accessToken) {
+      sessionHeaders = { Cookie: `__Secure-authjs.session-token=${user.accessToken}` };
+    }
+  } catch {
+    // auth() throws in test/build environments.
+  }
+
+  // label.view = ra-member+; label.approve/export = ra-lead (REQ-012).
+  const canView = role ? hasRole(role, 'ra-member') : false;
+  const canApprove = role ? hasRole(role, 'ra-lead') : false;
+  const canExport = canApprove; // label.export mirrors label.approve (ra-lead).
+
+  if (!canView || !orgId) {
+    return (
+      <section
+        className="mx-auto flex max-w-content flex-col gap-6 px-6 py-8"
+        data-testid="labeling-detail-forbidden"
+      >
+        <div
+          className="rounded-md border border-ink-200 bg-ink-50 px-4 py-6 text-sm text-ink-600"
+          role="alert"
+        >
+          라벨링 문서 조회는 RA Member 권한 이상 필요합니다 (label.view).
+        </div>
+      </section>
+    );
+  }
+
+  // Fetch server-side via the API route (RLS-scoped, withPermission-gated).
+  // Forward session cookies so auth() works inside the route handler.
+  let detail: LabelingDocumentDetailResponse | null = null;
+  let fetchFailed = false;
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+    const res = await fetch(`${baseUrl}/api/labeling/documents/${documentId}`, {
+      headers: sessionHeaders ?? {},
+      cache: 'no-store',
+    });
+    if (res.status === 404) {
+      notFound();
+    }
+    if (!res.ok) {
+      fetchFailed = true;
+    } else {
+      detail = (await res.json()) as LabelingDocumentDetailResponse;
+    }
+  } catch {
+    fetchFailed = true;
+  }
+
+  if (fetchFailed || !detail) {
+    return (
+      <section
+        className="mx-auto flex max-w-content flex-col gap-6 px-6 py-8"
+        data-testid="labeling-detail-error"
+      >
+        <div
+          className="rounded-md border border-danger/30 bg-danger-bg px-4 py-6 text-sm text-danger"
+          role="alert"
+        >
+          라벨링 문서를 불러오지 못했습니다. 잠시 후 다시 시도하세요.
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="mx-auto flex max-w-content flex-col gap-6 px-6 py-8"
+      data-testid="labeling-detail-page"
+    >
+      <LabelingWorkbench
+        documentId={documentId}
+        initial={detail}
+        canEdit={canView}
+        canApprove={canApprove}
+        canExport={canExport}
+      />
+    </section>
+  );
+}

--- a/app/(app)/labeling/_components/LabelingCreateForm.tsx
+++ b/app/(app)/labeling/_components/LabelingCreateForm.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+// @MX:NOTE [AUTO] LabelingCreateForm — structured document creation (REQ-001, AC-01).
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001, REQ-002, AC-01)
+//
+// Client island that captures the structured labeling document input and POSTs
+// to /api/labeling/documents. On success, router.push to the document workbench.
+// Mirrors the ChangeControlForm client-island pattern (RSC shell + client form).
+
+import { createLabelingDocument } from '@/lib/labeling/api-client';
+import type { LabelingJurisdiction } from '@/lib/labeling/types';
+import type { ProjectSummary } from '@/lib/queries/useProjects';
+import { useRouter } from 'next/navigation';
+import { type FormEvent, useCallback, useRef, useState } from 'react';
+
+/** Canonical jurisdiction options — mirrors the backend enum + checklist map. */
+const JURISDICTION_OPTIONS: ReadonlyArray<{ value: LabelingJurisdiction; label: string }> = [
+  { value: 'FDA', label: 'FDA (미국 — 21 CFR 801)' },
+  { value: 'EU_MDR', label: 'EU MDR (유럽 — Annex I Ch. III)' },
+  { value: 'MFDS', label: 'MFDS (한국 — 의료기기법 제12조)' },
+  { value: 'NMPA', label: 'NMPA (중국)' },
+  { value: 'PMDA', label: 'PMDA (일본)' },
+] as const;
+
+interface LabelingCreateFormProps {
+  projects: Array<Pick<ProjectSummary, 'id' | 'name'>>;
+  /** ra-member+ can create documents. */
+  canCreate: boolean;
+}
+
+export function LabelingCreateForm({ projects, canCreate }: LabelingCreateFormProps) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const [projectId, setProjectId] = useState(projects[0]?.id ?? '');
+  const [productName, setProductName] = useState('');
+  const [jurisdiction, setJurisdiction] = useState<LabelingJurisdiction>('FDA');
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!canCreate) return;
+      if (!projectId || !productName.trim()) {
+        setError('프로젝트와 제품명을 모두 입력하세요.');
+        return;
+      }
+
+      // Abort any in-flight submit (L-007: avoid race on double-click).
+      abortRef.current?.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+
+      setSubmitting(true);
+      setError(null);
+
+      try {
+        const result = await createLabelingDocument(
+          {
+            projectId,
+            productName: productName.trim(),
+            jurisdiction,
+            locale: 'ko',
+          },
+          ac.signal,
+        );
+        router.push(`/labeling/${result.documentId}`);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : '라벨링 문서 생성 중 오류가 발생했습니다.');
+        setSubmitting(false);
+      }
+    },
+    [canCreate, projectId, productName, jurisdiction, router],
+  );
+
+  if (!canCreate) {
+    return (
+      <div
+        className="rounded-md border border-ink-200 bg-ink-50 px-4 py-6 text-sm text-ink-600"
+        role="alert"
+      >
+        라벨링 문서 생성은 RA Member 권한 이상 필요합니다 (label.create).
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-5"
+      data-testid="labeling-create-form"
+      aria-label="라벨링 문서 생성"
+    >
+      {/* Project select */}
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="label-project" className="text-sm font-medium text-ink-700">
+          프로젝트{' '}
+          <span aria-hidden="true" className="text-danger">
+            *
+          </span>
+        </label>
+        <select
+          id="label-project"
+          value={projectId}
+          onChange={(e) => setProjectId(e.target.value)}
+          required
+          className="rounded-md border border-ink-200 bg-surface px-3 py-2 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+          data-testid="label-project-select"
+        >
+          <option value="" disabled>
+            프로젝트 선택
+          </option>
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Product name */}
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="label-product-name" className="text-sm font-medium text-ink-700">
+          제품명{' '}
+          <span aria-hidden="true" className="text-danger">
+            *
+          </span>
+        </label>
+        <input
+          id="label-product-name"
+          type="text"
+          value={productName}
+          onChange={(e) => setProductName(e.target.value)}
+          required
+          maxLength={500}
+          placeholder="예: CardioPatch Model X1"
+          className="rounded-md border border-ink-200 bg-surface px-3 py-2 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+          data-testid="label-product-name-input"
+        />
+      </div>
+
+      {/* Jurisdiction select */}
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="label-jurisdiction" className="text-sm font-medium text-ink-700">
+          관할권{' '}
+          <span aria-hidden="true" className="text-danger">
+            *
+          </span>
+        </label>
+        <select
+          id="label-jurisdiction"
+          value={jurisdiction}
+          onChange={(e) => setJurisdiction(e.target.value as LabelingJurisdiction)}
+          required
+          className="rounded-md border border-ink-200 bg-surface px-3 py-2 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
+          data-testid="label-jurisdiction-select"
+        >
+          {JURISDICTION_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-ink-500">
+          선택한 관할권의 필수 표시사항 체크리스트가 문서 생성 시 자동 적용됩니다.
+        </p>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <p
+          className="rounded-xs border border-danger/30 bg-danger-bg px-3 py-2 text-sm text-danger"
+          role="alert"
+          data-testid="labeling-create-error"
+        >
+          {error}
+        </p>
+      )}
+
+      {/* Submit */}
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center gap-2 rounded-md bg-brand-800 px-5 py-2.5 text-sm font-medium text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+          data-testid="labeling-create-submit"
+          aria-busy={submitting}
+        >
+          {submitting ? '생성 중…' : '라벨링 문서 생성'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(app)/labeling/page.tsx
+++ b/app/(app)/labeling/page.tsx
@@ -1,0 +1,90 @@
+// @MX:NOTE [AUTO] Labeling entry page — document creation form (REQ-001, AC-01).
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001, REQ-002, REQ-012, AC-01)
+//
+// Server Component shell: resolves role server-side via auth() + hasRole and
+// pre-fetches the project list (RLS scoped via org_id). Passes capability
+// booleans + project list to the client island (LabelingCreateForm).
+// Mirrors the change-control RSC pattern (app/(app)/change-control/page.tsx).
+
+import { auth } from '@/lib/auth';
+import { type Role, hasRole } from '@/lib/auth/rbac';
+import { db } from '@/lib/db/client';
+import { projects } from '@/lib/db/schema';
+import { desc, eq } from 'drizzle-orm';
+import type { Metadata } from 'next';
+import { LabelingCreateForm } from './_components/LabelingCreateForm';
+
+export const metadata: Metadata = {
+  title: '라벨링·IFU 워크벤치 — Regula',
+  description: '의료기기 라벨·IFU·claim의 관할권별 검토·승인 (SPEC-REGULA-LABELING-001)',
+  robots: { index: false, follow: false },
+};
+
+export default async function LabelingPage() {
+  let role: Role | undefined;
+  let orgId: string | undefined;
+  try {
+    const session = await auth();
+    const user = session?.user as { role?: string; organizationId?: string } | undefined;
+    role = user?.role as Role | undefined;
+    orgId = user?.organizationId;
+  } catch {
+    // auth() throws in test/build environments — fall through with no perms.
+  }
+
+  // label.create = ra-member+ (REQ-001). label.view also ra-member+.
+  const canView = role ? hasRole(role, 'ra-member') : false;
+  const canCreate = canView;
+
+  let projectList: Array<{ id: string; name: string }> = [];
+  if (canView && orgId) {
+    try {
+      const rows = await db
+        .select({ id: projects.id, name: projects.name })
+        .from(projects)
+        .where(eq(projects.organizationId, orgId))
+        .orderBy(desc(projects.createdAt))
+        .limit(50);
+      projectList = rows;
+    } catch {
+      // DB unavailable in test environments — empty list.
+    }
+  }
+
+  return (
+    <section
+      className="mx-auto flex max-w-content flex-col gap-6 px-6 py-8"
+      data-testid="labeling-page"
+    >
+      <header>
+        <h1 className="font-serif text-3xl text-brand-800">라벨링·IFU 워크벤치</h1>
+        <p className="mt-2 text-sm text-ink-600">
+          의료기기 라벨, IFU, intended use, indication, 마케팅 claim을 FDA·EU MDR·MFDS·PMDA·NMPA
+          관할권별 규제 기준에 맞춰 작성·검토·승인합니다. 모든 claim은 근거 citation 연결이
+          강제되며, 비교·우월성 표현은 자동 경고됩니다 (21 CFR 801, MDR Annex I, 의료기기법 제12조).
+        </p>
+      </header>
+
+      {!canView ? (
+        <div
+          className="rounded-md border border-ink-200 bg-ink-50 px-4 py-6 text-sm text-ink-600"
+          role="alert"
+        >
+          라벨링 워크벤치 접근은 RA Member 권한 이상 필요합니다 (label.view).
+        </div>
+      ) : projectList.length === 0 ? (
+        <div
+          className="rounded-md border border-ink-200 bg-ink-50 px-4 py-6 text-sm text-ink-600"
+          role="alert"
+        >
+          라벨링 문서를 생성하려면 먼저 프로젝트를 생성하세요.
+        </div>
+      ) : (
+        <div className="rounded-lg border border-ink-200 bg-surface p-6">
+          <h2 className="mb-4 font-serif text-xl text-brand-700">새 라벨링 문서</h2>
+          <LabelingCreateForm projects={projectList} canCreate={canCreate} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -32,6 +32,8 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   let showPms = false;
   // SPEC-REGULA-CHANGE-CONTROL-001 (Issue #54): Change Control nav gated to ra-member+ (change.view).
   let showChangeControl = false;
+  // SPEC-REGULA-LABELING-001 (Issue #66): Labeling nav gated to ra-member+ (label.view).
+  let showLabeling = false;
   try {
     const { auth } = await import('@/lib/auth');
     const { hasRole } = await import('@/lib/auth/rbac');
@@ -44,6 +46,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       showTraceability = hasRole(userRole as Parameters<typeof hasRole>[0], 'ra-member');
       showPms = hasRole(userRole as Parameters<typeof hasRole>[0], 'ra-member');
       showChangeControl = hasRole(userRole as Parameters<typeof hasRole>[0], 'ra-member');
+      showLabeling = hasRole(userRole as Parameters<typeof hasRole>[0], 'ra-member');
     }
     const department = (session?.user as { department?: string } | undefined)?.department;
     if (department) {
@@ -73,6 +76,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         showTraceability={showTraceability}
         showPms={showPms}
         showChangeControl={showChangeControl}
+        showLabeling={showLabeling}
         initialLocale={initialLocale}
       />
       <div className="flex min-w-0 flex-1 flex-col">

--- a/app/api/labeling/documents/[id]/approve/route.ts
+++ b/app/api/labeling/documents/[id]/approve/route.ts
@@ -1,0 +1,240 @@
+// @MX:NOTE [AUTO] POST /api/labeling/documents/[id]/approve — RA-lead approval gate.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-006, REQ-009, REQ-010, REQ-012, AC-03, AC-07, AC-08)
+//
+// RBAC: withPermission('label.approve') restricts to ra-lead (REQ-012).
+// Preconditions (REQ-006): zero unsupported claims, checklist 100% coverage,
+// all translations approved. eSubmit forward hook fires on success (REQ-009).
+
+import { internalDocsRetrieve } from '@/lib/ai/retrievers/internal-docs';
+import { createHybridRaFetch } from '@/lib/api/hybrid-ra-client';
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import {
+  labelingClaims,
+  labelingDocuments,
+  labelingSections,
+  labelingTranslations,
+} from '@/lib/db/schema';
+import { linkLabelingChangeToChangeControl } from '@/lib/labeling/change-control-link';
+import { forwardLabelingToESubmit } from '@/lib/labeling/esubmit-bridge';
+import { evaluateChecklist } from '@/lib/labeling/jurisdiction-checklist';
+import { and, eq, sql } from 'drizzle-orm';
+
+export const POST = withPermission('label.approve', async (_req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const documentId = (ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {}))
+    .id;
+  if (typeof documentId !== 'string') {
+    return Response.json({ error: 'Invalid document id' }, { status: 400 });
+  }
+
+  // IDOR defense: document must belong to caller's org.
+  const docs = await db
+    .select({
+      id: labelingDocuments.id,
+      jurisdiction: labelingDocuments.jurisdiction,
+      projectId: labelingDocuments.projectId,
+      status: labelingDocuments.status,
+    })
+    .from(labelingDocuments)
+    .where(and(eq(labelingDocuments.id, documentId), eq(labelingDocuments.orgId, organizationId)))
+    .limit(1);
+  if (docs.length === 0 || !docs[0]) {
+    return Response.json({ error: 'Document not found' }, { status: 404 });
+  }
+  const doc = docs[0];
+
+  if (doc.status === 'approved') {
+    return Response.json({ error: 'Document already approved' }, { status: 409 });
+  }
+
+  // REQ-006 precondition 1: zero unsupported / expert-review-required claims.
+  const blockingClaims = await db
+    .select({ id: labelingClaims.id })
+    .from(labelingClaims)
+    .innerJoin(labelingSections, eq(labelingClaims.sectionId, labelingSections.id))
+    .innerJoin(labelingDocuments, eq(labelingSections.documentId, labelingDocuments.id))
+    .where(
+      and(
+        eq(labelingDocuments.id, documentId),
+        eq(labelingDocuments.orgId, organizationId),
+        sql`${labelingClaims.claimType} = 'unsupported' OR ${labelingClaims.expertReviewRequired} = true`,
+      ),
+    );
+  if (blockingClaims.length > 0) {
+    return Response.json(
+      {
+        error: 'Cannot approve: unsupported or pending-review claims exist',
+        blockingClaimCount: blockingClaims.length,
+      },
+      { status: 409 },
+    );
+  }
+
+  // REQ-002/011 precondition 2: checklist 100% coverage.
+  const sections = await db
+    .select({
+      sectionType: labelingSections.sectionType,
+      content: labelingSections.content,
+    })
+    .from(labelingSections)
+    .where(
+      and(eq(labelingSections.documentId, documentId), eq(labelingSections.orgId, organizationId)),
+    );
+  const checklist = evaluateChecklist(
+    sections.map((s) => ({
+      sectionType: s.sectionType as Parameters<typeof evaluateChecklist>[0][number]['sectionType'],
+      content: s.content,
+    })),
+    doc.jurisdiction as Parameters<typeof evaluateChecklist>[1],
+  );
+  if (checklist.coveragePercent < 100) {
+    return Response.json(
+      {
+        error: 'Cannot approve: checklist coverage incomplete',
+        coveragePercent: checklist.coveragePercent,
+        missingCount: checklist.missing.length,
+      },
+      { status: 409 },
+    );
+  }
+
+  // REQ-007 precondition 3: all translations approved (no pending major_diff).
+  const pendingTranslations = await db
+    .select({ id: labelingTranslations.id })
+    .from(labelingTranslations)
+    .innerJoin(labelingSections, eq(labelingTranslations.sectionId, labelingSections.id))
+    .innerJoin(labelingDocuments, eq(labelingSections.documentId, labelingDocuments.id))
+    .where(
+      and(
+        eq(labelingDocuments.id, documentId),
+        eq(labelingDocuments.orgId, organizationId),
+        eq(labelingTranslations.approvalStatus, 'pending'),
+      ),
+    );
+  if (pendingTranslations.length > 0) {
+    return Response.json(
+      {
+        error: 'Cannot approve: pending translation approvals exist',
+        count: pendingTranslations.length,
+      },
+      { status: 409 },
+    );
+  }
+
+  // All preconditions satisfied — approve.
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .update(labelingDocuments)
+        .set({
+          status: 'approved',
+          approvedBy: session.user.id,
+          approvedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(labelingDocuments.id, documentId));
+
+      // REQ-010: audit the approval (21 CFR Part 11).
+      await writeAudit(
+        {
+          actor_id: session.user.id,
+          action: 'label.approved',
+          resource_type: 'labelingDocument',
+          resource_id: documentId,
+          meta_json: {
+            projectId: doc.projectId,
+            jurisdiction: doc.jurisdiction,
+            checklistCoverage: checklist.coveragePercent,
+          },
+        },
+        tx,
+      );
+    });
+
+    // REQ-009: forward to eSubmit (stub — #65 not yet implemented).
+    const esubmitResult = await forwardLabelingToESubmit({
+      documentId,
+      projectId: doc.projectId,
+      orgId: organizationId,
+    });
+
+    // REQ-008 / AC-06: link the labeling change to #54 Change Control. Runs
+    // OUTSIDE the approval transaction (which already committed) so the approval's
+    // 21 CFR Part 11 audit integrity is never compromised by the linkage's
+    // separate change_assessment write. Best-effort: failure is logged and surfaced
+    // via meta, but does NOT block the approval (linkage is an ancillary action,
+    // not a precondition). Mirrors the createHybridRaFetch pattern from
+    // /api/change-control/run/route.ts (H-1) — offline dev falls back to the
+    // engine's stubVerdict via fetchFn=undefined.
+    let changeControlLinked = false;
+    let changeControlError: string | undefined;
+    try {
+      let fetchFn: Parameters<typeof linkLabelingChangeToChangeControl>[1]['fetchFn'] | undefined;
+      try {
+        const hybridFetch = createHybridRaFetch();
+        fetchFn = async (endpoint, init) => {
+          const res = await hybridFetch(endpoint, init);
+          return { json: async () => res };
+        };
+      } catch {
+        // Hybrid-RA not configured (dev/test) — engine uses stubVerdict.
+        fetchFn = undefined;
+      }
+      await linkLabelingChangeToChangeControl(
+        {
+          documentId,
+          projectId: doc.projectId,
+          changeDescription: `Labeling document approved (${doc.jurisdiction}).`,
+          targetMarkets: [doc.jurisdiction],
+        },
+        {
+          orgId: organizationId,
+          userId: session.user.id,
+          retrieveFn: internalDocsRetrieve,
+          fetchFn,
+        },
+      );
+      changeControlLinked = true;
+    } catch (err) {
+      // Ancillary failure — approval already committed. Do not block the response.
+      changeControlError = err instanceof Error ? err.message : 'unknown_error';
+    }
+
+    return Response.json(
+      {
+        documentId,
+        status: 'approved',
+        esubmitForwarded: esubmitResult.forwarded,
+        esubmitDetail: esubmitResult.detail,
+        changeControlLinked,
+        ...(changeControlError ? { changeControlError } : {}),
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown_error';
+    try {
+      await db.transaction(async (tx) => {
+        await writeAudit(
+          {
+            actor_id: session.user.id,
+            action: 'label.approved',
+            resource_type: 'labelingDocument',
+            resource_id: documentId,
+            meta_json: { error: message, failed: true },
+          },
+          tx,
+        );
+      });
+    } catch {
+      return Response.json({ error: 'labeling_approve_audit_lost' }, { status: 500 });
+    }
+    return Response.json({ error: 'labeling_approve_failed' }, { status: 502 });
+  }
+});

--- a/app/api/labeling/documents/[id]/checklist/route.ts
+++ b/app/api/labeling/documents/[id]/checklist/route.ts
@@ -1,0 +1,73 @@
+// @MX:NOTE [AUTO] GET /api/labeling/documents/[id]/checklist — jurisdiction required-elements checklist.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-002, REQ-011, AC-01)
+
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { labelingDocuments, labelingSections } from '@/lib/db/schema';
+import { evaluateChecklist } from '@/lib/labeling/jurisdiction-checklist';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+const ChecklistQuerySchema = z.object({
+  jurisdiction: z.enum(['FDA', 'EU_MDR', 'MFDS', 'NMPA', 'PMDA']).optional(),
+});
+
+export const GET = withPermission('label.view', async (req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const documentId = (ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {}))
+    .id;
+  if (typeof documentId !== 'string') {
+    return Response.json({ error: 'Invalid document id' }, { status: 400 });
+  }
+
+  // IDOR defense: document must belong to caller's org.
+  const docs = await db
+    .select({ id: labelingDocuments.id, jurisdiction: labelingDocuments.jurisdiction })
+    .from(labelingDocuments)
+    .where(and(eq(labelingDocuments.id, documentId), eq(labelingDocuments.orgId, organizationId)))
+    .limit(1);
+  if (docs.length === 0) {
+    return Response.json({ error: 'Document not found' }, { status: 404 });
+  }
+
+  // Parse ?jurisdiction= override (defaults to the document's jurisdiction).
+  const url = new URL(req.url);
+  const parsed = ChecklistQuerySchema.safeParse({
+    jurisdiction: url.searchParams.get('jurisdiction') ?? undefined,
+  });
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Invalid jurisdiction', issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const jurisdiction = (parsed.data.jurisdiction ?? docs[0]?.jurisdiction ?? 'FDA') as Parameters<
+    typeof evaluateChecklist
+  >[1];
+
+  const sections = await db
+    .select({
+      sectionType: labelingSections.sectionType,
+      content: labelingSections.content,
+    })
+    .from(labelingSections)
+    .where(
+      and(eq(labelingSections.documentId, documentId), eq(labelingSections.orgId, organizationId)),
+    );
+
+  // REQ-002/011: evaluate coverage (AC-01 — 100% required for approval).
+  // Cast sectionType (string from DB) to the LabelingSectionType union.
+  const evaluation = evaluateChecklist(
+    sections.map((s) => ({
+      sectionType: s.sectionType as Parameters<typeof evaluateChecklist>[0][number]['sectionType'],
+      content: s.content,
+    })),
+    jurisdiction,
+  );
+
+  return Response.json(evaluation);
+});

--- a/app/api/labeling/documents/[id]/claims/route.ts
+++ b/app/api/labeling/documents/[id]/claims/route.ts
@@ -1,0 +1,184 @@
+// @MX:NOTE [AUTO] POST /api/labeling/documents/[id]/claims — create + validate a claim.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-003, REQ-004, REQ-005, REQ-010, AC-02, AC-04)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import {
+  labelingClaimCitations,
+  labelingClaims,
+  labelingDocuments,
+  labelingSections,
+} from '@/lib/db/schema';
+import { validateClaimCitations } from '@/lib/labeling/claim-validator';
+import { detectComparativeClaim } from '@/lib/labeling/comparable-detector';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+const CitationSchema = z.object({
+  source: z.string().min(1).max(256),
+  section: z.string().max(256).optional(),
+  excerpt: z.string().min(1).max(8000),
+});
+
+const CreateClaimSchema = z.object({
+  sectionId: z.string().uuid(),
+  claimText: z.string().min(1).max(8000),
+  citations: z.array(CitationSchema).max(20).default([]),
+});
+
+export const POST = withPermission('label.create', async (req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const documentId = (ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {}))
+    .id;
+  if (typeof documentId !== 'string') {
+    return Response.json({ error: 'Invalid document id' }, { status: 400 });
+  }
+
+  const parsed = CreateClaimSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Invalid input', issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
+
+  // IDOR defense: document + section must belong to the caller's org.
+  const doc = await db
+    .select({ id: labelingDocuments.id })
+    .from(labelingDocuments)
+    .where(and(eq(labelingDocuments.id, documentId), eq(labelingDocuments.orgId, organizationId)))
+    .limit(1);
+  if (doc.length === 0) {
+    return Response.json({ error: 'Document not found' }, { status: 404 });
+  }
+
+  const section = await db
+    .select({ id: labelingSections.id })
+    .from(labelingSections)
+    .where(
+      and(
+        eq(labelingSections.id, body.sectionId),
+        eq(labelingSections.documentId, documentId),
+        eq(labelingSections.orgId, organizationId),
+      ),
+    )
+    .limit(1);
+  if (section.length === 0) {
+    return Response.json({ error: 'Section not found' }, { status: 404 });
+  }
+
+  // REQ-003/004: validate citations (forces expert_review when ungrounded).
+  const validation = validateClaimCitations(body.citations);
+
+  // REQ-005: detect comparative/superiority language.
+  const comparable = detectComparativeClaim(body.claimText);
+
+  // Resolve final claim_type: unsupported (no citations) > superiority > comparative > supported.
+  let claimType = comparable.claimType;
+  if (!validation.hasGroundedCitation) {
+    claimType = 'unsupported';
+  }
+
+  // H-2 prompt-injection note: claimText is persisted as-is and never flows
+  // into an LLM in this route. When translation-diff later sends it to an
+  // LLM, it MUST be wrapped in <claim_text> UNTRUSTED DATA tags (CC pattern).
+  try {
+    const result = await db.transaction(async (tx) => {
+      const [claim] = await tx
+        .insert(labelingClaims)
+        .values({
+          orgId: organizationId,
+          sectionId: body.sectionId,
+          claimText: body.claimText,
+          claimType,
+          expertReviewRequired: validation.expertReviewRequired,
+          matchedKeywords:
+            comparable.matchedKeywords.length > 0 ? comparable.matchedKeywords : null,
+          createdBy: session.user.id,
+        })
+        .returning({ id: labelingClaims.id });
+
+      const claimId = claim?.id;
+      if (!claimId) throw new Error('failed_to_insert_labeling_claim');
+
+      // REQ-003: persist grounded citations (excerpt NOT NULL DB defense).
+      for (const c of validation.groundedCitations) {
+        await tx.insert(labelingClaimCitations).values({
+          orgId: organizationId,
+          claimId,
+          excerpt: c.excerpt,
+          sourceLabel: c.source,
+          citationId: c.section,
+        });
+      }
+
+      // REQ-010: audit. Use the citation-rejected action when expert review
+      // was forced; otherwise claim_validated (CC H-4 distinction pattern).
+      const auditAction = validation.expertReviewRequired
+        ? 'label.claim_citation_rejected'
+        : 'label.claim_validated';
+
+      await writeAudit(
+        {
+          actor_id: session.user.id,
+          action: auditAction,
+          resource_type: 'labelingClaim',
+          resource_id: claimId,
+          meta_json: {
+            documentId,
+            sectionId: body.sectionId,
+            claimType,
+            expertReviewRequired: validation.expertReviewRequired,
+            rejectedCitationCount: validation.rejectedCitationCount,
+            groundedCitationCount: validation.groundedCitations.length,
+            isComparative: comparable.isComparative,
+            isSuperiority: comparable.isSuperiority,
+            matchedKeywords: comparable.matchedKeywords,
+          },
+        },
+        tx,
+      );
+
+      return { claimId };
+    });
+
+    return Response.json(
+      {
+        claimId: result.claimId,
+        claimType,
+        expertReviewRequired: validation.expertReviewRequired,
+        groundedCitationCount: validation.groundedCitations.length,
+        rejectedCitationCount: validation.rejectedCitationCount,
+        isComparative: comparable.isComparative,
+        isSuperiority: comparable.isSuperiority,
+        matchedKeywords: comparable.matchedKeywords,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown_error';
+    try {
+      await db.transaction(async (tx) => {
+        await writeAudit(
+          {
+            actor_id: session.user.id,
+            action: 'label.claim_validated',
+            resource_type: 'labelingClaim',
+            resource_id: 'unknown',
+            meta_json: { error: message, documentId, failed: true },
+          },
+          tx,
+        );
+      });
+    } catch {
+      return Response.json({ error: 'labeling_claim_audit_lost' }, { status: 500 });
+    }
+    return Response.json({ error: 'labeling_claim_failed' }, { status: 502 });
+  }
+});

--- a/app/api/labeling/documents/[id]/export/route.ts
+++ b/app/api/labeling/documents/[id]/export/route.ts
@@ -1,0 +1,91 @@
+// @MX:NOTE [AUTO] POST /api/labeling/documents/[id]/export — export with unsupported-claim gate.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-006, REQ-010, AC-03)
+//
+// RBAC: withPermission('label.export') restricts to ra-lead.
+// REQ-006: canExportLabelingDocument gate — blocks on unsupported/pending claims.
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { labelingDocuments } from '@/lib/db/schema';
+import { canExportLabelingDocument } from '@/lib/labeling/export-gate';
+import { and, eq } from 'drizzle-orm';
+
+export const POST = withPermission('label.export', async (_req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const documentId = (ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {}))
+    .id;
+  if (typeof documentId !== 'string') {
+    return Response.json({ error: 'Invalid document id' }, { status: 400 });
+  }
+
+  // IDOR defense: document must belong to caller's org.
+  const docs = await db
+    .select({
+      id: labelingDocuments.id,
+      status: labelingDocuments.status,
+      productName: labelingDocuments.productName,
+      jurisdiction: labelingDocuments.jurisdiction,
+    })
+    .from(labelingDocuments)
+    .where(and(eq(labelingDocuments.id, documentId), eq(labelingDocuments.orgId, organizationId)))
+    .limit(1);
+  if (docs.length === 0 || !docs[0]) {
+    return Response.json({ error: 'Document not found' }, { status: 404 });
+  }
+  const doc = docs[0];
+
+  // REQ-006: export gate — blocks when unsupported/pending claims exist.
+  const gate = await canExportLabelingDocument(documentId, organizationId);
+
+  if (!gate.allowed) {
+    // REQ-010: audit the denial (21 CFR Part 11 — distinguishes from approval).
+    try {
+      await db.transaction(async (tx) => {
+        await writeAudit(
+          {
+            actor_id: session.user.id,
+            action: 'label.export_blocked',
+            resource_type: 'labelingDocument',
+            resource_id: documentId,
+            meta_json: {
+              reason: gate.reason ?? 'unknown',
+              blockingClaimCount: gate.blockingClaims.length,
+              blockingClaimIds: gate.blockingClaims,
+            },
+          },
+          tx,
+        );
+      });
+    } catch {
+      // Audit failure is a compliance issue — surface 500.
+      return Response.json({ error: 'labeling_export_block_audit_lost' }, { status: 500 });
+    }
+    return Response.json(
+      {
+        error: 'Export blocked: unsupported or pending-review claims exist',
+        reason: gate.reason,
+        blockingClaimCount: gate.blockingClaims.length,
+      },
+      { status: 403 },
+    );
+  }
+
+  // Export allowed — return the document payload for the export-hub to format.
+  // (The full export-hub LabelingExporter is wired in Phase 3 UI; the route
+  // returns structured JSON the hub consumes.)
+  return Response.json(
+    {
+      documentId,
+      productName: doc.productName,
+      jurisdiction: doc.jurisdiction,
+      status: doc.status,
+      exportedAt: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+});

--- a/app/api/labeling/documents/[id]/route.ts
+++ b/app/api/labeling/documents/[id]/route.ts
@@ -1,0 +1,44 @@
+// @MX:NOTE [AUTO] GET /api/labeling/documents/[id] — fetch a labeling document with sections.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001, REQ-012, AC-01)
+//
+// IDOR defense: org_id scope enforced (404 on cross-org access — never 403,
+// to avoid leaking the existence of foreign-org document UUIDs).
+
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { labelingDocuments, labelingSections } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+export const GET = withPermission('label.view', async (_req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  // Next.js 15: params is a Promise. Await before reading (mirrors CC [assessmentId] route).
+  const resolvedParams = ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {});
+  const documentId = resolvedParams.id;
+  if (typeof documentId !== 'string') {
+    return Response.json({ error: 'Invalid document id' }, { status: 400 });
+  }
+
+  // IDOR defense: org_id scope (returns 404 to avoid existence leak).
+  const docs = await db
+    .select()
+    .from(labelingDocuments)
+    .where(and(eq(labelingDocuments.id, documentId), eq(labelingDocuments.orgId, organizationId)))
+    .limit(1);
+
+  if (docs.length === 0) {
+    return Response.json({ error: 'Document not found' }, { status: 404 });
+  }
+
+  const sections = await db
+    .select()
+    .from(labelingSections)
+    .where(
+      and(eq(labelingSections.documentId, documentId), eq(labelingSections.orgId, organizationId)),
+    );
+
+  return Response.json({ document: docs[0], sections });
+});

--- a/app/api/labeling/documents/[id]/translations/route.ts
+++ b/app/api/labeling/documents/[id]/translations/route.ts
@@ -1,0 +1,154 @@
+// @MX:NOTE [AUTO] POST /api/labeling/documents/[id]/translations — register + diff a translation.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-007, REQ-010, AC-05)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { labelingDocuments, labelingSections, labelingTranslations } from '@/lib/db/schema';
+import { detectSemanticDiff } from '@/lib/labeling/translation-diff';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+const CreateTranslationSchema = z.object({
+  sectionId: z.string().uuid(),
+  sourceLocale: z.string().min(2).max(16),
+  targetLocale: z.string().min(2).max(16),
+  targetText: z.string().min(1).max(20000),
+});
+
+export const POST = withPermission('label.create', async (req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const documentId = (ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {}))
+    .id;
+  if (typeof documentId !== 'string') {
+    return Response.json({ error: 'Invalid document id' }, { status: 400 });
+  }
+
+  const parsed = CreateTranslationSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Invalid input', issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
+
+  // IDOR defense: document + section must belong to caller's org.
+  const doc = await db
+    .select({ id: labelingDocuments.id })
+    .from(labelingDocuments)
+    .where(and(eq(labelingDocuments.id, documentId), eq(labelingDocuments.orgId, organizationId)))
+    .limit(1);
+  if (doc.length === 0) {
+    return Response.json({ error: 'Document not found' }, { status: 404 });
+  }
+
+  const section = await db
+    .select({ id: labelingSections.id, content: labelingSections.content })
+    .from(labelingSections)
+    .where(
+      and(
+        eq(labelingSections.id, body.sectionId),
+        eq(labelingSections.documentId, documentId),
+        eq(labelingSections.orgId, organizationId),
+      ),
+    )
+    .limit(1);
+  if (section.length === 0 || !section[0]) {
+    return Response.json({ error: 'Section not found' }, { status: 404 });
+  }
+
+  const sourceText = section[0].content;
+
+  // REQ-007: detect semantic diff (MVP heuristic). major_diff forces approval.
+  const diff = detectSemanticDiff(
+    sourceText,
+    body.sourceLocale,
+    body.targetText,
+    body.targetLocale,
+  );
+
+  try {
+    const result = await db.transaction(async (tx) => {
+      const [translation] = await tx
+        .insert(labelingTranslations)
+        .values({
+          orgId: organizationId,
+          sectionId: body.sectionId,
+          sourceLocale: body.sourceLocale,
+          targetLocale: body.targetLocale,
+          sourceTextSnapshot: sourceText,
+          targetText: body.targetText,
+          semanticDiffStatus: diff.status,
+          diffDetails: diff.details.length > 0 ? diff.details : null,
+          // REQ-007: major_diff/review_required → approval_status stays 'pending'.
+          approvalStatus:
+            diff.status === 'match' || diff.status === 'minor_diff' ? 'approved' : 'pending',
+          // Auto-approve match/minor_diff; major_diff forces RA re-approval gate.
+          approvedBy:
+            diff.status === 'match' || diff.status === 'minor_diff' ? session.user.id : null,
+          approvedAt: diff.status === 'match' || diff.status === 'minor_diff' ? new Date() : null,
+          createdBy: session.user.id,
+        })
+        .returning({ id: labelingTranslations.id });
+
+      const translationId = translation?.id;
+      if (!translationId) throw new Error('failed_to_insert_labeling_translation');
+
+      // REQ-010/007: audit semantic diff detection when major_diff/review_required.
+      if (diff.status === 'major_diff' || diff.status === 'review_required') {
+        await writeAudit(
+          {
+            actor_id: session.user.id,
+            action: 'label.translation_diff_detected',
+            resource_type: 'labelingTranslation',
+            resource_id: translationId,
+            meta_json: {
+              documentId,
+              sectionId: body.sectionId,
+              sourceLocale: body.sourceLocale,
+              targetLocale: body.targetLocale,
+              diffStatus: diff.status,
+              detailCount: diff.details.length,
+            },
+          },
+          tx,
+        );
+      }
+
+      return { translationId };
+    });
+
+    return Response.json(
+      {
+        translationId: result.translationId,
+        diffStatus: diff.status,
+        details: diff.details,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown_error';
+    try {
+      await db.transaction(async (tx) => {
+        await writeAudit(
+          {
+            actor_id: session.user.id,
+            action: 'label.translation_diff_detected',
+            resource_type: 'labelingTranslation',
+            resource_id: 'unknown',
+            meta_json: { error: message, documentId, failed: true },
+          },
+          tx,
+        );
+      });
+    } catch {
+      return Response.json({ error: 'labeling_translation_audit_lost' }, { status: 500 });
+    }
+    return Response.json({ error: 'labeling_translation_failed' }, { status: 502 });
+  }
+});

--- a/app/api/labeling/documents/route.ts
+++ b/app/api/labeling/documents/route.ts
@@ -1,0 +1,116 @@
+// @MX:NOTE [AUTO] POST /api/labeling/documents — create a structured labeling document.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001, REQ-010, REQ-012, AC-01)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { labelingDocuments, labelingSections } from '@/lib/db/schema';
+import { buildInitialSections } from '@/lib/labeling/section-builder';
+import { assertPmsProjectAccess } from '@/lib/pms/project-ownership';
+import { z } from 'zod';
+
+const CreateLabelingDocumentSchema = z.object({
+  projectId: z.string().uuid(),
+  productName: z.string().min(1).max(500),
+  jurisdiction: z.enum(['FDA', 'EU_MDR', 'MFDS', 'NMPA', 'PMDA']),
+  locale: z.string().min(2).max(16).optional(),
+});
+
+export const POST = withPermission('label.create', async (req, _ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const parsed = CreateLabelingDocumentSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Invalid input', issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
+
+  // C-1 IDOR defense: prove the project belongs to the caller's org BEFORE any
+  // write (mirrors change-control run route + assertPmsProjectAccess pattern).
+  const projectAccessDenied = await assertPmsProjectAccess(body.projectId, organizationId);
+  if (projectAccessDenied) {
+    return Response.json({ error: 'Project access denied' }, { status: 403 });
+  }
+
+  const locale = body.locale ?? 'en';
+
+  // REQ-001: insert document + 5 initial empty sections in a single tx so a
+  // mid-write failure rolls back both (21 CFR Part 11 atomicity).
+  try {
+    const result = await db.transaction(async (tx) => {
+      const [doc] = await tx
+        .insert(labelingDocuments)
+        .values({
+          orgId: organizationId,
+          projectId: body.projectId,
+          productName: body.productName,
+          jurisdiction: body.jurisdiction,
+          status: 'draft',
+          createdBy: session.user.id,
+        })
+        .returning({ id: labelingDocuments.id });
+
+      const documentId = doc?.id;
+      if (!documentId) throw new Error('failed_to_insert_labeling_document');
+
+      const sections = buildInitialSections(locale);
+      for (const s of sections) {
+        await tx.insert(labelingSections).values({
+          orgId: organizationId,
+          documentId,
+          sectionType: s.sectionType,
+          content: s.content,
+          locale: s.locale,
+        });
+      }
+
+      // REQ-010: 21 CFR Part 11 audit (label.document_created).
+      await writeAudit(
+        {
+          actor_id: session.user.id,
+          action: 'label.document_created',
+          resource_type: 'labelingDocument',
+          resource_id: documentId,
+          meta_json: {
+            projectId: body.projectId,
+            productName: body.productName,
+            jurisdiction: body.jurisdiction,
+            locale,
+          },
+        },
+        tx,
+      );
+
+      return { documentId };
+    });
+
+    return Response.json({ documentId: result.documentId }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown_error';
+    // Failure-path audit (atomic; mirrors CC H-3 pattern).
+    try {
+      await db.transaction(async (tx) => {
+        await writeAudit(
+          {
+            actor_id: session.user.id,
+            action: 'label.document_created',
+            resource_type: 'labelingDocument',
+            resource_id: 'unknown',
+            meta_json: { error: message, projectId: body.projectId, failed: true },
+          },
+          tx,
+        );
+      });
+    } catch {
+      // Audit write failed — surface 500 (compliance material not recorded).
+      return Response.json({ error: 'labeling_create_audit_lost' }, { status: 500 });
+    }
+    return Response.json({ error: 'labeling_create_failed' }, { status: 502 });
+  }
+});

--- a/components/labeling/ClaimWarningBadges.tsx
+++ b/components/labeling/ClaimWarningBadges.tsx
@@ -1,0 +1,60 @@
+// @MX:NOTE [AUTO] ClaimWarningBadges — REQ-004/005 warning markers.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-004, REQ-005, AC-02, AC-04)
+//
+// Two badge variants:
+//   - ExpertReviewRequiredBadge (REQ-004): citation missing → forces expert review.
+//   - ComparableClaimBadge (REQ-005): comparative/superiority language detected.
+// WCAG 2.1 AA: amber-800 on amber-100; danger on danger-bg; warn on warn-bg.
+// Icons are decorative (aria-hidden); text carries the meaning.
+
+import { AlertTriangle, TrendingUp } from 'lucide-react';
+
+/** REQ-004: claim has no grounded citation — expert review required. */
+export function ExpertReviewRequiredBadge() {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-xs border border-danger/30 bg-danger-bg px-2 py-0.5 text-xs font-medium text-danger"
+      data-testid="labeling-expert-review-required"
+      title="근거 citation이 없어 전문가 검토가 필요합니다 (REQ-004)"
+    >
+      <AlertTriangle aria-hidden="true" size={12} className="shrink-0" />
+      전문가 검토 필요
+    </span>
+  );
+}
+
+interface ComparableClaimBadgeProps {
+  /** REQ-005: true when superiority language (superior/better than) detected. */
+  isSuperiority: boolean;
+  /** REQ-005: true when comparative language (compared to/vs) detected. */
+  isComparative: boolean;
+  /** Matched keyword list (for tooltip context). */
+  matchedKeywords: string[];
+}
+
+/**
+ * REQ-005: renders an amber warning when comparative or superiority language
+ * is detected in a claim. No-op when neither flag is set (clean claim).
+ */
+export function ComparableClaimBadge({
+  isSuperiority,
+  isComparative,
+  matchedKeywords,
+}: ComparableClaimBadgeProps) {
+  if (!isComparative && !isSuperiority) return null;
+
+  const label = isSuperiority ? '우월성 주의 (Superiority)' : '비교 주의 (Comparative)';
+  const keywordHint =
+    matchedKeywords.length > 0 ? `감지 키워드: ${matchedKeywords.join(', ')}` : undefined;
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-xs border border-amber-400/40 bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+      data-testid="labeling-comparable-warning"
+      title={keywordHint ?? '비교/우월성 표현이 감지되었습니다 (REQ-005)'}
+    >
+      <TrendingUp aria-hidden="true" size={12} className="shrink-0" />
+      {label}
+    </span>
+  );
+}

--- a/components/labeling/LabelingStatusBadge.tsx
+++ b/components/labeling/LabelingStatusBadge.tsx
@@ -1,0 +1,57 @@
+// @MX:NOTE [AUTO] LabelingStatusBadge — REQ-006/012 visual marker for document status.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-006, REQ-012, AC-03, AC-08)
+//
+// Mirrors the change-control ProvisionalBadge pattern: amber for draft/in_review,
+// green for approved. WCAG 2.1 AA: amber-800 on amber-100 >= 4.5:1; success on
+// success-bg >= 4.5:1. Icon is decorative (aria-hidden); text carries meaning.
+
+import type { LabelingDocumentStatus } from '@/lib/labeling/types';
+import { AlertTriangle, CheckCircle2 } from 'lucide-react';
+
+interface LabelingStatusBadgeProps {
+  status: LabelingDocumentStatus;
+}
+
+const STATUS_LABEL: Readonly<Record<LabelingDocumentStatus, string>> = {
+  draft: '초안 (Draft)',
+  in_review: '검토 중 (In Review)',
+  approved: '승인 완료 (Approved)',
+  rejected: '반려 (Rejected)',
+};
+
+export function LabelingStatusBadge({ status }: LabelingStatusBadgeProps) {
+  if (status === 'approved') {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 rounded-xs border border-success/30 bg-success-bg px-2.5 py-1 text-xs font-medium text-success"
+        data-testid="labeling-status-approved"
+      >
+        <CheckCircle2 aria-hidden="true" size={14} className="shrink-0" />
+        {STATUS_LABEL.approved}
+      </span>
+    );
+  }
+
+  if (status === 'rejected') {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 rounded-xs border border-danger/30 bg-danger-bg px-2.5 py-1 text-xs font-medium text-danger"
+        data-testid="labeling-status-rejected"
+      >
+        <AlertTriangle aria-hidden="true" size={14} className="shrink-0" />
+        {STATUS_LABEL.rejected}
+      </span>
+    );
+  }
+
+  // draft or in_review — amber provisional marker.
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-xs border border-amber-400/40 bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-800"
+      data-testid={`labeling-status-${status}`}
+    >
+      <AlertTriangle aria-hidden="true" size={14} className="shrink-0" />
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -54,6 +54,9 @@ interface SidebarProps {
   // SPEC-REGULA-CHANGE-CONTROL-001 (Issue #54): Change Control is visible to
   // roles with change.view (ra-member+). Gated server-side and passed down.
   showChangeControl?: boolean;
+  // SPEC-REGULA-LABELING-001 (Issue #66): Labeling workbench is visible to
+  // roles with label.view (ra-member+). Gated server-side and passed down.
+  showLabeling?: boolean;
   initialLocale?: string;
 }
 
@@ -65,6 +68,7 @@ export default function Sidebar(props?: SidebarProps) {
   const showTraceability = props?.showTraceability ?? false;
   const showPms = props?.showPms ?? false;
   const showChangeControl = props?.showChangeControl ?? false;
+  const showLabeling = props?.showLabeling ?? false;
   const currentProjectId = useUIStore((s) => s.currentProjectId);
   const setCurrentProjectId = useUIStore((s) => s.setCurrentProjectId);
   const { data = [] } = useProjects();
@@ -225,6 +229,19 @@ export default function Sidebar(props?: SidebarProps) {
             className="rounded-md px-3 py-2 text-sm text-ink-700 hover:bg-ink-50 block"
           >
             변경 관리
+          </Link>
+        </nav>
+      )}
+
+      {/* SPEC-REGULA-LABELING-001 (Issue #66): Labeling workbench conditional link. */}
+      {showLabeling && (
+        <nav className="px-2 py-1">
+          <Link
+            href="/labeling"
+            data-testid="sidebar-labeling-link"
+            className="rounded-md px-3 py-2 text-sm text-ink-700 hover:bg-ink-50 block"
+          >
+            라벨링·IFU
           </Link>
         </nav>
       )}

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -247,7 +247,21 @@ export type AuditAction =
   | 'change.verdict_citation_rejected'
   | 'change.assessment_reviewed'
   | 'change.report_exported'
-  | 'change.export_blocked';
+  | 'change.export_blocked'
+  // SPEC-REGULA-LABELING-001 (Issue #66, REQ-LABEL-010):
+  // 6 labeling lifecycle audit actions for 21 CFR Part 11 traceability.
+  //   label.document_created            — new labeling document inserted (REQ-001)
+  //   label.claim_validated             — claim passed citation validation (REQ-003)
+  //   label.claim_citation_rejected     — claim blocked: no grounded citation → expert-review (REQ-004)
+  //   label.translation_diff_detected   — semantic diff detected in translation (REQ-007)
+  //   label.approved                    — RA-lead approved labeling document (REQ-012)
+  //   label.export_blocked              — export denied: unsupported claims exist (REQ-006)
+  | 'label.document_created'
+  | 'label.claim_validated'
+  | 'label.claim_citation_rejected'
+  | 'label.translation_diff_detected'
+  | 'label.approved'
+  | 'label.export_blocked';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -75,7 +75,17 @@ export type PermissionAction =
   // view: ra-member+ — assessment results are transparent across the RA team.
   | 'change.assess'
   | 'change.view'
-  | 'change.export';
+  | 'change.export'
+  // Labeling actions (SPEC-REGULA-LABELING-001, Issue #66)
+  // create/view: ra-member+ — structured authoring is a team-wide activity.
+  // approve: ra-lead ONLY — REQ-LABEL-012 RBAC gate (21 CFR Part 11 approval
+  //          authority). Mirrors risk.approve / change.assess pattern.
+  // export: ra-lead ONLY — REQ-LABEL-006 unsupported-claim gate is a regulatory
+  //         submission decision (audit-material record). Mirrors change.export.
+  | 'label.create'
+  | 'label.view'
+  | 'label.approve'
+  | 'label.export';
 
 export interface PermissionSpec {
   minRole: Role;
@@ -244,4 +254,14 @@ export const PERMISSIONS: Record<PermissionAction, PermissionSpec> = {
   'change.assess': { minRole: 'ra-lead', scope: 'org', resourceType: 'changeAssessment' },
   'change.view': { minRole: 'ra-member', scope: 'org', resourceType: 'changeAssessment' },
   'change.export': { minRole: 'ra-lead', scope: 'org', resourceType: 'changeAssessment' },
+
+  // @MX:ANCHOR [AUTO] label.approve — RA-lead ONLY approval gate invariant.
+  // @MX:REASON REQ-LABEL-012: only qualified RA-lead may approve labeling documents
+  //           (21 CFR Part 11 approval authority). Mirrors risk.approve.
+  // @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-LABEL-012)
+  // Labeling actions (SPEC-REGULA-LABELING-001, Issue #66)
+  'label.create': { minRole: 'ra-member', scope: 'org', resourceType: 'labelingDocument' },
+  'label.view': { minRole: 'ra-member', scope: 'org', resourceType: 'labelingDocument' },
+  'label.approve': { minRole: 'ra-lead', scope: 'org', resourceType: 'labelingDocument' },
+  'label.export': { minRole: 'ra-lead', scope: 'org', resourceType: 'labelingDocument' },
 };

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -276,6 +276,15 @@ export const auditActionEnum = pgEnum('audit_action', [
   'change.assessment_reviewed',
   'change.report_exported',
   'change.export_blocked',
+  // SPEC-REGULA-LABELING-001 (Issue #66, REQ-LABEL-010):
+  // 6 labeling lifecycle audit actions (21 CFR Part 11). label.export_blocked
+  // records export denial when unsupported claims exist (REQ-LABEL-006).
+  'label.document_created',
+  'label.claim_validated',
+  'label.claim_citation_rejected',
+  'label.translation_diff_detected',
+  'label.approved',
+  'label.export_blocked',
 ]);
 
 // @MX:NOTE [AUTO] Knowledge gap enums — SPEC-REGULA-KNOWLEDGE-GAP-001 (Issue #35).
@@ -315,6 +324,7 @@ export const gapClassificationEnum = pgEnum('gap_classification', [
 // 'classify' added via 0067_classify.sql (tasks.md canonical value, mirrors 'risk' naming).
 // SPEC-REGULA-PMS-001: 'pms_report', 'pmcf_plan', 'pmcf_evaluation' added via 0069_pms.sql.
 // SPEC-REGULA-CHANGE-CONTROL-001: 'change_control_assessment' added via 0071_change_control.sql.
+// SPEC-REGULA-LABELING-001: 'labeling' added via 0072_labeling.sql.
 export const workflowTypeEnum = pgEnum('workflow_type', [
   'submission_drafter',
   'audit_response',
@@ -330,6 +340,7 @@ export const workflowTypeEnum = pgEnum('workflow_type', [
   'pmcf_plan',
   'pmcf_evaluation',
   'change_control_assessment',
+  'labeling',
 ]);
 
 // REQ-WF-049: workflow_status pgEnum — lifecycle states for workflow_runs.
@@ -1966,5 +1977,177 @@ export const changeRiskLinks = pgTable(
     assessmentIdx: index('idx_change_risk_links_assessment').on(t.assessmentId),
     orgIdx: index('idx_change_risk_links_org').on(t.orgId),
     riskItemIdx: index('idx_change_risk_links_risk_item').on(t.riskItemId),
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// SPEC-REGULA-LABELING-001 — Labeling & IFU Structured Authoring (Issue #66)
+// Migration: 0072_labeling.sql
+// REQ-LABEL-001 (workflow_type) handled above in workflowTypeEnum.
+// REQ-LABEL-010 (audit_action) handled above in auditActionEnum.
+// ---------------------------------------------------------------------------
+
+// REQ-001: 5 structured section types.
+export const labelingSectionTypeEnum = pgEnum('labeling_section_type_enum', [
+  'intended_use',
+  'indication',
+  'contraindication',
+  'warning',
+  'precaution',
+]);
+
+// REQ-005: claim classification — supported/comparative/superiority/unsupported.
+export const labelingClaimTypeEnum = pgEnum('labeling_claim_type_enum', [
+  'supported',
+  'comparative',
+  'superiority',
+  'unsupported',
+]);
+
+// REQ-006: document lifecycle — draft → in_review → approved.
+export const labelingDocumentStatusEnum = pgEnum('labeling_document_status', [
+  'draft',
+  'in_review',
+  'approved',
+  'rejected',
+]);
+
+// REQ-007: translation semantic-diff status (MVP heuristic).
+export const labelingDiffStatusEnum = pgEnum('labeling_diff_status', [
+  'match',
+  'minor_diff',
+  'major_diff',
+  'review_required',
+]);
+
+// @MX:ANCHOR [AUTO] labelingDocuments — top-level labeling/IFU record per project.
+// @MX:REASON Referenced by labeling_sections, labeling_claims (transitively),
+//           BFF routes, change-control linkage, and export hub. fan_in >= 3.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-LABEL-001, REQ-LABEL-006, REQ-LABEL-012)
+export const labelingDocuments = pgTable(
+  'labeling_documents',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id').notNull(),
+    projectId: uuid('project_id').notNull(),
+    workflowRunId: uuid('workflow_run_id'),
+    productName: text('product_name').notNull(),
+    // REQ-002/011: jurisdiction drives the required-elements checklist
+    jurisdiction: text('jurisdiction').notNull(),
+    // REQ-006/012: approval gate
+    status: text('status').notNull().default('draft'),
+    approvedBy: uuid('approved_by'),
+    approvedAt: timestamp('approved_at', { withTimezone: true, mode: 'date' }),
+    createdBy: uuid('created_by').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    projectIdx: index('idx_labeling_documents_project').on(t.projectId),
+    orgIdx: index('idx_labeling_documents_org').on(t.orgId),
+    runIdx: index('idx_labeling_documents_run').on(t.workflowRunId),
+  }),
+);
+
+// @MX:NOTE [AUTO] labeling_sections — structured sections per document.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-LABEL-001)
+export const labelingSections = pgTable(
+  'labeling_sections',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id').notNull(),
+    documentId: uuid('document_id')
+      .notNull()
+      .references(() => labelingDocuments.id, { onDelete: 'cascade' }),
+    sectionType: text('section_type').notNull(),
+    content: text('content').notNull().default(''),
+    locale: text('locale').notNull().default('en'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    documentIdx: index('idx_labeling_sections_document').on(t.documentId),
+    orgIdx: index('idx_labeling_sections_org').on(t.orgId),
+  }),
+);
+
+// @MX:ANCHOR [AUTO] labeling_claims — atomic claims linked to a section.
+// @MX:REASON REQ-003/004: claim-citation enforcement (expert_review_required
+//           when no grounded citation). REQ-005: comparative/superiority detection.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-LABEL-003, REQ-LABEL-004, REQ-LABEL-005)
+export const labelingClaims = pgTable(
+  'labeling_claims',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id').notNull(),
+    sectionId: uuid('section_id')
+      .notNull()
+      .references(() => labelingSections.id, { onDelete: 'cascade' }),
+    claimText: text('claim_text').notNull(),
+    claimType: text('claim_type').notNull().default('supported'),
+    expertReviewRequired: boolean('expert_review_required').notNull().default(false),
+    matchedKeywords: jsonb('matched_keywords'),
+    createdBy: uuid('created_by').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    sectionIdx: index('idx_labeling_claims_section').on(t.sectionId),
+    orgIdx: index('idx_labeling_claims_org').on(t.orgId),
+    expertReviewIdx: index('idx_labeling_claims_expert_review').on(t.expertReviewRequired),
+  }),
+);
+
+// @MX:ANCHOR [AUTO] labeling_claim_citations — REQ-003 citation enforcement table.
+// @MX:REASON excerpt is the DB-level NOT NULL defense (dual with
+//           validateClaimCitations) against claims without a grounded excerpt.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-LABEL-003)
+export const labelingClaimCitations = pgTable(
+  'labeling_claim_citations',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id').notNull(),
+    claimId: uuid('claim_id')
+      .notNull()
+      .references(() => labelingClaims.id, { onDelete: 'cascade' }),
+    sourceSectionId: uuid('source_section_id'),
+    // REQ-003: excerpt NOT NULL — DB-level defense. Migration CHECK rejects empty.
+    excerpt: text('excerpt').notNull(),
+    sourceLabel: text('source_label'),
+    citationId: text('citation_id'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    claimIdx: index('idx_labeling_claim_citations_claim').on(t.claimId),
+    orgIdx: index('idx_labeling_claim_citations_org').on(t.orgId),
+  }),
+);
+
+// @MX:NOTE [AUTO] labeling_translations — translated sections with semantic-diff.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-LABEL-007)
+export const labelingTranslations = pgTable(
+  'labeling_translations',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id').notNull(),
+    sectionId: uuid('section_id')
+      .notNull()
+      .references(() => labelingSections.id, { onDelete: 'cascade' }),
+    sourceLocale: text('source_locale').notNull(),
+    targetLocale: text('target_locale').notNull(),
+    sourceTextSnapshot: text('source_text_snapshot').notNull(),
+    targetText: text('target_text').notNull(),
+    semanticDiffStatus: text('semantic_diff_status').notNull().default('match'),
+    diffDetails: jsonb('diff_details'),
+    approvalStatus: text('approval_status').notNull().default('pending'),
+    approvedBy: uuid('approved_by'),
+    approvedAt: timestamp('approved_at', { withTimezone: true, mode: 'date' }),
+    createdBy: uuid('created_by').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    sectionIdx: index('idx_labeling_translations_section').on(t.sectionId),
+    orgIdx: index('idx_labeling_translations_org').on(t.orgId),
   }),
 );

--- a/lib/labeling/api-client.ts
+++ b/lib/labeling/api-client.ts
@@ -1,0 +1,280 @@
+// @MX:NOTE [AUTO] Client-side API helpers + response types for labeling — SPEC-REGULA-LABELING-001.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001, REQ-002, REQ-003, REQ-006, REQ-007, REQ-012)
+//
+// These types mirror the shapes returned by the Route Handlers in
+// app/api/labeling/*/route.ts. The server is the single source of truth;
+// these interfaces exist so the client island can type-check the fetch results.
+// Mirrors the change-control api-client pattern (lib/change-control/api-client.ts).
+
+import type {
+  LabelingClaimType,
+  LabelingDocumentStatus,
+  LabelingJurisdiction,
+  LabelingSectionType,
+  SemanticDiffStatus,
+} from './types';
+
+/** REQ-001: POST /api/labeling/documents input. */
+export interface CreateLabelingDocumentInput {
+  projectId: string;
+  productName: string;
+  jurisdiction: LabelingJurisdiction;
+  locale?: string;
+}
+
+/** REQ-001: POST /api/labeling/documents response. */
+export interface CreateLabelingDocumentResponse {
+  documentId: string;
+}
+
+/** Section row as returned by GET /api/labeling/documents/[id]. */
+export interface LabelingSectionResponse {
+  id: string;
+  documentId: string;
+  sectionType: LabelingSectionType;
+  content: string;
+  locale: string;
+}
+
+/** Document row as returned by GET /api/labeling/documents/[id]. */
+export interface LabelingDocumentResponse {
+  id: string;
+  projectId: string;
+  productName: string;
+  jurisdiction: LabelingJurisdiction;
+  status: LabelingDocumentStatus;
+  orgId: string;
+  createdBy: string | null;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+/** GET /api/labeling/documents/[id] response. */
+export interface LabelingDocumentDetailResponse {
+  document: LabelingDocumentResponse;
+  sections: LabelingSectionResponse[];
+}
+
+/** REQ-002/011: GET /api/labeling/documents/[id]/checklist response. */
+export interface ChecklistEvaluationResponse {
+  jurisdiction: LabelingJurisdiction;
+  total: number;
+  satisfied: number;
+  missing: Array<{
+    id: string;
+    title: string;
+    ref?: string;
+    sectionType?: LabelingSectionType;
+  }>;
+  coveragePercent: number;
+}
+
+/** REQ-003: citation input posted alongside a claim. */
+export interface ClaimCitationInput {
+  source: string;
+  section?: string;
+  excerpt: string;
+}
+
+/** REQ-003: POST /api/labeling/documents/[id]/claims input. */
+export interface CreateClaimInput {
+  sectionId: string;
+  claimText: string;
+  citations: ClaimCitationInput[];
+}
+
+/** REQ-003/004/005: POST /api/labeling/documents/[id]/claims response. */
+export interface CreateClaimResponse {
+  claimId: string;
+  claimType: LabelingClaimType;
+  expertReviewRequired: boolean;
+  groundedCitationCount: number;
+  rejectedCitationCount: number;
+  isComparative: boolean;
+  isSuperiority: boolean;
+  matchedKeywords: string[];
+}
+
+/** REQ-007: POST /api/labeling/documents/[id]/translations input. */
+export interface CreateTranslationInput {
+  sectionId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  targetText: string;
+}
+
+/** REQ-007: POST /api/labeling/documents/[id]/translations response. */
+export interface CreateTranslationResponse {
+  translationId: string;
+  diffStatus: SemanticDiffStatus;
+  details: Array<{ type: string; description: string }>;
+}
+
+/** REQ-006/009: POST /api/labeling/documents/[id]/approve response. */
+export interface ApproveDocumentResponse {
+  documentId: string;
+  status: 'approved';
+  /** #65 eSubmit forward result — stub returns forwarded:false until #65 ships. */
+  esubmitForwarded: boolean;
+  esubmitDetail?: string;
+}
+
+/** REQ-006: POST /api/labeling/documents/[id]/export response (success). */
+export interface ExportDocumentResponse {
+  documentId: string;
+  productName: string;
+  jurisdiction: LabelingJurisdiction;
+  status: LabelingDocumentStatus;
+  exportedAt: string;
+}
+
+/** REQ-006: export 403 error body. */
+export interface ExportBlockedResponse {
+  error: string;
+  reason?: string;
+  blockingClaimCount: number;
+}
+
+/**
+ * REQ-001: POST /api/labeling/documents — create a structured labeling document.
+ * Returns the freshly-created documentId so the caller can router.push to it.
+ */
+export async function createLabelingDocument(
+  input: CreateLabelingDocumentInput,
+  signal?: AbortSignal,
+): Promise<CreateLabelingDocumentResponse> {
+  const res = await fetch('/api/labeling/documents', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+    signal,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const message = body?.error ?? `요청 실패 (${res.status})`;
+    throw new Error(typeof message === 'string' ? message : '요청 실패');
+  }
+  return (await res.json()) as CreateLabelingDocumentResponse;
+}
+
+/**
+ * REQ-002/011: GET /api/labeling/documents/[id]/checklist — jurisdiction
+ * required-elements coverage. Optional jurisdiction override.
+ */
+export async function fetchChecklist(
+  documentId: string,
+  jurisdiction?: LabelingJurisdiction,
+  signal?: AbortSignal,
+): Promise<ChecklistEvaluationResponse> {
+  const qs = jurisdiction ? `?jurisdiction=${jurisdiction}` : '';
+  const res = await fetch(`/api/labeling/documents/${documentId}/checklist${qs}`, {
+    headers: { 'Content-Type': 'application/json' },
+    signal,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const message = body?.error ?? `체크리스트 조회 실패 (${res.status})`;
+    throw new Error(typeof message === 'string' ? message : '체크리스트 조회 실패');
+  }
+  return (await res.json()) as ChecklistEvaluationResponse;
+}
+
+/**
+ * REQ-003/004/005: POST /api/labeling/documents/[id]/claims — create + validate
+ * a claim. Returns the claim classification + warning flags.
+ */
+export async function createClaim(
+  documentId: string,
+  input: CreateClaimInput,
+  signal?: AbortSignal,
+): Promise<CreateClaimResponse> {
+  const res = await fetch(`/api/labeling/documents/${documentId}/claims`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+    signal,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const message = body?.error ?? `claim 생성 실패 (${res.status})`;
+    throw new Error(typeof message === 'string' ? message : 'claim 생성 실패');
+  }
+  return (await res.json()) as CreateClaimResponse;
+}
+
+/**
+ * REQ-007: POST /api/labeling/documents/[id]/translations — register + diff
+ * a translation. major_diff forces the RA approval gate.
+ */
+export async function createTranslation(
+  documentId: string,
+  input: CreateTranslationInput,
+  signal?: AbortSignal,
+): Promise<CreateTranslationResponse> {
+  const res = await fetch(`/api/labeling/documents/${documentId}/translations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+    signal,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const message = body?.error ?? `번역 등록 실패 (${res.status})`;
+    throw new Error(typeof message === 'string' ? message : '번역 등록 실패');
+  }
+  return (await res.json()) as CreateTranslationResponse;
+}
+
+/**
+ * REQ-012: POST /api/labeling/documents/[id]/approve — RA-lead approval gate.
+ * Server rejects (409) when preconditions fail (unsupported claims, incomplete
+ * checklist, pending translations).
+ */
+export async function approveDocument(
+  documentId: string,
+  signal?: AbortSignal,
+): Promise<ApproveDocumentResponse> {
+  const res = await fetch(`/api/labeling/documents/${documentId}/approve`, {
+    method: 'POST',
+    signal,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    if (res.status === 409) {
+      // Precondition failure — surface the server's reason verbatim.
+      const reason =
+        body?.error ?? '승인 조건이 충족되지 않았습니다 (미해결 claim/체크리스트/번역).';
+      throw new Error(typeof reason === 'string' ? reason : '승인 조건 미충족');
+    }
+    const message = body?.error ?? `승인 실패 (${res.status})`;
+    throw new Error(typeof message === 'string' ? message : '승인 실패');
+  }
+  return (await res.json()) as ApproveDocumentResponse;
+}
+
+/**
+ * REQ-006: POST /api/labeling/documents/[id]/export — export with unsupported
+ * claim gate. Returns 403 when blocking claims exist.
+ */
+export async function exportDocument(
+  documentId: string,
+  signal?: AbortSignal,
+): Promise<ExportDocumentResponse> {
+  const res = await fetch(`/api/labeling/documents/${documentId}/export`, {
+    method: 'POST',
+    signal,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    if (res.status === 403) {
+      const err = body as ExportBlockedResponse;
+      const count = typeof err?.blockingClaimCount === 'number' ? err.blockingClaimCount : 0;
+      throw new Error(`export가 차단되었습니다. 미해결 claim ${count}건이 존재합니다. (REQ-006)`);
+    }
+    const message = body?.error ?? `export 실패 (${res.status})`;
+    throw new Error(typeof message === 'string' ? message : 'export 실패');
+  }
+  return (await res.json()) as ExportDocumentResponse;
+}

--- a/lib/labeling/change-control-link.ts
+++ b/lib/labeling/change-control-link.ts
@@ -1,0 +1,37 @@
+// @MX:NOTE [AUTO] REQ-008 — link labeling changes to #54 Change Control.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-008, AC-06)
+//
+// REUSE (L-002): assessChange already accepts changeType='labeling' — the
+// ChangeType union (lib/change-control/types.ts:10) and DEFAULT_VERDICT_HINT
+// (lib/change-control/jurisdictions.ts:62) both include 'labeling'. This
+// module is a thin wrapper that prepares the ChangeInput and invokes
+// assessChange, mirroring how /api/change-control/run/route.ts calls it.
+
+import { type AssessOptions, assessChange } from '@/lib/change-control/engine';
+import type { AssessmentOutput } from '@/lib/change-control/types';
+import type { LabelingChangeLinkInput } from './types';
+
+/**
+ * REQ-008: link a labeling document change to the change-control assessment.
+ *
+ * Delegates to assessChange with changeType='labeling'. The caller MUST
+ * supply a retrieveFn (mirrors the change-control run route boundary —
+ * keeps this module pure and testable without the db-client import graph).
+ *
+ * Returns the AssessmentOutput so the caller can persist or display it.
+ */
+export async function linkLabelingChangeToChangeControl(
+  input: LabelingChangeLinkInput,
+  options: AssessOptions,
+): Promise<AssessmentOutput> {
+  return assessChange(
+    {
+      changeType: 'labeling',
+      description: input.changeDescription,
+      // Labeling changes impact the labeling scope specifically.
+      impactScope: `Labeling document ${input.documentId}`,
+      targetMarkets: input.targetMarkets,
+    },
+    options,
+  );
+}

--- a/lib/labeling/claim-validator.ts
+++ b/lib/labeling/claim-validator.ts
@@ -1,0 +1,63 @@
+// @MX:NOTE [AUTO] REQ-003/004 — claim ↔ citation enforcement.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-003, REQ-004, AC-02)
+//
+// Mirrors the change-control validateVerdictCitations pattern (REQ-006 dual
+// defense): application-level validation + DB NOT NULL excerpt. A claim
+// without a grounded citation forces expertReviewRequired=true (REQ-004).
+
+import type { ClaimCitation, ClaimValidationResult } from './types';
+
+/**
+ * REQ-003: validate a claim's citations.
+ *
+ * - Citations with empty/whitespace excerpts are REJECTED (DB CHECK mirrors this).
+ * - If ZERO grounded citations remain → expertReviewRequired=true (REQ-004).
+ * - The caller persists expertReviewRequired on the labeling_claims row.
+ */
+export function validateClaimCitations(
+  citations: ReadonlyArray<ClaimCitation>,
+): ClaimValidationResult {
+  let rejectedCitationCount = 0;
+  const groundedCitations: ClaimCitation[] = [];
+
+  for (const c of citations) {
+    const excerptOk = typeof c.excerpt === 'string' && c.excerpt.trim().length > 0;
+    if (!excerptOk) {
+      rejectedCitationCount++;
+      continue;
+    }
+    const sourceOk = typeof c.source === 'string' && c.source.trim().length > 0;
+    if (!sourceOk) {
+      rejectedCitationCount++;
+      continue;
+    }
+    groundedCitations.push({
+      source: c.source,
+      section: c.section,
+      excerpt: c.excerpt,
+    });
+  }
+
+  const hasGroundedCitation = groundedCitations.length > 0;
+
+  return {
+    hasGroundedCitation,
+    // REQ-004: no grounded citation → forces expert review.
+    expertReviewRequired: !hasGroundedCitation,
+    groundedCitations,
+    rejectedCitationCount,
+  };
+}
+
+/**
+ * REQ-003/004: classify whether a claim is "unsupported" (zero citations) for
+ * export-gating purposes (REQ-006). This is separate from the comparative/
+ * superiority detection (comparable-detector.ts) — a claim can be "supported"
+ * in citation terms but still "comparative" in type.
+ *
+ * Returns true when the claim has no grounded citation backing it.
+ */
+export function isUnsupportedClaim(citationCount: number, rejectedCitationCount: number): boolean {
+  const groundedCount = citationCount - rejectedCitationCount;
+  return groundedCount <= 0;
+}

--- a/lib/labeling/comparable-detector.ts
+++ b/lib/labeling/comparable-detector.ts
@@ -1,0 +1,115 @@
+// @MX:NOTE [AUTO] REQ-005 — comparative/superiority claim auto-detection.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-005, AC-04)
+//
+// MVP heuristic: keyword-based detection. False-positive risk is accepted
+// because (1) the detector only flags the claim for RA review — it does NOT
+// block export on its own (REQ-006 only blocks on "unsupported"), and (2)
+// the keyword set is conservative. A follow-up LLM classifier can layer in
+// via createHybridRaFetch when available (mirrors translation-diff.ts).
+
+import type { ComparableDetectionResult, LabelingClaimType } from './types';
+
+/**
+ * Comparative-language keywords (multi-lingual). Match is case-insensitive
+ * substring. "compared to" / "versus" / "vs." / "비교".
+ */
+export const COMPARATIVE_KEYWORDS: readonly string[] = [
+  // English
+  'compared to',
+  'compared with',
+  'in comparison',
+  'versus',
+  ' vs.',
+  ' vs ',
+  'relative to',
+  'contrast with',
+  // Korean
+  '비교',
+  '대비',
+  // Japanese
+  '比較して',
+  'と比較',
+  // Chinese
+  '相比',
+  '对比',
+];
+
+/**
+ * Superiority-language keywords. "superior" / "better than" / "더 효과".
+ */
+export const SUPERIORITY_KEYWORDS: readonly string[] = [
+  // English
+  'superior',
+  'better than',
+  'more effective',
+  'outperforms',
+  'faster than',
+  'safer than',
+  'greater than',
+  'exceeds',
+  'best-in-class',
+  'industry-leading',
+  // Korean
+  '우수',
+  '더 효과',
+  '더 안전',
+  '더 빠르',
+  '최고',
+  '우위',
+  // Japanese
+  '優れ',
+  'より効果',
+  'より安全',
+  // Chinese
+  '更优',
+  '更好',
+  '更安全',
+  '更有效',
+];
+
+/**
+ * REQ-005: detect comparative/superiority language in a claim.
+ *
+ * Returns:
+ *   - isComparative=true if ANY comparative keyword matches.
+ *   - isSuperiority=true if ANY superiority keyword matches.
+ *   - claimType: 'superiority' (highest precedence) > 'comparative' > 'supported'.
+ *
+ * Note: "unsupported" is never assigned here — that status comes from
+ * claim-validator.isUnsupportedClaim (citation absence, not language).
+ */
+export function detectComparativeClaim(claimText: string): ComparableDetectionResult {
+  const lower = claimText.toLowerCase();
+  const matched: string[] = [];
+
+  let isComparative = false;
+  for (const kw of COMPARATIVE_KEYWORDS) {
+    if (lower.includes(kw.toLowerCase())) {
+      isComparative = true;
+      matched.push(kw);
+    }
+  }
+
+  let isSuperiority = false;
+  for (const kw of SUPERIORITY_KEYWORDS) {
+    if (lower.includes(kw.toLowerCase())) {
+      isSuperiority = true;
+      matched.push(kw);
+    }
+  }
+
+  // Precedence: superiority > comparative > supported.
+  let claimType: LabelingClaimType = 'supported';
+  if (isSuperiority) {
+    claimType = 'superiority';
+  } else if (isComparative) {
+    claimType = 'comparative';
+  }
+
+  return {
+    isComparative,
+    isSuperiority,
+    matchedKeywords: matched,
+    claimType,
+  };
+}

--- a/lib/labeling/esubmit-bridge.ts
+++ b/lib/labeling/esubmit-bridge.ts
@@ -1,0 +1,46 @@
+// @MX:TODO [AUTO] REQ-009 — #65 eSubmit forward hook (STUB).
+// @MX:REASON #65 eSubmit package generation is not yet implemented. Per L-004,
+//           only the interface + a no-op stub are provided here. When #65
+//           lands, replace the stub body with a real call to
+//           lib/esubmit/validators.ts validateSubmissionPackage, adding the
+//           labeling sections to the submission bundle.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-009, AC-07)
+// @MX:PRIORITY P2 — activate after #65 merges.
+
+/**
+ * REQ-009: forward an approved labeling document to the eSubmit pipeline.
+ *
+ * STUB BEHAVIOR (current): no-op + structured log. The function signature is
+ * stable so the approve route can wire it now; the real integration is a
+ * follow-up tracked in #65.
+ *
+ * Future contract (when #65 is implemented):
+ *   - Validate the labeling sections via validateSubmissionPackage.
+ *   - Append the labeling document to the eSubmission bundle.
+ *   - Return the updated package ID / validation result.
+ */
+export interface ESubmitBridgeResult {
+  /** True when the eSubmit package was updated; false for the stub. */
+  forwarded: boolean;
+  /** Stub reason or future package ID. */
+  detail: string;
+}
+
+export async function forwardLabelingToESubmit(params: {
+  documentId: string;
+  projectId: string;
+  orgId: string;
+}): Promise<ESubmitBridgeResult> {
+  // STUB: structured log only. The real implementation will live in #65.
+  // We intentionally do NOT throw — the approve route must still succeed when
+  // eSubmit is not yet wired (REQ-009 is a forward hook, not a gate).
+  console.warn('[esubmit-bridge] REQ-009 stub invoked — #65 eSubmit not yet implemented', {
+    documentId: params.documentId,
+    projectId: params.projectId,
+  });
+
+  return {
+    forwarded: false,
+    detail: 'esubmit_not_implemented_stub_invoked',
+  };
+}

--- a/lib/labeling/export-gate.ts
+++ b/lib/labeling/export-gate.ts
@@ -1,0 +1,79 @@
+// @MX:NOTE [AUTO] REQ-006 — export gate for unsupported claims.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-006, REQ-010, AC-03)
+//
+// Mirrors the PMS export-gating pattern (lib/pms/export-gate.ts). A labeling
+// document may only be exported when ALL claims are supported (zero
+// "unsupported" and zero pending expert_review_required). Denials are audited
+// as 'label.export_blocked' (21 CFR Part 11).
+
+import { db } from '@/lib/db/client';
+import { labelingClaims, labelingDocuments, labelingSections } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import type { ExportGateResult } from './types';
+
+/**
+ * REQ-006: determine whether a labeling document may be exported.
+ *
+ * Blocking conditions:
+ *   - Any claim with claim_type='unsupported' (REQ-003/004 + REQ-006).
+ *   - Any claim with expert_review_required=true (REQ-004 pending review).
+ *
+ * Returns blocking claim IDs so the route can surface them to the operator.
+ *
+ * IDOR defense: org_id scope enforced at both the document and claims level.
+ */
+export async function canExportLabelingDocument(
+  documentId: string,
+  orgId: string,
+): Promise<ExportGateResult> {
+  // IDOR defense: document must belong to the caller's org.
+  const doc = await db
+    .select({ id: labelingDocuments.id })
+    .from(labelingDocuments)
+    .where(and(eq(labelingDocuments.id, documentId), eq(labelingDocuments.orgId, orgId)))
+    .limit(1);
+
+  if (doc.length === 0) {
+    return {
+      allowed: false,
+      blockingClaims: [],
+      reason: 'document_not_found_or_org_mismatch',
+    };
+  }
+
+  // Fetch blocking claims: join sections → documents to scope by documentId,
+  // and org_id on every table for defense-in-depth.
+  const blocking = await db
+    .select({
+      id: labelingClaims.id,
+      claimType: labelingClaims.claimType,
+      expertReviewRequired: labelingClaims.expertReviewRequired,
+    })
+    .from(labelingClaims)
+    .innerJoin(labelingSections, eq(labelingClaims.sectionId, labelingSections.id))
+    .innerJoin(labelingDocuments, eq(labelingSections.documentId, labelingDocuments.id))
+    .where(
+      and(
+        eq(labelingDocuments.id, documentId),
+        eq(labelingDocuments.orgId, orgId),
+        eq(labelingClaims.orgId, orgId),
+      ),
+    );
+
+  const blockingClaims: string[] = [];
+  for (const claim of blocking) {
+    if (claim.claimType === 'unsupported' || claim.expertReviewRequired) {
+      blockingClaims.push(claim.id);
+    }
+  }
+
+  if (blockingClaims.length > 0) {
+    return {
+      allowed: false,
+      blockingClaims,
+      reason: 'unsupported_or_pending_review_claims_exist',
+    };
+  }
+
+  return { allowed: true, blockingClaims: [] };
+}

--- a/lib/labeling/index.ts
+++ b/lib/labeling/index.ts
@@ -1,0 +1,13 @@
+// @MX:NOTE [AUTO] Barrel export for the labeling domain module.
+// @MX:SPEC SPEC-REGULA-LABELING-001
+
+export * from './types';
+export * from './section-builder';
+export * from './jurisdiction-checklist';
+export * from './claim-validator';
+export * from './comparable-detector';
+export * from './translation-diff';
+export * from './export-gate';
+export * from './change-control-link';
+export * from './esubmit-bridge';
+export * from './traceability-integration';

--- a/lib/labeling/jurisdiction-checklist.ts
+++ b/lib/labeling/jurisdiction-checklist.ts
@@ -1,0 +1,347 @@
+// @MX:NOTE [AUTO] REQ-002/011 — per-jurisdiction required labeling elements.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-002, REQ-011, AC-01)
+//
+// The required-elements map is the single source of truth for the checklist
+// evaluator. Each jurisdiction's list is grounded in the labeling regulation
+// cited below; 100% coverage is enforced by evaluateChecklist() and the
+// unit-test suite (tests/integration/labeling.test.ts AC-01).
+
+import type {
+  ChecklistEvaluation,
+  LabelingJurisdiction,
+  LabelingSection,
+  LabelingSectionType,
+  RequiredLabelElement,
+} from './types';
+
+/** All 5 jurisdictions covered by labeling. */
+export const ALL_LABELING_JURISDICTIONS: readonly LabelingJurisdiction[] = [
+  'FDA',
+  'EU_MDR',
+  'MFDS',
+  'NMPA',
+  'PMDA',
+];
+
+/**
+ * REQ-002: FDA 21 CFR 801 required label elements.
+ * Source: 21 CFR Part 801 (General Labeling Provisions).
+ */
+export const FDA_REQUIRED_ELEMENTS: readonly RequiredLabelElement[] = [
+  {
+    id: 'device_name',
+    title: 'Device name (proprietary)',
+    ref: '21 CFR 801.61',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'manufacturer',
+    title: 'Manufacturer name and address',
+    ref: '21 CFR 801.1',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'intended_use',
+    title: 'Intended use statement',
+    ref: '21 CFR 801.4',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'indication',
+    title: 'Indications for use',
+    ref: '21 CFR 801.109(b)(1)',
+    sectionType: 'indication',
+  },
+  {
+    id: 'contraindication',
+    title: 'Contraindications',
+    ref: '21 CFR 801.109(b)(2)',
+    sectionType: 'contraindication',
+  },
+  {
+    id: 'warnings',
+    title: 'Warnings and precautions',
+    ref: '21 CFR 801.109(b)(3)',
+    sectionType: 'warning',
+  },
+  {
+    id: 'precautions',
+    title: 'Precautions section',
+    ref: '21 CFR 801.109(b)(4)',
+    sectionType: 'precaution',
+  },
+  { id: 'rx_otc', title: 'Rx-only / OTC designation', ref: '21 CFR 801.109' },
+  { id: 'lot_number', title: 'Lot or batch number', ref: '21 CFR 801.18' },
+  { id: 'expiration', title: 'Expiration date', ref: '21 CFR 801.18' },
+];
+
+/**
+ * REQ-002: EU MDR Annex I Chapter III required label/IFU elements.
+ * Source: EU MDR 2017/745 Annex I (GSPR), Chapter III.
+ */
+export const EU_MDR_REQUIRED_ELEMENTS: readonly RequiredLabelElement[] = [
+  {
+    id: 'device_name',
+    title: 'Device/trade name',
+    ref: 'MDR Annex I §23.1(a)',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'manufacturer',
+    title: 'Manufacturer name/address',
+    ref: 'MDR Annex I §23.1(b)',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'udi',
+    title: 'UDI carrier (Human Readable + AIDC)',
+    ref: 'MDR Annex I §23.4',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'ce_mark',
+    title: 'CE mark of conformity',
+    ref: 'MDR Annex I §23.2',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'intended_purpose',
+    title: 'Intended purpose',
+    ref: 'MDR Annex I §23.1(c)',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'indication',
+    title: 'Intended users / clinical indications',
+    ref: 'MDR Annex I §23.1(d)',
+    sectionType: 'indication',
+  },
+  {
+    id: 'contraindication',
+    title: 'Contraindications',
+    ref: 'MDR Annex I §23.1(e)',
+    sectionType: 'contraindication',
+  },
+  {
+    id: 'warnings',
+    title: 'Warnings and precautions',
+    ref: 'MDR Annex I §23.1(f)',
+    sectionType: 'warning',
+  },
+  { id: 'ifu_provided', title: 'IFU availability indication', ref: 'MDR Annex I §23.2' },
+  { id: 'sterile', title: 'Sterility status (if applicable)', ref: 'MDR Annex I §23.3' },
+  {
+    id: 'ifuprecautions',
+    title: 'Precautions for special populations',
+    ref: 'MDR Annex I §23.1(g)',
+    sectionType: 'precaution',
+  },
+];
+
+/**
+ * REQ-002: MFDS (Korea) required label elements.
+ * Source: 의료기기법 제12조 (표시기재 기준), 식약처 고시.
+ */
+export const MFDS_REQUIRED_ELEMENTS: readonly RequiredLabelElement[] = [
+  {
+    id: 'device_name',
+    title: '의료기기 명칭 (품목명)',
+    ref: '의료기기법 제12조',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'manufacturer',
+    title: '제조업자 명칭 및 주소',
+    ref: '의료기기법 제12조',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'intended_use',
+    title: '사용목적 (효능·효과)',
+    ref: '의료기기법 제12조',
+    sectionType: 'intended_use',
+  },
+  { id: 'indication', title: '적응증', ref: '의료기기법 시행규칙', sectionType: 'indication' },
+  {
+    id: 'contraindication',
+    title: '사용금기 (금기사항)',
+    ref: '의료기기법 시행규칙',
+    sectionType: 'contraindication',
+  },
+  {
+    id: 'warnings',
+    title: '경고사항 및 주의사항',
+    ref: '의료기기법 제12조',
+    sectionType: 'warning',
+  },
+  {
+    id: 'precautions',
+    title: '사용 시 주의사항',
+    ref: '의료기기법 시행규칙',
+    sectionType: 'precaution',
+  },
+  { id: 'lot_number', title: '제조번호 및 제조일자', ref: '의료기기법 제12조' },
+  { id: 'expiration', title: '사용기한 (유효기간)', ref: '의료기기법 제12조' },
+  { id: 'korea_license', title: '인허가 번호 (품목허가번호)', ref: '의료기기법 제12조' },
+];
+
+/**
+ * REQ-002: NMPA (China) required label elements.
+ * Source: NMPA 医疗器械说明书和标签管理规定.
+ */
+export const NMPA_REQUIRED_ELEMENTS: readonly RequiredLabelElement[] = [
+  {
+    id: 'device_name',
+    title: '医疗器械通用名称 (产品名称)',
+    ref: 'NMPA 标签管理规定',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'manufacturer',
+    title: '生产企业名称及地址',
+    ref: 'NMPA 标签管理规定',
+    sectionType: 'intended_use',
+  },
+  { id: 'registration', title: '注册证编号', ref: 'NMPA 标签管理规定' },
+  {
+    id: 'intended_use',
+    title: '适用范围 (预期用途)',
+    ref: 'NMPA 标签管理规定',
+    sectionType: 'intended_use',
+  },
+  { id: 'indication', title: '适应症', ref: 'NMPA 说明书管理规定', sectionType: 'indication' },
+  {
+    id: 'contraindication',
+    title: '禁忌症',
+    ref: 'NMPA 说明书管理规定',
+    sectionType: 'contraindication',
+  },
+  { id: 'warnings', title: '警示和注意事项', ref: 'NMPA 说明书管理规定', sectionType: 'warning' },
+  {
+    id: 'precautions',
+    title: '使用注意事项',
+    ref: 'NMPA 说明书管理规定',
+    sectionType: 'precaution',
+  },
+  { id: 'lot_number', title: '生产批号', ref: 'NMPA 标签管理规定' },
+  { id: 'expiration', title: '使用期限或失效日期', ref: 'NMPA 标签管理规定' },
+];
+
+/**
+ * REQ-002: PMDA (Japan) required label elements.
+ * Source: PMDA 医療機器の表示基準.
+ */
+export const PMDA_REQUIRED_ELEMENTS: readonly RequiredLabelElement[] = [
+  {
+    id: 'device_name',
+    title: '一般的名称 (販売名)',
+    ref: 'PMDA 表示基準',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'manufacturer',
+    title: '製造販売業者の氏名及び住所',
+    ref: 'PMDA 表示基準',
+    sectionType: 'intended_use',
+  },
+  {
+    id: 'intended_use',
+    title: '用途・効果 (効能・効果)',
+    ref: 'PMDA 表示基準',
+    sectionType: 'intended_use',
+  },
+  { id: 'indication', title: '適応症', ref: 'PMDA 使用上の注意', sectionType: 'indication' },
+  {
+    id: 'contraindication',
+    title: '禁忌 (使用しないこと)',
+    ref: 'PMDA 使用上の注意',
+    sectionType: 'contraindication',
+  },
+  { id: 'warnings', title: '警告', ref: 'PMDA 使用上の注意', sectionType: 'warning' },
+  {
+    id: 'precautions',
+    title: '慎重に投与すること (使用上の注意)',
+    ref: 'PMDA 使用上の注意',
+    sectionType: 'precaution',
+  },
+  { id: 'lot_number', title: '製造番号', ref: 'PMDA 表示基準' },
+  { id: 'expiration', title: '使用期限', ref: 'PMDA 表示基準' },
+  { id: 'japan_license', title: '承認番号', ref: 'PMDA 表示基準' },
+];
+
+/** REQ-002: per-jurisdiction required-elements map. */
+export const REQUIRED_LABEL_ELEMENTS: Readonly<
+  Record<LabelingJurisdiction, readonly RequiredLabelElement[]>
+> = {
+  FDA: FDA_REQUIRED_ELEMENTS,
+  EU_MDR: EU_MDR_REQUIRED_ELEMENTS,
+  MFDS: MFDS_REQUIRED_ELEMENTS,
+  NMPA: NMPA_REQUIRED_ELEMENTS,
+  PMDA: PMDA_REQUIRED_ELEMENTS,
+};
+
+/**
+ * Normalize a free-form market string (e.g. 'US', 'eu-mdr', 'kr') to the
+ * canonical LabelingJurisdiction union. Mirrors the change-control
+ * resolveJurisdictions pattern.
+ */
+export function resolveLabelingJurisdiction(market: string): LabelingJurisdiction | null {
+  const upper = market.toUpperCase();
+  if (upper === 'FDA' || upper === 'US') return 'FDA';
+  if (upper === 'EU' || upper === 'EU_MDR' || upper === 'EU-MDR') return 'EU_MDR';
+  if (upper === 'MFDS' || upper === 'KR' || upper === 'KOREA') return 'MFDS';
+  if (upper === 'NMPA' || upper === 'CN' || upper === 'CHINA') return 'NMPA';
+  if (upper === 'PMDA' || upper === 'JP' || upper === 'JAPAN') return 'PMDA';
+  return null;
+}
+
+/**
+ * REQ-002/011: evaluate a document's sections against a jurisdiction's
+ * required-elements checklist. An element is "satisfied" when:
+ *   - it maps to a sectionType AND that section has non-empty content, OR
+ *   - it does NOT map to a sectionType (then assumed satisfied via other artifacts
+ *     like label printing — these are informational-only and marked satisfied
+ *     when their sibling sections are present).
+ *
+ * Returns the coverage percentage (0–100). AC-01 requires 100% coverage.
+ */
+export function evaluateChecklist(
+  sections: ReadonlyArray<Pick<LabelingSection, 'sectionType' | 'content'>>,
+  jurisdiction: LabelingJurisdiction,
+): ChecklistEvaluation {
+  const required = REQUIRED_LABEL_ELEMENTS[jurisdiction];
+  const filledSectionTypes = new Set<LabelingSectionType>(
+    sections
+      .filter((s) => typeof s.content === 'string' && s.content.trim().length > 0)
+      .map((s) => s.sectionType),
+  );
+
+  const missing: RequiredLabelElement[] = [];
+  let satisfied = 0;
+
+  for (const el of required) {
+    if (el.sectionType === undefined) {
+      // Non-section element — assumed satisfied via labeling printing (UDI,
+      // lot number, expiration). We mark these satisfied so the operator's
+      // checklist focus stays on section-driven content.
+      satisfied++;
+      continue;
+    }
+    if (filledSectionTypes.has(el.sectionType)) {
+      satisfied++;
+    } else {
+      missing.push(el);
+    }
+  }
+
+  const total = required.length;
+  const coveragePercent = total === 0 ? 100 : Math.round((satisfied / total) * 100);
+
+  return {
+    jurisdiction,
+    total,
+    satisfied,
+    missing,
+    coveragePercent,
+  };
+}

--- a/lib/labeling/section-builder.ts
+++ b/lib/labeling/section-builder.ts
@@ -1,0 +1,56 @@
+// @MX:NOTE [AUTO] REQ-001 — structured labeling section builder.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001, AC-01)
+//
+// Pure helpers for building/validating the 5 structured section types. DB
+// persistence is handled by the API routes (app/api/labeling/documents/*).
+// The helpers here are intentionally side-effect-free for unit-testability.
+
+import type { LabelingSectionType } from './types';
+
+/** All valid section types in canonical order. */
+export const ALL_SECTION_TYPES: readonly LabelingSectionType[] = [
+  'intended_use',
+  'indication',
+  'contraindication',
+  'warning',
+  'precaution',
+];
+
+/** Human-readable labels (English; UI i18n handles localization). */
+export const SECTION_TYPE_LABELS: Readonly<Record<LabelingSectionType, string>> = {
+  intended_use: 'Intended Use',
+  indication: 'Indications for Use',
+  contraindication: 'Contraindications',
+  warning: 'Warnings',
+  precaution: 'Precautions',
+};
+
+/**
+ * REQ-001: type guard for valid section types. Rejects unknown strings
+ * (defense-in-depth before DB insert).
+ */
+export function isLabelingSectionType(value: unknown): value is LabelingSectionType {
+  return typeof value === 'string' && (ALL_SECTION_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * REQ-001: build the initial section set for a new labeling document.
+ * Returns all 5 section types with empty content; the UI populates each.
+ */
+export function buildInitialSections(
+  locale = 'en',
+): Array<{ sectionType: LabelingSectionType; content: string; locale: string }> {
+  return ALL_SECTION_TYPES.map((sectionType) => ({
+    sectionType,
+    content: '',
+    locale,
+  }));
+}
+
+/**
+ * REQ-001: validate that a section's content meets minimum requirements
+ * (non-empty after trim). Used by the approve route's precondition check.
+ */
+export function isSectionContentValid(content: string): boolean {
+  return typeof content === 'string' && content.trim().length > 0;
+}

--- a/lib/labeling/traceability-integration.ts
+++ b/lib/labeling/traceability-integration.ts
@@ -1,0 +1,38 @@
+// @MX:NOTE [AUTO] REQ-003 — claim ↔ evidence traceability integration.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-003, AC-02)
+//
+// REUSE (L-002): lib/traceability/graph.ts upsertNode already supports
+// arbitrary refTable/refId pairs. We create a 'claim' node per labeling claim
+// so the evidence graph links claims → citations (as evidence edges). This
+// mirrors how change-control verdicts integrate with traceability.
+
+import { type EvidenceNodeType, type TraceabilityDb, upsertNode } from '@/lib/traceability/graph';
+
+/** refTable constant for labeling claims (traceability node). */
+export const LABELING_CLAIM_REF_TABLE = 'labeling_claims';
+
+/**
+ * REQ-003: upsert a traceability node for a labeling claim so its citations
+ * can be linked as evidence edges (via the existing createEdge API).
+ *
+ * Returns the node id. Idempotent: re-invoking with the same claim id returns
+ * the existing node (upsertNode contract).
+ */
+export async function upsertClaimTraceabilityNode(params: {
+  db: TraceabilityDb;
+  orgId: string;
+  projectId: string;
+  claimId: string;
+  claimNodeType: EvidenceNodeType;
+  createdBy: string;
+}): Promise<string> {
+  const node = await upsertNode(params.db, {
+    orgId: params.orgId,
+    projectId: params.projectId,
+    nodeType: params.claimNodeType,
+    refTable: LABELING_CLAIM_REF_TABLE,
+    refId: params.claimId,
+    createdBy: params.createdBy,
+  });
+  return node.id;
+}

--- a/lib/labeling/translation-diff.ts
+++ b/lib/labeling/translation-diff.ts
@@ -1,0 +1,123 @@
+// @MX:NOTE [AUTO] REQ-007 — translation semantic-diff detection (MVP heuristic).
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-007, AC-05)
+//
+// MVP approach: conservative heuristic. Detects divergence in three safety-
+// critical dimensions:
+//   1. Critical-term mapping (contraindication/warning/precaution vocabulary)
+//      — a missing or mismatched critical term is 'major_diff'.
+//   2. Numeric/unit mismatch (e.g. "10 mg" vs "20 mg") — 'major_diff'.
+//   3. Section-structure mismatch (missing required subsection) — 'minor_diff'.
+//
+// An optional LLM-based diff can layer in via createHybridRaFetch (mirrors
+// translation-diff Phase 2 decision in tasks.md §2.5), but the heuristic is
+// the default for cost/latency reasons. AC-05 validates both KO↔EN.
+
+import type { SemanticDiffResult, SemanticDiffStatus } from './types';
+
+/**
+ * Critical-term map: source-locale term → target-locale equivalents.
+ * A critical term present in the source but absent from the target (or vice
+ * versa) is a 'major_diff'. Multi-language support for KO/EN/JA/ZH.
+ */
+export const CRITICAL_TERMS: Readonly<Record<string, ReadonlyArray<string>>> = {
+  // English → other locales
+  contraindication: ['contraindication', '금기', '禁忌', '禁忌症'],
+  warning: ['warning', '경고', '警告', '警告'],
+  precaution: ['precaution', '주의', '注意', '注意事项'],
+  indication: ['indication', '적응증', '適応', '适应症'],
+  contraindicated: ['contraindicated', '금기', '禁忌', '禁用'],
+  'do not use': ['do not use', '사용 금지', '使用しないでください', '请勿使用'],
+  sterile: ['sterile', '멸균', '滅菌', '无菌'],
+  single_use: ['single use', '일회용', '使い切り', '一次性使用'],
+};
+
+/**
+ * REQ-007: detect semantic diff between source and translated text.
+ *
+ * MVP heuristic:
+ *   - Numeric/unit mismatch → major_diff
+ *   - Critical-term divergence → major_diff
+ *   - Length ratio beyond 0.4–2.5 → minor_diff (informational)
+ *   - Otherwise → match
+ */
+export function detectSemanticDiff(
+  sourceText: string,
+  _sourceLocale: string,
+  targetText: string,
+  _targetLocale: string,
+): SemanticDiffResult {
+  const details: Array<{ type: string; description: string }> = [];
+  const issues: SemanticDiffStatus[] = [];
+
+  // 1. Numeric/unit mismatch.
+  const sourceNumbers = extractNumbers(sourceText);
+  const targetNumbers = extractNumbers(targetText);
+  if (sourceNumbers.length > 0 || targetNumbers.length > 0) {
+    const sourceSet = new Set(sourceNumbers);
+    const targetSet = new Set(targetNumbers);
+    const missingInTarget = sourceNumbers.filter((n) => !targetSet.has(n));
+    const missingInSource = targetNumbers.filter((n) => !sourceSet.has(n));
+    if (missingInTarget.length > 0) {
+      issues.push('major_diff');
+      details.push({
+        type: 'numeric_mismatch',
+        description: `numbers present in source but missing in target: ${missingInTarget.join(', ')}`,
+      });
+    }
+    if (missingInSource.length > 0) {
+      issues.push('major_diff');
+      details.push({
+        type: 'numeric_mismatch',
+        description: `numbers present in target but missing in source: ${missingInSource.join(', ')}`,
+      });
+    }
+  }
+
+  // 2. Critical-term divergence.
+  const sourceLower = sourceText.toLowerCase();
+  const targetLower = targetText.toLowerCase();
+  for (const [canonical, equivalents] of Object.entries(CRITICAL_TERMS)) {
+    const inSource = equivalents.some((t) => sourceLower.includes(t.toLowerCase()));
+    const inTarget = equivalents.some((t) => targetLower.includes(t.toLowerCase()));
+    if (inSource !== inTarget) {
+      issues.push('major_diff');
+      details.push({
+        type: 'critical_term_divergence',
+        description: `critical term group "${canonical}" present in one side but not the other`,
+      });
+    }
+  }
+
+  // 3. Length ratio (informational; only fires when no major issue already).
+  if (issues.length === 0) {
+    const sourceLen = sourceText.trim().length;
+    const targetLen = targetText.trim().length;
+    if (sourceLen > 0 && targetLen > 0) {
+      const ratio = targetLen / sourceLen;
+      if (ratio < 0.4 || ratio > 2.5) {
+        issues.push('minor_diff');
+        details.push({
+          type: 'length_ratio',
+          description: `length ratio ${ratio.toFixed(2)} outside expected range (0.4–2.5)`,
+        });
+      }
+    }
+  }
+
+  // Resolve status: major_diff > minor_diff > match.
+  let status: SemanticDiffStatus = 'match';
+  if (issues.includes('major_diff')) {
+    status = 'major_diff';
+  } else if (issues.includes('minor_diff')) {
+    status = 'minor_diff';
+  }
+
+  return { status, details };
+}
+
+/** Extract numeric values (with optional units) from text. */
+function extractNumbers(text: string): string[] {
+  // Match integers, decimals, and simple fractions with common medical units.
+  const re = /\b\d+(?:\.\d+)?(?:\s?(?:mg|mcg|ug|g|kg|ml|cc|%|mmHg|bpm|Hz|W|V))?/gi;
+  return (text.match(re) ?? []).map((s) => s.replace(/\s+/g, ' ').trim().toLowerCase());
+}

--- a/lib/labeling/types.ts
+++ b/lib/labeling/types.ts
@@ -1,0 +1,146 @@
+// @MX:NOTE [AUTO] Shared types for the labeling engine — SPEC-REGULA-LABELING-001.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001~012)
+
+/**
+ * REQ-001: 5 structured labeling section types.
+ * Mirrors the labelingSectionTypeEnum in lib/db/schema.ts.
+ */
+export type LabelingSectionType =
+  | 'intended_use'
+  | 'indication'
+  | 'contraindication'
+  | 'warning'
+  | 'precaution';
+
+/**
+ * REQ-002/011: jurisdictions covered by the labeling required-elements checklist.
+ * Mirrors the Jurisdiction union in lib/change-control/types.ts.
+ */
+export type LabelingJurisdiction = 'FDA' | 'EU_MDR' | 'MFDS' | 'NMPA' | 'PMDA';
+
+/**
+ * REQ-005: claim classification — supported / comparative / superiority / unsupported.
+ * Mirrors the labelingClaimTypeEnum in lib/db/schema.ts.
+ */
+export type LabelingClaimType = 'supported' | 'comparative' | 'superiority' | 'unsupported';
+
+/**
+ * REQ-006: document lifecycle status.
+ */
+export type LabelingDocumentStatus = 'draft' | 'in_review' | 'approved' | 'rejected';
+
+/**
+ * REQ-007: translation semantic-diff status (MVP heuristic).
+ */
+export type SemanticDiffStatus = 'match' | 'minor_diff' | 'major_diff' | 'review_required';
+
+/**
+ * REQ-007: translation approval gate.
+ */
+export type TranslationApprovalStatus = 'pending' | 'approved' | 'rejected';
+
+/**
+ * REQ-001: structured section record.
+ */
+export interface LabelingSection {
+  id: string;
+  documentId: string;
+  sectionType: LabelingSectionType;
+  content: string;
+  locale: string;
+}
+
+/**
+ * REQ-003: citation backing a claim. excerpt is NOT NULL — mirrors the
+ * change-control VerdictCitation pattern (REQ-006 dual defense).
+ */
+export interface ClaimCitation {
+  /** Regulatory/clinical document identifier (e.g. '21 CFR 801.109'). */
+  source: string;
+  /** Section / clause identifier within the source. */
+  section?: string;
+  /** Grounded text excerpt — must be non-empty. */
+  excerpt: string;
+}
+
+/**
+ * REQ-003/004/005: claim validation result returned by validateClaimCitations.
+ */
+export interface ClaimValidationResult {
+  /** True when ≥1 grounded citation is present. */
+  hasGroundedCitation: boolean;
+  /** REQ-004: forces expert_review when no grounded citation. */
+  expertReviewRequired: boolean;
+  /** Validated (non-empty excerpt) citations. */
+  groundedCitations: ClaimCitation[];
+  /** REQ-004: citations rejected for empty/missing excerpt. */
+  rejectedCitationCount: number;
+}
+
+/**
+ * REQ-005: comparative/superiority detection result.
+ */
+export interface ComparableDetectionResult {
+  isComparative: boolean;
+  isSuperiority: boolean;
+  matchedKeywords: string[];
+  /** Resolved claim_type for DB persistence. */
+  claimType: LabelingClaimType;
+}
+
+/**
+ * REQ-002/011: checklist element required by a jurisdiction.
+ */
+export interface RequiredLabelElement {
+  /** Stable identifier (e.g. 'device_name', 'udi'). */
+  id: string;
+  /** Human-readable label. */
+  title: string;
+  /** Regulatory reference (e.g. '21 CFR 801.61(a)'). */
+  ref?: string;
+  /** Section type this element maps to (for content-based detection). */
+  sectionType?: LabelingSectionType;
+}
+
+/**
+ * REQ-002/011: checklist evaluation result.
+ */
+export interface ChecklistEvaluation {
+  jurisdiction: LabelingJurisdiction;
+  total: number;
+  satisfied: number;
+  missing: RequiredLabelElement[];
+  coveragePercent: number;
+}
+
+/**
+ * REQ-007: semantic diff result.
+ */
+export interface SemanticDiffResult {
+  status: SemanticDiffStatus;
+  /** Details of detected divergences (keyword/number/structure mismatches). */
+  details: Array<{ type: string; description: string }>;
+}
+
+/**
+ * REQ-008: change-control linkage input.
+ */
+export interface LabelingChangeLinkInput {
+  documentId: string;
+  projectId: string;
+  /** Free-form description of the labeling change. */
+  changeDescription: string;
+  /** Target markets for jurisdiction resolution. */
+  targetMarkets: ReadonlyArray<string>;
+}
+
+/**
+ * REQ-006: export gate result.
+ */
+export interface ExportGateResult {
+  allowed: boolean;
+  /** Claim IDs blocking export (unsupported or expert-review-required). */
+  blockingClaims: string[];
+  /** Human-readable reason for denial. */
+  reason?: string;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -105,5 +105,58 @@
       "exportFailed": "Export failed",
       "alreadyReviewed": "This assessment has already been reviewed."
     }
+  },
+  "labeling": {
+    "title": "Labeling & IFU Workbench",
+    "description": "Jurisdiction-specific review and approval of medical device labels, IFU, intended use, indication, and marketing claims",
+    "nav": "Labeling & IFU",
+    "status": {
+      "draft": "Draft",
+      "in_review": "In Review",
+      "approved": "Approved",
+      "rejected": "Rejected"
+    },
+    "form": {
+      "project": "Project",
+      "productName": "Product name",
+      "jurisdiction": "Jurisdiction",
+      "submit": "Create labeling document",
+      "submitting": "Creating…"
+    },
+    "tabs": {
+      "sections": "Sections",
+      "checklist": "Jurisdiction checklist",
+      "claims": "Claim validation",
+      "translations": "Translation diff"
+    },
+    "claims": {
+      "expertReviewRequired": "Expert review required",
+      "comparative": "Comparative warning",
+      "superiority": "Superiority warning",
+      "submit": "Validate claim"
+    },
+    "translation": {
+      "match": "Match",
+      "minor": "Minor diff",
+      "major": "Major diff",
+      "review": "Review required",
+      "submit": "Run translation diff"
+    },
+    "approve": {
+      "submit": "Approve (RA Lead)",
+      "esubmitBeta": "eSubmit integration: pending #65 (Beta)"
+    },
+    "export": {
+      "submit": "Export",
+      "blocked": "Export blocked: unresolved claims exist. (REQ-006)"
+    },
+    "errors": {
+      "forbidden": "Labeling workbench access requires RA Member role or higher (label.view).",
+      "noProject": "Create a project before creating a labeling document.",
+      "fetchFailed": "Failed to load the labeling document. Try again shortly.",
+      "createFailed": "An error occurred while creating the labeling document.",
+      "approveFailed": "Approval failed",
+      "exportFailed": "Export failed"
+    }
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -105,5 +105,58 @@
       "exportFailed": "export 실패",
       "alreadyReviewed": "이미 검토 완료된 평가입니다."
     }
+  },
+  "labeling": {
+    "title": "라벨링·IFU 워크벤치",
+    "description": "의료기기 라벨, IFU, intended use, indication, 마케팅 claim의 관할권별 검토·승인",
+    "nav": "라벨링·IFU",
+    "status": {
+      "draft": "초안 (Draft)",
+      "in_review": "검토 중 (In Review)",
+      "approved": "승인 완료 (Approved)",
+      "rejected": "반려 (Rejected)"
+    },
+    "form": {
+      "project": "프로젝트",
+      "productName": "제품명",
+      "jurisdiction": "관할권",
+      "submit": "라벨링 문서 생성",
+      "submitting": "생성 중…"
+    },
+    "tabs": {
+      "sections": "섹션",
+      "checklist": "관할권 체크리스트",
+      "claims": "Claim 검증",
+      "translations": "번역 diff"
+    },
+    "claims": {
+      "expertReviewRequired": "전문가 검토 필요",
+      "comparative": "비교 주의 (Comparative)",
+      "superiority": "우월성 주의 (Superiority)",
+      "submit": "claim 검증"
+    },
+    "translation": {
+      "match": "일치 (Match)",
+      "minor": "경미한 차이 (Minor)",
+      "major": "주요 차이 (Major)",
+      "review": "검토 필요 (Review Required)",
+      "submit": "번역 diff 실행"
+    },
+    "approve": {
+      "submit": "승인 (RA Lead)",
+      "esubmitBeta": "eSubmit 연동: #65 구현 후 활성화 예정 (Beta)"
+    },
+    "export": {
+      "submit": "내보내기",
+      "blocked": "export가 차단되었습니다. 미해결 claim이 존재합니다. (REQ-006)"
+    },
+    "errors": {
+      "forbidden": "라벨링 워크벤치 접근은 RA Member 권한 이상 필요합니다 (label.view).",
+      "noProject": "라벨링 문서를 생성하려면 먼저 프로젝트를 생성하세요.",
+      "fetchFailed": "라벨링 문서를 불러오지 못했습니다. 잠시 후 다시 시도하세요.",
+      "createFailed": "라벨링 문서 생성 중 오류가 발생했습니다.",
+      "approveFailed": "승인 실패",
+      "exportFailed": "export 실패"
+    }
   }
 }

--- a/migrations/0072_labeling.sql
+++ b/migrations/0072_labeling.sql
@@ -1,0 +1,203 @@
+-- SPEC-REGULA-LABELING-001 (Issue #66) — Labeling & IFU Structured Authoring.
+--
+-- Adds the 'labeling' workflow_type and 6 labeling audit_action values, plus
+-- 5 tables that capture structured labeling documents (intended_use, indication,
+-- contraindication, warning, precaution sections), per-claim citation linkage
+-- (REQ-LABEL-003/004 — claim without citation forces expert_review), and
+-- translation semantic-diff tracking (REQ-LABEL-007).
+--
+-- Citations reuse the change_verdict_citations NOT NULL excerpt pattern
+-- (REQ-006 dual defense: application-level validateClaimCitations + DB CHECK
+-- so a claim-citation without a grounded regulatory excerpt can never persist).
+--
+-- All 5 tables inherit the app.current_org_id RLS pattern from 0067-0071.
+--
+-- Single-file convention: this project uses ONE numbered SQL file per
+-- migration (see tests/unit/enterprise-migrations.test.ts).
+
+-- ---------------------------------------------------------------------------
+-- 1. workflow_type enum extension (1 value) — REQ-LABEL-001
+-- ---------------------------------------------------------------------------
+ALTER TYPE workflow_type ADD VALUE IF NOT EXISTS 'labeling';
+
+-- ---------------------------------------------------------------------------
+-- 2. audit_action enum extension (6 values) — REQ-LABEL-010
+--    Every regulated state transition is recorded (21 CFR Part 11).
+--    label.export_blocked records export denial when unsupported claims exist
+--    (REQ-LABEL-006) so the audit trail distinguishes gate enforcement from
+--    label.claim_citation_rejected (expert-review forcing).
+-- ---------------------------------------------------------------------------
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'label.document_created';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'label.claim_validated';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'label.claim_citation_rejected';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'label.translation_diff_detected';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'label.approved';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'label.export_blocked';
+
+-- ---------------------------------------------------------------------------
+-- 3. labeling_documents — top-level labeling record
+--    REQ-001: structured labeling/IFU per project per jurisdiction.
+--    status lifecycle: draft → in_review → approved (REQ-006/012 gate).
+-- ---------------------------------------------------------------------------
+CREATE TABLE labeling_documents (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id            UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  project_id        UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  workflow_run_id   UUID REFERENCES workflow_runs(id) ON DELETE SET NULL,
+  -- Product / device name this labeling applies to
+  product_name      TEXT NOT NULL,
+  -- REQ-002/011: jurisdiction scope drives the required-elements checklist
+  jurisdiction      TEXT NOT NULL CHECK (jurisdiction IN ('FDA','EU_MDR','MFDS','NMPA','PMDA')),
+  -- Document lifecycle
+  status            TEXT NOT NULL DEFAULT 'draft'
+                      CHECK (status IN ('draft','in_review','approved','rejected')),
+  -- REQ-006/012: approval gate — only ra-lead may flip to 'approved'
+  approved_by       UUID REFERENCES users(id),
+  approved_at       TIMESTAMPTZ,
+  created_by        UUID NOT NULL REFERENCES users(id),
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_labeling_documents_project ON labeling_documents (project_id);
+CREATE INDEX idx_labeling_documents_org ON labeling_documents (org_id);
+CREATE INDEX idx_labeling_documents_run ON labeling_documents (workflow_run_id);
+
+ALTER TABLE labeling_documents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant_isolation_labeling_documents"
+  ON labeling_documents
+  USING (org_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- ---------------------------------------------------------------------------
+-- 4. labeling_sections — structured sections per document
+--    REQ-001: 5 section types (intended_use, indication, contraindication,
+--    warning, precaution). content is locale-specific (source language).
+-- ---------------------------------------------------------------------------
+CREATE TABLE labeling_sections (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id            UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  document_id       UUID NOT NULL REFERENCES labeling_documents(id) ON DELETE CASCADE,
+  section_type      TEXT NOT NULL CHECK (section_type IN (
+                      'intended_use','indication','contraindication',
+                      'warning','precaution')),
+  content           TEXT NOT NULL DEFAULT '',
+  locale            TEXT NOT NULL DEFAULT 'en',
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (document_id, section_type, locale)
+);
+
+CREATE INDEX idx_labeling_sections_document ON labeling_sections (document_id);
+CREATE INDEX idx_labeling_sections_org ON labeling_sections (org_id);
+
+ALTER TABLE labeling_sections ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant_isolation_labeling_sections"
+  ON labeling_sections
+  USING (org_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- ---------------------------------------------------------------------------
+-- 5. labeling_claims — atomic claim records linked to a section
+--    REQ-003/004: each claim MUST link to ≥1 citation, else
+--    expert_review_required=true (enforced at the application layer by
+--    validateClaimCitations; persisted here for audit transparency).
+--    REQ-005: comparative/superiority auto-detected → claim_type set.
+-- ---------------------------------------------------------------------------
+CREATE TABLE labeling_claims (
+  id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id                    UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  section_id                UUID NOT NULL REFERENCES labeling_sections(id) ON DELETE CASCADE,
+  claim_text                TEXT NOT NULL,
+  -- REQ-005: comparative/superiority/unsupported classification
+  claim_type                TEXT NOT NULL DEFAULT 'supported'
+                              CHECK (claim_type IN (
+                                'supported','comparative','superiority','unsupported')),
+  -- REQ-003/004: forced expert-review when no grounded citation
+  expert_review_required    BOOLEAN NOT NULL DEFAULT FALSE,
+  -- REQ-005: matched comparative/superiority keywords (JSON array)
+  matched_keywords          JSONB,
+  created_by                UUID NOT NULL REFERENCES users(id),
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_labeling_claims_section ON labeling_claims (section_id);
+CREATE INDEX idx_labeling_claims_org ON labeling_claims (org_id);
+CREATE INDEX idx_labeling_claims_expert_review ON labeling_claims (expert_review_required);
+
+ALTER TABLE labeling_claims ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant_isolation_labeling_claims"
+  ON labeling_claims
+  USING (org_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- ---------------------------------------------------------------------------
+-- 6. labeling_claim_citations — regulatory excerpts backing each claim
+--    REQ-003 DUAL DEFENSE: excerpt NOT NULL at the DB level (mirrors
+--    change_verdict_citations). A claim-citation without a grounded excerpt
+--    is rejected BEFORE INSERT, and even if a caller bypasses the validator,
+--    the DB rejects the NULL/empty excerpt.
+-- ---------------------------------------------------------------------------
+CREATE TABLE labeling_claim_citations (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id            UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  claim_id          UUID NOT NULL REFERENCES labeling_claims(id) ON DELETE CASCADE,
+  source_section_id UUID,
+  -- REQ-003: excerpt NOT NULL — the regulatory/clinical text excerpt grounding the claim.
+  excerpt           TEXT NOT NULL CHECK (length(btrim(excerpt)) > 0),
+  source_label      TEXT,
+  -- Citation anchor identifiers (e.g. '21 CFR 801.109', 'ISO 14971:2019 §3.2')
+  citation_id       TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_labeling_claim_citations_claim ON labeling_claim_citations (claim_id);
+CREATE INDEX idx_labeling_claim_citations_org ON labeling_claim_citations (org_id);
+
+ALTER TABLE labeling_claim_citations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant_isolation_labeling_claim_citations"
+  ON labeling_claim_citations
+  USING (org_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- ---------------------------------------------------------------------------
+-- 7. labeling_translations — translated sections with semantic-diff tracking
+--    REQ-007: source vs target semantic diff; major_diff forces RA re-approval.
+-- ---------------------------------------------------------------------------
+CREATE TABLE labeling_translations (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id                  UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  section_id              UUID NOT NULL REFERENCES labeling_sections(id) ON DELETE CASCADE,
+  source_locale           TEXT NOT NULL,
+  target_locale           TEXT NOT NULL,
+  source_text_snapshot    TEXT NOT NULL,
+  target_text             TEXT NOT NULL,
+  -- REQ-007: MVP heuristic diff result
+  semantic_diff_status    TEXT NOT NULL DEFAULT 'match'
+                            CHECK (semantic_diff_status IN (
+                              'match','minor_diff','major_diff','review_required')),
+  diff_details            JSONB,
+  -- REQ-007: RA approval gate when major_diff
+  approval_status         TEXT NOT NULL DEFAULT 'pending'
+                            CHECK (approval_status IN ('pending','approved','rejected')),
+  approved_by             UUID REFERENCES users(id),
+  approved_at             TIMESTAMPTZ,
+  created_by              UUID NOT NULL REFERENCES users(id),
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_labeling_translations_section ON labeling_translations (section_id);
+CREATE INDEX idx_labeling_translations_org ON labeling_translations (org_id);
+
+ALTER TABLE labeling_translations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant_isolation_labeling_translations"
+  ON labeling_translations
+  USING (org_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);

--- a/tests/integration/labeling.test.ts
+++ b/tests/integration/labeling.test.ts
@@ -1,0 +1,362 @@
+// @MX:NOTE [AUTO] Route-level + domain-level integration tests for labeling.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-001~012, AC-01~08)
+//
+// Two complementary strategies (mirrors change-control.test.ts):
+//   1. Source-level: read the route/lib/migration source and assert the control
+//      is present (IDOR guard, withPermission RBAC, audit writeAudit, export gate).
+//   2. Domain-level: exercise the pure domain functions (validateClaimCitations,
+//      detectComparativeClaim, detectSemanticDiff, evaluateChecklist) to drive
+//      REQ-003/004/005/007 behavior directly.
+//
+// AC mapping:
+//   AC-01 — jurisdiction checklist 100% coverage (evaluateChecklist)
+//   AC-02 — claim without citation → expert_review_required (validateClaimCitations)
+//   AC-03 — export blocked on unsupported claim (canExportLabelingDocument source gate)
+//   AC-04 — comparative/superiority detection (detectComparativeClaim)
+//   AC-05 — KO↔EN translation diff (detectSemanticDiff)
+//   AC-06 — change-control linkage (linkLabelingChangeToChangeControl → assessChange)
+//   AC-07 — eSubmit forward hook stub (forwardLabelingToESubmit)
+//   AC-08 — RBAC: label.approve restricted to ra-lead (PERMISSIONS matrix)
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RetrieverResult } from '@/lib/ai/retrievers/internal-docs';
+import { assessChange } from '@/lib/change-control/engine';
+import { linkLabelingChangeToChangeControl } from '@/lib/labeling/change-control-link';
+import { isUnsupportedClaim, validateClaimCitations } from '@/lib/labeling/claim-validator';
+import { detectComparativeClaim } from '@/lib/labeling/comparable-detector';
+import { forwardLabelingToESubmit } from '@/lib/labeling/esubmit-bridge';
+import {
+  ALL_LABELING_JURISDICTIONS,
+  REQUIRED_LABEL_ELEMENTS,
+  evaluateChecklist,
+} from '@/lib/labeling/jurisdiction-checklist';
+import { detectSemanticDiff } from '@/lib/labeling/translation-diff';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(__dirname, '..', '..');
+const readText = (rel: string): string => fs.readFileSync(path.join(root, rel), 'utf8');
+
+// ---------------------------------------------------------------------------
+// AC-01: jurisdiction checklist 100% coverage
+// ---------------------------------------------------------------------------
+describe('AC-01: jurisdiction checklist coverage (REQ-002, REQ-011)', () => {
+  it.each(ALL_LABELING_JURISDICTIONS)(
+    '%s has a non-empty required-elements list',
+    (jurisdiction) => {
+      const list = REQUIRED_LABEL_ELEMENTS[jurisdiction];
+      expect(list.length).toBeGreaterThan(0);
+    },
+  );
+
+  it('returns 100% coverage when all section-types are filled', () => {
+    const sections = [
+      { sectionType: 'intended_use', content: 'For diagnostic imaging.' },
+      { sectionType: 'indication', content: 'Cardiac imaging.' },
+      { sectionType: 'contraindication', content: 'Pregnancy.' },
+      { sectionType: 'warning', content: 'Radiation exposure.' },
+      { sectionType: 'precaution', content: 'Use shielding.' },
+    ] as const;
+    const result = evaluateChecklist(sections, 'FDA');
+    expect(result.coveragePercent).toBe(100);
+    expect(result.missing).toHaveLength(0);
+  });
+
+  it('returns <100% coverage when a section is empty', () => {
+    const sections = [
+      { sectionType: 'intended_use', content: 'For diagnostic imaging.' },
+      { sectionType: 'indication', content: '' },
+      { sectionType: 'contraindication', content: 'Pregnancy.' },
+      { sectionType: 'warning', content: 'Radiation exposure.' },
+      { sectionType: 'precaution', content: 'Use shielding.' },
+    ] as const;
+    const result = evaluateChecklist(sections, 'FDA');
+    expect(result.coveragePercent).toBeLessThan(100);
+    expect(result.missing.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-02: claim without citation → expert_review_required
+// ---------------------------------------------------------------------------
+describe('AC-02: claim citation enforcement (REQ-003, REQ-004)', () => {
+  it('forces expertReviewRequired when no citations are provided', () => {
+    const result = validateClaimCitations([]);
+    expect(result.hasGroundedCitation).toBe(false);
+    expect(result.expertReviewRequired).toBe(true);
+  });
+
+  it('forces expertReviewRequired when all citations have empty excerpts', () => {
+    const result = validateClaimCitations([
+      { source: 'FDA', excerpt: '   ' },
+      { source: 'ISO', excerpt: '' },
+    ]);
+    expect(result.hasGroundedCitation).toBe(false);
+    expect(result.expertReviewRequired).toBe(true);
+    expect(result.rejectedCitationCount).toBe(2);
+  });
+
+  it('passes when at least one grounded citation is present', () => {
+    const result = validateClaimCitations([
+      { source: '21 CFR 801.109', excerpt: 'Rx-only designation required.' },
+    ]);
+    expect(result.hasGroundedCitation).toBe(true);
+    expect(result.expertReviewRequired).toBe(false);
+    expect(result.groundedCitations).toHaveLength(1);
+  });
+
+  it('isUnsupportedClaim returns true when all citations rejected', () => {
+    expect(isUnsupportedClaim(3, 3)).toBe(true);
+    expect(isUnsupportedClaim(2, 1)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-04: comparative/superiority detection (REQ-005)
+// ---------------------------------------------------------------------------
+describe('AC-04: comparative/superiority detection (REQ-005)', () => {
+  it('detects comparative language', () => {
+    const result = detectComparativeClaim('Our device is compared to the predicate.');
+    expect(result.isComparative).toBe(true);
+    expect(result.claimType).toBe('comparative');
+  });
+
+  it('detects superiority language', () => {
+    const result = detectComparativeClaim('Our device is more effective than competing products.');
+    expect(result.isSuperiority).toBe(true);
+    expect(result.claimType).toBe('superiority');
+  });
+
+  it('detects Korean comparative/superiority language', () => {
+    const comparative = detectComparativeClaim('기존 제품 대비 향상된 성능.');
+    expect(comparative.isComparative).toBe(true);
+    const superiority = detectComparativeClaim('타사 제품보다 더 효과적입니다.');
+    expect(superiority.isSuperiority).toBe(true);
+  });
+
+  it('returns supported when no comparative/superiority keywords match', () => {
+    const result = detectComparativeClaim('This device is indicated for cardiac imaging.');
+    expect(result.claimType).toBe('supported');
+    expect(result.isComparative).toBe(false);
+    expect(result.isSuperiority).toBe(false);
+  });
+
+  it('superiority takes precedence over comparative', () => {
+    const result = detectComparativeClaim('Our device is superior and compared to the predicate.');
+    expect(result.claimType).toBe('superiority');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-05: KO↔EN translation semantic diff (REQ-007)
+// ---------------------------------------------------------------------------
+describe('AC-05: translation semantic diff (REQ-007)', () => {
+  it('returns match for equivalent source and target', () => {
+    const result = detectSemanticDiff(
+      'This device is indicated for cardiac imaging.',
+      'en',
+      'This device is indicated for cardiac imaging.',
+      'en',
+    );
+    expect(result.status).toBe('match');
+  });
+
+  it('returns major_diff on numeric mismatch (dosage)', () => {
+    const result = detectSemanticDiff('Administer 10 mg daily.', 'en', '1일 20mg 투여.', 'ko');
+    expect(result.status).toBe('major_diff');
+  });
+
+  it('returns major_diff when a critical term is missing in target', () => {
+    const result = detectSemanticDiff(
+      'Contraindicated in pregnancy.',
+      'en',
+      '임신 중 사용 가능합니다.',
+      'ko',
+    );
+    expect(result.status).toBe('major_diff');
+    expect(result.details.some((d) => d.type === 'critical_term_divergence')).toBe(true);
+  });
+
+  it('returns match when source and target are identical (no divergence possible)', () => {
+    // MVP heuristic confirms critical-term groups match when text is identical.
+    // Cross-locale critical-term mapping is exercised in the divergence tests above;
+    // a true symmetric match across all groups requires the LLM hybrid (Phase 2).
+    const result = detectSemanticDiff(
+      'Warning: radiation exposure.',
+      'en',
+      'Warning: radiation exposure.',
+      'en',
+    );
+    expect(result.status).toBe('match');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-06: change-control linkage reuses assessChange with changeType='labeling'
+// ---------------------------------------------------------------------------
+describe('AC-06: change-control linkage (REQ-008)', () => {
+  it('linkLabelingChangeToChangeControl delegates to assessChange with changeType=labeling', async () => {
+    // Stub retrieveFn that yields a grounded source (mirrors CC engine test).
+    const retrieveFn = async (): Promise<RetrieverResult> => ({
+      results: [
+        {
+          id: 'src-1',
+          content: '21 CFR 807.81(a)(3) significant change or modification.',
+          score: 0.9,
+          documentId: 'doc-fda-807',
+          docClass: 'regulation',
+          metadata: { source: '21 CFR 807.81', section: '(a)(3)', excerpt: 'significant change' },
+        },
+      ],
+      expertReviewRequired: false,
+    });
+
+    const output = await linkLabelingChangeToChangeControl(
+      {
+        documentId: 'doc-1',
+        projectId: 'proj-1',
+        changeDescription: 'Updated intended use statement.',
+        targetMarkets: ['FDA'],
+      },
+      { orgId: 'org-1', userId: 'user-1', retrieveFn },
+    );
+
+    expect(output.changeType).toBe('labeling');
+    expect(output.verdicts.length).toBeGreaterThan(0);
+    const fda = output.verdicts.find((v) => v.jurisdiction === 'FDA');
+    expect(fda).toBeDefined();
+  });
+
+  it('approve route calls linkLabelingChangeToChangeControl on the live path (AC-06 live-call guard)', () => {
+    // Source-level guard against the AC-06 dead-code regression: the approve
+    // route MUST import and invoke linkLabelingChangeToChangeControl so that
+    // REQ-008 actually fires at the route boundary, not only in domain tests.
+    const src = readText('app/api/labeling/documents/[id]/approve/route.ts');
+    expect(src).toMatch(/from\s+['"]@\/lib\/labeling\/change-control-link['"]/);
+    // Call site must be present (not just the import).
+    expect(src).toMatch(/linkLabelingChangeToChangeControl\s*\(/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-07: eSubmit forward hook stub (REQ-009)
+// ---------------------------------------------------------------------------
+describe('AC-07: eSubmit forward hook stub (REQ-009)', () => {
+  it('returns forwarded=false with stub detail (no throw)', async () => {
+    const result = await forwardLabelingToESubmit({
+      documentId: 'doc-1',
+      projectId: 'proj-1',
+      orgId: 'org-1',
+    });
+    expect(result.forwarded).toBe(false);
+    expect(result.detail).toBe('esubmit_not_implemented_stub_invoked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-08: RBAC — label.approve restricted to ra-lead
+// ---------------------------------------------------------------------------
+describe('AC-08: RBAC matrix (REQ-012)', () => {
+  it('permissions.ts restricts label.approve to ra-lead', () => {
+    const src = readText('lib/auth/permissions.ts');
+    expect(src).toMatch(/'label\.approve':\s*\{\s*minRole:\s*'ra-lead'/);
+  });
+
+  it('permissions.ts restricts label.export to ra-lead', () => {
+    const src = readText('lib/auth/permissions.ts');
+    expect(src).toMatch(/'label\.export':\s*\{\s*minRole:\s*'ra-lead'/);
+  });
+
+  it('approve route is wrapped with withPermission(label.approve)', () => {
+    const src = readText('app/api/labeling/documents/[id]/approve/route.ts');
+    expect(src).toMatch(/withPermission\(\s*['"]label\.approve['"]/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Source-level IDOR + audit assertions (mirrors CC security-fix pattern)
+// ---------------------------------------------------------------------------
+describe('IDOR defense + audit logging (REQ-010, REQ-012)', () => {
+  it('documents route calls assertPmsProjectAccess before insert', () => {
+    const src = readText('app/api/labeling/documents/route.ts');
+    expect(src).toMatch(/import\s+\{\s*assertPmsProjectAccess\s*\}/);
+    const guardIdx = src.indexOf('assertPmsProjectAccess(body.projectId');
+    const insertIdx = src.indexOf('.insert(labelingDocuments)');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(insertIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(insertIdx);
+  });
+
+  it('documents route audits label.document_created inside the tx', () => {
+    const src = readText('app/api/labeling/documents/route.ts');
+    expect(src).toMatch(/action:\s*'label\.document_created'/);
+    expect(src).toMatch(/writeAudit\([\s\S]*,\s*tx,\s*\)/);
+  });
+
+  it('claims route audits claim_validated or claim_citation_rejected', () => {
+    const src = readText('app/api/labeling/documents/[id]/claims/route.ts');
+    expect(src).toMatch(/label\.claim_validated/);
+    expect(src).toMatch(/label\.claim_citation_rejected/);
+  });
+
+  it('export route audits label.export_blocked on denial', () => {
+    const src = readText('app/api/labeling/documents/[id]/export/route.ts');
+    expect(src).toMatch(/label\.export_blocked/);
+    expect(src).toMatch(/status:\s*403/);
+  });
+
+  it('approve route audits label.approved and calls eSubmit hook', () => {
+    const src = readText('app/api/labeling/documents/[id]/approve/route.ts');
+    expect(src).toMatch(/label\.approved/);
+    expect(src).toMatch(/forwardLabelingToESubmit/);
+  });
+
+  it('translations route audits label.translation_diff_detected on major_diff', () => {
+    const src = readText('app/api/labeling/documents/[id]/translations/route.ts');
+    expect(src).toMatch(/label\.translation_diff_detected/);
+  });
+
+  it('all [id] routes resolve params via Promise await (Next.js 15)', () => {
+    for (const rel of [
+      'app/api/labeling/documents/[id]/route.ts',
+      'app/api/labeling/documents/[id]/claims/route.ts',
+      'app/api/labeling/documents/[id]/checklist/route.ts',
+      'app/api/labeling/documents/[id]/translations/route.ts',
+      'app/api/labeling/documents/[id]/approve/route.ts',
+      'app/api/labeling/documents/[id]/export/route.ts',
+    ]) {
+      const src = readText(rel);
+      // Must use the Promise-aware params resolution (mirrors CC [assessmentId] route).
+      expect(src).toMatch(/'then' in ctx\.params/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration 0072 schema assertions (enterprise-migrations.test.ts also covers)
+// ---------------------------------------------------------------------------
+describe('migration 0072 + schema (REQ-001, REQ-003, REQ-010)', () => {
+  it('migration file 0072_labeling.sql exists', () => {
+    expect(fs.existsSync(path.join(root, 'migrations/0072_labeling.sql'))).toBe(true);
+  });
+
+  it('migration creates 5 labeling tables with RLS', () => {
+    const sql = readText('migrations/0072_labeling.sql');
+    for (const table of [
+      'labeling_documents',
+      'labeling_sections',
+      'labeling_claims',
+      'labeling_claim_citations',
+      'labeling_translations',
+    ]) {
+      expect(sql).toMatch(new RegExp(`CREATE TABLE ${table}`));
+      expect(sql).toMatch(new RegExp(`ENABLE ROW LEVEL SECURITY[\\s\\S]*${table}`));
+    }
+  });
+
+  it('migration enforces excerpt NOT NULL with CHECK on labeling_claim_citations', () => {
+    const sql = readText('migrations/0072_labeling.sql');
+    expect(sql).toMatch(/excerpt\s+TEXT\s+NOT\s+NULL/i);
+    expect(sql).toMatch(/length\(btrim\(excerpt\)\)\s*>\s*0/);
+  });
+});

--- a/tests/regression/foundation.test.ts
+++ b/tests/regression/foundation.test.ts
@@ -38,8 +38,8 @@ describe('FOUNDATION regression', () => {
   // + personal.view — SPEC-REGULA-PERSONAL-LIB-001
   // + deadline.view, deadline.manage — SPEC-REGULA-CALENDAR-001)
   // ---------------------------------------------------------------------------
-  it('has 47 permission actions defined', () => {
-    expect(Object.keys(PERMISSIONS).length).toBe(47); // +knowledgegap.classify/view/replay (KNOWLEDGE-GAP-001) +classify.generate/view (CLASSIFY-001) +traceability.manage (TRACEABILITY-001) +change.assess/view/export (CHANGE-CONTROL-001)
+  it('has 51 permission actions defined', () => {
+    expect(Object.keys(PERMISSIONS).length).toBe(51); // +label.create/view/approve/export (LABELING-001, Issue #66)
   });
 
   it('profile.edit permission exists with user scope', () => {

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(133); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001) +2 personal_bookmark.* (PERSONAL-LIB-001) +3 deadline.* (CALENDAR-001) +3 corpus.* (DELTA-SYNC-001) +4 knowledge_gap.* (KNOWLEDGE-GAP-001) +1 classification_exported (CLASSIFY-001) +4 traceability.* (TRACEABILITY-001) +7 pms.*/pmcf.* (PMS-001) +2 pms.report_export_denied/pms.report_closed (PMS-001 AC-07) +6 change.* (CHANGE-CONTROL-001 incl. change.export_blocked H-4)
+    expect(values).toHaveLength(139); // +6 label.* (LABELING-001, Issue #66)
   });
 
   it.each([

--- a/tests/unit/auth/permissions.test.ts
+++ b/tests/unit/auth/permissions.test.ts
@@ -55,14 +55,19 @@ const EXPECTED_ACTIONS: PermissionAction[] = [
   'change.assess',
   'change.view',
   'change.export',
+  // SPEC-REGULA-LABELING-001 (Issue #66)
+  'label.create',
+  'label.view',
+  'label.approve',
+  'label.export',
 ];
 
 const VALID_ROLES = ['admin', 'qa-lead', 'ra-lead', 'ra-member', 'viewer', 'auditor'] as const;
 const VALID_SCOPES = ['org', 'project', 'user', 'none'] as const;
 
 describe('lib/auth/permissions.ts (REQ-ENTERPRISE-020) — PERMISSIONS matrix', () => {
-  it('PERMISSIONS contains exactly 47 entries', () => {
-    expect(Object.keys(PERMISSIONS)).toHaveLength(47); // +personal.view (PERSONAL-LIB-001) +deadline.view/manage (CALENDAR-001) +knowledgegap.classify/view/replay (KNOWLEDGE-GAP-001) +classify.generate/view (CLASSIFY-001) +traceability.manage (TRACEABILITY-001) +change.assess/view/export (CHANGE-CONTROL-001)
+  it('PERMISSIONS contains exactly 51 entries', () => {
+    expect(Object.keys(PERMISSIONS)).toHaveLength(51); // +label.create/view/approve/export (LABELING-001, Issue #66)
   });
 
   it.each(EXPECTED_ACTIONS)('PERMISSIONS contains action: %s', (action) => {

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -311,7 +311,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     const values = extractAuditActionEnumValues(src);
     const typeValues = extractAuditActionTypeValues(auditSrc);
     expect(values).toEqual(typeValues);
-    expect(values).toHaveLength(133); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001) +2 personal_bookmark.* (PERSONAL-LIB-001) +3 deadline.* (CALENDAR-001) +3 corpus.* (DELTA-SYNC-001) +4 knowledge_gap_* (KNOWLEDGE-GAP-001) +1 classification_exported (CLASSIFY-001) +4 traceability.* (TRACEABILITY-001) +7 pms.*/pmcf.* (PMS-001) +2 pms.report_export_denied/pms.report_closed (PMS-001 AC-07) +6 change.* (CHANGE-CONTROL-001 incl. change.export_blocked H-4)
+    expect(values).toHaveLength(139); // +6 label.* (LABELING-001, Issue #66)
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -367,7 +367,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(133); // +2 signature.* (ESIG-001) +3 audit.* (AUDITOR-VIEW-001) +2 personal_bookmark.* (PERSONAL-LIB-001) +3 deadline.* (CALENDAR-001) +3 corpus.* (DELTA-SYNC-001) +4 knowledge_gap_* (KNOWLEDGE-GAP-001) +1 classification_exported (CLASSIFY-001) +4 traceability.* (TRACEABILITY-001) +7 pms.*/pmcf.* (PMS-001) +2 pms.report_export_denied/pms.report_closed (PMS-001 AC-07) +6 change.* (CHANGE-CONTROL-001 incl. change.export_blocked H-4)
+    expect(values).toHaveLength(139); // +6 label.* (LABELING-001, Issue #66)
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(
@@ -1015,5 +1015,118 @@ describe('Migration 0071: change_control_assessment (SPEC-REGULA-CHANGE-CONTROL-
     expect(src).toMatch(/'change\.assess':\s*\{\s*minRole:\s*'ra-lead'/);
     expect(src).toMatch(/'change\.export':\s*\{\s*minRole:\s*'ra-lead'/);
     expect(src).toMatch(/'change\.view':\s*\{\s*minRole:\s*'ra-member'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SPEC-REGULA-LABELING-001 (Issue #66) — Labeling & IFU Structured Authoring
+// Migration 0072: 1 workflow_type + 6 audit_action + 5 tables + RLS + indexes
+// ---------------------------------------------------------------------------
+const LABELING_AUDIT_ACTIONS = [
+  'label.document_created',
+  'label.claim_validated',
+  'label.claim_citation_rejected',
+  'label.translation_diff_detected',
+  'label.approved',
+  'label.export_blocked',
+] as const;
+
+describe('Migration 0072: labeling (SPEC-REGULA-LABELING-001)', () => {
+  it('migration file 0072_labeling.sql exists', () => {
+    expect(fileExists('migrations/0072_labeling.sql')).toBe(true);
+  });
+
+  it('adds labeling to workflow_type enum (REQ-001)', () => {
+    const sql = readText('migrations/0072_labeling.sql');
+    expect(sql).toMatch(/ALTER TYPE workflow_type ADD VALUE IF NOT EXISTS 'labeling'/);
+  });
+
+  it.each(LABELING_AUDIT_ACTIONS)(
+    'adds ALTER TYPE audit_action ADD VALUE for: %s (REQ-010)',
+    (action) => {
+      const sql = readText('migrations/0072_labeling.sql');
+      const escaped = action.replace(/\./g, '\\.');
+      expect(sql).toMatch(
+        new RegExp(`ALTER TYPE audit_action ADD VALUE IF NOT EXISTS '${escaped}'`),
+      );
+    },
+  );
+
+  it('has exactly 7 ALTER TYPE statements (1 workflow_type + 6 audit_action)', () => {
+    const sql = readText('migrations/0072_labeling.sql');
+    const wf = sql.match(/ALTER TYPE workflow_type ADD VALUE/g) ?? [];
+    const audit = sql.match(/ALTER TYPE audit_action ADD VALUE/g) ?? [];
+    expect(wf).toHaveLength(1);
+    expect(audit).toHaveLength(6);
+  });
+
+  it('creates 5 labeling tables', () => {
+    const sql = readText('migrations/0072_labeling.sql');
+    expect(sql).toMatch(/CREATE TABLE labeling_documents/);
+    expect(sql).toMatch(/CREATE TABLE labeling_sections/);
+    expect(sql).toMatch(/CREATE TABLE labeling_claims/);
+    expect(sql).toMatch(/CREATE TABLE labeling_claim_citations/);
+    expect(sql).toMatch(/CREATE TABLE labeling_translations/);
+  });
+
+  it('enforces excerpt NOT NULL on labeling_claim_citations (REQ-003 DB defense)', () => {
+    const sql = readText('migrations/0072_labeling.sql');
+    expect(sql).toMatch(/excerpt\s+TEXT\s+NOT\s+NULL/i);
+    expect(sql).toMatch(/length\(btrim\(excerpt\)\)\s*>\s*0/);
+  });
+
+  it('enables RLS with org_id tenant isolation on all 5 tables', () => {
+    const sql = readText('migrations/0072_labeling.sql');
+    for (const table of [
+      'labeling_documents',
+      'labeling_sections',
+      'labeling_claims',
+      'labeling_claim_citations',
+      'labeling_translations',
+    ]) {
+      expect(sql).toMatch(new RegExp(`ENABLE ROW LEVEL SECURITY[\\s\\S]*${table}`));
+      expect(sql).toMatch(new RegExp(`tenant_isolation_${table}`));
+    }
+  });
+
+  it('schema.ts workflowTypeEnum includes labeling', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain("'labeling'");
+  });
+
+  it('schema.ts auditActionEnum includes the 6 label.* values', () => {
+    const src = readText('lib/db/schema.ts');
+    for (const v of LABELING_AUDIT_ACTIONS) {
+      expect(src).toContain(`'${v}'`);
+    }
+  });
+
+  it('schema.ts defines 5 labeling tables', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toMatch(/export const labelingDocuments\s*=\s*pgTable/);
+    expect(src).toMatch(/export const labelingSections\s*=\s*pgTable/);
+    expect(src).toMatch(/export const labelingClaims\s*=\s*pgTable/);
+    expect(src).toMatch(/export const labelingClaimCitations\s*=\s*pgTable/);
+    expect(src).toMatch(/export const labelingTranslations\s*=\s*pgTable/);
+  });
+
+  it('AuditAction type in audit.ts includes the 6 label.* values', () => {
+    const src = readText('lib/audit.ts');
+    for (const v of LABELING_AUDIT_ACTIONS) {
+      expect(src).toContain(`'${v}'`);
+    }
+  });
+
+  it('permissions.ts adds 4 label.* PermissionActions (REQ-012 RBAC)', () => {
+    const src = readText('lib/auth/permissions.ts');
+    expect(src).toMatch(/'label\.create'/);
+    expect(src).toMatch(/'label\.view'/);
+    expect(src).toMatch(/'label\.approve'/);
+    expect(src).toMatch(/'label\.export'/);
+    // ra-lead only for approve/export; ra-member+ for create/view
+    expect(src).toMatch(/'label\.approve':\s*\{\s*minRole:\s*'ra-lead'/);
+    expect(src).toMatch(/'label\.export':\s*\{\s*minRole:\s*'ra-lead'/);
+    expect(src).toMatch(/'label\.create':\s*\{\s*minRole:\s*'ra-member'/);
+    expect(src).toMatch(/'label\.view':\s*\{\s*minRole:\s*'ra-member'/);
   });
 });


### PR DESCRIPTION
## 개요

SPEC-REGULA-LABELING-001 (#66) 구현 — **라벨링·IFU·클레임 검토 워크벤치**. 구조화 섹션(5종) + 관할권별 필수 표시사항 체크리스트(FDA/EU MDR/MFDS/PMDA/NMPA) + claim-citation 강제 + comparable/superiority 자동 경고 + 번역 의미 diff(MVP) + #54 change-control 연계 + export 게이트.

의존: TRACEABILITY #47 + CHANGE-CONTROL #54 머지로 해금.

## 구현
- **migration 0072**: workflow_type +1(labeling), audit_action +6, 테이블 5(labeling_documents/sections/claims/claim_citations/translations) + RLS org_id
- **lib/labeling**: section-builder · jurisdiction-checklist(REQ-002/011) · claim-validator(REQ-003/004 삼중 방어) · comparable-detector(REQ-005) · translation-diff(REQ-007 MVP) · export-gate(REQ-006) · change-control-link(REQ-008) · esubmit-bridge(REQ-009 stub) · traceability-integration
- **API 7종**: documents POST/GET, claims, checklist, translations, approve(REQ-012), export(REQ-006 게이트)
- **UI**: app/(app)/labeling 워크벤치(4탭) + components/labeling + Sidebar 조건부 네비
- **권한**: label.create/view/approve/export(ra-lead: approve/export)

## #54/#47 재사용 (L-002)
- **REQ-008**: approve 라우트에서 `linkLabelingChangeToChangeControl` → `assessChange({changeType:'labeling'})` 호출(CC #54 ChangeType에 'labeling' 이미 포함)
- **REQ-003 보강**: #47 traceability `upsertNode`로 claim 노드 + citation edge

## 보안 (expert-security 리뷰 — **CRITICAL/HIGH 없음**)
CC #54 결함 클래스(IDOR/stub 무력화/audit tx/인젝션/RLS) **재발 없음**:
- IDOR: orgId WHERE + assertPmsProjectAccess 이중 게이트
- audit 무결성: writeAudit tx 내
- citation 삼중 방어: app validateClaimCitations + expert_review_required + DB NOT NULL CHECK
- export 서버 사이드 게이트(unsupported 403 + label.export_blocked)
- RBAC: label.approve/export ra-lead 강제
- RLS: 5 테이블 USING + WITH CHECK

## AC-06 fix (evaluator 리뷰)
`linkLabelingChangeToChangeControl`가 데드 코드였던 것을 approve 라우트 live 호출로 전환(REQ-008 실제 동작). source-level 테스트로 회귀 방지.

## QA Evidence (오케스트레이터 직접 실행, L-007)
```
pnpm typecheck   → exit 0
pnpm biome check → exit 0
pnpm test        → 3652 passed | 7 skipped (exit 0)
pnpm build       → exit 0
```

## AC 상태
AC-01~06·08 ✅ · **AC-07 eSubmit DEFERRED**(#249, #65 의존)

## 회귀 (count 단언)
workflow_type 14→15 · audit_action 133→139 · PermissionAction 47→51 · enterprise-migrations 0072

## Follow-up
- #249 — eSubmit 패키지 라벨링 포함 활성화 (AC-07 / REQ-009, #65 의존)

Fixes #66