### PR TITLE
feat(corpus-license): SPEC-REGULA-CORPUS-LICENSE-001 코퍼스 라이선스·사용권 관리 (#72)

### DIFF
--- a/app/api/change-control/[assessmentId]/export/route.ts
+++ b/app/api/change-control/[assessmentId]/export/route.ts
@@ -112,6 +112,58 @@ async function postExport(
 
   const riskLinks = await fetchLinkedRiskItems(assessmentId, organizationId);
 
+  // REQ-CORPUSLIC-011 — export-rights gate. Every cited corpus source must be
+  // licensed for export; blocked sources abort the export with 403 + audit.
+  // @MX:NOTE citations[].id is the corpus sourceId when the verdict cited RAG
+  // results; non-corpus citations (manual) fall outside the license scope and
+  // are skipped (no UUID → fetchPermittedUse returns null → no false block).
+  const citedSourceIds = Array.from(
+    new Set(
+      verdictsWithCitations
+        .flatMap((v) => v.citations.map((c) => c.id))
+        .filter((s): s is string => typeof s === 'string' && s.length > 0),
+    ),
+  );
+  const { verifyExportRights, auditExportBlockedBatch } = await import(
+    '@/lib/corpus-license/export-gate'
+  );
+  const exportGate = await verifyExportRights({ sourceIds: citedSourceIds, orgId: organizationId });
+  if (!exportGate.allowed) {
+    await auditExportBlockedBatch({
+      userId: session.user.id,
+      blockedSources: exportGate.blockedSources,
+    });
+    await writeAudit({
+      actor_id: session.user.id,
+      action: 'corpus.export_blocked',
+      resource_type: 'changeAssessment',
+      resource_id: assessmentId,
+      meta_json: {
+        blockedCount: exportGate.blockedSources.length,
+        reasons: exportGate.blockedSources.map((b) => b.reason),
+      },
+    });
+    return Response.json(
+      {
+        error: 'export_license_blocked',
+        blockedCount: exportGate.blockedSources.length,
+      },
+      { status: 403 },
+    );
+  }
+
+  // REQ-CORPUSLIC-007/011 — attach per-source usage-restriction notices to the
+  // exported payload so the PDF/JSON consumer sees redistribution restrictions.
+  let usageNotices: Array<{ sourceId: string; notice: string }> = [];
+  if (citedSourceIds.length > 0) {
+    try {
+      const { generateUsageNotice } = await import('@/lib/corpus-license/usage-notice');
+      usageNotices = await generateUsageNotice(citedSourceIds, organizationId);
+    } catch {
+      // License metadata unavailable — export proceeds without notices.
+    }
+  }
+
   try {
     await db.transaction(async (tx) => {
       await writeAudit(
@@ -152,6 +204,7 @@ async function postExport(
     try {
       pdfBuffer = await exportChangeAssessmentToPdf(assessment, verdictsWithCitations, riskLinks, {
         includeDraftWatermark,
+        usageNotices,
       });
     } catch (err) {
       console.error('change PDF render failed', err);
@@ -176,6 +229,7 @@ async function postExport(
       assessment,
       verdicts: verdictsWithCitations,
       riskLinks,
+      usageNotices,
       exportedAt: new Date().toISOString(),
       format: 'pdf-json',
     },

--- a/app/api/corpus-license/entitlement/route.ts
+++ b/app/api/corpus-license/entitlement/route.ts
@@ -1,0 +1,46 @@
+// @MX:NOTE [AUTO] POST /api/corpus-license/entitlement — grant/revoke entitlement.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-008, REQ-CORPUSLIC-012)
+import { withPermission } from '@/lib/auth/with-permission';
+import { assertSourceLicenseInOrg } from '@/lib/corpus-license/access';
+import { grantEntitlement, revokeEntitlement } from '@/lib/corpus-license/entitlement';
+import { entitlementInputSchema } from '@/lib/corpus-license/types';
+
+export const POST = withPermission('corpuslicense.manage', async (req, _ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+  const parsed = entitlementInputSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'validation_failed', issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
+
+  // REQ-CORPUSLIC-012 IDOR: source_license must belong to caller's org.
+  const lic = await assertSourceLicenseInOrg({
+    sourceLicenseId: body.sourceLicenseId,
+    orgId: organizationId,
+    userId: session.user.id,
+  });
+  if (!lic) {
+    return Response.json({ error: 'source_license_not_found' }, { status: 404 });
+  }
+
+  if (body.action === 'grant') {
+    const res = await grantEntitlement({
+      sourceLicenseId: body.sourceLicenseId,
+      orgId: organizationId,
+      grantedBy: session.user.id,
+    });
+    return Response.json(res, { status: 201 });
+  }
+  const res = await revokeEntitlement({
+    sourceLicenseId: body.sourceLicenseId,
+    orgId: organizationId,
+    revokedBy: session.user.id,
+  });
+  return Response.json(res);
+});

--- a/app/api/corpus-license/ingestion-gate/route.ts
+++ b/app/api/corpus-license/ingestion-gate/route.ts
@@ -1,0 +1,33 @@
+// @MX:NOTE [AUTO] POST /api/corpus-license/ingestion-gate — pre-ingest license check.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-002, REQ-CORPUSLIC-003, REQ-CORPUSLIC-004)
+//
+// Primary call site for assertIngestionLicensed (REQ-002 gate). The lib/ingest/
+// pipeline calls this endpoint (or the lib function directly) before embedding.
+import { withPermission } from '@/lib/auth/with-permission';
+import { assertIngestionLicensed } from '@/lib/corpus-license/license-gate';
+import { ingestionGateInputSchema } from '@/lib/corpus-license/types';
+
+export const POST = withPermission('corpuslicense.view', async (req, _ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+  const parsed = ingestionGateInputSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'validation_failed', issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
+
+  const result = await assertIngestionLicensed({
+    sourceId: body.sourceId,
+    orgId: organizationId,
+    userId: session.user.id,
+    wantsFullText: body.wantsFullText,
+  });
+
+  // REQ-003/004: blocked ingestion returns 403; allowed returns 200.
+  return Response.json(result, { status: result.allowed ? 200 : 403 });
+});

--- a/app/api/corpus-license/ingestion-gate/route.ts
+++ b/app/api/corpus-license/ingestion-gate/route.ts
@@ -1,8 +1,13 @@
-// @MX:NOTE [AUTO] POST /api/corpus-license/ingestion-gate — pre-ingest license check.
+// @MX:NOTE [AUTO] POST /api/corpus-license/ingestion-gate — manual pre-ingest license check.
 // @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-002, REQ-CORPUSLIC-003, REQ-CORPUSLIC-004)
 //
-// Primary call site for assertIngestionLicensed (REQ-002 gate). The lib/ingest/
-// pipeline calls this endpoint (or the lib function directly) before embedding.
+// Manual pre-ingest check endpoint: an admin UI (or external caller) probes
+// whether a sourceId would pass the license gate BEFORE starting an ingest.
+// The production ingest paths call the lib function (`assertIngestionLicensed`)
+// directly — the upload route (app/api/ra/admin/documents/upload/route.ts) and
+// the Inngest worker (lib/inngest/docingest/upload-processed.ts) both import
+// the gate rather than HTTP-calling this route. This endpoint exists for
+// ad-hoc/admin verification and is not on the hot ingest path.
 import { withPermission } from '@/lib/auth/with-permission';
 import { assertIngestionLicensed } from '@/lib/corpus-license/license-gate';
 import { ingestionGateInputSchema } from '@/lib/corpus-license/types';

--- a/app/api/corpus-license/source-license/route.ts
+++ b/app/api/corpus-license/source-license/route.ts
@@ -1,0 +1,139 @@
+// @MX:NOTE [AUTO] POST/GET/PUT /api/corpus-license/source-license — license metadata CRUD.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-001, REQ-CORPUSLIC-010, REQ-CORPUSLIC-012)
+import { withPermission } from '@/lib/auth/with-permission';
+import { assertSourceInOrg } from '@/lib/corpus-license/access';
+import { auditCorpusAccessDenied, auditLicenseSet } from '@/lib/corpus-license/audit';
+import { sourceLicenseInputSchema } from '@/lib/corpus-license/types';
+import { db } from '@/lib/db/client';
+import { sourceLicense } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+// GET — list licenses for the caller's org. REQ-CORPUSLIC-001.
+export const GET = withPermission('corpuslicense.view', async (_req, _ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+  const rows = await db.select().from(sourceLicense).where(eq(sourceLicense.orgId, organizationId));
+  return Response.json({ licenses: rows });
+});
+
+// POST — create license metadata. REQ-CORPUSLIC-001/010.
+export const POST = withPermission('corpuslicense.manage', async (req, _ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+  const parsed = sourceLicenseInputSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'validation_failed', issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
+
+  // REQ-CORPUSLIC-012 IDOR: source must belong to the caller's org.
+  const ok = await assertSourceInOrg({
+    sourceId: body.sourceId,
+    orgId: organizationId,
+    userId: session.user.id,
+  });
+  if (!ok) {
+    return Response.json({ error: 'source_not_found' }, { status: 404 });
+  }
+
+  return db.transaction(async (tx) => {
+    const inserted = await tx
+      .insert(sourceLicense)
+      .values({
+        orgId: organizationId,
+        sourceId: body.sourceId,
+        licenseType: body.licenseType,
+        entitlementRef: body.entitlementRef ?? null,
+        permittedUse: body.permittedUse,
+        fullTextAllowed: body.fullTextAllowed,
+        abstractOnly: body.abstractOnly,
+        confidentialityLevel: body.confidentialityLevel,
+        expiryDate: body.expiryDate ?? null,
+        createdBy: session.user.id,
+      })
+      .returning({ id: sourceLicense.id });
+
+    const created = inserted[0];
+    if (!created) throw new Error('source_license_insert_failed');
+
+    await auditLicenseSet(
+      {
+        userId: session.user.id,
+        sourceLicenseId: created.id,
+        sourceId: body.sourceId,
+        licenseType: body.licenseType,
+        expiryDate: body.expiryDate ?? null,
+      },
+      tx,
+    );
+    return Response.json({ id: created.id }, { status: 201 });
+  });
+});
+
+// PUT — update license metadata. REQ-CORPUSLIC-010.
+export const PUT = withPermission('corpuslicense.manage', async (req, _ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+  const parsed = sourceLicenseInputSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'validation_failed', issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
+
+  // IDOR: find existing license scoped to org. Cross-org → 404 + audit.
+  const [existing] = await db
+    .select({ id: sourceLicense.id, orgId: sourceLicense.orgId, sourceId: sourceLicense.sourceId })
+    .from(sourceLicense)
+    .where(eq(sourceLicense.sourceId, body.sourceId))
+    .limit(1);
+  if (!existing || existing.orgId !== organizationId) {
+    if (existing && existing.orgId !== organizationId) {
+      await auditCorpusAccessDenied({
+        userId: session.user.id,
+        sourceId: body.sourceId,
+        reason: 'source_license_cross_org',
+      });
+    }
+    return Response.json({ error: 'source_license_not_found' }, { status: 404 });
+  }
+
+  return db.transaction(async (tx) => {
+    await tx
+      .update(sourceLicense)
+      .set({
+        licenseType: body.licenseType,
+        entitlementRef: body.entitlementRef ?? null,
+        permittedUse: body.permittedUse,
+        fullTextAllowed: body.fullTextAllowed,
+        abstractOnly: body.abstractOnly,
+        confidentialityLevel: body.confidentialityLevel,
+        expiryDate: body.expiryDate ?? null,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(sourceLicense.id, existing.id), eq(sourceLicense.orgId, organizationId)));
+
+    await auditLicenseSet(
+      {
+        userId: session.user.id,
+        sourceLicenseId: existing.id,
+        sourceId: existing.sourceId,
+        licenseType: body.licenseType,
+        expiryDate: body.expiryDate ?? null,
+      },
+      tx,
+    );
+    return Response.json({ id: existing.id });
+  });
+});

--- a/app/api/pms/inputs/__tests__/route.test.ts
+++ b/app/api/pms/inputs/__tests__/route.test.ts
@@ -80,7 +80,8 @@ describe('PMS report route — citation + CER linkage + audit (REQ-PMS-002/004/0
 
   it('calls executePmsReport with a retriever (citation grounding path)', () => {
     expect(src).toMatch(/executePmsReport/);
-    expect(src).toMatch(/retrieveFn: retrievePmsReportSources/);
+    // C-3: retriever is now a factory that captures orgId for license filtering.
+    expect(src).toMatch(/retrieveFn: makePmsRetriever\(organizationId\)/);
     expect(src).toMatch(/hybridSearch/);
   });
 

--- a/app/api/ra/admin/documents/upload/route.ts
+++ b/app/api/ra/admin/documents/upload/route.ts
@@ -60,6 +60,7 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
   const file = form.get('file');
   const docClassRaw = form.get('docClass');
   const titleOverride = form.get('title');
+  const existingSourceIdRaw = form.get('sourceId');
 
   if (!(file instanceof File)) {
     return Response.json({ error: 'file_missing' }, { status: 400 });
@@ -70,6 +71,33 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
     return Response.json({ error: 'docClass_invalid' }, { status: 400 });
   }
   const docClass = parsedClass.data;
+
+  // REQ-CORPUSLIC-002 — pre-ingest license gate. When an existing sourceId is
+  // supplied (admin pre-registered the source + license), assert the license
+  // is valid BEFORE extract/chunk/embed. Primary wired call site for
+  // assertIngestionLicensed alongside the ingestion-gate API.
+  // @MX:TODO enforce gate for the new-source creation path (currently only the
+  // existing-source re-ingest path is gated; new sources require a follow-up
+  // to chain license creation + ingest in one transaction).
+  const existingSourceId =
+    typeof existingSourceIdRaw === 'string' && existingSourceIdRaw.trim().length > 0
+      ? existingSourceIdRaw.trim()
+      : null;
+  if (existingSourceId && session.user.organizationId) {
+    const { assertIngestionLicensed } = await import('@/lib/corpus-license/license-gate');
+    const gate = await assertIngestionLicensed({
+      sourceId: existingSourceId,
+      orgId: session.user.organizationId,
+      userId: session.user.id,
+      wantsFullText: true,
+    });
+    if (!gate.allowed) {
+      return Response.json(
+        { error: 'ingestion_license_blocked', reason: gate.reason, licenseType: gate.licenseType },
+        { status: 403 },
+      );
+    }
+  }
 
   // ---------------------------------------------------------------------
   // 2. REQ-QUAL-019 — input validation (size + MIME).

--- a/app/api/ra/admin/documents/upload/route.ts
+++ b/app/api/ra/admin/documents/upload/route.ts
@@ -19,7 +19,7 @@
 import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
 import { db } from '@/lib/db/client';
-import { sourceSections, sources } from '@/lib/db/schema';
+import { sourceSections } from '@/lib/db/schema';
 import { chunk } from '@/lib/ingest/chunkers';
 import { DocClass } from '@/lib/ingest/doc-class';
 import { embedChunks } from '@/lib/ingest/embed';
@@ -59,7 +59,6 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
 
   const file = form.get('file');
   const docClassRaw = form.get('docClass');
-  const titleOverride = form.get('title');
   const existingSourceIdRaw = form.get('sourceId');
 
   if (!(file instanceof File)) {
@@ -72,18 +71,40 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
   }
   const docClass = parsedClass.data;
 
-  // REQ-CORPUSLIC-002 — pre-ingest license gate. When an existing sourceId is
-  // supplied (admin pre-registered the source + license), assert the license
-  // is valid BEFORE extract/chunk/embed. Primary wired call site for
-  // assertIngestionLicensed alongside the ingestion-gate API.
-  // @MX:TODO enforce gate for the new-source creation path (currently only the
-  // existing-source re-ingest path is gated; new sources require a follow-up
-  // to chain license creation + ingest in one transaction).
+  // REQ-CORPUSLIC-002/003 — pre-ingest license gate. A source MUST have an
+  // active license before ingest (SPEC intent: "ingestion 이전에 사용권 검증
+  // gate"). New-source creation + ingest in one ungated flow is forbidden —
+  // unlicensed paid-standard content would enter the corpus. Therefore an
+  // existing sourceId with an active license is REQUIRED; uploads without one
+  // are rejected with 400 + audited as `corpus.ingestion_blocked`.
+  // Primary wired call site for assertIngestionLicensed.
   const existingSourceId =
     typeof existingSourceIdRaw === 'string' && existingSourceIdRaw.trim().length > 0
       ? existingSourceIdRaw.trim()
       : null;
-  if (existingSourceId && session.user.organizationId) {
+  if (!existingSourceId) {
+    // REQ-003: no pre-registered licensed source → block ingest at the gate.
+    await writeAudit({
+      action: 'corpus.ingestion_blocked',
+      actor_id: session.user.id,
+      resource_type: 'source',
+      resource_id: 'pending',
+      meta_json: {
+        reason: 'no_licensed_source',
+        docClass,
+        fileName: redactRegexPii(file.name).text,
+      },
+    });
+    return Response.json(
+      {
+        error: 'no_licensed_source',
+        reason:
+          'sourceId with active license required before ingestion — register license via POST /api/corpus-license/source-license first',
+      },
+      { status: 400 },
+    );
+  }
+  if (session.user.organizationId) {
     const { assertIngestionLicensed } = await import('@/lib/corpus-license/license-gate');
     const gate = await assertIngestionLicensed({
       sourceId: existingSourceId,
@@ -177,33 +198,15 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
   }
 
   // ---------------------------------------------------------------------
-  // 5. Persist sources + source_sections in a single transaction so a
-  //    partial failure cannot leave orphan sources rows.
+  // 5. Persist source_sections against the PRE-REGISTERED, LICENSED source
+  //    (existingSourceId). The upload route no longer creates new source
+  //    rows — SPEC REQ-003 requires a licensed source to exist before ingest.
+  //    The title override (if any) updates the existing source row.
   // ---------------------------------------------------------------------
-  const title =
-    typeof titleOverride === 'string' && titleOverride.trim().length > 0
-      ? redactRegexPii(titleOverride.trim()).text
-      : redactRegexPii(file.name).text;
-  const filenameExt = file.name.includes('.') ? file.name.split('.').pop()?.slice(0, 32) : null;
-
   const result: UploadSuccess = await db.transaction(async (tx) => {
-    const inserted = await tx
-      .insert(sources)
-      .values({
-        organizationId: session.user.organizationId ?? null,
-        orgLabel: 'Internal',
-        title,
-        type: 'Internal',
-        region: null,
-        url: null,
-      })
-      .returning({ id: sources.id });
-
-    const row = inserted[0];
-    if (!row) throw new Error('source_insert_failed');
-
+    // Attach sections to the pre-registered source (no new sources row).
     const sectionRows = chunks.map((c, idx) => ({
-      sourceId: row.id,
+      sourceId: existingSourceId,
       anchor: `${docClass}-${idx + 1}`,
       heading: typeof c.metadata.sectionPath === 'string' ? c.metadata.sectionPath : null,
       text: c.text,
@@ -212,7 +215,7 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
 
     await tx.insert(sourceSections).values(sectionRows);
 
-    return { sourceId: row.id, sectionCount: sectionRows.length };
+    return { sourceId: existingSourceId, sectionCount: sectionRows.length };
   });
 
   // ---------------------------------------------------------------------
@@ -229,7 +232,9 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
       mimeType,
       sizeBytes: file.size,
       sectionCount: result.sectionCount,
-      filenameExt,
+      filenameExt: file.name.includes('.')
+        ? (file.name.split('.').pop()?.slice(0, 32) ?? null)
+        : null,
       filenameLength: file.name.length,
     },
   });

--- a/app/api/ra/sources/[id]/route.ts
+++ b/app/api/ra/sources/[id]/route.ts
@@ -105,6 +105,29 @@ export const GET = withPermission('conversation.view', async (_req, ctx, session
     .where(eq(sourceSections.sourceId, id))
     .orderBy(sourceSections.anchor);
 
+  // REQ-CORPUSLIC-008/H-4 — redact full text for expired/revoked-entitlement
+  // sources so the admin API cannot leak revoked content. The source row stays
+  // visible (heading/anchor) but `text` is blanked when the license is inactive.
+  // Defense-in-depth: license-db hiccup → fall through with full text (RLS still
+  // isolates; the retriever path already filters via filterExpiredSources).
+  let licensedTextSections = sections;
+  if (session.user.organizationId && sections.length > 0) {
+    try {
+      const { filterExpiredSources } = await import(
+        '../../../../../lib/corpus-license/expiry-checker'
+      );
+      const eligible = await filterExpiredSources([id], session.user.organizationId);
+      if (!eligible.has(id)) {
+        licensedTextSections = sections.map((s) => ({
+          ...s,
+          text: '[revoked or expired license — full text redacted]',
+        }));
+      }
+    } catch {
+      // License metadata unavailable — leave full text intact (advisory filter).
+    }
+  }
+
   return Response.json({
     id: source.id,
     orgLabel: source.orgLabel,
@@ -112,6 +135,6 @@ export const GET = withPermission('conversation.view', async (_req, ctx, session
     year: source.year,
     type: source.type,
     url: source.url,
-    sections,
+    sections: licensedTextSections,
   });
 });

--- a/app/api/traceability/[deliverableId]/export/route.ts
+++ b/app/api/traceability/[deliverableId]/export/route.ts
@@ -45,7 +45,49 @@ export const GET = withPermission('traceability.view', async (req, ctx, session)
     return Response.json({ error: 'not_found' }, { status: 404 });
   }
 
-  const result = await exportPacket(packet, format);
+  // REQ-CORPUSLIC-007/011 — collect corpus sourceIds referenced by the packet
+  // (stale_source issues may reference source nodes). Run the export-rights
+  // gate; if any cited source is not export-entitled, abort with 403 + audit.
+  // Today the packet tree references deliverables (CER/DHF/risk), not corpus
+  // sources, so this is typically a no-op — but the gate is wired so a future
+  // source-cited packet cannot leak unentitled content.
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const packetSourceIds = Array.from(
+    new Set(packet.issues.map((i) => i.detail).flatMap((d) => (UUID_RE.test(d) ? [d] : []))),
+  );
+
+  if (packetSourceIds.length > 0) {
+    const { verifyExportRights, auditExportBlockedBatch } = await import(
+      '@/lib/corpus-license/export-gate'
+    );
+    const exportGate = await verifyExportRights({
+      sourceIds: packetSourceIds,
+      orgId: organizationId,
+    });
+    if (!exportGate.allowed) {
+      await auditExportBlockedBatch({
+        userId: session.user.id,
+        blockedSources: exportGate.blockedSources,
+      });
+      return Response.json(
+        { error: 'export_license_blocked', blockedCount: exportGate.blockedSources.length },
+        { status: 403 },
+      );
+    }
+  }
+
+  // REQ-CORPUSLIC-007 — usage-restriction notices for any cited corpus sources.
+  let usageNotices: Array<{ sourceId: string; notice: string }> = [];
+  if (packetSourceIds.length > 0) {
+    try {
+      const { generateUsageNotice } = await import('@/lib/corpus-license/usage-notice');
+      usageNotices = await generateUsageNotice(packetSourceIds, organizationId);
+    } catch {
+      // License metadata unavailable — export proceeds without notices.
+    }
+  }
+
+  const result = await exportPacket(packet, format, usageNotices);
   if (!result.success || !result.content) {
     // L2 (#241): do NOT forward exporter internals to the client — log server-side only.
     // MEDIUM-1 (#241): strip CRLF/control chars + cap length to prevent log-injection

--- a/app/api/workflows/pms-report/run/route.ts
+++ b/app/api/workflows/pms-report/run/route.ts
@@ -30,13 +30,17 @@ const PmsReportRunSchema = z.object({
     .default(null),
 });
 
-const retrievePmsReportSources: PmsRetriever = async (query) => {
-  const chunks = await hybridSearch(query, 'all', 8, 'regs');
-  return chunks.map((chunk) => ({
-    source: [chunk.orgLabel, chunk.title].filter(Boolean).join(' - '),
-    section: chunk.anchor || chunk.title,
-  }));
-};
+// REQ-CORPUSLIC-008 — factory captures orgId so filterExpiredSources fires
+// inside hybridSearch on the PMS report retrieval path too.
+function makePmsRetriever(orgId: string): PmsRetriever {
+  return async (query) => {
+    const chunks = await hybridSearch(query, 'all', 8, 'regs', orgId);
+    return chunks.map((chunk) => ({
+      source: [chunk.orgLabel, chunk.title].filter(Boolean).join(' - '),
+      section: chunk.anchor || chunk.title,
+    }));
+  };
+}
 
 function createRouteFetch(request: Request): PmsFetchFn {
   const origin = new URL(request.url).origin;
@@ -87,7 +91,7 @@ async function postRun(
         deviceClass: body.deviceClass,
       },
       {
-        retrieveFn: retrievePmsReportSources,
+        retrieveFn: makePmsRetriever(organizationId),
         fetchFn: createRouteFetch(request),
         cerData,
       },

--- a/lib/ai/consult.ts
+++ b/lib/ai/consult.ts
@@ -397,6 +397,28 @@ export async function* consult(
     } catch {
       // License metadata unavailable — answer proceeds without notices.
     }
+
+    // REQ-CORPUSLIC-013 — audit when an abstract-only source's full text is
+    // blocked at answer time (the consult path serves full section text by
+    // default; abstract-only licenses forbid that). Primary call site for
+    // auditAbstractOnlyEnforced. Swallowed: license-db hiccup never breaks answer.
+    try {
+      const { auditAbstractOnlyEnforced } = await import('@/lib/corpus-license/audit');
+      const { isFullTextBlocked, fetchPermittedUse } = await import(
+        '@/lib/corpus-license/permitted-use'
+      );
+      const actorId = session.user?.id;
+      if (actorId) {
+        for (const item of sourceItems) {
+          const policy = await fetchPermittedUse(item.id, orgIdForNotice);
+          if (policy?.abstractOnly && isFullTextBlocked(policy)) {
+            await auditAbstractOnlyEnforced({ userId: actorId, sourceId: item.id });
+          }
+        }
+      }
+    } catch {
+      // License metadata unavailable — skip audit (advisory).
+    }
   }
 
   yield* emit({ type: 'sources', items: allSourceItems });

--- a/lib/ai/consult.ts
+++ b/lib/ai/consult.ts
@@ -378,6 +378,27 @@ export async function* consult(
   const externalCitations = await externalCitationsPromise;
   const allSourceItems = [...sourceItems, ...externalCitations];
 
+  // REQ-CORPUSLIC-007/011 — attach per-source usage-restriction notices.
+  // Primary call site for generateUsageNotice. Errors are swallowed so a
+  // license-db hiccup never breaks the answer path (the notice is advisory).
+  const orgIdForNotice = (session.user as { organizationId?: string | null }).organizationId;
+  if (orgIdForNotice && sourceItems.length > 0) {
+    try {
+      const { generateUsageNotice } = await import('@/lib/corpus-license/usage-notice');
+      const notices = await generateUsageNotice(
+        sourceItems.map((s) => s.id),
+        orgIdForNotice,
+      );
+      const noticeMap = new Map(notices.map((n) => [n.sourceId, n.notice]));
+      for (const item of allSourceItems) {
+        const text = noticeMap.get(item.id);
+        if (text) item.usageNotice = text;
+      }
+    } catch {
+      // License metadata unavailable — answer proceeds without notices.
+    }
+  }
+
   yield* emit({ type: 'sources', items: allSourceItems });
 
   // ---- Phase C: structured blocks (REQ-STRUCT-002, REQ-STRUCT-003) ----

--- a/lib/ai/retrievers/eu-mdr.ts
+++ b/lib/ai/retrievers/eu-mdr.ts
@@ -14,7 +14,8 @@ export class EuMdrRetriever implements IRetriever {
 
   async retrieve(query: string, opts: RetrieverOptions = {}): Promise<RetrievalResult[]> {
     const limit = opts.limit ?? 10;
-    const chunks = await hybridSearch(query, 'eu-mdr' as never, limit, 'all');
+    // REQ-CORPUSLIC-008 — thread orgId so filterExpiredSources fires inside hybridSearch.
+    const chunks = await hybridSearch(query, 'eu-mdr' as never, limit, 'all', opts.orgId);
     return chunks.map(toRetrievalResult);
   }
 }

--- a/lib/ai/retrievers/fda.ts
+++ b/lib/ai/retrievers/fda.ts
@@ -10,8 +10,9 @@ export async function searchFDACorpus(
   query: string,
   k: number,
   sourceFilter: 'all' | 'regs' | 'internal',
+  orgId?: string,
 ): Promise<RetrievedChunk[]> {
-  return hybridSearch(query, 'fda', k, sourceFilter);
+  return hybridSearch(query, 'fda', k, sourceFilter, orgId);
 }
 
 /**
@@ -23,7 +24,8 @@ export class FdaRetriever implements IRetriever {
 
   async retrieve(query: string, opts: RetrieverOptions = {}): Promise<RetrievalResult[]> {
     const limit = opts.limit ?? 10;
-    const chunks = await hybridSearch(query, 'fda', limit, 'all');
+    // REQ-CORPUSLIC-008 — thread orgId so filterExpiredSources fires inside hybridSearch.
+    const chunks = await hybridSearch(query, 'fda', limit, 'all', opts.orgId);
     return chunks.map(toRetrievalResult);
   }
 }

--- a/lib/ai/retrievers/hybrid-search.ts
+++ b/lib/ai/retrievers/hybrid-search.ts
@@ -55,6 +55,7 @@ export async function hybridSearch(
   _corpus: 'fda' | 'all',
   k: number,
   sourceFilter: 'all' | 'regs' | 'internal',
+  orgId?: string,
 ): Promise<RetrievedChunk[]> {
   // 1. Attempt embedding — may fail when OPENAI_API_KEY is unavailable.
   // @MX:NOTE Cast bridges v3 provider → v1 SDK type. See lib/ai/intent.ts.
@@ -181,5 +182,24 @@ export async function hybridSearch(
   });
 
   chunks.sort((a, b) => b.combined_score - a.combined_score);
+
+  // REQ-CORPUSLIC-008 — exclude expired/revoked-entitlement sources from search.
+  // Primary call site for filterExpiredSources. Only applied when orgId is
+  // supplied (callers without session context fall through — they are
+  // non-RAG paths like the PMS report builder). Defense-in-depth: a license-db
+  // hiccup never blocks retrieval (RLS still enforces org isolation).
+  // @MX:TODO wire orgId through fda/eu-mdr/mfds/nmpa/pmda retriever opts for exhaustive coverage.
+  if (orgId && chunks.length > 0) {
+    try {
+      const { filterExpiredSources } = await import('@/lib/corpus-license/expiry-checker');
+      const sourceIds = Array.from(new Set(chunks.map((c) => c.sourceId)));
+      const eligible = await filterExpiredSources(sourceIds, orgId);
+      const filtered = chunks.filter((c) => eligible.has(c.sourceId));
+      return filtered.slice(0, k);
+    } catch {
+      // License metadata unavailable — return unfiltered (RLS still isolates).
+    }
+  }
+
   return chunks.slice(0, k);
 }

--- a/lib/ai/retrievers/hybrid-search.ts
+++ b/lib/ai/retrievers/hybrid-search.ts
@@ -184,11 +184,11 @@ export async function hybridSearch(
   chunks.sort((a, b) => b.combined_score - a.combined_score);
 
   // REQ-CORPUSLIC-008 — exclude expired/revoked-entitlement sources from search.
-  // Primary call site for filterExpiredSources. Only applied when orgId is
-  // supplied (callers without session context fall through — they are
-  // non-RAG paths like the PMS report builder). Defense-in-depth: a license-db
-  // hiccup never blocks retrieval (RLS still enforces org isolation).
-  // @MX:TODO wire orgId through fda/eu-mdr/mfds/nmpa/pmda retriever opts for exhaustive coverage.
+  // Primary call site for filterExpiredSources. orgId is threaded from all
+  // per-corpus retrievers (fda/eu-mdr/mfds/nmpa/pmda) via RetrieverOptions and
+  // from consult.ts → parallelRetrieveAndMerge. PMS-report builder passes orgId
+  // directly. Defense-in-depth: a license-db hiccup never blocks retrieval
+  // (RLS still enforces org isolation).
   if (orgId && chunks.length > 0) {
     try {
       const { filterExpiredSources } = await import('@/lib/corpus-license/expiry-checker');

--- a/lib/ai/retrievers/internal-docs.ts
+++ b/lib/ai/retrievers/internal-docs.ts
@@ -128,7 +128,45 @@ export async function internalDocsRetrieve(
       EXPERT_REVIEW_CLASSES.has(r.metadata?.docClass as string),
   );
 
+  // REQ-CORPUSLIC-008 — exclude expired/revoked-entitlement sources from
+  // internal-docs retrieval. sourceId is carried in metadata.sourceId by the
+  // ingest pipeline. Defense-in-depth: license-db hiccup never blocks retrieval.
+  const filteredResults =
+    results.length > 0 ? await filterInternalDocExpiredSources(results) : results;
+
   void userId; // ACL check done via RLS in withTenantScope
 
-  return { results, expertReviewRequired };
+  return { results: filteredResults, expertReviewRequired };
+}
+
+/**
+ * REQ-CORPUSLIC-008 — drop internal-doc chunks whose sourceId maps to an
+ * expired or revoked-entitlement source. Falls through unfiltered on any
+ * license-metadata error so RLS remains the sole guarantee.
+ */
+async function filterInternalDocExpiredSources(
+  results: InternalDocsResult[],
+): Promise<InternalDocsResult[]> {
+  const sourceIds = Array.from(
+    new Set(
+      results
+        .map((r) => r.metadata?.sourceId as string | undefined)
+        .filter((s): s is string => typeof s === 'string' && s.length > 0),
+    ),
+  );
+  if (sourceIds.length === 0) return results;
+  try {
+    const { filterExpiredSources } = await import('@/lib/corpus-license/expiry-checker');
+    // orgId is already validated by the caller (InternalDocsOptions.orgId is required).
+    // Re-derive from the first result's metadata to avoid threading another param.
+    const orgId = results[0]?.metadata?.orgId as string | undefined;
+    if (!orgId) return results;
+    const eligible = await filterExpiredSources(sourceIds, orgId);
+    return results.filter((r) => {
+      const sid = r.metadata?.sourceId as string | undefined;
+      return !sid || eligible.has(sid);
+    });
+  } catch {
+    return results;
+  }
 }

--- a/lib/ai/retrievers/internal-sops.ts
+++ b/lib/ai/retrievers/internal-sops.ts
@@ -131,7 +131,7 @@ export class InternalSopsRetriever implements IRetriever {
     }
 
     const list = rows as unknown as SopsRow[];
-    return list.map((r) => ({
+    let mapped = list.map((r) => ({
       id: r.section_id,
       content: r.text,
       score: r.combined_score,
@@ -145,5 +145,23 @@ export class InternalSopsRetriever implements IRetriever {
         url: r.url,
       },
     }));
+
+    // REQ-CORPUSLIC-008 — exclude expired/revoked-entitlement sources.
+    // Primary call site for filterExpiredSources on the internal-SOPs path.
+    // Defense-in-depth: if the license query fails (e.g. license table not yet
+    // migrated in a test/staging env), the retriever still returns results —
+    // RLS already enforces org isolation, and the filter is advisory here.
+    if (mapped.length > 0) {
+      try {
+        const { filterExpiredSources } = await import('@/lib/corpus-license/expiry-checker');
+        const sourceIds = Array.from(new Set(mapped.map((m) => m.sourceId)));
+        const eligible = await filterExpiredSources(sourceIds, orgId);
+        mapped = mapped.filter((m) => eligible.has(m.sourceId));
+      } catch {
+        // License metadata unavailable — fall through with unfiltered results.
+      }
+    }
+
+    return mapped;
   }
 }

--- a/lib/ai/retrievers/mfds.ts
+++ b/lib/ai/retrievers/mfds.ts
@@ -14,7 +14,8 @@ export class MfdsRetriever implements IRetriever {
 
   async retrieve(query: string, opts: RetrieverOptions = {}): Promise<RetrievalResult[]> {
     const limit = opts.limit ?? 10;
-    const chunks = await hybridSearch(query, 'mfds' as never, limit, 'all');
+    // REQ-CORPUSLIC-008 — thread orgId so filterExpiredSources fires inside hybridSearch.
+    const chunks = await hybridSearch(query, 'mfds' as never, limit, 'all', opts.orgId);
     return chunks.map(toRetrievalResult);
   }
 }

--- a/lib/ai/retrievers/nmpa.ts
+++ b/lib/ai/retrievers/nmpa.ts
@@ -14,7 +14,8 @@ export class NmpaRetriever implements IRetriever {
 
   async retrieve(query: string, opts: RetrieverOptions = {}): Promise<RetrievalResult[]> {
     const limit = opts.limit ?? 10;
-    const chunks = await hybridSearch(query, 'nmpa' as never, limit, 'all');
+    // REQ-CORPUSLIC-008 — thread orgId so filterExpiredSources fires inside hybridSearch.
+    const chunks = await hybridSearch(query, 'nmpa' as never, limit, 'all', opts.orgId);
     return chunks.map(toRetrievalResult);
   }
 }

--- a/lib/ai/retrievers/pmda.ts
+++ b/lib/ai/retrievers/pmda.ts
@@ -14,7 +14,8 @@ export class PmdaRetriever implements IRetriever {
 
   async retrieve(query: string, opts: RetrieverOptions = {}): Promise<RetrievalResult[]> {
     const limit = opts.limit ?? 10;
-    const chunks = await hybridSearch(query, 'pmda' as never, limit, 'all');
+    // REQ-CORPUSLIC-008 — thread orgId so filterExpiredSources fires inside hybridSearch.
+    const chunks = await hybridSearch(query, 'pmda' as never, limit, 'all', opts.orgId);
     return chunks.map(toRetrievalResult);
   }
 }

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -346,7 +346,28 @@ export type AuditAction =
   | 'cyber.evidence_bundled'
   | 'cyber.risk_linked'
   | 'cyber.access_denied'
-  | 'cyber.reassess_triggered';
+  | 'cyber.reassess_triggered'
+  // SPEC-REGULA-CORPUS-LICENSE-001 (Issue 72) — 9 corpus-license lifecycle audit
+  // actions for 21 CFR Part 11 traceability of license/entitlement state.
+  // Added via 0080_corpus_license.sql. Mirror the auditActionEnum in lib/db/schema.ts.
+  //   corpus.license_set            — license metadata created or updated (REQ-001/010)
+  //   corpus.ingestion_blocked      — ingestion gate blocked unlicensed source (REQ-002/003)
+  //   corpus.full_text_blocked      — paid full-text blocked without entitlement (REQ-004)
+  //   corpus.entitlement_granted    — entitlement granted for a source (REQ-001/008)
+  //   corpus.entitlement_revoked    — entitlement revoked, source search-excluded (REQ-008)
+  //   corpus.export_blocked         — export blocked for unentitled source (REQ-011)
+  //   corpus.access_denied          — cross-org or unauthorized access blocked (REQ-012)
+  //   corpus.expiry_warned          — admin warned of upcoming license expiry (REQ-014)
+  //   corpus.abstract_only_enforced — abstract-only policy enforced, full-text blocked (REQ-013)
+  | 'corpus.license_set'
+  | 'corpus.ingestion_blocked'
+  | 'corpus.full_text_blocked'
+  | 'corpus.entitlement_granted'
+  | 'corpus.entitlement_revoked'
+  | 'corpus.export_blocked'
+  | 'corpus.access_denied'
+  | 'corpus.expiry_warned'
+  | 'corpus.abstract_only_enforced';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -125,7 +125,13 @@ export type PermissionAction =
   // REQ-013 is an entitlement/view gate, not a regulatory signoff — no separate
   // approve action is needed (cyber.access_denied audit covers denial).
   | 'cyberdevice.manage'
-  | 'cyberdevice.view';
+  | 'cyberdevice.view'
+  // SPEC-REGULA-CORPUS-LICENSE-001 (Issue #72, REQ-CORPUSLIC-012): 2 RBAC actions.
+  //   manage: admin ONLY — license/entitlement writes are 21 CFR Part 11 audit-material
+  //           records (legal exposure if unauthorised). Stricter than cyberdevice.manage.
+  //   view: ra-member+ — license status visible across the RA team for retrieval checks.
+  | 'corpuslicense.manage'
+  | 'corpuslicense.view';
 
 export interface PermissionSpec {
   minRole: Role;
@@ -367,4 +373,12 @@ export const PERMISSIONS: Record<PermissionAction, PermissionSpec> = {
   //       (REQ-013 entitlement gate; denial audited as cyber.access_denied).
   'cyberdevice.manage': { minRole: 'ra-member', scope: 'org', resourceType: 'cyberdevice' },
   'cyberdevice.view': { minRole: 'ra-member', scope: 'org', resourceType: 'cyberdevice' },
+
+  // SPEC-REGULA-CORPUS-LICENSE-001 (Issue #72, REQ-CORPUSLIC-012): 2 RBAC actions.
+  // manage: admin ONLY — license/entitlement writes are audit-material records
+  //         with legal exposure. Stricter than cyberdevice.manage (which is a team
+  //         activity). Mirrors rbac.manage / sources.ingest admin gates.
+  // view: ra-member+ — retrieval gate reads license status on every search.
+  'corpuslicense.manage': { minRole: 'admin', scope: 'org', resourceType: 'sourceLicense' },
+  'corpuslicense.view': { minRole: 'ra-member', scope: 'org', resourceType: 'sourceLicense' },
 };

--- a/lib/change-control/exporters/pdf.tsx
+++ b/lib/change-control/exporters/pdf.tsx
@@ -66,6 +66,9 @@ export interface RiskLinkRecord {
 export interface ChangePdfExportOptions {
   /** Render a diagonal DRAFT watermark across the page (non-final assessments). */
   includeDraftWatermark: boolean;
+  /** REQ-CORPUSLIC-007/011 — per-source usage-restriction notices appended as a
+   * "Source Usage Restrictions" section so the exported PDF carries redistribution terms. */
+  usageNotices?: Array<{ sourceId: string; notice: string }>;
 }
 
 /** Human-readable labels for the 6 change classification types. */
@@ -257,6 +260,18 @@ export async function exportChangeAssessmentToPdf(
 
         <Text style={styles.sectionHeading}>Linked Risk Items (REQ-008)</Text>
         {riskLinkRows}
+
+        {/* REQ-CORPUSLIC-007/011 — per-source usage-restriction notices. */}
+        {options.usageNotices && options.usageNotices.length > 0 ? (
+          <>
+            <Text style={styles.sectionHeading}>Source Usage Restrictions</Text>
+            {options.usageNotices.map((n) => (
+              <Text key={`notice-${n.sourceId}`} style={styles.citationExcerpt}>
+                {n.notice}
+              </Text>
+            ))}
+          </>
+        ) : null}
 
         {/* REQ-010: provenance — model/prompt/template version metadata. */}
         <Text style={styles.sectionHeading}>Provenance</Text>

--- a/lib/corpus-license/access.ts
+++ b/lib/corpus-license/access.ts
@@ -1,0 +1,67 @@
+// @MX:NOTE [AUTO] IDOR guard for source_license rows (REQ-CORPUSLIC-012).
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-012)
+//
+// Cross-org access to a source_license returns 404 (not 403) to avoid leaking
+// the existence of rows outside the caller's org. Denials are audited.
+
+import { db } from '@/lib/db/client';
+import { sourceLicense } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { auditCorpusAccessDenied } from './audit';
+
+/**
+ * REQ-012 — verify the source_license belongs to `orgId`. Returns null if the
+ * row does not exist OR exists in a different org (404 in both cases).
+ *
+ * Side-effect: when the row exists but is cross-org, a `corpus.access_denied`
+ * audit row is written so inspectors can see the attempted trespass.
+ */
+export async function assertSourceLicenseInOrg(params: {
+  sourceLicenseId: string;
+  orgId: string;
+  userId: string;
+}): Promise<{ id: string; sourceId: string } | null> {
+  const [row] = await db
+    .select({ id: sourceLicense.id, sourceId: sourceLicense.sourceId, orgId: sourceLicense.orgId })
+    .from(sourceLicense)
+    .where(eq(sourceLicense.id, params.sourceLicenseId))
+    .limit(1);
+
+  if (!row) return null;
+  if (row.orgId !== params.orgId) {
+    await auditCorpusAccessDenied({
+      userId: params.userId,
+      sourceId: row.sourceId,
+      reason: 'source_license_cross_org',
+    });
+    return null;
+  }
+  return { id: row.id, sourceId: row.sourceId };
+}
+
+/**
+ * REQ-012 — variant: verify a sourceId is owned by the org before any license
+ * operation. Mirrors the sources.organization_id scoping.
+ */
+export async function assertSourceInOrg(params: {
+  sourceId: string;
+  orgId: string;
+  userId: string;
+}): Promise<boolean> {
+  const { sources } = await import('../db/schema');
+  const [row] = await db
+    .select({ id: sources.id, orgId: sources.organizationId })
+    .from(sources)
+    .where(and(eq(sources.id, params.sourceId)))
+    .limit(1);
+  if (!row) return false;
+  if (row.orgId !== params.orgId) {
+    await auditCorpusAccessDenied({
+      userId: params.userId,
+      sourceId: params.sourceId,
+      reason: 'source_cross_org',
+    });
+    return false;
+  }
+  return true;
+}

--- a/lib/corpus-license/audit.ts
+++ b/lib/corpus-license/audit.ts
@@ -1,0 +1,176 @@
+// @MX:NOTE [AUTO] Corpus-license-specific audit helpers wrapping writeAudit().
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-010/012/014)
+//
+// 21 CFR Part 11: every regulated license/entitlement action is recorded through
+// the central append-only audit pipeline. meta_json is PII-free — only source IDs,
+// license types, and status labels are stored.
+//
+// Atomicity (Part 11): every wrapper accepts an optional `tx` handle so the
+// audit insert rides the same transaction boundary as the mutation.
+
+import { type AuditDbHandle, writeAudit } from '../audit';
+
+type AuditTx = AuditDbHandle | undefined;
+
+/** REQ-001/010: license metadata created or updated. */
+export async function auditLicenseSet(
+  params: {
+    userId: string;
+    sourceLicenseId: string;
+    sourceId: string;
+    licenseType: string;
+    expiryDate?: string | null;
+  },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.license_set',
+      resource_type: 'sourceLicense',
+      resource_id: params.sourceLicenseId,
+      meta_json: {
+        sourceId: params.sourceId,
+        licenseType: params.licenseType,
+        expiryDate: params.expiryDate ?? null,
+      },
+    },
+    tx,
+  );
+}
+
+/** REQ-002/003: ingestion gate blocked an unlicensed source. */
+export async function auditIngestionBlocked(
+  params: { userId: string; sourceId: string; reason: string },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.ingestion_blocked',
+      resource_type: 'source',
+      resource_id: params.sourceId,
+      meta_json: { reason: params.reason },
+    },
+    tx,
+  );
+}
+
+/** REQ-004: paid full-text blocked without entitlement. */
+export async function auditFullTextBlocked(
+  params: { userId: string; sourceId: string; licenseType: string },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.full_text_blocked',
+      resource_type: 'source',
+      resource_id: params.sourceId,
+      meta_json: { licenseType: params.licenseType },
+    },
+    tx,
+  );
+}
+
+/** REQ-008: entitlement granted for a source_license. */
+export async function auditEntitlementGranted(
+  params: { userId: string; entitlementId: string; sourceLicenseId: string },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.entitlement_granted',
+      resource_type: 'entitlement',
+      resource_id: params.entitlementId,
+      meta_json: { sourceLicenseId: params.sourceLicenseId },
+    },
+    tx,
+  );
+}
+
+/** REQ-008: entitlement revoked — source search-excluded. */
+export async function auditEntitlementRevoked(
+  params: { userId: string; entitlementId: string; sourceLicenseId: string },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.entitlement_revoked',
+      resource_type: 'entitlement',
+      resource_id: params.entitlementId,
+      meta_json: { sourceLicenseId: params.sourceLicenseId },
+    },
+    tx,
+  );
+}
+
+/** REQ-011: export blocked for an unentitled source. */
+export async function auditExportBlocked(
+  params: { userId: string; sourceId: string; reason: string },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.export_blocked',
+      resource_type: 'source',
+      resource_id: params.sourceId,
+      meta_json: { reason: params.reason },
+    },
+    tx,
+  );
+}
+
+/** REQ-012: cross-org or unauthorized access blocked. */
+export async function auditCorpusAccessDenied(
+  params: { userId: string; sourceId: string; reason: string },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.access_denied',
+      resource_type: 'source',
+      resource_id: params.sourceId,
+      meta_json: { reason: params.reason },
+    },
+    tx,
+  );
+}
+
+/** REQ-014: admin warned of upcoming license expiry. */
+export async function auditExpiryWarned(
+  params: { userId: string; sourceLicenseId: string; sourceId: string; expiryDate: string },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.expiry_warned',
+      resource_type: 'sourceLicense',
+      resource_id: params.sourceLicenseId,
+      meta_json: { sourceId: params.sourceId, expiryDate: params.expiryDate },
+    },
+    tx,
+  );
+}
+
+/** REQ-013: abstract-only policy enforced, full-text blocked. */
+export async function auditAbstractOnlyEnforced(
+  params: { userId: string; sourceId: string },
+  tx?: AuditTx,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.userId,
+      action: 'corpus.abstract_only_enforced',
+      resource_type: 'source',
+      resource_id: params.sourceId,
+      meta_json: {},
+    },
+    tx,
+  );
+}

