### PR TITLE
fix(traceability): export 에러 정보노출 마스킹 + matrix audit 세분화 (#241, #240)

### DIFF
--- a/app/api/traceability/[deliverableId]/export/route.ts
+++ b/app/api/traceability/[deliverableId]/export/route.ts
@@ -48,10 +48,13 @@ export const GET = withPermission('traceability.view', async (req, ctx, session)
   const result = await exportPacket(packet, format);
   if (!result.success || !result.content) {
     // L2 (#241): do NOT forward exporter internals to the client — log server-side only.
+    // MEDIUM-1 (#241): strip CRLF/control chars + cap length to prevent log-injection
+    // (exporter errors may carry DB-sourced chars); protects Part 11 log integrity.
+    const safeError = (result.error?.message ?? 'unknown').replace(/[\p{Cc}]/gu, ' ').slice(0, 500);
     console.error('[traceability.export] packet export failed', {
       deliverableId,
       format,
-      error: result.error?.message ?? 'unknown',
+      error: safeError,
     });
     return Response.json({ error: 'export_failed' }, { status: 502 });
   }

--- a/app/api/traceability/[deliverableId]/export/route.ts
+++ b/app/api/traceability/[deliverableId]/export/route.ts
@@ -47,10 +47,13 @@ export const GET = withPermission('traceability.view', async (req, ctx, session)
 
   const result = await exportPacket(packet, format);
   if (!result.success || !result.content) {
-    return Response.json(
-      { error: 'export_failed', detail: result.error?.message ?? 'unknown' },
-      { status: 502 },
-    );
+    // L2 (#241): do NOT forward exporter internals to the client — log server-side only.
+    console.error('[traceability.export] packet export failed', {
+      deliverableId,
+      format,
+      error: result.error?.message ?? 'unknown',
+    });
+    return Response.json({ error: 'export_failed' }, { status: 502 });
   }
 
   // 21 CFR Part 11 — every packet export is audited.

--- a/app/api/traceability/route.ts
+++ b/app/api/traceability/route.ts
@@ -43,7 +43,7 @@ export const GET = withPermission('traceability.view', async (req, _ctx, session
   // Keep the audit row minimal (non-PII) and scoped to the project.
   await writeAudit({
     actor_id: session.user.id,
-    action: 'traceability.matrix_viewed', // matrix-specific read audit (#240) — distinct from dashboard.view for Part 11 clarity
+    action: 'traceability.matrix_viewed', // matrix-specific read audit — distinct from dashboard.view for Part 11 clarity
     resource_type: 'traceability',
     resource_id: parsed.data.projectId ?? organizationId,
     meta_json: {

--- a/app/api/traceability/route.ts
+++ b/app/api/traceability/route.ts
@@ -43,7 +43,7 @@ export const GET = withPermission('traceability.view', async (req, _ctx, session
   // Keep the audit row minimal (non-PII) and scoped to the project.
   await writeAudit({
     actor_id: session.user.id,
-    action: 'dashboard.view', // reuse existing read audit action (no matrix-specific read action in scope)
+    action: 'traceability.matrix_viewed', // matrix-specific read audit (#240) — distinct from dashboard.view for Part 11 clarity
     resource_type: 'traceability',
     resource_id: parsed.data.projectId ?? organizationId,
     meta_json: {

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -222,10 +222,12 @@ export type AuditAction =
   | 'knowledge_gap_resolved'
   // SPEC-REGULA-TRACEABILITY-001 (Issue #47, REQ-TRACEABILITY-010).
   // Four edge lifecycle actions for the local evidence graph layer.
+  // #240: +1 matrix_viewed (0075) — distinct read audit for the evidence matrix.
   | 'traceability.edge_created'
   | 'traceability.edge_deleted'
   | 'traceability.packet_exported'
   | 'traceability.stale_propagated'
+  | 'traceability.matrix_viewed'
   // SPEC-REGULA-PMS-001 (Issue #53, REQ-PMS-010). EU MDR Article 83-86
   // PMS/PMCF state-transition audit trail (21 CFR Part 11).
   | 'pms.report_created'

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -262,6 +262,9 @@ export const auditActionEnum = pgEnum('audit_action', [
   'traceability.edge_deleted',
   'traceability.packet_exported',
   'traceability.stale_propagated',
+  // #240 — added via 0075_traceability_matrix_viewed_audit_action.sql: matrix
+  // view read audit (+1), distinct from dashboard.view for 21 CFR Part 11 clarity.
+  'traceability.matrix_viewed',
   // SPEC-REGULA-PMS-001 (Issue #53): EU MDR Article 83-86 PMS/PMCF audit trail.
   'pms.report_created',
   'pms.compliance_checked',

--- a/lib/traceability/__tests__/integration-real-pipeline.test.ts
+++ b/lib/traceability/__tests__/integration-real-pipeline.test.ts
@@ -181,6 +181,7 @@ describe('real-pipeline: audit action enum lock-step (AC-06)', () => {
     expect(values).toContain('traceability.edge_deleted');
     expect(values).toContain('traceability.packet_exported');
     expect(values).toContain('traceability.stale_propagated');
+    expect(values).toContain('traceability.matrix_viewed');
   });
 });
 

--- a/migrations/0075_traceability_matrix_viewed_audit_action.sql
+++ b/migrations/0075_traceability_matrix_viewed_audit_action.sql
@@ -1,0 +1,7 @@
+-- Migration: Add traceability.matrix_viewed audit action (Issue #240, REQ-TRACEABILITY-010)
+-- SPEC: SPEC-REGULA-TRACEABILITY-001
+-- 21 CFR Part 11 compliance — distinct read audit for the traceability matrix view
+-- (separate from dashboard.view) so FDA inspectors can unambiguously identify
+-- when a user viewed the per-project evidence matrix.
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'traceability.matrix_viewed';
+--> statement-breakpoint

--- a/tests/integration/capa.test.ts
+++ b/tests/integration/capa.test.ts
@@ -523,20 +523,20 @@ describe('Count regression (L-007 baseline)', () => {
     expect(vals).toContain("'complaint'");
   });
 
-  it('audit_action enum has 147 values (139 + 7 capa + 1 cer_persisted)', () => {
+  it('audit_action enum has 148 values (139 + 7 capa + 1 cer_persisted + 1 traceability.matrix_viewed)', () => {
     const src = readText('lib/db/schema.ts');
     const match = src.match(
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(147);
+    expect(vals.length).toBe(148);
   });
 
-  it('AuditAction type has 147 values (sync with schema enum)', () => {
+  it('AuditAction type has 148 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(147);
+    expect(vals.length).toBe(148);
   });
 
   it('PermissionAction union has 33 members (26 + 7 capa)', () => {

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(147); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255)
+    expect(values).toHaveLength(148); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255) +1 traceability.matrix_viewed (#240)
   });
 
   it.each([

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -311,7 +311,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     const values = extractAuditActionEnumValues(src);
     const typeValues = extractAuditActionTypeValues(auditSrc);
     expect(values).toEqual(typeValues);
-    expect(values).toHaveLength(147); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255)
+    expect(values).toHaveLength(148); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255) +1 traceability.matrix_viewed (#240)
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -367,7 +367,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(147); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255)
+    expect(values).toHaveLength(148); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255) +1 traceability.matrix_viewed (#240)
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(
@@ -1272,5 +1272,40 @@ describe('Migration 0074: cer_persisted audit action (Issue #255)', () => {
   it('AuditAction type in audit.ts includes cer_persisted', () => {
     const src = readText('lib/audit.ts');
     expect(src).toContain("'cer_persisted'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration 0075: traceability.matrix_viewed audit action (Issue #240)
+// SPEC-REGULA-TRACEABILITY-001 — distinct read audit for the evidence matrix
+// view (separate from dashboard.view) so 21 CFR Part 11 inspectors can
+// unambiguously identify when a user viewed the per-project traceability matrix.
+// ---------------------------------------------------------------------------
+describe('Migration 0075: traceability.matrix_viewed audit action (Issue #240)', () => {
+  it('migration file 0075_traceability_matrix_viewed_audit_action.sql exists', () => {
+    expect(fileExists('migrations/0075_traceability_matrix_viewed_audit_action.sql')).toBe(true);
+  });
+
+  it('adds traceability.matrix_viewed to audit_action enum', () => {
+    const sql = readText('migrations/0075_traceability_matrix_viewed_audit_action.sql');
+    expect(sql).toMatch(
+      /ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'traceability.matrix_viewed'/,
+    );
+  });
+
+  it('has exactly 1 ALTER TYPE audit_action statement', () => {
+    const sql = readText('migrations/0075_traceability_matrix_viewed_audit_action.sql');
+    const matches = sql.match(/ALTER TYPE audit_action ADD VALUE/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('auditActionEnum in schema.ts includes traceability.matrix_viewed', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain("'traceability.matrix_viewed'");
+  });
+
+  it('AuditAction type in audit.ts includes traceability.matrix_viewed', () => {
+    const src = readText('lib/audit.ts');
+    expect(src).toContain("'traceability.matrix_viewed'");
   });
 });


### PR DESCRIPTION
## 목적

Traceability 보안 그룹 2종 (SPEC-REGULA-TRACEABILITY-001 follow-up):
- **#241 (L2 info disclosure)**: 패킷 export 502 응답이 exporter 내부 에러 메시지를 클라이언트에 노출 → 제거
- **#240 (L1 audit clarity)**: matrix GET audit이 `dashboard.view`를 재사용 → `traceability.matrix_viewed` 신규 action으로 세분화

## 변경

**#241** — `app/api/traceability/[deliverableId]/export/route.ts`
- 502 응답에서 `detail`(exporter 에러 메시지) 제거, 클라이언트엔 generic `{ error: 'export_failed' }`
- 서버 `console.error` 로깅만 남김 + **MEDIUM-1**: 제어문자 살균(`\p{Cc}` Unicode escape) + 길이 cap 500 (Part 11 로그 무결성/log-injection 방어)

**#240** — 이슈 옵션 (a)
- `migrations/0075_traceability_matrix_viewed_audit_action.sql`: `ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'traceability.matrix_viewed'`
- `lib/db/schema.ts` + `lib/audit.ts`: enum/union +1
- `app/api/traceability/route.ts:46`: matrix GET audit `dashboard.view` → `traceability.matrix_viewed` (Part 11 감사 시 dashboard 조회와 구분, `meta_json.scope` 파싱 불필요)

audit_action 카운트 **147→148**, enterprise-migrations +1 (0075 검증 블록 5종). 권한(PermissionAction) 미변경 — `matrix_viewed`는 audit_action.

## QA evidence (게이트 직검, L-007)

| 게이트 | 결과 |
|---|---|
| `pnpm typecheck` | exit 0 |
| `pnpm biome check .` | exit 0 (1068 files) |
| `pnpm test` 전체 | **3759 passed | 7 skipped** (baseline 3754 +5 enterprise-migrations 0075, 회귀 0) |
| `pnpm build` | exit 0 |

## 보안 리뷰 (sync Phase 0.55, expert-security)

**Verdict: PASS-WITH-CONDITIONS → MEDIUM-1 fix 적용 후 게이트 재통과.**

- **MEDIUM-1** (fix 적용): export 에러 로그 제어문자 미살균 → `\p{Cc}` 살균 + 500 cap
- **LOW-1** (비차단, 기존 동작 비회귀): matrix audit이 `buildMatrix` throw 시 미기록 — 본 PR 이전과 동일(audit 배치 미변경). 별도 follow-up 가능
- **LOW-2** (informational): projectId 미지정 시 resource_id=orgId (기존 의도, consumer 영향 없음)

명시 확인: (a) traceability 라우트 전수 grep — 클라이언트 향 내부 에러 노출 경로 잔존 없음, (b) `dashboard.view`+`scope:matrix` audit consumer 부재 → matrix_viewed 전환 파급 0, (c) enum 3곳 동기화, (d) 로그 PII/secret-free, (e) auth/IDOR 미변경(`traceability.view` + org 스코프), (f) migration 안전(idempotent ADD VALUE).

> 참고 (out-of-scope): `app/api/ra/risk/*`, `app/api/ra/traceability/*` BFF 라우트 일부가 `{ error: err.message }` 직접 반환 — 본 PR 외 별개 영역. 추후 스윕 이슈 권장.

Fixes #241
Fixes #240

🗿 MoAI <email@mo.ai.kr>