### PR TITLE
feat(rlhf): SPEC-REGULA-RLHF-001 프론트엔드 머지 누락 복구 (#56)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ env/
 # Test Coverage
 # ===========================================
 .coverage
+coverage/
 coverage.json
 htmlcov/
 

--- a/.moai/specs/SPEC-REGULA-RLHF-001/tasks.md
+++ b/.moai/specs/SPEC-REGULA-RLHF-001/tasks.md
@@ -1,0 +1,304 @@
+# SPEC-REGULA-RLHF-001 — Implementation Plan (tasks.md)
+
+> **Status**: draft plan, pending approval. Branch: `feat/issue-56-rlhf` (from `main` `a386149`).
+> **Methodology**: TDD (brownfield). Project has 4169+ passing tests, high coverage. Pre-RED reading required.
+> **Scope guard**: v1.0.0 REQs only. NO confidence-calibration, NO alternate-answers, NO qualityTags expansion. See §7 Follow-up.
+
+---
+
+## §1 Verified Baseline (by execution — L-007)
+
+All counts verified by running the authoritative test extractors on 2026-06-25. Source test cited per row.
+
+| Metric | Value | Source (test file:line) | Method |
+|---|---|---|---|
+| Latest migration | `0081_source_governance.sql` | `ls migrations/0*.sql \| tail -1` | Next = **0082** |
+| `audit_action` pgEnum | **191** | `tests/unit/enterprise-migrations.test.ts:329` (`extractAuditActionEnumValues`) | runtime regex extractor, **lock-stepped** to `AuditAction` type (also 191, line 385) |
+| `workflow_type` pgEnum | **17** | `lib/db/schema.ts:422` (pgEnum parse) | — |
+| `PermissionAction` type | **38** | `lib/auth/permissions.ts:5` (union parse) | single source of truth for RBAC |
+| Inngest registry | **4 functions** | `lib/inngest/functions.ts:16` (`export const functions = [...]`) | central registry — single point of registration |
+| `PermissionAction` test (if any) | — | runtime assertion not found in enterprise-migrations; covered by `lib/signature/__tests__/rbac.test.ts` | — |
+
+### Discrepancy resolved (orchestrator schema.ts parse)
+
+The orchestrator's `audit_action = 39` (schema.ts pgEnum parse) was **wrong**. The authoritative runtime assertion in `tests/unit/enterprise-migrations.test.ts:329` asserts **191**, and the full test (377 tests) passes green. Root cause of the orchestrator's error: the test's extractor regex `[\s\S]*?(?=\n\/\/|\nexport|$)` is **non-greedy and stops at the next line-comment `//`**, so naive greedy parsing over-counts (208) or under-counts (39) depending on where the parser stops. **191 is authoritative.** The enum and `AuditAction` type are in strict 1:1 lock-step by the same test (line 328: `expect(values).toEqual(typeValues)`).
+
+### Baseline test command
+```
+pnpm test --silent -- tests/unit/enterprise-migrations.test.ts
+# → 377 passed (377)
+```
+
+---
+
+## §2 Phase Decomposition (7 phases, 10 tasks max)
+
+Phases ordered by dependency. Each phase = one TDD RED→GREEN→REFACTOR cycle batch. Files per phase align with SPEC §4.1.
+
+### Phase A — DB Schema & Migration (foundational, blocks all)
+**Target files**:
+- NEW `migrations/0082_rlhf.sql` — `answer_feedback` table + RLS, `source_sections.feedback_score` column, 3 new `audit_action` enum values
+- EDIT `lib/db/schema.ts` — add `answerFeedback` pgTable, `feedbackRatingEnum`, `qualityTagEnum` (8 values), extend `sourceSections` with `feedbackScore` column, extend `auditActionEnum` (+3)
+- EDIT `lib/audit.ts` — extend `AuditAction` union (+3) to preserve lock-step
+
+**Tasks**:
+- **A1** (RED→GREEN): migration `0082_rlhf.sql` + schema.ts `answerFeedback` table, `feedbackRatingEnum` (up/down), `qualityTagEnum` (8 values: `citation_missing, citation_wrong, answer_incomplete, answer_wrong, outdated_info, jurisdiction_mismatch, helpful, excellent`), `source_sections.feedback_score` (numeric, nullable). RLS policy: users can only insert feedback for their own org. Test: migration file exists, table columns match, enum validation rejects non-enum values. → **AC-02**
+- **A2** (RED→GREEN): extend `auditActionEnum` + `AuditAction` type with 3 values: `feedback_submitted`, `reranking_applied`, `reranking_rolled_back`. Lock-step test update: `enterprise-migrations.test.ts:329,385` → 194. → **AC-06** (partial)
+
+**Delta after Phase A**: audit_action 191 → **194**, `source_sections` +1 column, 1 new table + 2 new enums.
+
+### Phase B — Feedback Aggregation Library (pure logic, no I/O deps)
+**Target files**:
+- NEW `lib/rlhf/feedback-aggregator.ts` — `aggregateFeedback(records)`, `detectDownwardTrend(history)`, `computeMessageScore(records)`
+- NEW `lib/rlhf/__tests__/feedback-aggregator.test.ts`
+
+**Tasks**:
+- **B1** (RED→GREEN): `aggregateFeedback` (mean of up=+1/down=-1 per messageId), `detectDownwardTrend` (sliding window 7-day, slope < 0 with ≥3 datapoints). Pure functions, deterministic. → **REQ-RLHF-005, REQ-RLHF-006**
+
+### Phase C — Retrieval Re-ranker + Version Tracker (model-governance reuse)
+**Target files**:
+- NEW `lib/rlhf/reranker.ts` — `computeFeedbackWeight(sourceSectionId)`, `applyReranking(results, feedbackScores)`
+- NEW `lib/rlhf/version-tracker.ts` — wraps `submitRlhfProposal` (existing) + `rollbackCombination` (existing) for re-ranking version metadata
+- EDIT `lib/model-governance/rlhf-gate.ts` — **verify** `submitRlhfProposal` current API (already verified: takes `{orgId, submittedBy, promptId?, proposalText}`, returns `{changeRequestId}`, stores as `pending_review` — reuse as-is, do NOT modify gate semantics)
+- NEW `lib/rlhf/__tests__/reranker.test.ts`, `version-tracker.test.ts`
+
+**Tasks**:
+- **C1** (RED→GREEN): `applyReranking` blends base vector score with `feedback_score` (weighted, configurable λ default 0.2). Test: reranking preserves ordering when all scores equal, boosts high-feedback sections, suppresses negative. → **REQ-RLHF-009, REQ-RLHF-010**
+- **C2** (RED→GREEN): `version-tracker.recordReranking(version)` → calls `submitRlhfProposal` with metadata; `version-tracker.rollback(versionRef)` → calls `rollbackCombination`. Version metadata stored in `change_request` audit `meta_json` (reuse `buildAnswerVersionMetadata` from `audit-metadata.ts`). → **REQ-RLHF-013**
+- **C3** (RED→GREEN): post-rerank verification gate — `verifyPostRerankInvariants(messageId)` re-checks confidence ≥ threshold, citation present, expert-review conditions. Reuse `evalGatePassed` / `checkEvalThreshold` from `eval-gate.ts`. **MUST be called from every reranking code path** (see §6 dead-code risk). → **REQ-RLHF-014, AC-07**
+
+### Phase D — Knowledge Gap + Knowledge Promo Bridges (reuse-heavy, stub promo)
+**Target files**:
+- NEW `lib/rlhf/gap-promo-bridge.ts` — `createGapIssueForLowRatedAnswer(messageId, feedback)`, `proposePromotionCandidateForHighRatedAnswer(messageId, feedback)`
+- NEW `lib/rlhf/__tests__/gap-promo-bridge.test.ts`
+
+**Tasks**:
+- **D1** (RED→GREEN): `createGapIssueForLowRatedAnswer` → wraps `createGitHubIssue` (existing in `lib/knowledge-gap/github-issue.ts`) with `GapIssueContext` derived from the low-rated message + qualityTags. Low-rated = rating `down` AND any of {citation_missing, citation_wrong, answer_incomplete, answer_wrong, outdated_info, jurisdiction_mismatch}. → **REQ-RLHF-007, AC-03**
+- **D2** (RED→GREEN): `proposePromotionCandidateForHighRatedAnswer` → high-rated = rating `up` AND (`excellent` OR `helpful` in qualityTags). **Returns only a candidate descriptor** `{messageId, userId, evidence: {rating, tags}}`. Does NOT call `submitRlhfProposal` with auto-confirm. Writes an audit `feedback_submitted` + a `@MX:TODO` marker that the actual promotion wiring is deferred to #50. → **REQ-RLHF-008, REQ-RLHF-015 [HARD no-auto-confirm], AC-04**
+  - **[HARD invariant]**: no code path in this function may insert into `change_request` with `approval_status != 'pending_review'`. Test asserts this.
+
+### Phase E — Langfuse Emitter (thin wrapper, existing SDK)
+**Target files**:
+- NEW `lib/rlhf/langfuse-emitter.ts` — `emitFeedbackEvent(event)` wrapping `lib/observability/langfuse.ts`
+- NEW `lib/rlhf/__tests__/langfuse-emitter.test.ts`
+
+**Tasks**:
+- **E1** (RED→GREEN): `emitFeedbackEvent` sends `{messageId, userId, rating, qualityTags, comment}` to Langfuse as a `feedback` event. Fails gracefully (no throw) when Langfuse is unavailable (matching existing `lib/observability/langfuse.ts` contract). → **REQ-RLHF-011**
+
+### Phase F — API Routes + AnswerBlock UI Integration
+**Target files**:
+- NEW `app/api/rlhf/feedback/route.ts` — POST handler (zod-validated, `withPermission`-wrapped, writes `answer_feedback`, emits Langfuse, triggers gap/promo bridges async)
+- NEW `app/api/rlhf/feedback/aggregate/route.ts` — GET (per-messageId aggregation)
+- NEW `app/api/rlhf/heatmap/route.ts` — GET (per-question-type × corpus heatmap data)
+- EDIT `components/chat/AnswerBlock.tsx` — extend with `FeedbackControl` sub-component (already `'use client'`, has `messageId` prop — clean integration point)
+- NEW `components/answer-block/feedback-control.tsx` — thumbs up/down + tag chips + optional textarea
+- NEW `app/(app)/quality/heatmap/page.tsx` — heatmap dashboard (admin-gated)
+- NEW `tests/unit/api/rlhf-feedback.test.ts`, `__tests__/feedback-control.test.tsx`, `heatmap.test.tsx`
+
+**Tasks**:
+- **F1** (RED→GREEN): POST `/api/rlhf/feedback` — validates `qualityTags` ∈ 8-enum (AC-02 invariant at API boundary), inserts `answer_feedback` with `userId` from session, emits Langfuse, triggers `createGapIssueForLowRatedAnswer` or `proposePromotionCandidateForHighRatedAnswer` based on rating. `withPermission` requires new `rlhf.feedback` PermissionAction. → **REQ-RLHF-003, REQ-RLHF-004, AC-01**
+- **F2** (RED→GREEN): GET `/api/rlhf/heatmap` — returns per-question-type × per-corpus mean feedback score, downward-trend flags. → **REQ-RLHF-012, AC-08**
+- **F3** (RED→GREEN): `FeedbackControl` component renders in AnswerBlock, calls POST `/api/rlhf/feedback`, shows optimistic state + server confirmation. → **AC-01**
+
+### Phase G — Reranking Wiring + Post-Rerank Gate Integration (cross-cutting)
+**Target files**:
+- EDIT retrieval pipeline (locate via grep `lib/rag/` or wherever retrieval scoring happens) — insert `applyReranking` call
+- NEW `tests/integration/rlhf-reranking-flow.test.ts`
+
+**Tasks**:
+- **G1** (RED→GREEN): wire `applyReranking` into the actual retrieval pipeline. **Every retrieval path that returns AnswerBlock content MUST call `applyReranking` then `verifyPostRerankInvariants`**. Integration test: full feedback → aggregation → reranking → invariant-verification flow. → **REQ-RLHF-010, AC-05, AC-07** (these REQs are NOT satisfied by Phase C alone — only by wiring).
+
+**Delta after Phase G**: PermissionAction 38 → **39** (new `rlhf.feedback`).
+
+---
+
+## §3 Migration Plan — `migrations/0082_rlhf.sql`
+
+Follows project numbering convention (`NNNN_slug.sql`).
+
+```sql
+-- 0082_rlhf.sql — SPEC-REGULA-RLHF-001 (Issue #56)
+
+-- §1 New pgEnum: feedback_rating
+CREATE TYPE feedback_rating AS ENUM ('up', 'down');
+
+-- §2 New pgEnum: quality_tag (8 values — REQ-RLHF-002, AC-02)
+CREATE TYPE quality_tag AS ENUM (
+  'citation_missing',
+  'citation_wrong',
+  'answer_incomplete',
+  'answer_wrong',
+  'outdated_info',
+  'jurisdiction_mismatch',
+  'helpful',
+  'excellent'
+);
+
+-- §3 New table: answer_feedback (REQ-RLHF-001, REQ-RLHF-004)
+CREATE TABLE answer_feedback (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id   uuid NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+  user_id      text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  rating       feedback_rating NOT NULL,
+  quality_tags quality_tag[] NOT NULL DEFAULT '{}'::quality_tag[],
+  comment      text,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(message_id, user_id)  -- one feedback per user per message
+);
+
+CREATE INDEX idx_answer_feedback_message ON answer_feedback(message_id);
+CREATE INDEX idx_answer_feedback_created ON answer_feedback(created_at);
+
+-- RLS: users see only their org's feedback
+ALTER TABLE answer_feedback ENABLE ROW LEVEL SECURITY;
+CREATE POLICY answer_feedback_org_isolation ON answer_feedback
+  USING (EXISTS (
+    SELECT 1 FROM org_members om
+    WHERE om.user_id = answer_feedback.user_id
+      AND om.org_id = (SELECT org_id FROM messages WHERE id = answer_feedback.message_id)
+  ));
+
+-- §4 Extend audit_action enum (+3, REQ-RLHF-013)
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'feedback_submitted';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'reranking_applied';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'reranking_rolled_back';
+
+-- §5 Extend source_sections (REQ-RLHF-009)
+ALTER TABLE source_sections
+  ADD COLUMN feedback_score numeric DEFAULT 0;
+
+-- NOTE: message.feedback (audit_action) already exists in enum (verified 2026-06-25)
+-- and will be reused for REQ-RLHF-004 where appropriate.
+```
+
+### Post-migration count deltas
+| Metric | Before | After | Δ |
+|---|---|---|---|
+| Latest migration | 0081 | **0082** | +1 |
+| `audit_action` enum | 191 | **194** | +3 (`feedback_submitted`, `reranking_applied`, `reranking_rolled_back`) |
+| `PermissionAction` type | 38 | **39** | +1 (`rlhf.feedback`) — added in Phase F, not migration |
+| `source_sections` columns | existing | +1 | `feedback_score` |
+| New tables | — | 1 | `answer_feedback` |
+| New enums | — | 2 | `feedback_rating`, `quality_tag` |
+
+**Test updates required** (non-negotiable, lock-step tests):
+- `tests/unit/enterprise-migrations.test.ts:329` → `194`
+- `tests/unit/enterprise-migrations.test.ts:385` → `194`
+
+---
+
+## §4 Reuse Map (per REQ)
+
+| REQ | Reused module (exists) | New module | Reuse type |
+|---|---|---|---|
+| REQ-RLHF-001 | `pgTable` pattern (schema.ts) | `answerFeedback` table | pattern-reuse |
+| REQ-RLHF-002 | `pgEnum` pattern | `qualityTagEnum` (8 values) | new enum, established pattern |
+| REQ-RLHF-003 | `components/chat/AnswerBlock.tsx` (has `messageId`, `'use client'`) | `FeedbackControl` sub-component | extend existing |
+| REQ-RLHF-004 | `lib/audit.ts` (`writeAudit`, action `message.feedback` already in enum) | POST route inserts + audits | reuse writeAudit |
+| REQ-RLHF-005 | — | `lib/rlhf/feedback-aggregator.ts` | new (pure fn) |
+| REQ-RLHF-006 | — | `lib/rlhf/feedback-aggregator.ts` (`detectDownwardTrend`) | new (pure fn) |
+| REQ-RLHF-007 | `lib/knowledge-gap/github-issue.ts` (`createGitHubIssue`) + `detector.ts` | `lib/rlhf/gap-promo-bridge.ts` wraps | **wrap existing** |
+| REQ-RLHF-008 | (none — #50 not implemented) | candidate-proposal interface only | **stub** |
+| REQ-RLHF-009 | `sourceSections` table (schema.ts:706) | +1 column `feedbackScore` | extend existing |
+| REQ-RLHF-010 | retrieval pipeline (locate via grep pre-RED) | `lib/rlhf/reranker.ts` + wiring | **wire into existing** |
+| REQ-RLHF-011 | `lib/observability/langfuse.ts` (Langfuse SDK already wrapped) | `lib/rlhf/langfuse-emitter.ts` thin wrapper | **wrap existing** |
+| REQ-RLHF-012 | — | heatmap route + page | new |
+| REQ-RLHF-013 | `lib/model-governance/rlhf-gate.ts` (`submitRlhfProposal`) + `rollback.ts` (`rollbackCombination`) + `audit-metadata.ts` (`buildAnswerVersionMetadata`) | `lib/rlhf/version-tracker.ts` orchestrator | **compose 3 existing** |
+| REQ-RLHF-014 | `lib/model-governance/eval-gate.ts` (`checkEvalThreshold`, `evalGatePassed`) | `verifyPostRerankInvariants` | **reuse gates** |
+| REQ-RLHF-015 [HARD] | existing `submitRlhfProposal` already blocks auto-confirm (`approval_status='pending_review'`, `eval_status='pending'`) | — no new code, add assertion test | **gate already correct** |
+
+---
+
+## §5 AC → Phase Mapping
+
+| AC# | Phase(s) | Satisfied by |
+|---|---|---|
+| AC-01 | F1, F3 | POST route + FeedbackControl component |
+| AC-02 | A1 | qualityTagEnum 8-value + API zod validation |
+| AC-03 | D1 | `createGapIssueForLowRatedAnswer` wraps `createGitHubIssue` |
+| AC-04 | D2 | `proposePromotionCandidateForHighRatedAnswer` returns candidate only; auto-confirm blocked by assertion test |
+| AC-05 | C1 + G1 | reranker logic + wiring into retrieval |
+| AC-06 | A2 + C2 | audit_action enum extension + version-tracker wrapping existing gate |
+| AC-07 | C3 + G1 | `verifyPostRerankInvariants` + wiring into every rerank path |
+| AC-08 | E1 + F2 | Langfuse emitter + heatmap route |
+
+---
+
+## §6 Dead-Code Risk Flags (recurring defect class — 5 prior PRs)
+
+Based on the recurring dead-code defect class in Regula (import-but-not-called, gate wired to only some paths, called with empty `[]`, source-grep instead of behavior), flag highest-risk REQs.
+
+### Risk Tier 1 (CRITICAL — add explicit anti-dead-code test)
+
+| REQ | Risk pattern | Mitigation test |
+|---|---|---|
+| **REQ-RLHF-010** (retrieval re-ranking wired) | "applyReranking defined but never called from retrieval path" — exactly the import-but-not-called pattern that has bitten 3 prior PRs | Integration test (Phase G1) that inserts a feedback row, runs actual retrieval, asserts the returned ordering differs from baseline. **A unit test on `applyReranking` alone does NOT satisfy this REQ.** |
+| **REQ-RLHF-014** (post-rerank gate on every path) | "`verifyPostRerankInvariants` called from the happy path but skipped on the cached path / the streaming path / the fallback path" — the gate-wired-to-only-some-paths pattern | Integration test that exercises every retrieval entrypoint (grep all `retrieval` callers) and asserts the gate fires. List the entrypoints in the test as a `entryPoints: string[]` literal so missing ones fail loudly. |
+| **REQ-RLHF-007** (low-rated → gap issue) | "`createGapIssueForLowRatedAnswer` called with empty qualityTags or with the wrong GapIssueContext shape, producing an empty GitHub issue body" — the called-with-empty-`[]` pattern | Test that injects a realistic low-rated feedback and asserts the created issue body contains the actual message text + at least one qualityTag. |
+| **REQ-RLHF-013** (version metadata recorded on every rerank) | "version-tracker.recordReranking imported but the retrieval pipeline bypasses it for performance" | Test that exercises the full reranking flow and asserts a `change_request` audit row with `source: 'rlhf'` exists afterward. |
+
+### Risk Tier 2 (MEDIUM — add characterization test)
+
+| REQ | Risk pattern |
+|---|---|
+| **REQ-RLHF-005/006** (aggregation) | aggregation computed but never read by any consumer (heatmap or dashboard). Mitigation: wire into `/api/rlhf/heatmap` in Phase F2 and assert non-empty response. |
+| **REQ-RLHF-011** (Langfuse emit) | "emitter imported but only called in non-error path; error-path feedback silently dropped." Mitigation: test that emits after a simulated DB error still reaches Langfuse. |
+| **REQ-RLHF-015** [HARD] | "auto-confirm gate accidentally bypassed by a future PR that calls `submitRlhfProposal` with `approval_status='approved'`." Mitigation: assertion test that the high-rated → promo path produces zero rows in `change_request` with non-pending status. |
+
+### Risk Tier 3 (LOW — standard coverage)
+
+REQ-RLHF-001, 002, 003, 004, 008, 009, 012 — straightforward CRUD/UI, covered by normal unit tests.
+
+**Top dead-code-risk REQs to actively defend**: **REQ-RLHF-010, REQ-RLHF-014, REQ-RLHF-007, REQ-RLHF-013** (Tier 1).
+
+---
+
+## §7 Follow-up Issue Draft (excluded scope, Issue #56 comment)
+
+**Recommendation**: Open as **follow-up issue #N (assign after #56 merges)**, not as a blocker to #56. These are the 3 extra requirements from the Issue #56 comment that are explicitly **excluded** from SPEC-REGULA-RLHF-001 v1.0.0.
+
+```markdown
+**Title**: [RLHF-v2] qualityTags expansion + confidence calibration + alternate-answer feedback
+
+**Source**: Issue #56 comment (extra requirements), deferred during SPEC-REGULA-RLHF-001 planning.
+
+**Scope** (3 items):
+1. **qualityTags expansion (+4)**: add `citation_coverage_low`, `source_recency_stale`,
+   `source_authority_weak`, `source_agreement_conflict` to the `quality_tag` enum
+   (brings total from 8 → 12). Requires migration `00NN_rlhf_v2_quality_tags.sql`
+   + zod schema update + UI tag-chip grid update.
+2. **Confidence calibration retraining**: when sufficient feedback accumulates,
+   retrain the confidence calibration layer (requires a calibration job, eval gate,
+   and rollback). Depends on #50 KNOWLEDGE-PROMO landing first.
+3. **Alternate answers implicit feedback**: when a user asks a follow-up after a
+   low-rated answer, treat it as implicit negative feedback on the prior answer.
+   Requires a conversation-state tracker.
+
+**Depends on**: SPEC-REGULA-RLHF-001 (#56) merge, SPEC-REGULA-KNOWLEDGE-PROMO-001 (#50) merge.
+
+**Why deferred**: keeps #56 to a reviewable size; the 3 items each touch a
+different layer (enum/DB, ML pipeline, conversation tracking) and mixing them
+with the v1 loop would inflate the PR beyond the 5-PR pipeline session pattern.
+```
+
+---
+
+## §8 Open Questions for Approval
+
+1. **Migration numbering**: confirmed `0082_rlhf.sql` (0081 is the latest, verified). ✓
+2. **`rlhf.feedback` permission**: new `PermissionAction` value, granted to `ra-lead` and `ra-member` (not `viewer`). Confirm RBAC matrix — planned to add in `lib/auth/rbac.ts` during Phase F1.
+3. **Langfuse event schema**: the wrapper will send `{messageId, userId, rating, qualityTags, comment}`. Confirm this matches the Langfuse team's expected event shape (no upstream contract found in `lib/observability/langfuse.ts` beyond the SDK wrapper).
+4. **Heatmap dashboard route gate**: `app/(app)/quality/heatmap/page.tsx` — confirm `audit.read` or a new `quality.view` permission. Planned: `audit.read` (already exists, no PermissionAction delta).
+
+---
+
+## §9 Completion Criteria (per phase)
+
+- Phase A: migration applies cleanly on fresh DB; lock-step tests green at 194; AC-02 green.
+- Phase B: aggregator/trend unit tests green; AC-08 dependency satisfied.
+- Phase C: reranker + version-tracker + post-rerank gate unit tests green; AC-05/06/07 unit portion.
+- Phase D: gap/promo bridges green; AC-03/04 green; **REQ-RLHF-015 assertion test green**.
+- Phase E: Langfuse emitter test green (including unavailable-SDK graceful path).
+- Phase F: API routes + UI tests green; AC-01/08 green.
+- Phase G: integration test green; **all Tier-1 dead-code-risk tests green**; AC-05/07 end-to-end.
+- Final: full `pnpm test` green, `pnpm lint` (lint:hex) clean, no `#NNN` code-line refs (L-008), staged scope verified (L-009).

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -40,6 +40,10 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   let showClinicalInvestigation = false;
   // SPEC-REGULA-SOURCE-GOVERNANCE-001 (Issue #48): Governance dashboard nav gated to ra-member+ (sourcegov.view).
   let showGovernance = false;
+  // SPEC-REGULA-RLHF-001 (Issue #56): Quality heatmap nav gated to ra-member+
+  // (rlhf.feedback submitters). The heatmap route uses audit.read, but feedback
+  // submitters also see the nav to track answer quality.
+  let showQualityHeatmap = false;
   try {
     const { auth } = await import('@/lib/auth');
     const { hasRole } = await import('@/lib/auth/rbac');
@@ -56,6 +60,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       showCapa = hasRole(userRole as Parameters<typeof hasRole>[0], 'ra-member');
       showClinicalInvestigation = hasRole(userRole as Parameters<typeof hasRole>[0], 'ra-member');
       showGovernance = hasRole(userRole as Parameters<typeof hasRole>[0], 'ra-member');
+      showQualityHeatmap = hasRole(userRole as Parameters<typeof hasRole>[0], 'ra-member');
     }
     const department = (session?.user as { department?: string } | undefined)?.department;
     if (department) {
@@ -89,6 +94,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         showCapa={showCapa}
         showClinicalInvestigation={showClinicalInvestigation}
         showGovernance={showGovernance}
+        showQualityHeatmap={showQualityHeatmap}
         initialLocale={initialLocale}
       />
       <div className="flex min-w-0 flex-1 flex-col">

--- a/app/(app)/quality/heatmap/page.tsx
+++ b/app/(app)/quality/heatmap/page.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+// @MX:NOTE [AUTO] Quality heatmap page — feedback score by corpus.
+// @MX:SPEC SPEC-REGULA-RLHF-001 (REQ-RLHF-012, AC-08)
+//
+// Architecture: client page fetching GET /api/rlhf/heatmap. The heatmap route is
+// gated by audit.read, so RA leads and auditors can view quality trends. v1
+// groups feedback by conversationId as the corpus proxy (see route comment for
+// the deferred per-source-type breakdown). The dashboard renders a corpus list
+// with mean-score bars and up/down counts.
+
+import { useEffect, useState } from 'react';
+
+interface CorpusEntry {
+  meanScore: number;
+  total: number;
+  upCount: number;
+  downCount: number;
+}
+interface HeatmapResponse {
+  heatmap: Record<string, CorpusEntry>;
+  sampledAt: string;
+}
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; data: HeatmapResponse }
+  | { kind: 'empty' }
+  | { kind: 'error'; message: string };
+
+function scoreColor(mean: number): string {
+  if (mean >= 0.75) return 'bg-success';
+  if (mean >= 0.5) return 'bg-warn';
+  return 'bg-danger';
+}
+
+function scoreLabel(mean: number): string {
+  if (mean >= 0.75) return '높음';
+  if (mean >= 0.5) return '보통';
+  return '낮음';
+}
+
+function truncateCorpus(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
+}
+
+export default function HeatmapPage() {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch('/api/rlhf/heatmap?limit=200', { cache: 'no-store' });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const body = (await res.json()) as HeatmapResponse;
+        if (cancelled) return;
+        const entries = Object.keys(body.heatmap ?? {});
+        setState(entries.length === 0 ? { kind: 'empty' } : { kind: 'ready', data: body });
+      } catch (err) {
+        if (!cancelled) {
+          setState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : '히트맵 로드에 실패했습니다.',
+          });
+        }
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-8">
+      <header className="mb-6">
+        <h1 className="font-serif text-2xl text-ink-900">품질 히트맵</h1>
+        <p className="mt-1 text-sm text-ink-500">
+          사용자 피드백 기반 답변 품질 분포. 항목별 평균 점수와 엄지 위/아래 비율.
+        </p>
+      </header>
+
+      {state.kind === 'loading' && (
+        <output data-testid="heatmap-loading" className="text-sm text-ink-500">
+          불러오는 중…
+        </output>
+      )}
+
+      {state.kind === 'error' && (
+        <div
+          data-testid="heatmap-error"
+          className="rounded-md border border-danger bg-danger-bg px-4 py-3 text-sm text-danger"
+        >
+          <p className="font-medium">히트맵을 불러오지 못했습니다.</p>
+          <p className="mt-1 text-xs">{state.message}</p>
+        </div>
+      )}
+
+      {state.kind === 'empty' && (
+        <div
+          data-testid="heatmap-empty"
+          className="rounded-md border border-ink-100 bg-surface-elevated px-4 py-6 text-center text-sm text-ink-500"
+        >
+          아직 집계된 피드백이 없습니다. 답변에 평가를 남기면 이 대시보드에 반영됩니다.
+        </div>
+      )}
+
+      {state.kind === 'ready' && <HeatmapTable data={state.data} />}
+    </div>
+  );
+}
+
+function HeatmapTable({ data }: { data: HeatmapResponse }) {
+  const entries = Object.entries(data.heatmap)
+    .map(([id, e]) => ({ id, ...e }))
+    .sort((a, b) => a.meanScore - b.meanScore); // lowest scores first (biggest gaps on top)
+
+  const sampledAt = new Date(data.sampledAt).toLocaleString('ko-KR');
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs text-ink-400">집계 시각: {sampledAt}</p>
+      <div className="overflow-hidden rounded-md border border-ink-100">
+        <table className="w-full text-sm" data-testid="heatmap-table">
+          <caption className="sr-only">항목별 평균 점수와 엄지 위/아래 횟수</caption>
+          <thead className="bg-ink-50 text-left text-xs text-ink-500">
+            <tr>
+              <th scope="col" className="px-4 py-2 font-medium">
+                항목 (conversation)
+              </th>
+              <th scope="col" className="px-4 py-2 font-medium">
+                평균 점수
+              </th>
+              <th scope="col" className="px-4 py-2 font-medium">
+                평가
+              </th>
+              <th scope="col" className="px-4 py-2 font-medium">
+                비율
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-ink-100">
+            {entries.map((e) => {
+              const pct = e.total === 0 ? 0 : Math.round((e.upCount / e.total) * 100);
+              return (
+                <tr key={e.id} className="text-ink-700">
+                  <td className="px-4 py-2 font-mono text-xs" title={e.id}>
+                    {truncateCorpus(e.id)}
+                  </td>
+                  <td className="px-4 py-2">
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="h-1.5 w-16 rounded-full bg-ink-100"
+                        role="img"
+                        aria-label={`평균 점수 ${e.meanScore.toFixed(2)} (${scoreLabel(e.meanScore)})`}
+                      >
+                        <div
+                          className={`h-full rounded-full ${scoreColor(e.meanScore)}`}
+                          style={{ width: `${Math.round(e.meanScore * 100)}%` }}
+                        />
+                      </div>
+                      <span className="font-mono text-xs text-ink-600">
+                        {e.meanScore.toFixed(2)}
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-2 text-xs">
+                    <span className="text-success">▲ {e.upCount}</span>
+                    {' / '}
+                    <span className="text-danger">▼ {e.downCount}</span>
+                    <span className="ml-2 text-ink-400">(총 {e.total})</span>
+                  </td>
+                  <td className="px-4 py-2 font-mono text-xs text-ink-600">{pct}%</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-xs text-ink-400">
+        v1 집계 기준: 항목별 대화(conversation) 단위 그룹. 출처 유형별 분해는 추후 확장 예정.
+      </p>
+    </div>
+  );
+}

--- a/components/answer-block/__tests__/feedback-control.test.tsx
+++ b/components/answer-block/__tests__/feedback-control.test.tsx
@@ -1,0 +1,145 @@
+// @MX:NOTE Unit tests for FeedbackControl — SPEC-REGULA-RLHF-001 (REQ-RLHF-003, AC-01).
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FeedbackControl } from '../feedback-control';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+const OK_RESPONSE = {
+  ok: true,
+  feedbackId: 'fb-1',
+  messageId: '00000000-0000-0000-0000-000000000001',
+};
+function mockFetchOk() {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(OK_RESPONSE), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+  return fetchSpy;
+}
+
+describe('FeedbackControl (REQ-RLHF-003, AC-01)', () => {
+  it('renders rating buttons with accessible names', () => {
+    render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
+    expect(screen.getByRole('button', { name: '유용해요' })).toBeDefined();
+    expect(screen.getByRole('button', { name: '아쉬워요' })).toBeDefined();
+  });
+
+  it('does not render tags or submit before a rating is chosen', () => {
+    render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
+    expect(screen.queryByTestId('feedback-submit')).toBeNull();
+    expect(screen.queryAllByRole('button', { name: /출처 누락/ }).length).toBe(0);
+  });
+
+  it('shows 8 quality tags after selecting a rating', () => {
+    render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
+    fireEvent.click(screen.getByRole('button', { name: '아쉬워요' }));
+    expect(screen.getByTestId('feedback-tag-citation_missing')).toBeDefined();
+    expect(screen.getByTestId('feedback-tag-excellent')).toBeDefined();
+    const tagButtons = screen
+      .getAllByRole('button')
+      .filter((b) => b.dataset.testid?.startsWith('feedback-tag-'));
+    expect(tagButtons.length).toBe(8);
+  });
+
+  it('submits up-rating feedback with selected tags and forwards the messageId', async () => {
+    const fetchSpy = mockFetchOk();
+    render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '유용해요' }));
+    fireEvent.click(screen.getByTestId('feedback-tag-helpful'));
+    fireEvent.click(screen.getByTestId('feedback-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-submitted')).toBeDefined();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calls = fetchSpy.mock.calls;
+    const init = calls[0]?.[1];
+    expect(init).toBeDefined();
+    const body = JSON.parse(init?.body as string);
+    expect(body.messageId).toBe('00000000-0000-0000-0000-000000000001');
+    expect(body.rating).toBe('up');
+    expect(body.qualityTags).toEqual(['helpful']);
+  });
+
+  it('shows the knowledge-gap acknowledgement for low-rated gap-signal tags', async () => {
+    mockFetchOk();
+    render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '아쉬워요' }));
+    fireEvent.click(screen.getByTestId('feedback-tag-citation_missing'));
+    fireEvent.click(screen.getByTestId('feedback-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-gap-ack')).toBeDefined();
+    });
+  });
+
+  it('does not show the gap acknowledgement for up-rating', async () => {
+    mockFetchOk();
+    render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '유용해요' }));
+    fireEvent.click(screen.getByTestId('feedback-tag-helpful'));
+    fireEvent.click(screen.getByTestId('feedback-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-submitted')).toBeDefined();
+    });
+    expect(screen.queryByTestId('feedback-gap-ack')).toBeNull();
+  });
+
+  it('shows an error when submit fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'validation_failed' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '아쉬워요' }));
+    fireEvent.click(screen.getByTestId('feedback-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-error')).toBeDefined();
+    });
+  });
+});
+
+describe('FeedbackControl enum invariant (AC-02)', () => {
+  beforeEach(() => {
+    mockFetchOk();
+  });
+
+  it('only sends enum values — toggling a tag sends exactly that tag', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '아쉬워요' }));
+    fireEvent.click(screen.getByTestId('feedback-tag-answer_wrong'));
+    fireEvent.click(screen.getByTestId('feedback-tag-jurisdiction_mismatch'));
+    fireEvent.click(screen.getByTestId('feedback-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-submitted')).toBeDefined();
+    });
+
+    const calls = fetchSpy.mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const init = calls[0]?.[1];
+    expect(init).toBeDefined();
+    const body = JSON.parse(init?.body as string);
+    expect(body.qualityTags).toEqual(['answer_wrong', 'jurisdiction_mismatch']);
+  });
+});