--- a/lib/corpus-license/entitlement.ts
+++ b/lib/corpus-license/entitlement.ts
@@ -1,0 +1,111 @@
+// @MX:NOTE [AUTO] Entitlement grant/revoke lifecycle helpers (REQ-CORPUSLIC-008).
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-008)
+import { db } from '@/lib/db/client';
+import { entitlement, sourceLicense } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { auditEntitlementGranted, auditEntitlementRevoked } from './audit';
+
+/**
+ * REQ-008 — grant an entitlement for a source_license. Idempotent: if an active
+ * entitlement already exists, returns it without creating a duplicate.
+ *
+ * The `tx` parameter infers its full Drizzle type from db.transaction; it
+ * satisfies AuditDbHandle structurally (has `insert`) so it can be passed to
+ * the audit helpers without a cast.
+ */
+export async function grantEntitlement(params: {
+  sourceLicenseId: string;
+  orgId: string;
+  grantedBy: string;
+}): Promise<{ entitlementId: string; created: boolean }> {
+  return db.transaction(async (tx) => {
+    // Verify the source_license belongs to this org (IDOR guard).
+    const [lic] = await tx
+      .select({ id: sourceLicense.id, orgId: sourceLicense.orgId })
+      .from(sourceLicense)
+      .where(eq(sourceLicense.id, params.sourceLicenseId))
+      .limit(1);
+    if (!lic || lic.orgId !== params.orgId) {
+      return { entitlementId: '', created: false };
+    }
+
+    const [existing] = await tx
+      .select({ id: entitlement.id })
+      .from(entitlement)
+      .where(
+        and(
+          eq(entitlement.sourceLicenseId, params.sourceLicenseId),
+          eq(entitlement.orgId, params.orgId),
+          eq(entitlement.status, 'active'),
+        ),
+      )
+      .limit(1);
+    if (existing) {
+      return { entitlementId: existing.id, created: false };
+    }
+
+    const inserted = await tx
+      .insert(entitlement)
+      .values({
+        orgId: params.orgId,
+        sourceLicenseId: params.sourceLicenseId,
+        status: 'active',
+        grantedBy: params.grantedBy,
+      })
+      .returning({ id: entitlement.id });
+    const created = inserted[0];
+    if (!created) throw new Error('entitlement_insert_failed');
+
+    await auditEntitlementGranted(
+      {
+        userId: params.grantedBy,
+        entitlementId: created.id,
+        sourceLicenseId: params.sourceLicenseId,
+      },
+      tx,
+    );
+    return { entitlementId: created.id, created: true };
+  });
+}
+
+/**
+ * REQ-008 — revoke an active entitlement. The source is immediately excluded
+ * from corpus search (filterExpiredSources reads status 'revoked').
+ */
+export async function revokeEntitlement(params: {
+  sourceLicenseId: string;
+  orgId: string;
+  revokedBy: string;
+}): Promise<{ entitlementId: string; revoked: boolean }> {
+  return db.transaction(async (tx) => {
+    const [active] = await tx
+      .select({ id: entitlement.id })
+      .from(entitlement)
+      .where(
+        and(
+          eq(entitlement.sourceLicenseId, params.sourceLicenseId),
+          eq(entitlement.orgId, params.orgId),
+          eq(entitlement.status, 'active'),
+        ),
+      )
+      .limit(1);
+    if (!active) {
+      return { entitlementId: '', revoked: false };
+    }
+
+    await tx
+      .update(entitlement)
+      .set({ status: 'revoked', revokedBy: params.revokedBy, revokedAt: new Date() })
+      .where(eq(entitlement.id, active.id));
+
+    await auditEntitlementRevoked(
+      {
+        userId: params.revokedBy,
+        entitlementId: active.id,
+        sourceLicenseId: params.sourceLicenseId,
+      },
+      tx,
+    );
+    return { entitlementId: active.id, revoked: true };
+  });
+}

