### PR TITLE
fix(cer): cer_persisted audit action 도입 — Part 11 provenance 분리 (#255)

### DIFF
--- a/app/api/ra/workflows/cer/route.ts
+++ b/app/api/ra/workflows/cer/route.ts
@@ -80,7 +80,7 @@ async function postCer(request: Request, session: AuthSession): Promise<Response
 
   // SPEC-REGULA-PMS-001 (AC-04 / REQ-PMS-004): persist to workflow_runs when a
   // projectId is present, so PMS report auto-linkage resolves in production.
-  // The workflow_runs insert and a cer_created audit (with persisted meta) ride
+  // The workflow_runs insert and a cer_persisted audit (with persisted meta) ride
   // the SAME db.transaction — 21 CFR Part 11 atomicity (H2 pattern): a failure
   // between the two rolls back both.
   // input_json is PII-safe: PubMed query text is NOT stored, only its length
@@ -117,7 +117,7 @@ async function postCer(request: Request, session: AuthSession): Promise<Response
       await writeAudit(
         {
           actor_id: session.user.id,
-          action: 'cer_created',
+          action: 'cer_persisted',
           resource_type: 'cer_run',
           resource_id: runId,
           meta_json: {

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -126,6 +126,9 @@ export type AuditAction =
   | 'cer_expert_approved'
   | 'cer_exported'
   | 'cer_literature_search'
+  // #255 — deliverable-persist row (in-tx with workflow_runs insert). Distinct from
+  // cer_created (run initiation) for unambiguous 21 CFR Part 11 provenance.
+  | 'cer_persisted'
   // SPEC-REGULA-IMPACT-001 — impact analysis events via 0034_impact_audit_actions.sql:
   | 'impact.assessment_created'
   | 'impact.critical_detected'

--- a/lib/cer/audit.ts
+++ b/lib/cer/audit.ts
@@ -13,20 +13,17 @@ import { writeAudit } from '../audit';
  * BEFORE any external work (PubMed search) so the initiation is recorded even
  * if later steps fail.
  *
- * Two-row note (21 CFR Part 11 provenance): when the CER run supplies a
- * projectId, the route (`app/api/ra/workflows/cer/route.ts`) ALSO emits a
- * second `cer_created` row with `meta_json: { workflowRunId, projectId,
- * persisted: true }` INSIDE the persist transaction. This is intentional and
- * NOT a bug:
- *   - Row 1 (this function, autocommit)  = run was INITIATED (REQ-CER-036).
- *   - Row 2 (route, in-tx)               = deliverable was PERSISTED (AC-04),
- *                                          atomic with the workflow_runs insert.
- * A reviewer reading two `cer_created` rows for one run should treat row 1 as
- * "initiation" and the row carrying `persisted: true` as "deliverable stored".
+ * Two-row provenance (21 CFR Part 11) — distinct actions, unambiguous semantics:
+ *   - Row 1 — `cer_created`  (this function, autocommit OUTSIDE any tx)
+ *                            = run was INITIATED (REQ-CER-036).
+ *   - Row 2 — `cer_persisted` (route, INSIDE the persist db.transaction)
+ *                            = deliverable was PERSISTED (AC-04), atomic with
+ *                              the workflow_runs insert. Emitted with
+ *                              `meta_json: { workflowRunId, projectId,
+ *                              persisted: true }` when the run supplies a
+ *                              projectId.
  * If only row 1 is present (persist tx rolled back), the run was initiated but
  * no deliverable was stored — the PMS linkage query will return null.
- * Follow-up option: split into a distinct `cer_persisted` action for unambiguous
- * semantics (requires an audit_action enum migration).
  */
 export async function auditCerCreated(actorId: string, cerRunId: string): Promise<void> {
   await writeAudit({

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -110,6 +110,8 @@ export const userDepartmentEnum = pgEnum('user_department', ['RA', 'Dev', 'Exec'
 // Phase 8 DocIngest: +6 via 0016_docingest_audit_actions.sql.
 // Phase 10 Radar: +3 via 0018_radar.sql. chat.query: +1. answer.refine: +1. Total: 48.
 // CER-001: +5 via 0037_cer_audit_actions.sql. Total: 53. (REQ-CER-036~040)
+// #255: +1 cer_persisted via 0074_cer_persisted_audit_action.sql (CER deliverable
+//        persist, REQ-CER-036 provenance split — separates initiation from persist).
 // VIGILANCE-001: +4 via 0042_vigilance_audit_actions.sql. Total: 57.
 // NOTE: auth.mfa_fail is NOT included (removed in v0.3.0 H-5).
 export const auditActionEnum = pgEnum('audit_action', [
@@ -175,6 +177,9 @@ export const auditActionEnum = pgEnum('audit_action', [
   'cer_expert_approved',
   'cer_exported',
   'cer_literature_search',
+  // #255 — added via 0074_cer_persisted_audit_action.sql: deliverable-persist row,
+  // atomic with workflow_runs insert (distinct from cer_created = run initiated).
+  'cer_persisted',
   // SPEC-REGULA-IMPACT-001 — added via 0034_impact_audit_actions.sql (3):
   'impact.assessment_created',
   'impact.critical_detected',

--- a/migrations/0074_cer_persisted_audit_action.sql
+++ b/migrations/0074_cer_persisted_audit_action.sql
@@ -1,0 +1,6 @@
+-- Migration: Add cer_persisted audit action (Issue #255, REQ-CER-036 provenance split)
+-- SPEC: SPEC-REGULA-CER-001 follow-up
+-- 21 CFR Part 11 compliance — splits the CER deliverable-persist audit row from
+-- the run-initiation row so `cer_created` unambiguously means "run initiated"
+-- and `cer_persisted` means "deliverable stored, atomic with workflow_runs insert".
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'cer_persisted';

--- a/tests/integration/capa.test.ts
+++ b/tests/integration/capa.test.ts
@@ -523,20 +523,20 @@ describe('Count regression (L-007 baseline)', () => {
     expect(vals).toContain("'complaint'");
   });
 
-  it('audit_action enum has 146 values (139 + 7 capa)', () => {
+  it('audit_action enum has 147 values (139 + 7 capa + 1 cer_persisted)', () => {
     const src = readText('lib/db/schema.ts');
     const match = src.match(
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(146);
+    expect(vals.length).toBe(147);
   });
 
-  it('AuditAction type has 146 values (sync with schema enum)', () => {
+  it('AuditAction type has 147 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(146);
+    expect(vals.length).toBe(147);
   });
 
   it('PermissionAction union has 33 members (26 + 7 capa)', () => {

--- a/tests/integration/cer-persist-roundtrip.test.ts
+++ b/tests/integration/cer-persist-roundtrip.test.ts
@@ -46,10 +46,12 @@ interface WorkflowRunRow {
 
 const workflowRunsStore: WorkflowRunRow[] = [];
 const projectsStore: Set<string> = new Set(); // projectIds belonging to ORG_A
-const auditRecords: Array<{ action: string; resource_id: string; tx?: unknown }> = [];
+const auditRecords: Array<{ action: string; resource_id: string; tx?: unknown; failed?: boolean }> =
+  [];
 
+let activeTransactionWorkflowRunsStore: WorkflowRunRow[] | null = null;
 let transactionShouldFail = false;
-let auditShouldFail = false;
+let auditShouldFailInTransaction = false;
 
 // ---------------------------------------------------------------------------
 // DB mock — the route inserts via db.transaction(tx => tx.insert(...).returning());
@@ -121,6 +123,10 @@ function getDrizzleTableName(table: unknown): string | undefined {
   return undefined;
 }
 
+function getWorkflowRunsWriteStore(): WorkflowRunRow[] {
+  return activeTransactionWorkflowRunsStore ?? workflowRunsStore;
+}
+
 // Explicit interface breaks the self-referential type cycle (dbMock.transaction
 // references dbMock via closure in its own initializer) without resorting to `any`.
 interface DbMock {
@@ -147,12 +153,13 @@ const dbMock: DbMock = {
             result_json: ((input.resultJson ?? input.result_json) as Row | null) ?? null,
             created_at: new Date(),
           };
-          workflowRunsStore.push(row);
+          getWorkflowRunsWriteStore().push(row);
         }
         return chain;
       }),
       returning: vi.fn(async () => {
-        const last = workflowRunsStore[workflowRunsStore.length - 1];
+        const writeStore = getWorkflowRunsWriteStore();
+        const last = writeStore[writeStore.length - 1];
         return [{ id: last?.id ?? crypto.randomUUID() }];
       }),
     };
@@ -166,7 +173,16 @@ const dbMock: DbMock = {
   }),
   transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
     if (transactionShouldFail) throw new Error('simulated transaction failure');
-    return fn(dbMock as unknown);
+    const previousTransactionStore = activeTransactionWorkflowRunsStore;
+    const stagedWorkflowRuns = [...workflowRunsStore];
+    activeTransactionWorkflowRunsStore = stagedWorkflowRuns;
+    try {
+      const result = await fn(dbMock as unknown);
+      workflowRunsStore.splice(0, workflowRunsStore.length, ...stagedWorkflowRuns);
+      return result;
+    } finally {
+      activeTransactionWorkflowRunsStore = previousTransactionStore;
+    }
   }),
 };
 
@@ -178,8 +194,14 @@ vi.mock('@/lib/db/client', () => ({ db: dbMock }));
 
 vi.mock('@/lib/audit', () => ({
   writeAudit: vi.fn(async (params: { action: string; resource_id: string }, tx?: unknown) => {
-    if (auditShouldFail) throw new Error('simulated audit failure');
-    auditRecords.push({ action: params.action, resource_id: params.resource_id, tx });
+    const shouldFail = auditShouldFailInTransaction && Boolean(tx);
+    auditRecords.push({
+      action: params.action,
+      resource_id: params.resource_id,
+      tx,
+      ...(shouldFail ? { failed: true } : {}),
+    });
+    if (shouldFail) throw new Error('simulated audit failure');
   }),
 }));
 
@@ -263,8 +285,9 @@ function resetStores() {
   workflowRunsStore.length = 0;
   projectsStore.clear();
   auditRecords.length = 0;
+  activeTransactionWorkflowRunsStore = null;
   transactionShouldFail = false;
-  auditShouldFail = false;
+  auditShouldFailInTransaction = false;
 }
 
 function buildCerBody(overrides: Partial<Record<string, unknown>> = {}): string {
@@ -325,8 +348,8 @@ describe('CER persist → PMS auto-linkage roundtrip (AC-04 / REQ-PMS-004)', () 
     expect(resultJson.deviceName).toBe('CardioStent-X');
     expect(resultJson.intendedUse).toBe('coronary artery stenting');
 
-    // 5. The cer_created audit rode the same transaction (H2 atomicity).
-    expect(auditRecords.some((a) => a.action === 'cer_created' && a.tx)).toBe(true);
+    // 5. The cer_persisted audit rode the same transaction (H2 atomicity).
+    expect(auditRecords.some((a) => a.action === 'cer_persisted' && a.tx)).toBe(true);
 
     // 6. REAL resolveCerLinkage against the SAME store → cerLinked true.
     const linkage = await resolveCerLinkage(PROJECT_ID, ORG_A, null);
@@ -364,14 +387,18 @@ describe('CER persist → PMS auto-linkage roundtrip (AC-04 / REQ-PMS-004)', () 
   });
 
   it('rolls back the workflow_runs insert when the audit write fails (H2 atomicity)', async () => {
-    auditShouldFail = true;
+    auditShouldFailInTransaction = true;
     const req = new Request('http://localhost/api/ra/workflows/cer', {
       method: 'POST',
       body: buildCerBody({ projectId: PROJECT_ID }),
     });
 
     await expect(postCer(req, {})).rejects.toBeDefined();
-    // Transaction rolled back → no row survives in the store.
+    expect(dbMock.transaction).toHaveBeenCalledTimes(1);
+    expect(auditRecords.some((a) => a.action === 'cer_created' && !a.tx)).toBe(true);
+    expect(auditRecords.some((a) => a.action === 'cer_literature_search' && !a.tx)).toBe(true);
+    expect(auditRecords.some((a) => a.action === 'cer_persisted' && a.tx && a.failed)).toBe(true);
+    // The in-transaction insert was staged, then rolled back after writeAudit failed.
     expect(workflowRunsStore).toHaveLength(0);
   });
 });

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(146); // +7 complaint/capa.* (CAPA-001, Issue #68)
+    expect(values).toHaveLength(147); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255)
   });
 
   it.each([

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -311,7 +311,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     const values = extractAuditActionEnumValues(src);
     const typeValues = extractAuditActionTypeValues(auditSrc);
     expect(values).toEqual(typeValues);
-    expect(values).toHaveLength(146); // +7 complaint/capa.* (CAPA-001, Issue #68)
+    expect(values).toHaveLength(147); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255)
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -367,7 +367,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(146); // +7 complaint/capa.* (CAPA-001, Issue #68)
+    expect(values).toHaveLength(147); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255)
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(
@@ -1239,5 +1239,38 @@ describe('Migration 0073: capa (SPEC-REGULA-CAPA-001)', () => {
     expect(src).toMatch(/'capa\.qms_sync':\s*\{\s*minRole:\s*'ra-lead'/);
     expect(src).toMatch(/'complaint\.create':\s*\{\s*minRole:\s*'ra-member'/);
     expect(src).toMatch(/'capa\.create':\s*\{\s*minRole:\s*'ra-member'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration 0074: cer_persisted audit action (SPEC-REGULA-CER-001, Issue #255)
+// Splits CER deliverable-persist provenance from run-initiation so cer_created
+// unambiguously means "run initiated" and cer_persisted means "deliverable
+// stored, atomic with workflow_runs insert" (21 CFR Part 11, REQ-CER-036).
+// ---------------------------------------------------------------------------
+describe('Migration 0074: cer_persisted audit action (Issue #255)', () => {
+  it('migration file 0074_cer_persisted_audit_action.sql exists', () => {
+    expect(fileExists('migrations/0074_cer_persisted_audit_action.sql')).toBe(true);
+  });
+
+  it('adds cer_persisted to audit_action enum', () => {
+    const sql = readText('migrations/0074_cer_persisted_audit_action.sql');
+    expect(sql).toMatch(/ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'cer_persisted'/);
+  });
+
+  it('has exactly 1 ALTER TYPE audit_action statement', () => {
+    const sql = readText('migrations/0074_cer_persisted_audit_action.sql');
+    const matches = sql.match(/ALTER TYPE audit_action ADD VALUE/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('auditActionEnum in schema.ts includes cer_persisted', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain("'cer_persisted'");
+  });
+
+  it('AuditAction type in audit.ts includes cer_persisted', () => {
+    const src = readText('lib/audit.ts');
+    expect(src).toContain("'cer_persisted'");
   });
 });


### PR DESCRIPTION
## 목적

CER 워크플로우의 persist-tx audit을 `cer_created`에서 `cer_persisted`로 분리 (#243 M-1 이관, #255).

기존: projectId 있는 CER run 당 `cer_created`가 **2행** 생성됨 (① 개시 autocommit / ② persist in-tx). Part 11 감사 리뷰 시 `meta_json.persisted` 파싱 전까지 구분 불가.

개선: persist-tx audit을 `cer_persisted`로 전환 → `cer_created`는 오직 REQ-CER-036 개시 1행만 의미. action 이름만으로 개시 vs 저장 구분.

## 변경 (9 files)

- `migrations/0074_cer_persisted_audit_action.sql` — `ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'cer_persisted'`
- `lib/db/schema.ts` — `auditActionEnum` pgEnum +1
- `lib/audit.ts` — `AuditAction` union +1
- `app/api/ra/workflows/cer/route.ts` — in-tx persist audit action 전환 (H2 원자성 유지, `tx` 인자 보존)
- `lib/cer/audit.ts` — two-row 주석 single-row 의미로 갱신 (follow-up 구현 완료)
- count 단언 146→147 (`capa.test.ts` 2곳, `audit.test.ts` 1곳) + `enterprise-migrations.test.ts` 0074 검증 +5
- `cer-persist-roundtrip.test.ts` — rollback 테스트 false-positive 수정 통합 (직전 세션 review-fix: mock tx staging + in-tx audit 실패 시나리오)

## QA evidence (게이트 직검, L-007)

| 게이트 | 결과 |
|---|---|
| `pnpm typecheck` | exit 0 |
| `pnpm biome check .` | exit 0 (1068 files) |
| 타깃 (audit/cer-persist/enterprise-migrations/capa) | 339 passed |
| `pnpm test` 전체 | **3754 passed | 7 skipped** (baseline 3749 +5 신규 enterprise-migrations, 회귀 0) |
| `pnpm build` | exit 0 |

## 보안 리뷰 (sync Phase 0.55, expert-security)

**Verdict: PASS** — CRITICAL/HIGH/MEDIUM 0. 명시 확인:
- (a) H2 원자성 유지 — in-tx audit의 `tx` 인자 존속, workflow_runs insert와 동일 tx
- (b) audit-emission 경로 손실 없음 — 3행(개시/문헌/persist) 그대로, persist 행만 action 변경
- (c) enum 3곳 동기화 (migration SQL / schema.ts / audit.ts) — 동일 literal, exhaustive switch/Zod 영향 없음
- (d) rollback 테스트 true positive — mock tx staging이 실제 Postgres rollback 시맨틱 모사 검증

LOW 2건(비차단 informational): PG ALTER TYPE 트랜잭션 풋건 메모 / count 단언 source-string 매칭(프로젝트 기존 패턴, 본 PR에선 구조적 검증 추가로 완화).

## 영향 축

schema(API x) · audit(enum +1, 시맨틱 분리) · migration(0074). RBAC/권한/인증/IDOR 미변경 (expert-security 확인). 하위호환: `cer_created` 값 유지, 기존 감사 로그 호환.

Fixes #255

🗿 MoAI <email@mo.ai.kr>