--- a/components/answer-block/feedback-control.tsx
+++ b/components/answer-block/feedback-control.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+// @MX:NOTE [AUTO] FeedbackControl — inline answer feedback island.
+// @MX:SPEC SPEC-REGULA-RLHF-001 (REQ-RLHF-003, REQ-RLHF-004, REQ-RLHF-007, AC-01)
+//
+// Architecture: client island rendered below the AnswerBlock prose. The userId
+// is resolved server-side at the API boundary (session.user.id) so this client
+// never handles credentials. qualityTags is limited to the 8-value enum via
+// strict TypeScript + the API re-validates with zod (AC-02). The low-rated
+// acknowledgement surfaces REQ-RLHF-007 (knowledge-gap bridge) without any
+// client-side issue creation.
+
+import { ThumbsDown, ThumbsUp } from 'lucide-react';
+import { useState } from 'react';
+
+/** REQ-RLHF-002 / AC-02: EXACTLY 8 quality tag values (frozen enum). */
+export const QUALITY_TAGS_8 = [
+  'citation_missing',
+  'citation_wrong',
+  'answer_incomplete',
+  'answer_wrong',
+  'outdated_info',
+  'jurisdiction_mismatch',
+  'helpful',
+  'excellent',
+] as const;
+
+export type QualityTag = (typeof QUALITY_TAGS_8)[number];
+
+const TAG_LABELS: Record<QualityTag, string> = {
+  citation_missing: '출처 누락',
+  citation_wrong: '출처 오류',
+  answer_incomplete: '답변 불완전',
+  answer_wrong: '답변 오류',
+  outdated_info: '구식 정보',
+  jurisdiction_mismatch: '관할권 불일치',
+  helpful: '유용함',
+  excellent: '우수함',
+};
+
+/**
+ * Tags that indicate a knowledge-gap signal. When the user rates "down" with
+ * any of these tags selected, the UI surfaces a non-blocking acknowledgement.
+ * The backend independently runs the gap/promo bridge — this list is display-only.
+ */
+const GAP_SIGNAL_TAGS: ReadonlySet<QualityTag> = new Set<QualityTag>([
+  'citation_missing',
+  'answer_wrong',
+  'outdated_info',
+  'jurisdiction_mismatch',
+]);
+
+interface FeedbackControlProps {
+  messageId: string;
+  /** Optional PII-free question snippet forwarded to the gap/promo bridge. */
+  redactedQuestion?: string;
+}
+
+type Rating = 'up' | 'down';
+
+type SubmitState =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'success'; rating: Rating }
+  | { kind: 'error'; message: string };
+
+function isGapSignal(rating: Rating, tags: readonly QualityTag[]): boolean {
+  return rating === 'down' && tags.some((t) => GAP_SIGNAL_TAGS.has(t));
+}
+
+export function FeedbackControl({ messageId, redactedQuestion }: FeedbackControlProps) {
+  const [rating, setRating] = useState<Rating | null>(null);
+  const [selectedTags, setSelectedTags] = useState<QualityTag[]>([]);
+  const [comment, setComment] = useState('');
+  const [state, setState] = useState<SubmitState>({ kind: 'idle' });
+
+  const showGapAck = state.kind === 'success' && isGapSignal(state.rating, selectedTags);
+
+  function toggleTag(tag: QualityTag) {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }
+
+  function selectRating(next: Rating) {
+    setRating((prev) => (prev === next ? null : next));
+    // Clear any prior error when the user adjusts their input.
+    if (state.kind === 'error') setState({ kind: 'idle' });
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (rating === null) {
+      setState({ kind: 'error', message: '엄지 위/아래 평가를 선택해 주세요.' });
+      return;
+    }
+    setState({ kind: 'submitting' });
+    try {
+      const res = await fetch('/api/rlhf/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messageId,
+          rating,
+          qualityTags: selectedTags,
+          comment: comment.trim() ? comment.trim() : null,
+          redactedQuestion,
+        }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setState({ kind: 'success', rating });
+    } catch (err) {
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : '피드백 전송에 실패했습니다.',
+      });
+    }
+  }
+
+  const submitting = state.kind === 'submitting';
+  const submitted = state.kind === 'success';
+
+  return (
+    <section
+      data-testid="feedback-control"
+      aria-label="답변 품질 피드백"
+      className="mt-2 rounded-md border border-ink-100 bg-surface-elevated px-4 py-3"
+    >
+      <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <p className="section-label font-serif text-[10px] uppercase tracking-widest text-ink-400">
+            답변 품질 평가
+          </p>
+          <div className="flex items-center gap-2">
+            <RatingButton
+              rating="up"
+              active={rating === 'up'}
+              disabled={submitting}
+              onClick={() => selectRating('up')}
+            />
+            <RatingButton
+              rating="down"
+              active={rating === 'down'}
+              disabled={submitting}
+              onClick={() => selectRating('down')}
+            />
+          </div>
+          {submitted && (
+            <output data-testid="feedback-submitted" className="text-xs font-medium text-success">
+              피드백이 저장되었습니다.
+            </output>
+          )}
+          {state.kind === 'error' && (
+            <p data-testid="feedback-error" className="text-xs font-medium text-danger">
+              {state.message}
+            </p>
+          )}
+        </div>
+
+        {/* Quality tag chips — multi-select, only visible after a rating is chosen. */}
+        {rating !== null && !submitted && (
+          <fieldset className="flex flex-col gap-2" aria-label="품질 태그">
+            <legend className="sr-only">품질 태그 (여러 개 선택 가능)</legend>
+            <div className="flex flex-wrap gap-1.5">
+              {QUALITY_TAGS_8.map((tag) => {
+                const active = selectedTags.includes(tag);
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    data-testid={`feedback-tag-${tag}`}
+                    aria-pressed={active}
+                    onClick={() => toggleTag(tag)}
+                    disabled={submitting}
+                    className={`rounded-xs border px-2.5 py-1 text-xs transition-colors motion-safe:duration-200 ${
+                      active
+                        ? 'border-brand-500 bg-brand-100 text-brand-800'
+                        : 'border-ink-200 bg-white text-ink-600 hover:bg-ink-50'
+                    } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60`}
+                  >
+                    {TAG_LABELS[tag]}
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+        )}
+
+        {/* Optional comment textarea. */}
+        {rating !== null && !submitted && (
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-ink-500">추가 의견 (선택, 최대 2000자)</span>
+            <textarea
+              data-testid="feedback-comment"
+              aria-label="추가 의견"
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              disabled={submitting}
+              maxLength={2000}
+              rows={2}
+              className="resize-y rounded-xs border border-ink-200 bg-white px-2.5 py-1.5 text-sm text-ink-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:opacity-60"
+              placeholder="구체적인 개선점이나 우수한 점을 알려주세요."
+            />
+          </label>
+        )}
+
+        {rating !== null && !submitted && (
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              data-testid="feedback-submit"
+              disabled={submitting}
+              className="rounded-xs bg-brand-800 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting ? '전송 중…' : '피드백 전송'}
+            </button>
+          </div>
+        )}
+      </form>
+
+      {/*
+       * REQ-RLHF-007 surface: a non-blocking acknowledgement when the user flags
+       * a low-quality answer. The backend creates the knowledge-gap issue; this
+       * banner only acknowledges the action. Mirrors the inline-status pattern
+       * used by ExpertReviewCallout (no global toast system in the project).
+       */}
+      {showGapAck && (
+        <output data-testid="feedback-gap-ack" className="mt-2 text-xs text-warn">
+          해당 답변은 지식 간극(knowledge-gap) 검토용으로 플래그되었습니다.
+        </output>
+      )}
+    </section>
+  );
+}
+
+interface RatingButtonProps {
+  rating: Rating;
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+function RatingButton({ rating, active, disabled, onClick }: RatingButtonProps) {
+  const Icon = rating === 'up' ? ThumbsUp : ThumbsDown;
+  const label = rating === 'up' ? '유용해요' : '아쉬워요';
+  return (
+    <button
+      type="button"
+      data-testid={`feedback-rating-${rating}`}
+      aria-pressed={active}
+      aria-label={label}
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex items-center gap-1.5 rounded-xs border px-2.5 py-1.5 text-xs font-medium transition-colors motion-safe:duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 ${
+        active
+          ? rating === 'up'
+            ? 'border-success bg-success-bg text-success'
+            : 'border-danger bg-danger-bg text-danger'
+          : 'border-ink-200 bg-white text-ink-600 hover:bg-ink-50'
+      }`}
+    >
+      <Icon size={14} aria-hidden="true" />
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/components/chat/AnswerBlock.tsx
+++ b/components/chat/AnswerBlock.tsx
@@ -23,6 +23,7 @@ import type {
   SourceItem,
   TimelineEvent,
 } from '../../types/streaming';
+import { FeedbackControl } from '../answer-block/feedback-control';
 import { ExpertReviewCallout } from '../expert-review/ExpertReviewCallout';
 import { ExportHub } from '../export/ExportHub';
 import type { ExportArtifact } from '../export/FormatOptions';
@@ -255,6 +256,12 @@ export function AnswerBlock({
           </div>
         </section>
       )}
+
+      {/* Section 12: Feedback control (SPEC-REGULA-RLHF-001, REQ-RLHF-003).
+          Rendered only when a messageId is available — the backend needs it to
+          record the feedback row. Gated server-side by rlhf.feedback; unauthorized
+          roles still see the answer but this island's POST is 403-rejected. */}
+      {messageId && <FeedbackControl messageId={messageId} />}
 
       {/* DocViewer modal — lazy loaded */}
       <DocViewer />

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -66,6 +66,10 @@ interface SidebarProps {
   // SPEC-REGULA-SOURCE-GOVERNANCE-001 (Issue #48): Governance dashboard is visible
   // to roles with sourcegov.view (ra-member+). Gated server-side and passed down.
   showGovernance?: boolean;
+  // SPEC-REGULA-RLHF-001 (Issue #56): Quality heatmap nav gated to ra-member+
+  // (rlhf.feedback submitters). The page route uses audit.read, but ra-member+
+  // feedback submitters also see the nav so they can track answer quality.
+  showQualityHeatmap?: boolean;
   initialLocale?: string;
 }
 
@@ -81,6 +85,7 @@ export default function Sidebar(props?: SidebarProps) {
   const showCapa = props?.showCapa ?? false;
   const showClinicalInvestigation = props?.showClinicalInvestigation ?? false;
   const showGovernance = props?.showGovernance ?? false;
+  const showQualityHeatmap = props?.showQualityHeatmap ?? false;
   const currentProjectId = useUIStore((s) => s.currentProjectId);
   const setCurrentProjectId = useUIStore((s) => s.setCurrentProjectId);
   const { data = [] } = useProjects();
@@ -319,6 +324,19 @@ export default function Sidebar(props?: SidebarProps) {
             className="rounded-md px-3 py-2 text-sm text-ink-700 hover:bg-ink-50 block"
           >
             출처 거버넌스
+          </Link>
+        </nav>
+      )}
+
+      {/* SPEC-REGULA-RLHF-001 (Issue #56): Quality heatmap conditional link. */}
+      {showQualityHeatmap && (
+        <nav className="px-2 py-1">
+          <Link
+            href="/quality/heatmap"
+            data-testid="sidebar-quality-heatmap-link"
+            className="rounded-md px-3 py-2 text-sm text-ink-700 hover:bg-ink-50 block"
+          >
+            품질 히트맵
           </Link>
         </nav>
       )}


### PR DESCRIPTION
## 배경

PR #265(RLHF #56) squash merge 시 `git add` 범위에서 **RLHF 프론트엔드가 누락**되었습니다. main `609858d`에는 백엔드/API/라이브러리(`app/api/rlhf/*`, `lib/rlhf/*`)만 포함되고, FeedbackControl·heatmap UI가 working tree에 미커밋 상태로 방치되어 있었습니다.

세션 메모가 기록한 "4262 passed / CI 녹색"은 **working tree 기준**이었으며(프론트엔드가 커밋되지 않은 상태로 게이트 실행), main HEAD 기준이 아니었습니다 — L-007 오탐 사례 + L-009(staged 범위 직검) 누락.

## 변경 내용

- `components/answer-block/feedback-control.tsx` — FeedbackControl 컴포넌트 (REQ-RLHF-003)
- `components/answer-block/__tests__/feedback-control.test.tsx` — 8 tests
- `app/(app)/quality/heatmap/page.tsx` — 품질 히트맵 대시보드 (REQ-RLHF-012)
- `components/chat/AnswerBlock.tsx` — Section 12 FeedbackControl 통합
- `components/shell/Sidebar.tsx` + `app/(app)/layout.tsx` — 품질 히트맵 네비 (ra-member+ 게이트)
- `.gitignore` — `coverage/` vitest 산출물 추가
- `.moai/specs/SPEC-REGULA-RLHF-001/tasks.md` — SPEC 계획 문서 보존

## Gate 직검 (L-007/008/009)

| 게이트 | 결과 |
|---|---|
| typecheck (`tsc --noEmit`) | 0 errors |
| lint (biome + lint:hex) | 0 errors (pre-existing warning 1, 무관) |
| test FULL | **4262 passed** \| 8 skipped |
| build (`next build`) | OK |
| staged 범위 직검 | 8개 파일 전부 staged 확인 (이전 누락 재발 방지) |

Fixes #56

🗿 MoAI <email@mo.ai.kr>