--- a/lib/corpus-license/expiry-checker.ts
+++ b/lib/corpus-license/expiry-checker.ts
@@ -1,0 +1,103 @@
+// @MX:ANCHOR [AUTO] filterExpiredSources — corpus search license-status filter.
+// @MX:REASON fan_in >= 3: lib/ai/retrievers/hybrid-search.ts, internal-sops.ts,
+//   and integration tests all call this. REQ-008 compliance gate — expired or
+//   revoked-entitlement sources MUST be excluded from RAG retrieval results.
+//   A dead-code definition without a call site is a SPEC violation.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-008, REQ-CORPUSLIC-014)
+import { db } from '@/lib/db/client';
+import { entitlement, sourceLicense } from '@/lib/db/schema';
+import { and, eq, inArray } from 'drizzle-orm';
+
+/**
+ * REQ-008 — given a set of sourceIds, return the subset that are LICENSED and
+ * SEARCH-ELIGIBLE (not expired, not entitlement-revoked).
+ *
+ * Wired at:
+ *   - lib/ai/retrievers/hybrid-search.ts (post-filter on retrieved sections)
+ *   - lib/ai/retrievers/internal-sops.ts (post-filter on retrieved sections)
+ *
+ * Sources with NO source_license row are considered unlicensed and excluded
+ * from the eligible set (REQ-003 strict mode: ingestion gate prevents such
+ * sources from entering source_sections, but defense-in-depth here too).
+ */
+export async function filterExpiredSources(
+  sourceIds: string[],
+  orgId: string,
+): Promise<Set<string>> {
+  if (sourceIds.length === 0) return new Set();
+
+  // Fetch all licenses for the candidate set, then filter in-app by date.
+  // Drizzle date comparison on text columns is simpler in JS than SQL here.
+  const candidates = await db
+    .select({
+      sourceId: sourceLicense.sourceId,
+      id: sourceLicense.id,
+      expiryDate: sourceLicense.expiryDate,
+    })
+    .from(sourceLicense)
+    .where(and(eq(sourceLicense.orgId, orgId), inArray(sourceLicense.sourceId, sourceIds)));
+
+  const today = new Date().toISOString().slice(0, 10);
+  const activeLicenses = candidates.filter((r) => r.expiryDate === null || r.expiryDate >= today);
+
+  // Among active licenses, drop any whose entitlement is revoked or expired.
+  const licenseIds = activeLicenses.map((r) => r.id);
+  if (licenseIds.length === 0) return new Set();
+
+  const revoked = await db
+    .select({ sourceLicenseId: entitlement.sourceLicenseId })
+    .from(entitlement)
+    .where(
+      and(
+        eq(entitlement.orgId, orgId),
+        inArray(entitlement.sourceLicenseId, licenseIds),
+        inArray(entitlement.status, ['revoked', 'expired']),
+      ),
+    );
+  const revokedLicenseIds = new Set(revoked.map((r) => r.sourceLicenseId));
+
+  const eligible = new Set<string>();
+  for (const row of activeLicenses) {
+    if (!revokedLicenseIds.has(row.id)) {
+      eligible.add(row.sourceId);
+    }
+  }
+  return eligible;
+}
+
+/**
+ * REQ-014 — return source_licenses expiring within `withinDays` (default 30),
+ * for the admin expiry-warning dashboard. PII-free.
+ */
+export async function getExpiryWarnings(
+  orgId: string,
+  withinDays = 30,
+): Promise<
+  Array<{ sourceLicenseId: string; sourceId: string; licenseType: string; expiryDate: string }>
+> {
+  const today = new Date();
+  const horizon = new Date(today.getTime() + withinDays * 24 * 60 * 60 * 1000);
+  const todayStr = today.toISOString().slice(0, 10);
+  const horizonStr = horizon.toISOString().slice(0, 10);
+
+  // Fetch all org licenses and filter in-app: upcoming expiries (>= today, <= horizon).
+  // NULL expiry_date rows are excluded (they never expire).
+  const rows = await db
+    .select({
+      sourceLicenseId: sourceLicense.id,
+      sourceId: sourceLicense.sourceId,
+      licenseType: sourceLicense.licenseType,
+      expiryDate: sourceLicense.expiryDate,
+    })
+    .from(sourceLicense)
+    .where(eq(sourceLicense.orgId, orgId));
+
+  return rows
+    .filter((r) => r.expiryDate !== null && r.expiryDate >= todayStr && r.expiryDate <= horizonStr)
+    .map((r) => ({
+      sourceLicenseId: r.sourceLicenseId,
+      sourceId: r.sourceId,
+      licenseType: r.licenseType,
+      expiryDate: r.expiryDate as string,
+    }));
+}

--- a/lib/corpus-license/export-gate.ts
+++ b/lib/corpus-license/export-gate.ts
@@ -1,0 +1,70 @@
+// @MX:ANCHOR [AUTO] verifyExportRights — export-time license/entitlement gate.
+// @MX:REASON fan_in >= 3: traceability export route, change-control export route,
+//   and integration tests all call this. REQ-011 compliance gate — sources whose
+//   permitted_use.export is false (or whose entitlement is inactive) MUST NOT
+//   leave the system in an export package. A dead-code definition without a call
+//   site is a SPEC violation.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-007, REQ-CORPUSLIC-011)
+import { auditExportBlocked } from './audit';
+import { fetchPermittedUse } from './permitted-use';
+
+export interface ExportGateResult {
+  /** True when every sourceId is export-entitled; false otherwise. */
+  allowed: boolean;
+  /** SourceIds blocked from export (empty when allowed). */
+  blockedSources: Array<{ sourceId: string; reason: string }>;
+}
+
+/**
+ * REQ-011 — verify that every sourceId in an export package is licensed for
+ * export (`permitted_use.export === true`) AND has an active entitlement when
+ * the license type requires one.
+ *
+ * On denial, callers SHOULD return 403 + call `auditExportBlocked` (the route
+ * handles the audit write so it can attach the actor/session context). This
+ * function returns the structured result; it does not audit itself to keep
+ * the lib side-effect-free w.r.t. actor identity.
+ *
+ * Wired at:
+ *   - app/api/traceability/[deliverableId]/export/route.ts
+ *   - app/api/change-control/[assessmentId]/export/route.ts
+ */
+export async function verifyExportRights(params: {
+  sourceIds: string[];
+  orgId: string;
+}): Promise<ExportGateResult> {
+  const { sourceIds, orgId } = params;
+  if (sourceIds.length === 0) {
+    return { allowed: true, blockedSources: [] };
+  }
+
+  const blockedSources: ExportGateResult['blockedSources'] = [];
+  for (const sourceId of sourceIds) {
+    const policy = await fetchPermittedUse(sourceId, orgId);
+    if (!policy) {
+      blockedSources.push({ sourceId, reason: 'no_license_metadata' });
+      continue;
+    }
+    if (!policy.permittedUse.export) {
+      blockedSources.push({ sourceId, reason: 'export_not_permitted' });
+    }
+    // REQ-004: paid-standard without active entitlement collapses permittedUse
+    // (including export=false) inside fetchPermittedUse, so the check above
+    // already covers entitlement expiry. No separate entitlement query needed.
+  }
+
+  return { allowed: blockedSources.length === 0, blockedSources };
+}
+
+/**
+ * Convenience: write audit for each blocked source. Routes call this after
+ * verifyExportRights returns allowed=false so the audit carries the actor id.
+ */
+export async function auditExportBlockedBatch(params: {
+  userId: string;
+  blockedSources: ExportGateResult['blockedSources'];
+}): Promise<void> {
+  for (const b of params.blockedSources) {
+    await auditExportBlocked({ userId: params.userId, sourceId: b.sourceId, reason: b.reason });
+  }
+}

--- a/lib/corpus-license/license-gate.ts
+++ b/lib/corpus-license/license-gate.ts
@@ -1,0 +1,66 @@
+// @MX:ANCHOR [AUTO] assertIngestionLicensed — ingestion pre-flight license gate.
+// @MX:REASON fan_in >= 3: lib/ingest route, ingestion-gate API, integration tests
+//   all call this. REQ-002/003/004 compliance gate — unlicensed sources MUST NOT
+//   enter the corpus. A dead-code definition without a call site is a SPEC violation.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-002, REQ-CORPUSLIC-003, REQ-CORPUSLIC-004)
+import { auditFullTextBlocked, auditIngestionBlocked } from './audit';
+import { fetchPermittedUse, isFullTextBlocked } from './permitted-use';
+import type { GateResult } from './types';
+
+/**
+ * REQ-002/003/004 — ingestion pre-flight gate.
+ *
+ * - REQ-003: NO license metadata ⇒ blocked (`no_license_metadata`).
+ * - REQ-002: permitted_use.ingest false ⇒ blocked (`ingest_not_permitted`).
+ * - REQ-004: paid-standard full-text without active entitlement ⇒ blocked
+ *   (`full_text_requires_entitlement`).
+ *
+ * Wired at:
+ *   - app/api/corpus-license/ingestion-gate/route.ts (POST handler)
+ *   - app/api/ra/ingest/route.ts (primary ingest entry, pre-embedding)
+ */
+export async function assertIngestionLicensed(params: {
+  sourceId: string;
+  orgId: string;
+  userId: string;
+  wantsFullText?: boolean;
+}): Promise<GateResult> {
+  const wantsFullText = params.wantsFullText ?? true;
+  const policy = await fetchPermittedUse(params.sourceId, params.orgId);
+
+  // REQ-003: license metadata missing ⇒ ingestion forbidden.
+  if (!policy) {
+    await auditIngestionBlocked({
+      userId: params.userId,
+      sourceId: params.sourceId,
+      reason: 'no_license_metadata',
+    });
+    return { allowed: false, reason: 'no_license_metadata' };
+  }
+
+  // REQ-002: explicit permitted_use.ingest=false override.
+  if (!policy.permittedUse.ingest) {
+    await auditIngestionBlocked({
+      userId: params.userId,
+      sourceId: params.sourceId,
+      reason: 'ingest_not_permitted',
+    });
+    return { allowed: false, reason: 'ingest_not_permitted', licenseType: policy.licenseType };
+  }
+
+  // REQ-004: paid-standard full-text blocked without entitlement.
+  if (wantsFullText && isFullTextBlocked(policy)) {
+    await auditFullTextBlocked({
+      userId: params.userId,
+      sourceId: params.sourceId,
+      licenseType: policy.licenseType,
+    });
+    return {
+      allowed: false,
+      reason: 'full_text_requires_entitlement',
+      licenseType: policy.licenseType,
+    };
+  }
+
+  return { allowed: true, licenseType: policy.licenseType };
+}

--- a/lib/corpus-license/permitted-use.ts
+++ b/lib/corpus-license/permitted-use.ts
@@ -1,0 +1,100 @@
+// @MX:NOTE [AUTO] permitted_use policy evaluation (REQ-CORPUSLIC-005/013).
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-005, REQ-CORPUSLIC-013)
+//
+// REQ-005: PubMed/Embase journals distinguish abstract-only vs full-text rights.
+// REQ-013: abstract-only sources block full-text search/summarize, allow abstract.
+
+import { db } from '@/lib/db/client';
+import { entitlement, sourceLicense } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import type { LicenseType, PermittedUse } from './runtime-types';
+
+export interface PermittedUseRow {
+  sourceId: string;
+  licenseType: LicenseType;
+  permittedUse: PermittedUse;
+  fullTextAllowed: boolean;
+  abstractOnly: boolean;
+  hasActiveEntitlement: boolean;
+}
+
+/**
+ * REQ-005/013 — Fetch the effective permitted-use policy for a source.
+ *
+ * A `standard_paid` source requires an active entitlement for any permitted_use
+ * (REQ-004). Journal/internal_sop/open derive rights from the license row itself.
+ */
+export async function fetchPermittedUse(
+  sourceId: string,
+  orgId: string,
+): Promise<PermittedUseRow | null> {
+  const [row] = await db
+    .select({
+      id: sourceLicense.id,
+      licenseType: sourceLicense.licenseType,
+      permittedUse: sourceLicense.permittedUse,
+      fullTextAllowed: sourceLicense.fullTextAllowed,
+      abstractOnly: sourceLicense.abstractOnly,
+    })
+    .from(sourceLicense)
+    .where(and(eq(sourceLicense.sourceId, sourceId), eq(sourceLicense.orgId, orgId)))
+    .limit(1);
+  if (!row) return null;
+
+  const [activeEntitlement] = await db
+    .select({ id: entitlement.id })
+    .from(entitlement)
+    .where(
+      and(
+        eq(entitlement.sourceLicenseId, row.id),
+        eq(entitlement.orgId, orgId),
+        eq(entitlement.status, 'active'),
+      ),
+    )
+    .limit(1);
+
+  const pu = (row.permittedUse ?? {}) as PermittedUse;
+  const hasActiveEntitlement = Boolean(activeEntitlement);
+
+  // REQ-004: paid-standard sources are gated by entitlement. Without an active
+  // grant, permitted_use collapses to nothing (no ingest/embed/search/summarize/export).
+  if (row.licenseType === 'standard_paid' && !hasActiveEntitlement) {
+    return {
+      sourceId,
+      licenseType: row.licenseType,
+      permittedUse: {
+        ingest: false,
+        embed: false,
+        search: false,
+        summarize: false,
+        export: false,
+      },
+      fullTextAllowed: false,
+      abstractOnly: true,
+      hasActiveEntitlement: false,
+    };
+  }
+
+  return {
+    sourceId,
+    licenseType: row.licenseType,
+    permittedUse: {
+      ingest: pu.ingest ?? true,
+      embed: pu.embed ?? true,
+      search: pu.search ?? true,
+      summarize: pu.summarize ?? true,
+      export: pu.export ?? true,
+    },
+    fullTextAllowed: row.fullTextAllowed,
+    abstractOnly: row.abstractOnly,
+    hasActiveEntitlement,
+  };
+}
+
+/**
+ * REQ-013 — returns true if a full-text operation is forbidden on this source.
+ * Fires when abstract_only is set OR full_text_allowed is false.
+ */
+export function isFullTextBlocked(policy: PermittedUseRow): boolean {
+  return policy.abstractOnly || !policy.fullTextAllowed;
+}

--- a/lib/corpus-license/runtime-types.ts
+++ b/lib/corpus-license/runtime-types.ts
@@ -1,0 +1,13 @@
+// @MX:NOTE [AUTO] Runtime type aliases for corpus-license (avoids circular import on schema).
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001
+export type LicenseType = 'standard_paid' | 'journal' | 'internal_sop' | 'open';
+export type ConfidentialityLevel = 'public' | 'internal' | 'trade_secret';
+export type EntitlementStatus = 'active' | 'revoked' | 'expired';
+
+export interface PermittedUse {
+  ingest: boolean;
+  embed: boolean;
+  search: boolean;
+  summarize: boolean;
+  export: boolean;
+}

--- a/lib/corpus-license/types.ts
+++ b/lib/corpus-license/types.ts
@@ -1,0 +1,59 @@
+// @MX:NOTE [AUTO] Zod input schemas + result types for corpus-license lib.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-001~014)
+import { z } from 'zod';
+
+// REQ-CORPUSLIC-001 — permitted_use boolean map. Each gate reads its key.
+export const permittedUseSchema = z
+  .object({
+    ingest: z.boolean().default(true),
+    embed: z.boolean().default(true),
+    search: z.boolean().default(true),
+    summarize: z.boolean().default(true),
+    export: z.boolean().default(true),
+  })
+  .default({});
+
+export const licenseTypeSchema = z.enum(['standard_paid', 'journal', 'internal_sop', 'open']);
+export const confidentialityLevelSchema = z.enum(['public', 'internal', 'trade_secret']);
+export const entitlementStatusSchema = z.enum(['active', 'revoked', 'expired']);
+
+// REQ-CORPUSLIC-001 — POST/PUT /api/corpus-license/source-license payload.
+export const sourceLicenseInputSchema = z.object({
+  sourceId: z.string().uuid(),
+  licenseType: licenseTypeSchema,
+  entitlementRef: z.string().max(256).optional().nullable(),
+  permittedUse: permittedUseSchema,
+  fullTextAllowed: z.boolean().default(true),
+  abstractOnly: z.boolean().default(false),
+  confidentialityLevel: confidentialityLevelSchema.default('internal'),
+  expiryDate: z.string().date().optional().nullable(),
+});
+
+// REQ-CORPUSLIC-002/003/004 — POST /api/corpus-license/ingestion-gate payload.
+export const ingestionGateInputSchema = z.object({
+  sourceId: z.string().uuid(),
+  wantsFullText: z.boolean().default(true),
+});
+
+// REQ-CORPUSLIC-008 — POST /api/corpus-license/entitlement payload.
+export const entitlementInputSchema = z.object({
+  sourceLicenseId: z.string().uuid(),
+  action: z.enum(['grant', 'revoke']),
+});
+
+export type SourceLicenseInput = z.infer<typeof sourceLicenseInputSchema>;
+export type IngestionGateInput = z.infer<typeof ingestionGateInputSchema>;
+export type EntitlementInput = z.infer<typeof entitlementInputSchema>;
+
+// Result of a license-gate evaluation. `allowed=false` ⇒ `reason` is set.
+export interface GateResult {
+  allowed: boolean;
+  reason?: string;
+  licenseType?: string;
+}
+
+// REQ-CORPUSLIC-007/011 — per-source usage restriction text for answers/exports.
+export interface SourceUsageNotice {
+  sourceId: string;
+  notice: string;
+}

--- a/lib/corpus-license/usage-notice.ts
+++ b/lib/corpus-license/usage-notice.ts
@@ -1,0 +1,50 @@
+// @MX:ANCHOR [AUTO] generateUsageNotice — answer/export per-source usage restriction text.
+// @MX:REASON fan_in >= 3: lib/ai/consult.ts (answer path), export-hub route, and
+//   integration tests all call this. REQ-007/011 compliance gate — every answer
+//   or export MUST include the per-source usage-restriction notice. A dead-code
+//   definition without a call site is a SPEC violation.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-007, REQ-CORPUSLIC-011)
+import { db } from '@/lib/db/client';
+import { sourceLicense } from '@/lib/db/schema';
+import { and, eq, inArray } from 'drizzle-orm';
+import type { SourceUsageNotice } from './types';
+
+const NOTICE_TEXT: Record<string, string> = {
+  standard_paid:
+    'ISO/IEC/ASTM paid standard — full text under subscription license; redistribution prohibited.',
+  journal:
+    'Published under journal copyright; abstract-only use permitted without full-text entitlement.',
+  internal_sop:
+    'Company-internal SOP — confidential, trade-secret protected; external distribution forbidden.',
+  open: 'Public-domain regulatory text; standard attribution required.',
+};
+
+/**
+ * REQ-007/011 — produce per-source usage-restriction notices for the given
+ * sourceIds. Returns one entry per source that has a license row.
+ *
+ * Wired at:
+ *   - lib/ai/consult.ts (consult answer assembly, post-retrieval)
+ *   - app/api/ra/export/route.ts (export package assembly)
+ */
+export async function generateUsageNotice(
+  sourceIds: string[],
+  orgId: string,
+): Promise<SourceUsageNotice[]> {
+  if (sourceIds.length === 0) return [];
+
+  const rows = await db
+    .select({
+      sourceId: sourceLicense.sourceId,
+      licenseType: sourceLicense.licenseType,
+      abstractOnly: sourceLicense.abstractOnly,
+    })
+    .from(sourceLicense)
+    .where(and(eq(sourceLicense.orgId, orgId), inArray(sourceLicense.sourceId, sourceIds)));
+
+  return rows.map((r) => {
+    const base = NOTICE_TEXT[r.licenseType] ?? 'Usage restricted per source license terms.';
+    const suffix = r.abstractOnly ? ' Abstract-only policy applies.' : '';
+    return { sourceId: r.sourceId, notice: `${base}${suffix}` };
+  });
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -347,6 +347,18 @@ export const auditActionEnum = pgEnum('audit_action', [
   // SPEC-REGULA-CYBERDEVICE-001 (Issue 67, H-2 fix) — added via
   // 0079_cyberdevice_linkage_hardening.sql: REQ-011 durable reassessment signal.
   'cyber.reassess_triggered',
+  // SPEC-REGULA-CORPUS-LICENSE-001 — added via 0080_corpus_license.sql
+  // (Issue 72, REQ-CORPUSLIC-010/012/014): 9 corpus-license lifecycle audit
+  // actions for 21 CFR Part 11 traceability of license/entitlement state.
+  'corpus.license_set',
+  'corpus.ingestion_blocked',
+  'corpus.full_text_blocked',
+  'corpus.entitlement_granted',
+  'corpus.entitlement_revoked',
+  'corpus.export_blocked',
+  'corpus.access_denied',
+  'corpus.expiry_warned',
+  'corpus.abstract_only_enforced',
 ]);
 
 // @MX:NOTE [AUTO] Knowledge gap enums — SPEC-REGULA-KNOWLEDGE-GAP-001 (Issue #35).
@@ -2807,5 +2819,95 @@ export const cyberEvidenceBundle = pgTable(
     samdIdx: index('idx_cyber_evidence_bundle_samd').on(t.linkedSamdId),
     dhfIdx: index('idx_cyber_evidence_bundle_dhf').on(t.linkedDhfId),
     submissionIdx: index('idx_cyber_evidence_bundle_submission').on(t.linkedSubmissionId),
+  }),
+);
+
+// @MX:NOTE [AUTO] Corpus license enums — SPEC-REGULA-CORPUS-LICENSE-001 (Issue #72).
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-001, REQ-CORPUSLIC-006)
+// @MX:REASON Drizzle pgEnum mirrors the SQL types created in 0080_corpus_license.sql.
+// Keep in lock-step with the migration or runtime inserts fail.
+// license_type: permitted-use policy group (paid standard / journal / internal SOP / open).
+// confidentiality_level: trade-secret protection scoping for internal SOPs.
+// entitlement_status: active / revoked / expired lifecycle for source access grants.
+export const licenseTypeEnum = pgEnum('license_type', [
+  'standard_paid',
+  'journal',
+  'internal_sop',
+  'open',
+]);
+export const confidentialityLevelEnum = pgEnum('confidentiality_level', [
+  'public',
+  'internal',
+  'trade_secret',
+]);
+export const entitlementStatusEnum = pgEnum('entitlement_status', ['active', 'revoked', 'expired']);
+
+// @MX:NOTE [AUTO] source_license — per-source license metadata gating ingest/search/export (REQ-CORPUSLIC-001).
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-001~014)
+// Links to #48 Source Governance (sources.id). permitted_use JSONB boolean map
+// is evaluated by lib/corpus-license/license-gate.ts before embedding/ingest.
+export const sourceLicense = pgTable(
+  'source_license',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    sourceId: uuid('source_id')
+      .notNull()
+      .references(() => sources.id, { onDelete: 'cascade' }),
+    licenseType: licenseTypeEnum('license_type').notNull(),
+    entitlementRef: text('entitlement_ref'),
+    permittedUse: jsonb('permitted_use').notNull().default({
+      ingest: true,
+      embed: true,
+      search: true,
+      summarize: true,
+      export: true,
+    }),
+    fullTextAllowed: boolean('full_text_allowed').notNull().default(true),
+    abstractOnly: boolean('abstract_only').notNull().default(false),
+    confidentialityLevel: confidentialityLevelEnum('confidentiality_level')
+      .notNull()
+      .default('internal'),
+    expiryDate: date('expiry_date'),
+    createdBy: uuid('created_by')
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    sourceUnique: unique('idx_source_license_source_unique').on(t.sourceId),
+    orgIdx: index('idx_source_license_org').on(t.orgId),
+    expiryIdx: index('idx_source_license_expiry').on(t.orgId, t.expiryDate),
+  }),
+);
+
+// @MX:NOTE [AUTO] entitlement — grant/revoke lifecycle for a source_license (REQ-CORPUSLIC-008).
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-008)
+// status 'revoked' / 'expired' excludes the source from corpus search.
+export const entitlement = pgTable(
+  'entitlement',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    sourceLicenseId: uuid('source_license_id')
+      .notNull()
+      .references(() => sourceLicense.id, { onDelete: 'cascade' }),
+    status: entitlementStatusEnum('status').notNull().default('active'),
+    grantedBy: uuid('granted_by')
+      .notNull()
+      .references(() => users.id),
+    grantedAt: timestamp('granted_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    revokedBy: uuid('revoked_by').references(() => users.id),
+    revokedAt: timestamp('revoked_at', { withTimezone: true, mode: 'date' }),
+  },
+  (t) => ({
+    orgIdx: index('idx_entitlement_org').on(t.orgId),
+    licenseIdx: index('idx_entitlement_license').on(t.sourceLicenseId),
+    statusIdx: index('idx_entitlement_status').on(t.orgId, t.status),
   }),
 );

--- a/lib/inngest/docingest/upload-processed.ts
+++ b/lib/inngest/docingest/upload-processed.ts
@@ -1,6 +1,7 @@
 // @MX:NOTE [AUTO] Inngest function for docingest/document.created — full ingest pipeline.
-// @MX:SPEC SPEC-REGULA-DOCINGEST-001 (REQ-DOC-021, REQ-DOC-022, REQ-DOC-025)
-// Steps: extract → redact → chunk → embed → insert chunks → update status
+// @MX:SPEC SPEC-REGULA-DOCINGEST-001 (REQ-DOC-021, REQ-DOC-022, REQ-DOC-025),
+//   SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-002)
+// Steps: license-gate → extract → redact → chunk → embed → insert chunks → update status
 // Each step is wrapped in Inngest step.run for independent retry + observability.
 
 import type { DocClass } from '../../ingest/doc-class';
@@ -15,6 +16,12 @@ export interface DocCreatedEvent {
     r2Key: string;
     mimeType: string;
     uploadedBy: string;
+    /**
+     * REQ-CORPUSLIC-002 — the pre-registered, licensed sourceId this document
+     * attaches to. The upload route enforces this before enqueuing; the worker
+     * re-checks (defense-in-depth) so a bypassed enqueue cannot store chunks.
+     */
+    sourceId: string;
   };
 }
 
@@ -30,7 +37,7 @@ export const uploadProcessedFn = inngest.createFunction(
     triggers: [{ event: INNGEST_EVENTS.DOCINGEST_DOCUMENT_CREATED }],
   },
   async ({ event, step }) => {
-    const { documentId, orgId, docClass, r2Key, mimeType } = event.data;
+    const { documentId, orgId, docClass, r2Key, mimeType, sourceId } = event.data;
 
     // Pipeline modules imported dynamically so module load does not pull the
     // ingest/embed (openai) dependency chain eagerly (keeps tests side-effect-free).
@@ -39,6 +46,29 @@ export const uploadProcessedFn = inngest.createFunction(
     const { extractText } = await import('../../ingest/extract/index');
     const { redactPiiForIngest } = await import('../../ingest/pii/redact');
     const { notifyAdminQuarantine } = await import('../../notifications/admin-quarantine');
+
+    // Step 0: REQ-CORPUSLIC-002 license gate — defense-in-depth. The upload
+    // route already gates before enqueuing, but the Inngest worker is the
+    // actual storage path. On denial, SKIP insertChunks + audit + bail.
+    const ingestAllowed = await step.run('license-gate', async () => {
+      const { assertIngestionLicensed } = await import('@/lib/corpus-license/license-gate');
+      const gate = await assertIngestionLicensed({
+        sourceId,
+        orgId,
+        userId: event.data.uploadedBy,
+        wantsFullText: true,
+      });
+      return gate.allowed;
+    });
+
+    if (!ingestAllowed) {
+      // Do NOT proceed to extract/chunk/embed/insertChunks. Mark the document
+      // as ingestion-blocked so the upload UI surfaces the rejection.
+      await step.run('mark-blocked', async () =>
+        updateDocumentStatus(documentId, 'ingestion_blocked'),
+      );
+      return { status: 'ingestion_blocked', chunkCount: 0 };
+    }
 
     // Step 1: Download and extract text
     const rawText = await step.run('extract-text', async () => {

--- a/lib/radar/delta-sync/ingest.ts
+++ b/lib/radar/delta-sync/ingest.ts
@@ -4,6 +4,13 @@
 // Reuses chunkers registry (generic chunker for Radar documents) for text
 // segmentation. Embedding is deferred to the vectorstore layer so this module
 // stays pure and unit-testable without OpenAI dependency (Enforce Simplicity).
+//
+// @MX:TODO [AUTO] REQ-CORPUSLIC-002 follow-up: this incremental-crawler path
+// does NOT yet call assertIngestionLicensed. Seed scripts (scripts/seed-fda-corpus.ts,
+// scripts/seed-corpus.ts, scripts/ingest-gitea-wiki.ts) and this delta-sync path
+// assume pre-licensed curated sources — they ingest public regulatory text whose
+// license is registered out-of-band. The production upload route (C-1) and Inngest
+// worker (C-2) are the primary gated paths. Gating this crawler is a follow-up.
 
 import type { Chunk } from '../../ingest/chunkers/base';
 import { chunk } from '../../ingest/chunkers/index';

--- a/lib/traceability/export-packet.ts
+++ b/lib/traceability/export-packet.ts
@@ -58,7 +58,10 @@ export function sanitizeFilename(filename: string): string {
  * final "Compliance Notes" section. The same content string feeds both the
  * Markdown and PDF renderers so output stays consistent.
  */
-export function packetToMarkdown(packet: EvidencePacket): string {
+export function packetToMarkdown(
+  packet: EvidencePacket,
+  usageNotices: Array<{ sourceId: string; notice: string }> = [],
+): string {
   const d = packet.deliverable;
   const lines: string[] = [];
   lines.push(`# Evidence Packet — ${escapeMd(d.refTable)}:${escapeMd(d.refId)}`);
@@ -88,6 +91,17 @@ export function packetToMarkdown(packet: EvidencePacket): string {
     lines.push('## Compliance Notes');
     for (const issue of packet.issues) {
       lines.push(`- [${escapeMd(issue.kind)}] ${escapeMd(issue.detail)}`);
+    }
+    lines.push('');
+  }
+
+  // REQ-CORPUSLIC-007/011 — append per-source usage-restriction section when the
+  // caller derived corpus sourceIds from the packet (evidence nodes may
+  // reference corpus sources via artifactHash/refId in future expansions).
+  if (usageNotices.length > 0) {
+    lines.push('## Source Usage Restrictions');
+    for (const n of usageNotices) {
+      lines.push(`- ${escapeMd(n.notice)}`);
     }
     lines.push('');
   }
@@ -152,6 +166,7 @@ export function packetToExportData(packet: EvidencePacket): {
 export async function exportPacket(
   packet: EvidencePacket,
   format: PacketFormat,
+  usageNotices: Array<{ sourceId: string; notice: string }> = [],
 ): Promise<ExportResult> {
   const exportFormat = format === 'pdf' ? ExportFormat.PDF : ExportFormat.MARKDOWN;
   const options: ExportOptions = {
@@ -160,6 +175,6 @@ export async function exportPacket(
     includeTimestamp: true,
     customFilename: packetFilename(packet, format),
   };
-  const data = { content: packetToMarkdown(packet) };
+  const data = { content: packetToMarkdown(packet, usageNotices) };
   return defaultExportHub.export(data, options);
 }

--- a/migrations/0080_corpus_license.sql
+++ b/migrations/0080_corpus_license.sql
@@ -1,0 +1,115 @@
+-- Migration: Corpus License & Entitlement Management (Issue 72, REQ-CORPUSLIC-001~014)
+-- SPEC: SPEC-REGULA-CORPUS-LICENSE-001
+-- Scope:
+--   1. audit_action +9 (corpus.* lifecycle for 21 CFR Part 11 traceability)
+--   2. 3 new enums: license_type, confidentiality_level, entitlement_status
+--   3. 2 new tables: source_license, entitlement (org_id scoped, FK to sources)
+--   4. RLS org-isolation on both tables (mirror 0067~0079 USING-only pattern)
+--
+-- Regulatory anchors:
+--   Copyright / Standard licenses (ISO/IEC/ASTM) — paid full-text storage gating
+--   Database subscription terms (PubMed/Embase) — abstract-only vs full-text use
+--   Trade secret protection — internal SOP confidentiality scoping
+--   21 CFR Part 11 — electronic records of license/entitlement changes & denials
+--
+-- Both tables inherit the app.current_org_id RLS pattern from 0067-0079.
+-- WITH CHECK clauses remain a project-wide follow-up (Issue #239); USING-only
+-- is consistent with all previously merged SPEC migrations.
+
+-- -------------------------------------
+-- §1 Enum extensions
+-- -------------------------------------
+
+-- corpus.* audit actions (Issue 72, REQ-CORPUSLIC-010/012/014). 9 lifecycle
+-- audit actions for 21 CFR Part 11 traceability of license/entitlement state.
+-- Mirror the schema enum and AuditAction type (lock-step).
+--   corpus.license_set          — license metadata created or updated (REQ-001/010)
+--   corpus.ingestion_blocked    — ingestion gate blocked unlicensed source (REQ-002/003)
+--   corpus.full_text_blocked    — paid full-text blocked without entitlement (REQ-004)
+--   corpus.entitlement_granted  — entitlement granted for a source (REQ-001/008)
+--   corpus.entitlement_revoked  — entitlement revoked, source search-excluded (REQ-008)
+--   corpus.export_blocked       — export blocked for unentitled source (REQ-011)
+--   corpus.access_denied        — cross-org or unauthorized access blocked (REQ-012)
+--   corpus.expiry_warned        — admin warned of upcoming license expiry (REQ-014)
+--   corpus.abstract_only_enforced — abstract-only policy enforced, full-text blocked (REQ-013)
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.license_set';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.ingestion_blocked';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.full_text_blocked';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.entitlement_granted';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.entitlement_revoked';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.export_blocked';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.access_denied';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.expiry_warned';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'corpus.abstract_only_enforced';
+
+-- License type enum. REQ-CORPUSLIC-001. Mirrors permitted-use policy groups.
+--   standard_paid  — ISO/IEC/ASTM paid standards (entitlement required for full text)
+--   journal        — PubMed/Embase journals (abstract-only vs full-text split)
+--   internal_sop   — company-internal SOPs / submission docs (confidentiality-scoped)
+--   open          — public-domain regulatory texts (no entitlement requirement)
+CREATE TYPE license_type AS ENUM ('standard_paid', 'journal', 'internal_sop', 'open');
+
+-- Confidentiality level enum. REQ-CORPUSLIC-006. Trade secret protection.
+CREATE TYPE confidentiality_level AS ENUM ('public', 'internal', 'trade_secret');
+
+-- Entitlement status enum. REQ-CORPUSLIC-001/008. Active vs revoked lifecycle.
+CREATE TYPE entitlement_status AS ENUM ('active', 'revoked', 'expired');
+
+-- -------------------------------------
+-- §2 Tables
+-- -------------------------------------
+
+-- source_license: per-source license metadata (REQ-CORPUSLIC-001).
+-- Links to #48 Source Governance (sources.id) and gates ingestion / search / export.
+--   permitted_use      — JSONB boolean map: {ingest, embed, search, summarize, export}
+--   full_text_allowed  — master switch; false ⇒ only abstract may be stored/served
+--   abstract_only      — derivative flag enforcing REQ-005/013 abstract-only policy
+--   expiry_date        — nullable; when past, source is search-excluded (REQ-008)
+CREATE TABLE source_license (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  source_id uuid NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  license_type license_type NOT NULL,
+  entitlement_ref text,
+  permitted_use jsonb NOT NULL DEFAULT '{"ingest":true,"embed":true,"search":true,"summarize":true,"export":true}'::jsonb,
+  full_text_allowed boolean NOT NULL DEFAULT true,
+  abstract_only boolean NOT NULL DEFAULT false,
+  confidentiality_level confidentiality_level NOT NULL DEFAULT 'internal',
+  expiry_date date,
+  created_by uuid NOT NULL REFERENCES users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_source_license_source_unique ON source_license(source_id);
+CREATE INDEX idx_source_license_org ON source_license(org_id);
+CREATE INDEX idx_source_license_expiry ON source_license(org_id, expiry_date);
+
+ALTER TABLE source_license ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tenant_isolation_source_license"
+  ON source_license FOR ALL
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- entitlement: grant/revoke lifecycle for a source_license (REQ-CORPUSLIC-008).
+--   status 'active'   — source is search-eligible
+--   status 'revoked'  — manual revoke, source search-excluded
+--   status 'expired'  — license expiry reached (kept for audit trail)
+CREATE TABLE entitlement (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  source_license_id uuid NOT NULL REFERENCES source_license(id) ON DELETE CASCADE,
+  status entitlement_status NOT NULL DEFAULT 'active',
+  granted_by uuid NOT NULL REFERENCES users(id),
+  granted_at timestamptz NOT NULL DEFAULT now(),
+  revoked_by uuid REFERENCES users(id),
+  revoked_at timestamptz
+);
+
+CREATE INDEX idx_entitlement_org ON entitlement(org_id);
+CREATE INDEX idx_entitlement_license ON entitlement(source_license_id);
+CREATE INDEX idx_entitlement_status ON entitlement(org_id, status);
+
+ALTER TABLE entitlement ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "tenant_isolation_entitlement"
+  ON entitlement FOR ALL
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);

--- a/tests/integration/capa.test.ts
+++ b/tests/integration/capa.test.ts
@@ -531,20 +531,20 @@ describe('Count regression (L-007 baseline)', () => {
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(174);
+    expect(vals.length).toBe(183);
   });
 
-  it('AuditAction type has 174 values (sync with schema enum)', () => {
+  it('AuditAction type has 183 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(174);
+    expect(vals.length).toBe(183);
   });
 
-  it('PERMISSIONS matrix has 66 entries (54 + 3 clinical_investigation.* + 7 complaint/capa.* + 3 modelgov.* + 2 cyberdevice.*)', () => {
+  it('PERMISSIONS matrix has 68 entries (66 + 2 corpuslicense.* CORPUS-LICENSE Issue #72)', () => {
     // Runtime count is the authoritative source of truth (matches
     // tests/unit/auth/permissions.test.ts and tests/regression/foundation.test.ts).
-    expect(Object.keys(PERMISSIONS).length).toBe(66);
+    expect(Object.keys(PERMISSIONS).length).toBe(68);
   });
 });
 

--- a/tests/integration/corpus-license.test.ts
+++ b/tests/integration/corpus-license.test.ts
@@ -316,3 +316,239 @@ describe('Anti-dead-code: gate functions have confirmed call sites', () => {
     expect(consult.includes('generateUsageNotice')).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// C-1: upload new-source creation path gated (REQ-002/003)
+// ---------------------------------------------------------------------------
+describe('C-1: upload rejects new-source ingest without licensed sourceId', () => {
+  it('source-level: upload route requires existingSourceId and rejects with 400', () => {
+    const src = readText('app/api/ra/admin/documents/upload/route.ts');
+    expect(src).toContain('no_licensed_source');
+    expect(src).toContain("reason: 'no_licensed_source'");
+    expect(src).toContain('corpus.ingestion_blocked');
+    expect(src).not.toContain('@MX:TODO enforce gate for the new-source creation path');
+  });
+
+  it('source-level: upload route no longer creates new sources rows', () => {
+    const src = readText('app/api/ra/admin/documents/upload/route.ts');
+    // The insert(sources) path was removed; sections attach to existingSourceId.
+    expect(src).not.toContain('insert(sources)');
+    expect(src).toContain('sourceId: existingSourceId');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-2: Inngest upload-processed pipeline gated (REQ-002)
+// ---------------------------------------------------------------------------
+describe('C-2: Inngest upload-processed enforces license gate', () => {
+  it('source-level: upload-processed calls assertIngestionLicensed at step 0', () => {
+    const src = readText('lib/inngest/docingest/upload-processed.ts');
+    expect(src).toContain('assertIngestionLicensed');
+    expect(src).toContain("run('license-gate'");
+    expect(src).toContain('ingestion_blocked');
+    expect(src).toContain('sourceId: string');
+  });
+
+  it('source-level: DocCreatedEvent carries sourceId', () => {
+    const src = readText('lib/inngest/docingest/upload-processed.ts');
+    expect(src).toMatch(/sourceId:\s*string/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-3: orgId threaded through per-corpus retrievers (REQ-008)
+// ---------------------------------------------------------------------------
+describe('C-3: per-corpus retrievers thread orgId to hybridSearch', () => {
+  const retrievers = [
+    'lib/ai/retrievers/fda.ts',
+    'lib/ai/retrievers/eu-mdr.ts',
+    'lib/ai/retrievers/mfds.ts',
+    'lib/ai/retrievers/nmpa.ts',
+    'lib/ai/retrievers/pmda.ts',
+  ];
+  for (const rel of retrievers) {
+    it(`source-level: ${rel} passes opts.orgId to hybridSearch`, () => {
+      const src = readText(rel);
+      expect(src).toContain('opts.orgId');
+    });
+  }
+
+  it('source-level: hybrid-search @MX:TODO removed (wiring complete)', () => {
+    const src = readText('lib/ai/retrievers/hybrid-search.ts');
+    expect(src).not.toContain('@MX:TODO wire orgId through');
+  });
+
+  it('source-level: internal-docs applies filterExpiredSources', () => {
+    const src = readText('lib/ai/retrievers/internal-docs.ts');
+    expect(src).toContain('filterExpiredSources');
+  });
+
+  it('source-level: pms-report route threads orgId into hybridSearch', () => {
+    const src = readText('app/api/workflows/pms-report/run/route.ts');
+    expect(src).toMatch(/hybridSearch\([^)]*orgId/);
+  });
+
+  it('domain: expired source excluded when orgId threaded', async () => {
+    const pastDate = '2020-01-01';
+    const futureDate = '2099-12-31';
+    vi.doMock('@/lib/db/client', () => ({
+      db: makeMockDb({
+        select: [
+          { sourceId: 'expired-src', id: 'lic-a', expiryDate: pastDate },
+          { sourceId: 'active-src', id: 'lic-b', expiryDate: futureDate },
+        ],
+      }),
+    }));
+    const mod = await import('@/lib/corpus-license/expiry-checker');
+    const eligible = await mod.filterExpiredSources(['expired-src', 'active-src'], 'org-1');
+    expect(eligible.has('expired-src')).toBe(false);
+    expect(eligible.has('active-src')).toBe(true);
+    vi.doUnmock('@/lib/db/client');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-4: export rights gate + usage notice in exports (REQ-007/011)
+// ---------------------------------------------------------------------------
+describe('C-4: export rights gate + usage notice', () => {
+  it('source-level: verifyExportRights exists in export-gate lib', () => {
+    const src = readText('lib/corpus-license/export-gate.ts');
+    expect(src).toContain('verifyExportRights');
+    expect(src).toContain('export_not_permitted');
+  });
+
+  it('source-level: change-control export route wires verifyExportRights + 403', () => {
+    const src = readText('app/api/change-control/[assessmentId]/export/route.ts');
+    expect(src).toContain('verifyExportRights');
+    expect(src).toContain('export_license_blocked');
+    expect(src).toContain('auditExportBlockedBatch');
+  });
+
+  it('source-level: change-control export route wires generateUsageNotice', () => {
+    const src = readText('app/api/change-control/[assessmentId]/export/route.ts');
+    expect(src).toContain('generateUsageNotice');
+  });
+
+  it('source-level: traceability export route wires verifyExportRights + notices', () => {
+    const src = readText('app/api/traceability/[deliverableId]/export/route.ts');
+    expect(src).toContain('verifyExportRights');
+    expect(src).toContain('generateUsageNotice');
+  });
+
+  it('source-level: PDF renderer accepts usageNotices option', () => {
+    const src = readText('lib/change-control/exporters/pdf.tsx');
+    expect(src).toContain('usageNotices');
+    expect(src).toContain('Source Usage Restrictions');
+  });
+
+  it('source-level: packetToMarkdown accepts usageNotices param', () => {
+    const src = readText('lib/traceability/export-packet.ts');
+    expect(src).toMatch(/packetToMarkdown\([\s\S]*usageNotices/);
+    expect(src).toContain('Source Usage Restrictions');
+  });
+
+  it('domain: verifyExportRights blocks source with export=false', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/db/client', () => ({ db: makeMockDb({ select: [] }) }));
+    vi.doMock('@/lib/corpus-license/permitted-use', () => ({
+      fetchPermittedUse: vi.fn().mockResolvedValue({
+        sourceId: 'iso-src',
+        licenseType: 'standard_paid',
+        permittedUse: { ingest: true, embed: true, search: true, summarize: true, export: false },
+        fullTextAllowed: false,
+        abstractOnly: true,
+        hasActiveEntitlement: false,
+      }),
+      isFullTextBlocked: vi.fn().mockReturnValue(true),
+    }));
+    vi.doMock('@/lib/corpus-license/audit', () => ({ auditExportBlocked: vi.fn() }));
+    const mod = await import('@/lib/corpus-license/export-gate');
+    const result = await mod.verifyExportRights({ sourceIds: ['iso-src'], orgId: 'org-1' });
+    expect(result.allowed).toBe(false);
+    expect(result.blockedSources).toHaveLength(1);
+    expect(result.blockedSources[0]?.reason).toBe('export_not_permitted');
+    vi.doUnmock('@/lib/corpus-license/permitted-use');
+    vi.doUnmock('@/lib/db/client');
+    vi.doUnmock('@/lib/corpus-license/audit');
+  });
+
+  it('domain: verifyExportRights allows sources with export=true', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/db/client', () => ({ db: makeMockDb({ select: [] }) }));
+    vi.doMock('@/lib/corpus-license/permitted-use', () => ({
+      fetchPermittedUse: vi.fn().mockResolvedValue({
+        sourceId: 'open-src',
+        licenseType: 'open',
+        permittedUse: { ingest: true, embed: true, search: true, summarize: true, export: true },
+        fullTextAllowed: true,
+        abstractOnly: false,
+        hasActiveEntitlement: true,
+      }),
+      isFullTextBlocked: vi.fn().mockReturnValue(false),
+    }));
+    vi.doMock('@/lib/corpus-license/audit', () => ({ auditExportBlocked: vi.fn() }));
+    const mod = await import('@/lib/corpus-license/export-gate');
+    const result = await mod.verifyExportRights({ sourceIds: ['open-src'], orgId: 'org-1' });
+    expect(result.allowed).toBe(true);
+    expect(result.blockedSources).toHaveLength(0);
+    vi.doUnmock('@/lib/corpus-license/permitted-use');
+    vi.doUnmock('@/lib/db/client');
+    vi.doUnmock('@/lib/corpus-license/audit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-4 (H-2): abstract-only enforcement audit wired at retrieval/answer time
+// ---------------------------------------------------------------------------
+describe('C-4 (H-2): auditAbstractOnlyEnforced wired in consult answer path', () => {
+  it('source-level: consult.ts calls auditAbstractOnlyEnforced after retrieval', () => {
+    const src = readText('lib/ai/consult.ts');
+    expect(src).toContain('auditAbstractOnlyEnforced');
+    expect(src).toContain('isFullTextBlocked');
+  });
+
+  it('source-level: auditAbstractOnlyEnforced is NOT dead code (has call site)', () => {
+    const consult = readText('lib/ai/consult.ts');
+    const auditLib = readText('lib/corpus-license/audit.ts');
+    expect(auditLib).toContain('auditAbstractOnlyEnforced');
+    expect(consult.includes('auditAbstractOnlyEnforced')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-4 (H-1): auditExportBlocked is NOT dead code (wired via export-gate)
+// ---------------------------------------------------------------------------
+describe('C-4 (H-1): auditExportBlocked wired via export-gate batch helper', () => {
+  it('source-level: export-gate calls auditExportBlocked via auditExportBlockedBatch', () => {
+    const gate = readText('lib/corpus-license/export-gate.ts');
+    expect(gate).toContain('auditExportBlocked');
+    expect(gate).toContain('auditExportBlockedBatch');
+  });
+
+  it('source-level: change-control export route calls auditExportBlockedBatch', () => {
+    const src = readText('app/api/change-control/[assessmentId]/export/route.ts');
+    expect(src).toContain('auditExportBlockedBatch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H-3: ingestion-gate route is documented as manual pre-ingest check
+// ---------------------------------------------------------------------------
+describe('H-3: ingestion-gate route doc-comment clarifies manual use', () => {
+  it('source-level: route comment explains it is a manual pre-ingest check', () => {
+    const src = readText('app/api/corpus-license/ingestion-gate/route.ts');
+    expect(src).toMatch(/manual pre-ingest check endpoint/i);
+    expect(src).toMatch(/directly|direct/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H-4: revoked source full text redacted in admin sources API
+// ---------------------------------------------------------------------------
+describe('H-4: revoked source full text redacted in sources [id] route', () => {
+  it('source-level: sources [id] route applies filterExpiredSources + redacts text', () => {
+    const src = readText('app/api/ra/sources/[id]/route.ts');
+    expect(src).toContain('filterExpiredSources');
+    expect(src).toContain('revoked or expired license — full text redacted');
+  });
+});

--- a/tests/integration/corpus-license.test.ts
+++ b/tests/integration/corpus-license.test.ts
@@ -1,0 +1,318 @@
+// @MX:NOTE [AUTO] Route-level + domain-level integration tests for Corpus License.
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-001~014, AC-01~07)
+//
+// Hybrid strategy (mirrors cyberdevice.test.ts / capa.test.ts):
+//   1. Source-level: read route/lib source and assert the control is present
+//      (withPermission RBAC, writeAudit tx, IDOR guard, gate wiring).
+//      This is the anti-dead-code guarantee: every gate function MUST have a
+//      confirmed call site in the live route/lib path.
+//   2. Domain-level: exercise the pure gate functions (license-gate,
+//      expiry-checker, usage-notice) directly with a mocked db client.
+//
+// AC mapping:
+//   AC-01 — ingestion blocked without license metadata (source-level gate + domain)
+//   AC-02 — paid-standard full-text blocked without entitlement (domain + source)
+//   AC-03 — expired source excluded from search (domain filterExpiredSources)
+//   AC-04 — export includes usage notice (domain generateUsageNotice + source wiring)
+//   AC-05 — every license change audited (source-level audit tx assertions)
+//   AC-06 — abstract-only blocks full-text, allows abstract (domain permitted-use)
+//   AC-07 — unauthorized license change → 403 + audit (source-level RBAC + IDOR)
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+const root = path.resolve(__dirname, '..', '..');
+const readText = (rel: string): string => fs.readFileSync(path.join(root, rel), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Shared mock db — CAPA #251 hybrid pattern. Each test configures the rows
+// its gate needs, then exercises the REAL lib function.
+// The select chain returns a Promise-like (array) that ALSO has `.limit()` so
+// both `await db.select().from().where()` and `...where().limit(1)` work.
+// ---------------------------------------------------------------------------
+function makeThenable(rowsFor: () => unknown[]) {
+  // A Promise that carries a `.limit` method on it via assignment.
+  const p = Promise.resolve(rowsFor()) as Promise<unknown[]> & {
+    limit: () => Promise<unknown[]>;
+  };
+  p.limit = () => Promise.resolve(rowsFor());
+  return p;
+}
+
+function makeMockDb(rows: Record<string, unknown[]>) {
+  const rowsFor = (key: string): unknown[] => rows[key] ?? [];
+  const selectMock = () => ({
+    from: () => ({
+      where: () => makeThenable(() => rowsFor('select')),
+    }),
+  });
+  return {
+    select: vi.fn(selectMock),
+    insert: vi.fn(() => ({
+      values: () => ({ returning: () => Promise.resolve(rowsFor('insert')) }),
+    })),
+    update: vi.fn(() => ({ set: () => ({ where: () => Promise.resolve() }) })),
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb({
+        select: selectMock,
+        insert: vi.fn(() => ({
+          values: () => ({ returning: () => Promise.resolve(rowsFor('insert')) }),
+        })),
+        update: vi.fn(() => ({ set: () => ({ where: () => Promise.resolve() }) })),
+      }),
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC-01: ingestion blocked without license metadata (REQ-003)
+// ---------------------------------------------------------------------------
+describe('AC-01: ingestion blocked without license metadata (REQ-003)', () => {
+  it('source-level: ingest upload route wires assertIngestionLicensed', () => {
+    const src = readText('app/api/ra/admin/documents/upload/route.ts');
+    expect(src).toContain('assertIngestionLicensed');
+    expect(src).toContain('ingestion_license_blocked');
+  });
+
+  it('source-level: ingestion-gate route wraps withPermission', () => {
+    const src = readText('app/api/corpus-license/ingestion-gate/route.ts');
+    expect(src).toContain("withPermission('corpuslicense.view'");
+    expect(src).toContain('assertIngestionLicensed');
+  });
+
+  it('domain: assertIngestionLicensed blocks when no license row exists', async () => {
+    vi.doMock('@/lib/db/client', () => ({ db: makeMockDb({ select: [] }) }));
+    vi.doMock('@/lib/corpus-license/audit', () => ({
+      auditIngestionBlocked: vi.fn(),
+      auditFullTextBlocked: vi.fn(),
+    }));
+    const mod = await import('@/lib/corpus-license/license-gate');
+    const result = await mod.assertIngestionLicensed({
+      sourceId: 'src-1',
+      orgId: 'org-1',
+      userId: 'user-1',
+      wantsFullText: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('no_license_metadata');
+    vi.doUnmock('@/lib/db/client');
+    vi.doUnmock('@/lib/corpus-license/audit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-02: paid-standard full-text blocked without entitlement (REQ-004)
+// ---------------------------------------------------------------------------
+describe('AC-02: paid-standard full-text blocked without entitlement (REQ-004)', () => {
+  it('domain: isFullTextBlocked enforces the gate predicate (REQ-004 logic)', async () => {
+    // REQ-004 collapses to: a standard_paid source without entitlement is
+    // full-text-blocked. The policy is constructed inline to test the pure
+    // predicate the gate relies on (avoids env-validating db re-import).
+    const { isFullTextBlocked } = await import('@/lib/corpus-license/permitted-use');
+    const policyWithoutEntitlement = {
+      sourceId: 'iso-src',
+      licenseType: 'standard_paid' as const,
+      permittedUse: { ingest: false, embed: false, search: false, summarize: false, export: false },
+      fullTextAllowed: false,
+      abstractOnly: true,
+      hasActiveEntitlement: false,
+    };
+    expect(isFullTextBlocked(policyWithoutEntitlement)).toBe(true);
+  });
+
+  it('source-level: license-gate blocks full_text_requires_entitlement + audits', () => {
+    const src = readText('lib/corpus-license/license-gate.ts');
+    expect(src).toContain('full_text_requires_entitlement');
+    expect(src).toContain('auditFullTextBlocked');
+  });
+
+  it('source-level: permitted-use collapses standard_paid without entitlement', () => {
+    const src = readText('lib/corpus-license/permitted-use.ts');
+    expect(src).toMatch(/licenseType === 'standard_paid' && !hasActiveEntitlement/);
+    expect(src).toMatch(/fullTextAllowed: false/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-03: expired source excluded from search (REQ-008)
+// ---------------------------------------------------------------------------
+describe('AC-03: expired source excluded from search (REQ-008)', () => {
+  it('source-level: hybrid-search wires filterExpiredSources', () => {
+    const src = readText('lib/ai/retrievers/hybrid-search.ts');
+    expect(src).toContain('filterExpiredSources');
+  });
+
+  it('source-level: internal-sops retriever wires filterExpiredSources', () => {
+    const src = readText('lib/ai/retrievers/internal-sops.ts');
+    expect(src).toContain('filterExpiredSources');
+  });
+
+  it('domain: filterExpiredSources drops past-expiry sources', async () => {
+    const pastDate = '2020-01-01';
+    const futureDate = '2099-12-31';
+    vi.doMock('@/lib/db/client', () => ({
+      db: makeMockDb({
+        select: [
+          { sourceId: 'expired-src', id: 'lic-a', expiryDate: pastDate },
+          { sourceId: 'active-src', id: 'lic-b', expiryDate: futureDate },
+        ],
+      }),
+    }));
+    const mod = await import('@/lib/corpus-license/expiry-checker');
+    const eligible = await mod.filterExpiredSources(['expired-src', 'active-src'], 'org-1');
+    expect(eligible.has('expired-src')).toBe(false);
+    expect(eligible.has('active-src')).toBe(true);
+    vi.doUnmock('@/lib/db/client');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-04: export includes usage notice (REQ-007/011)
+// ---------------------------------------------------------------------------
+describe('AC-04: export/answer includes usage notice (REQ-007/011)', () => {
+  it('source-level: consult.ts wires generateUsageNotice into sources event', () => {
+    const src = readText('lib/ai/consult.ts');
+    expect(src).toContain('generateUsageNotice');
+    expect(src).toContain('usageNotice');
+  });
+
+  it('source-level: SourceItem carries optional usageNotice field', () => {
+    const src = readText('types/streaming.ts');
+    expect(src).toMatch(/usageNotice\?:\s*string/);
+  });
+
+  it('domain: generateUsageNotice returns per-source restriction text', async () => {
+    vi.doMock('@/lib/db/client', () => ({
+      db: makeMockDb({
+        select: [
+          { sourceId: 'iso-src', licenseType: 'standard_paid', abstractOnly: false },
+          { sourceId: 'pubmed-src', licenseType: 'journal', abstractOnly: true },
+        ],
+      }),
+    }));
+    const mod = await import('@/lib/corpus-license/usage-notice');
+    const notices = await mod.generateUsageNotice(['iso-src', 'pubmed-src'], 'org-1');
+    expect(notices).toHaveLength(2);
+    const iso = notices.find((n) => n.sourceId === 'iso-src');
+    const pubmed = notices.find((n) => n.sourceId === 'pubmed-src');
+    expect(iso?.notice).toMatch(/paid standard/i);
+    expect(pubmed?.notice).toMatch(/abstract-only policy applies/i);
+    vi.doUnmock('@/lib/db/client');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-05: every license change audited (REQ-010)
+// ---------------------------------------------------------------------------
+describe('AC-05: every license change audited (REQ-010)', () => {
+  it('source-level: source-license route writes auditLicenseSet inside tx', () => {
+    const src = readText('app/api/corpus-license/source-license/route.ts');
+    expect(src).toContain('auditLicenseSet(');
+    expect(src).toMatch(/db\.transaction/);
+  });
+
+  it('source-level: entitlement route wires grant/revoke audit helpers', () => {
+    const src = readText('app/api/corpus-license/entitlement/route.ts');
+    expect(src).toContain('grantEntitlement');
+    expect(src).toContain('revokeEntitlement');
+  });
+
+  it('source-level: entitlement.ts writes audit inside db.transaction', () => {
+    const src = readText('lib/corpus-license/entitlement.ts');
+    expect(src).toMatch(/auditEntitlementGranted\(/);
+    expect(src).toMatch(/auditEntitlementRevoked\(/);
+    expect(src).toMatch(/db\.transaction/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-06: abstract-only blocks full-text, allows abstract (REQ-013)
+// ---------------------------------------------------------------------------
+describe('AC-06: abstract-only blocks full-text, allows abstract (REQ-013)', () => {
+  it('domain: isFullTextBlocked returns true when abstractOnly flag is set', async () => {
+    // Inline fixture for the pure predicate — no DB needed.
+    const policy = {
+      sourceId: 'src-1',
+      licenseType: 'journal' as const,
+      permittedUse: { ingest: true, embed: true, search: true, summarize: true, export: true },
+      fullTextAllowed: true,
+      abstractOnly: true,
+      hasActiveEntitlement: true,
+    };
+    const { isFullTextBlocked } = await import('@/lib/corpus-license/permitted-use');
+    expect(isFullTextBlocked(policy)).toBe(true);
+  });
+
+  it('source-level: abstract-only enforcement audit action exists', () => {
+    const src = readText('lib/corpus-license/audit.ts');
+    expect(src).toContain('auditAbstractOnlyEnforced');
+    expect(src).toContain('corpus.abstract_only_enforced');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-07: unauthorized license change → 403 + audit (REQ-012)
+// ---------------------------------------------------------------------------
+describe('AC-07: unauthorized license change → 403 + audit (REQ-012)', () => {
+  it('source-level: source-license route enforces corpuslicense.manage RBAC', () => {
+    const src = readText('app/api/corpus-license/source-license/route.ts');
+    expect(src).toContain("withPermission('corpuslicense.manage'");
+  });
+
+  it('source-level: entitlement route enforces corpuslicense.manage RBAC', () => {
+    const src = readText('app/api/corpus-license/entitlement/route.ts');
+    expect(src).toContain("withPermission('corpuslicense.manage'");
+  });
+
+  it('source-level: IDOR guard returns 404 on cross-org source_license', () => {
+    const src = readText('lib/corpus-license/access.ts');
+    expect(src).toContain('auditCorpusAccessDenied');
+    expect(src).toContain('source_license_cross_org');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IDOR + revoke + expiry warning (additional coverage)
+// ---------------------------------------------------------------------------
+describe('Additional: entitlement revoke → search exclusion (REQ-008)', () => {
+  it('source-level: revokeEntitlement sets status revoked', () => {
+    const src = readText('lib/corpus-license/entitlement.ts');
+    expect(src).toMatch(/status:\s*'revoked'/);
+    expect(src).toContain('revokeEntitlement');
+  });
+});
+
+describe('Additional: expiry warning query (REQ-014)', () => {
+  it('source-level: getExpiryWarnings exists and filters upcoming window', () => {
+    const src = readText('lib/corpus-license/expiry-checker.ts');
+    expect(src).toContain('getExpiryWarnings');
+    expect(src).toMatch(/withinDays/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anti-dead-code: every gate function has a confirmed call site (L-006)
+// ---------------------------------------------------------------------------
+describe('Anti-dead-code: gate functions have confirmed call sites', () => {
+  it('assertIngestionLicensed is called in a route/lib path', () => {
+    const upload = readText('app/api/ra/admin/documents/upload/route.ts');
+    const gate = readText('app/api/corpus-license/ingestion-gate/route.ts');
+    expect(
+      upload.includes('assertIngestionLicensed') || gate.includes('assertIngestionLicensed'),
+    ).toBe(true);
+  });
+
+  it('filterExpiredSources is called in a retriever path', () => {
+    const hybrid = readText('lib/ai/retrievers/hybrid-search.ts');
+    const sops = readText('lib/ai/retrievers/internal-sops.ts');
+    expect(hybrid.includes('filterExpiredSources') || sops.includes('filterExpiredSources')).toBe(
+      true,
+    );
+  });
+
+  it('generateUsageNotice is called in the consult answer path', () => {
+    const consult = readText('lib/ai/consult.ts');
+    expect(consult.includes('generateUsageNotice')).toBe(true);
+  });
+});

--- a/tests/integration/cyberdevice.test.ts
+++ b/tests/integration/cyberdevice.test.ts
@@ -592,25 +592,25 @@ describe('AC-07: entitlement denial → 403 + audit (REQ-013)', () => {
 // ---------------------------------------------------------------------------
 // Count-sync (L-009): audit_action + PermissionAction deltas.
 // ---------------------------------------------------------------------------
-describe('count-sync: audit_action (173→174) + PermissionAction (64→66)', () => {
-  it('audit_action enum has 174 values', () => {
+describe('count-sync: audit_action (174→183) + PermissionAction (66→68)', () => {
+  it('audit_action enum has 183 values', () => {
     const src = readText('lib/db/schema.ts');
     const match = src.match(
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(174);
+    expect(vals.length).toBe(183);
   });
 
-  it('AuditAction type has 174 values (sync with schema enum)', () => {
+  it('AuditAction type has 183 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(174);
+    expect(vals.length).toBe(183);
   });
 
-  it('PERMISSIONS matrix has 66 entries', () => {
-    expect(Object.keys(PERMISSIONS).length).toBe(66);
+  it('PERMISSIONS matrix has 68 entries', () => {
+    expect(Object.keys(PERMISSIONS).length).toBe(68);
   });
 
   it('schema.ts defines all 4 cyberdevice tables', () => {

--- a/tests/integration/docingest-e2e.test.ts
+++ b/tests/integration/docingest-e2e.test.ts
@@ -25,6 +25,14 @@ vi.mock('@/lib/auth/acl', () => ({
 const writeAuditMock = vi.fn(async () => {});
 vi.mock('@/lib/audit', () => ({ writeAudit: writeAuditMock }));
 
+// C-1: upload route now requires a pre-registered licensed sourceId. Mock the
+// license gate to allow ingestion so the e2e suite exercises the post-gate
+// extract/chunk/embed/persist path (the gate's domain logic is covered in
+// tests/integration/corpus-license.test.ts).
+vi.mock('@/lib/corpus-license/license-gate', () => ({
+  assertIngestionLicensed: vi.fn(async () => ({ allowed: true, licenseType: 'internal_sop' })),
+}));
+
 const insertedSources: unknown[] = [];
 const insertedSections: unknown[] = [];
 
@@ -87,6 +95,7 @@ function buildFormData(opts: {
   mime?: string;
   docClass?: string;
   filename?: string;
+  sourceId?: string;
 }): FormData {
   const fd = new FormData();
   const bytes = opts.bytes ?? readFileSync(FIXTURE_PATH);
@@ -96,6 +105,8 @@ function buildFormData(opts: {
     new File([new Uint8Array(bytes)], opts.filename ?? 'sample-regulatory.txt', { type: mime }),
   );
   fd.append('docClass', opts.docClass ?? 'internal_sop');
+  // C-1: a pre-registered licensed sourceId is required to pass the ingestion gate.
+  fd.append('sourceId', opts.sourceId ?? '00000000-0000-4000-8000-000000000001');
   return fd;
 }
 
@@ -132,7 +143,8 @@ describe('Document Ingestion E2E (REQ-QUAL-015..019)', () => {
     const res = await callPost(buildFormData({}));
     expect(res.status).toBe(201);
     const body = (await res.json()) as { sourceId: string; sectionCount: number };
-    expect(body.sourceId).toMatch(/^src-/);
+    // C-1: upload attaches sections to the pre-registered licensed sourceId.
+    expect(body.sourceId).toBe('00000000-0000-4000-8000-000000000001');
     expect(body.sectionCount).toBeGreaterThanOrEqual(1);
 
     expect(embedChunksMock).toHaveBeenCalledOnce();
@@ -176,11 +188,9 @@ describe('Document Ingestion E2E (REQ-QUAL-015..019)', () => {
     expect(persistedText).not.toContain('patient@example.com');
     expect(persistedText).not.toContain('123-45-6789');
 
-    expect(insertedSources[0]).toEqual(
-      expect.objectContaining({
-        title: '[REDACTED:EMAIL] [REDACTED:SSN].txt',
-      }),
-    );
+    // C-1: the upload route no longer creates a new sources row (the title
+    // redaction previously asserted via insertedSources is now covered by the
+    // filenameExt redaction in the audit meta + the persisted section text above).
     expect(writeAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'document.redact',

--- a/tests/regression/foundation.test.ts
+++ b/tests/regression/foundation.test.ts
@@ -38,8 +38,8 @@ describe('FOUNDATION regression', () => {
   // + personal.view — SPEC-REGULA-PERSONAL-LIB-001
   // + deadline.view, deadline.manage — SPEC-REGULA-CALENDAR-001)
   // ---------------------------------------------------------------------------
-  it('has 66 permission actions defined', () => {
-    expect(Object.keys(PERMISSIONS).length).toBe(66); // +7 complaint/capa.* (CAPA-001, Issue #68) +3 clinical_investigation.* (Issue #69) +3 modelgov.* (MODEL-GOVERNANCE, Issue 71) +2 cyberdevice.* (CYBERDEVICE, Issue 67)
+  it('has 68 permission actions defined', () => {
+    expect(Object.keys(PERMISSIONS).length).toBe(68); // +2 corpuslicense.* (CORPUS-LICENSE, Issue #72)
   });
 
   it('profile.edit permission exists with user scope', () => {

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(174); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255) +1 traceability.matrix_viewed (#240) +8 ci.* (CLINICAL-INVESTIGATION, #69) +8 modelgov.* (MODEL-GOVERNANCE, Issue 71) +9 cyber.* (CYBERDEVICE, Issue 67) +1 cyber.reassess_triggered (CYBERDEVICE H-2 fix, Issue 67)
+    expect(values).toHaveLength(183); // +9 corpus.* (CORPUS-LICENSE, Issue #72)
   });
 
   it.each([

--- a/tests/unit/auth/permissions.test.ts
+++ b/tests/unit/auth/permissions.test.ts
@@ -67,14 +67,17 @@ const EXPECTED_ACTIONS: PermissionAction[] = [
   // SPEC-REGULA-CYBERDEVICE-001 (Issue 67)
   'cyberdevice.manage',
   'cyberdevice.view',
+  // SPEC-REGULA-CORPUS-LICENSE-001 (Issue #72)
+  'corpuslicense.manage',
+  'corpuslicense.view',
 ];
 
 const VALID_ROLES = ['admin', 'qa-lead', 'ra-lead', 'ra-member', 'viewer', 'auditor'] as const;
 const VALID_SCOPES = ['org', 'project', 'user', 'none'] as const;
 
 describe('lib/auth/permissions.ts (REQ-ENTERPRISE-020) — PERMISSIONS matrix', () => {
-  it('PERMISSIONS contains exactly 66 entries', () => {
-    expect(Object.keys(PERMISSIONS)).toHaveLength(66); // +7 complaint/capa.* (CAPA-001, Issue #68) +3 clinical_investigation.* (Issue #69) +3 modelgov.* (MODEL-GOVERNANCE, Issue 71) +2 cyberdevice.* (CYBERDEVICE, Issue 67)
+  it('PERMISSIONS contains exactly 68 entries', () => {
+    expect(Object.keys(PERMISSIONS)).toHaveLength(68); // +2 corpuslicense.* (CORPUS-LICENSE, Issue #72)
   });
 
   it.each(EXPECTED_ACTIONS)('PERMISSIONS contains action: %s', (action) => {

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -326,7 +326,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     const values = extractAuditActionEnumValues(src);
     const typeValues = extractAuditActionTypeValues(auditSrc);
     expect(values).toEqual(typeValues);
-    expect(values).toHaveLength(174); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255) +1 traceability.matrix_viewed (#240) +8 ci.* (CLINICAL-INVESTIGATION, #69) +8 modelgov.* (MODEL-GOVERNANCE, Issue 71) +9 cyber.* (CYBERDEVICE, Issue 67) +1 cyber.reassess_triggered (CYBERDEVICE H-2 fix, Issue 67)
+    expect(values).toHaveLength(183); // +9 corpus.* (CORPUS-LICENSE, Issue #72)
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -382,7 +382,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(174); // +7 complaint/capa.* (CAPA-001, #68) +1 cer_persisted (#255) +1 traceability.matrix_viewed (#240) +8 ci.* (CLINICAL-INVESTIGATION, #69) +8 modelgov.* (MODEL-GOVERNANCE, Issue 71) +9 cyber.* (CYBERDEVICE, Issue 67) +1 cyber.reassess_triggered (CYBERDEVICE H-2 fix, Issue 67)
+    expect(values).toHaveLength(183); // +9 corpus.* (CORPUS-LICENSE, Issue #72)
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(
@@ -1547,5 +1547,70 @@ describe('migrations/0078_cyberdevice.sql (SPEC-REGULA-CYBERDEVICE-001, Issue 67
     expect(src).toMatch(/export const sbom = pgTable/);
     expect(src).toMatch(/export const cveImpact = pgTable/);
     expect(src).toMatch(/export const cyberEvidenceBundle = pgTable/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SPEC-REGULA-CORPUS-LICENSE-001 — Issue #72 (migration 0080_corpus_license)
+// ---------------------------------------------------------------------------
+
+describe('SPEC-REGULA-CORPUS-LICENSE-001 (Issue #72, migration 0080)', () => {
+  it('has exactly 9 ALTER TYPE audit_action statements', () => {
+    const sql = readText('migrations/0080_corpus_license.sql');
+    const matches = sql.match(/ALTER TYPE audit_action ADD VALUE/g) ?? [];
+    expect(matches).toHaveLength(9);
+  });
+
+  it('creates the 2 new tables with org_id scoping', () => {
+    const sql = readText('migrations/0080_corpus_license.sql');
+    expect(sql).toMatch(/CREATE TABLE source_license/);
+    expect(sql).toMatch(/CREATE TABLE entitlement/);
+    expect(sql).toMatch(/REFERENCES organizations\(id\)/);
+    expect(sql).toMatch(/REFERENCES sources\(id\)/);
+  });
+
+  it('enables RLS with org-isolation on both tables', () => {
+    const sql = readText('migrations/0080_corpus_license.sql');
+    expect(sql).toMatch(/ENABLE ROW LEVEL SECURITY/g);
+    const policies = sql.match(/tenant_isolation_\w+/g) ?? [];
+    expect(policies.length).toBeGreaterThanOrEqual(2);
+    expect(sql).toMatch(/current_setting\('app.current_org_id'/);
+  });
+
+  it('creates the 3 new enums (license_type, confidentiality_level, entitlement_status)', () => {
+    const sql = readText('migrations/0080_corpus_license.sql');
+    expect(sql).toMatch(
+      /CREATE TYPE license_type AS ENUM \('standard_paid', 'journal', 'internal_sop', 'open'\)/,
+    );
+    expect(sql).toMatch(
+      /CREATE TYPE confidentiality_level AS ENUM \('public', 'internal', 'trade_secret'\)/,
+    );
+    expect(sql).toMatch(
+      /CREATE TYPE entitlement_status AS ENUM \('active', 'revoked', 'expired'\)/,
+    );
+  });
+
+  it.each([
+    'corpus.license_set',
+    'corpus.ingestion_blocked',
+    'corpus.full_text_blocked',
+    'corpus.entitlement_granted',
+    'corpus.entitlement_revoked',
+    'corpus.export_blocked',
+    'corpus.access_denied',
+    'corpus.expiry_warned',
+    'corpus.abstract_only_enforced',
+  ])('auditActionEnum in schema.ts includes %s', (action) => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain(`'${action}'`);
+  });
+
+  it('schema.ts defines the 2 new tables + 3 new enums', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toMatch(/export const licenseTypeEnum/);
+    expect(src).toMatch(/export const confidentialityLevelEnum/);
+    expect(src).toMatch(/export const entitlementStatusEnum/);
+    expect(src).toMatch(/export const sourceLicense = pgTable/);
+    expect(src).toMatch(/export const entitlement = pgTable/);
   });
 });

--- a/tests/unit/retrievers/eu-mdr.test.ts
+++ b/tests/unit/retrievers/eu-mdr.test.ts
@@ -60,7 +60,13 @@ describe('lib/ai/retrievers/eu-mdr.ts (REQ-BREADTH-034)', () => {
     const retriever = new EuMdrRetriever();
     const results = await retriever.retrieve('safety requirements', { limit: 5 });
 
-    expect(mockedHybridSearch).toHaveBeenCalledWith('safety requirements', 'eu-mdr', 5, 'all');
+    expect(mockedHybridSearch).toHaveBeenCalledWith(
+      'safety requirements',
+      'eu-mdr',
+      5,
+      'all',
+      undefined,
+    );
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({
       id: 'sec-1',
@@ -80,6 +86,6 @@ describe('lib/ai/retrievers/eu-mdr.ts (REQ-BREADTH-034)', () => {
     const retriever = new EuMdrRetriever();
     await retriever.retrieve('query');
 
-    expect(mockedHybridSearch).toHaveBeenCalledWith('query', 'eu-mdr', 10, 'all');
+    expect(mockedHybridSearch).toHaveBeenCalledWith('query', 'eu-mdr', 10, 'all', undefined);
   });
 });

--- a/tests/unit/retrievers/mfds.test.ts
+++ b/tests/unit/retrievers/mfds.test.ts
@@ -37,7 +37,7 @@ describe('lib/ai/retrievers/mfds.ts (REQ-BREADTH-035)', () => {
     const retriever = new MfdsRetriever();
     await retriever.retrieve('의료기기 허가', { limit: 3 });
 
-    expect(mockedHybridSearch).toHaveBeenCalledWith('의료기기 허가', 'mfds', 3, 'all');
+    expect(mockedHybridSearch).toHaveBeenCalledWith('의료기기 허가', 'mfds', 3, 'all', undefined);
   });
 
   it('retrieve() returns RetrievalResult array shape', async () => {

--- a/tests/unit/retrievers/nmpa.test.ts
+++ b/tests/unit/retrievers/nmpa.test.ts
@@ -33,7 +33,13 @@ describe('lib/ai/retrievers/nmpa.ts (REQ-BREADTH-036)', () => {
 
     const { NmpaRetriever } = await import('@/lib/ai/retrievers/nmpa');
     await new NmpaRetriever().retrieve('medical device registration', { limit: 8 });
-    expect(hybridSearch).toHaveBeenCalledWith('medical device registration', 'nmpa', 8, 'all');
+    expect(hybridSearch).toHaveBeenCalledWith(
+      'medical device registration',
+      'nmpa',
+      8,
+      'all',
+      undefined,
+    );
   });
 
   it('retrieve() maps hybridSearch results to RetrievalResult shape', async () => {

--- a/tests/unit/retrievers/pmda.test.ts
+++ b/tests/unit/retrievers/pmda.test.ts
@@ -33,7 +33,7 @@ describe('lib/ai/retrievers/pmda.ts (REQ-BREADTH-036)', () => {
 
     const { PmdaRetriever } = await import('@/lib/ai/retrievers/pmda');
     await new PmdaRetriever().retrieve('薬機法', { limit: 6 });
-    expect(hybridSearch).toHaveBeenCalledWith('薬機法', 'pmda', 6, 'all');
+    expect(hybridSearch).toHaveBeenCalledWith('薬機法', 'pmda', 6, 'all', undefined);
   });
 
   it('retrieve() uses default limit 10', async () => {
@@ -42,6 +42,6 @@ describe('lib/ai/retrievers/pmda.ts (REQ-BREADTH-036)', () => {
 
     const { PmdaRetriever } = await import('@/lib/ai/retrievers/pmda');
     await new PmdaRetriever().retrieve('query');
-    expect(hybridSearch).toHaveBeenCalledWith('query', 'pmda', 10, 'all');
+    expect(hybridSearch).toHaveBeenCalledWith('query', 'pmda', 10, 'all', undefined);
   });
 });

--- a/types/streaming.ts
+++ b/types/streaming.ts
@@ -54,6 +54,10 @@ export interface SourceItem {
   url: string | null;
   anchor: string;
   offset: number;
+  // REQ-CORPUSLIC-007/011 — per-source usage-restriction notice attached by
+  // generateUsageNotice() at the answer/export path. Optional: present when a
+  // source_license row exists for the source.
+  usageNotice?: string;
 }
 
 export interface SourcesEvent {


### PR DESCRIPTION
## 목적

RAG corpus 법적 컴플라이언스 — source별 license/entitlement/permitted_use 관리 + ingestion/search/export 권한 게이트. 무권한 자료 corpus 진입 원천 차단 + expiry/revoke 검색 제외 + 답변/export 사용 제한 문구. 마지막 high SPEC.

## 변경

**DB (migration 0080)**: 2 테이블(source_license/entitlement) + 3 enum + audit +9 corpus.* + RLS. source_license.source_id FK→sources(#48).

**lib/corpus-license (11 모듈)**: license-gate·permitted-use·usage-notice·expiry-checker·entitlement·export-gate·access·audit. API 3종(source-license/ingestion-gate/entitlement). RBAC corpuslicense.manage/view.

## AC 커버리지
| AC | 상태 | 근거 |
|---|---|---|
| AC-01 무license ingestion 차단 | ✅ | assertIngestionLicensed — upload new-source 400 + Inngest gate |
| AC-02 유료 표준 전문 무권한 block | ✅ | license-gate REQ-004 (entitlement 필수) |
| AC-03 expiry 시 검색 제외 | ✅ | filterExpiredSources — per-corpus retrievers 모두 orgId threading |
| AC-04 export 사용제한 문구 | ✅ | generateUsageNotice + verifyExportRights (traceability/cc export) |
| AC-05 license 변경 audit | ✅ | corpus.* audit tx |
| AC-06 abstract-only 전문 차단 | ✅ | isFullTextBlocked + auditAbstractOnlyEnforced |
| AC-07 무권한 license 변경 403+audit | ✅ | RBAC + IDOR audit |

## QA evidence (게이트 직견, L-007/L-008/L-009)

| 게이트 | 결과 |
|---|---|
| `pnpm typecheck` | exit 0 |
| `pnpm lint` (biome + lint:hex) | exit 0 |
| `pnpm test` 전체 | **4105 passed | 8 skipped** (baseline 3938 → +167, 회귀 0) |
| `pnpm build` | exit 0 |
| 게이트 live call site | 6함수 전부 grep 확인 (dead-code 제로) |

## 보안 리뷰 (sync Phase 0.55)

**expert-security BLOCK-MERGE + evaluator PASS-WITH-CONDITIONS 일치** → 결함 4건+ fix (전부 직견):
- **C-1 CRITICAL**: upload new-source path @MX:TODO로 ungated → new-source 생성 금지, licensed sourceId 필수(400 + audit).
- **C-2 CRITICAL**: Inngest production ingest pipeline gate 無 → Step 0 license-gate 추가.
- **C-3 CRITICAL**: per-corpus retrievers orgId 미전달 → filterExpiredSources 미발화. merge→retrievers→hybridSearch orgId threading (주 RAG 경로).
- **C-4 CRITICAL**: export 경로 notice·검증 無 + auditExportBlocked dead → export-gate.ts verifyExportRights 신규 + 2 export route wiring + PDF/markdown notice 섹션 + auditAbstractOnlyEnforced.
- H-4: sources admin API revoked redaction. H-3: ingestion-gate route 주석.

★ **dead-code 패턴 4회째** (#69/#71/#67/#72): gate 함수를 '일부'가 아닌 핵심 production 경로에 wiring 필수 — 본 세션 핵심 교훈.

**DEFER**: seed scripts·delta-sync(@MX:TODO)·외부 라이선스 API·DRM·admin UI·Inngest expiry cron·M-2 RLS WITH CHECK(#239)·M-3 cross-field Zod.

Fixes #72

🗿 MoAI <email@mo.ai.kr>