### PR TITLE
feat(rls): SPEC-REGULA-RLS-ENFORCE-001 Phase 2 — rlhf 도메인 wiring (#239)

### DIFF
--- a/app/api/rlhf/feedback/aggregate/route.ts
+++ b/app/api/rlhf/feedback/aggregate/route.ts
@@ -9,7 +9,7 @@
 //           scoped to the caller's org.
 
 import { withPermission } from '@/lib/auth/with-permission';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { answerFeedback, conversations, messages, projects } from '@/lib/db/schema';
 import { assertMessageInOrg } from '@/lib/rlhf/access';
 import { aggregateFeedback, detectDownwardTrend } from '@/lib/rlhf/feedback-aggregator';
@@ -36,16 +36,20 @@ export const GET = withPermission('rlhf.feedback', async (request, _ctx, session
   // C-2 defense-in-depth: even though assertMessageInOrg passed, the feedback
   // select itself is org-scoped via the 3-hop join so a race (message moved
   // projects between the assert and the select) cannot leak cross-org rows.
-  const rows = await db
-    .select({
-      rating: answerFeedback.rating,
-      createdAt: answerFeedback.createdAt,
-    })
-    .from(answerFeedback)
-    .innerJoin(messages, eq(messages.id, answerFeedback.messageId))
-    .innerJoin(conversations, eq(conversations.id, messages.conversationId))
-    .innerJoin(projects, eq(projects.id, conversations.projectId))
-    .where(and(eq(answerFeedback.messageId, messageId), eq(projects.organizationId, orgId)));
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  // App-level eq(projects.organizationId, orgId) retained as defense-in-depth.
+  const rows = await withTenantScope(orgId, async (dbs) =>
+    dbs
+      .select({
+        rating: answerFeedback.rating,
+        createdAt: answerFeedback.createdAt,
+      })
+      .from(answerFeedback)
+      .innerJoin(messages, eq(messages.id, answerFeedback.messageId))
+      .innerJoin(conversations, eq(conversations.id, messages.conversationId))
+      .innerJoin(projects, eq(projects.id, conversations.projectId))
+      .where(and(eq(answerFeedback.messageId, messageId), eq(projects.organizationId, orgId))),
+  );
 
   const agg = aggregateFeedback(rows);
   const trend = detectDownwardTrend(rows);

--- a/app/api/rlhf/feedback/route.ts
+++ b/app/api/rlhf/feedback/route.ts
@@ -15,6 +15,7 @@
 import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
 import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { answerFeedback, messages } from '@/lib/db/schema';
 import { redactQuestion } from '@/lib/knowledge-gap/redaction';
 import { logger } from '@/lib/observability/logger';
@@ -134,9 +135,10 @@ export const POST = withPermission('rlhf.feedback', async (request, _ctx, sessio
   // C-3: wrap the mutation + the 21 CFR Part 11 audit row in ONE transaction so
   // a crash between them cannot leave a feedback row with no audit trail. The
   // tx handle is threaded into writeAudit so the insert rides the same tx.
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
   let feedbackId = '';
   try {
-    feedbackId = await db.transaction(async (tx) => {
+    feedbackId = await withTenantScope(orgId, async (tx) => {
       if (existingRow) {
         // L-2: the audit row carries `revised: true` in meta_json so regulators
         // can tell initial submissions apart from changed minds without adding

--- a/app/api/rlhf/heatmap/route.ts
+++ b/app/api/rlhf/heatmap/route.ts
@@ -13,7 +13,7 @@
 // heatmap.
 
 import { withPermission } from '@/lib/auth/with-permission';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { answerFeedback, conversations, messages, projects } from '@/lib/db/schema';
 import { computeMessageScore } from '@/lib/rlhf/feedback-aggregator';
 import { desc, eq } from 'drizzle-orm';
@@ -40,20 +40,25 @@ export const GET = withPermission('audit.read', async (request, _ctx, session) =
 
   // Fetch recent feedback joined to message -> conversation -> project, scoped
   // to the caller's org so NO cross-org feedback rows are returned.
-  const rows = await db
-    .select({
-      rating: answerFeedback.rating,
-      createdAt: answerFeedback.createdAt,
-      messageId: answerFeedback.messageId,
-      conversationId: messages.conversationId,
-    })
-    .from(answerFeedback)
-    .innerJoin(messages, eq(messages.id, answerFeedback.messageId))
-    .innerJoin(conversations, eq(conversations.id, messages.conversationId))
-    .innerJoin(projects, eq(projects.id, conversations.projectId))
-    .where(eq(projects.organizationId, orgId))
-    .orderBy(desc(answerFeedback.createdAt))
-    .limit(limit);
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  // App-level eq(projects.organizationId, orgId) retained as defense-in-depth
+  // (RLS is inert project-wide until service-role bypass is dropped).
+  const rows = await withTenantScope(orgId, async (dbs) =>
+    dbs
+      .select({
+        rating: answerFeedback.rating,
+        createdAt: answerFeedback.createdAt,
+        messageId: answerFeedback.messageId,
+        conversationId: messages.conversationId,
+      })
+      .from(answerFeedback)
+      .innerJoin(messages, eq(messages.id, answerFeedback.messageId))
+      .innerJoin(conversations, eq(conversations.id, messages.conversationId))
+      .innerJoin(projects, eq(projects.id, conversations.projectId))
+      .where(eq(projects.organizationId, orgId))
+      .orderBy(desc(answerFeedback.createdAt))
+      .limit(limit),
+  );
 
   // Group by conversationId as the corpus proxy (v1). Each conversation tends
   // to be scoped to a single regulatory topic / corpus in practice.

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -29,14 +29,19 @@ export type DrizzleClient = typeof db;
  * Execute a function within a tenant-scoped transaction.
  * Sets `app.current_org_id` GUC so RLS policies can enforce org isolation.
  * REQ-DOC-042: all org document queries MUST use this wrapper.
+ *
+ * SECURITY: uses parameterized `set_config(..., true)` instead of string
+ * interpolation. The third arg `true` makes the setting transaction-local
+ * (equivalent to SET LOCAL), and the sql template literal binds orgId as a
+ * parameter so it cannot break out into arbitrary SQL.
  */
 export async function withTenantScope<T>(
   orgId: string,
   fn: (db: DrizzleClient) => Promise<T>,
 ): Promise<T> {
   return db.transaction(async (tx) => {
-    // Set the GUC for RLS policy enforcement
-    await tx.execute(sql.raw(`SET LOCAL app.current_org_id = '${orgId}'`));
+    // Set the GUC for RLS policy enforcement (parameterized, injection-safe).
+    await tx.execute(sql`SELECT set_config('app.current_org_id', ${orgId}, true)`);
     return fn(tx as unknown as DrizzleClient);
   });
 }

--- a/tests/integration/rlhf-idor-runtime.test.ts
+++ b/tests/integration/rlhf-idor-runtime.test.ts
@@ -227,7 +227,17 @@ function resolveRows(fromTable: string): Row[] {
   }
 }
 
-vi.mock('@/lib/db/client', () => ({ db: dbMock }));
+vi.mock('@/lib/db/client', () => ({
+  db: dbMock,
+  // Mirror the real withTenantScope: delegate to dbMock.transaction so the
+  // C-3 assertion on dbMock.transaction call count still holds, and the fn
+  // receives dbMock as the scoped tx handle (same object the real impl passes).
+  withTenantScope: vi.fn(
+    async <T>(orgId: string, fn: (db: typeof dbMock) => Promise<T>): Promise<T> => {
+      return dbMock.transaction(async (tx: typeof dbMock) => fn(tx));
+    },
+  ),
+}));
 
 // ---------------------------------------------------------------------------
 // Audit mock — records every writeAudit call. Forwards to dbMock.insert so

--- a/tests/unit/db/with-tenant-scope-coverage.test.ts
+++ b/tests/unit/db/with-tenant-scope-coverage.test.ts
@@ -1,0 +1,120 @@
+// @MX:NOTE [AUTO] Static coverage gate for withTenantScope wiring.
+// @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 (Phase 2 — rlhf domain wiring)
+// @MX:REASON #239 Phase 2 enforces that every DB mutation/select in a wired
+//           domain route runs inside withTenantScope(...) so the
+//           app.current_org_id GUC is set for RLS policies. The gate scans
+//           route files statically: any file containing db.select|insert|
+//           update|delete|transaction MUST also contain a withTenantScope
+//           call. Only rlhf is whitelisted in Phase 2; other domains are
+//           listed as pending wiring and explicitly skipped (do not fail).
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+
+/**
+ * Domains wired into withTenantScope as of Phase 2. Add a domain here when
+ * its routes are wired in a follow-up PR. Each entry is a subdirectory under
+ * app/api/.
+ *
+ * Phase 2 scope: rlhf only.
+ */
+const WIRED_DOMAINS = ['rlhf'];
+
+/**
+ * Domains NOT yet wired. Listed for explicit tracking; the gate does NOT
+ * scan these. Remove a domain from this list when you add it to WIRED_DOMAINS.
+ *
+ * Pending: pms, cyberdevice, model-governance, knowledge-gap, traceability,
+ * change-control (and any other org-scoped domain under app/api/).
+ */
+const PENDING_DOMAINS = [
+  'pms',
+  'cyberdevice',
+  'model-governance',
+  'knowledge-gap',
+  'traceability',
+  'change-control',
+];
+
+/** Pattern that flags a file as performing DB operations. */
+const DB_OP_PATTERN = /\b(?:db|tx|dbs)\s*\.(?:select|insert|update|delete|transaction)\s*\(/;
+
+/** Pattern confirming the file routes DB ops through withTenantScope. */
+const TENANT_SCOPE_PATTERN = /\bwithTenantScope\s*\(/;
+
+/**
+ * Recursively collect route.ts files under a given directory.
+ */
+function collectRouteFiles(dir: string): string[] {
+  const results: string[] = [];
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true }) as unknown as import('node:fs').Dirent[];
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const name = String(entry.name);
+    const full = join(dir, name);
+    if (entry.isDirectory()) {
+      results.push(...collectRouteFiles(full));
+    } else if (entry.isFile() && name === 'route.ts') {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+describe('withTenantScope static coverage gate (SPEC-REGULA-RLS-ENFORCE-001 Phase 2)', () => {
+  for (const domain of WIRED_DOMAINS) {
+    describe(`domain: ${domain}`, () => {
+      const domainDir = join(ROOT, 'app', 'api', domain);
+      const files = collectRouteFiles(domainDir);
+
+      if (files.length === 0) {
+        it.skip(`no route files under app/api/${domain}`, () => {});
+      } else {
+        for (const file of files) {
+          const rel = file.replace(`${ROOT}/`, '');
+          it(`${rel}: every DB op runs inside withTenantScope`, () => {
+            const source = readFileSync(file, 'utf8');
+            const hasDbOp = DB_OP_PATTERN.test(source);
+            if (!hasDbOp) {
+              // No DB ops in this file — nothing to enforce.
+              return;
+            }
+            expect(
+              TENANT_SCOPE_PATTERN.test(source),
+              `${rel} performs DB operations (db.select|insert|update|delete|transaction) but does not call withTenantScope. Every org-scoped DB op MUST run inside withTenantScope(orgId, ...) per SPEC-REGULA-RLS-ENFORCE-001 Phase 2.`,
+            ).toBe(true);
+          });
+        }
+      }
+    });
+  }
+
+  // Explicit pending tracking — informational, does not fail the gate.
+  // When a pending domain is wired, move it to WIRED_DOMAINS and delete its
+  // entry here. This block exists so reviewers notice when a domain should
+  // have been moved.
+  describe('pending wiring (informational)', () => {
+    it('lists domains not yet wired into withTenantScope', () => {
+      // This assertion exists to surface the pending list in test output.
+      expect(PENDING_DOMAINS.length).toBeGreaterThanOrEqual(0);
+      // Snapshot for visibility — update freely when wiring a domain.
+      expect(PENDING_DOMAINS).toEqual(
+        expect.arrayContaining([
+          'pms',
+          'cyberdevice',
+          'model-governance',
+          'knowledge-gap',
+          'traceability',
+          'change-control',
+        ]),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Phase 2/3 — rlhf 도메인 wiring + withTenantScope 강화 (Issue #239)

Phase 1(#267 WITH CHECK 정책 형상)에 이어, 라우트가 `app.current_org_id` GUC를 설정하도록 `withTenantScope`로 wiring. 33개 라우트 중 **첫 도메인 rlhf(3 라우트) + 정적 커버리지 게이트 도입**.

### 변경
- **`lib/db/client.ts`** — `withTenantScope` **SQL injection 결함 제거**: `sql.raw(\`... = '${orgId}'\`)` 문자열 보간 → `sql\`SELECT set_config('app.current_org_id', \${orgId}, true)\`` parameterized. 시그니처 유지(internal-docs.ts:58 호환).
- **`app/api/rlhf/feedback`** — 기존 `db.transaction` → `withTenantScope(orgId, tx => ...)`. insert + `writeAudit(tx)` 동일 트랜잭션 (C-3 Part 11 atomicity 유지).
- **`app/api/rlhf/heatmap`, `feedback/aggregate`** — SELECT를 `withTenantScope`로 래핑. `eq(orgId)` 앱 필터는 defense-in-depth로 유지(RLS inert 상태라 실제 isolation).
- **`tests/unit/db/with-tenant-scope-coverage.test.ts`** (신규) — 정적 게이트. rlhf 화이트리스트 enforce, 타 6도메인 PENDING 명시(향후 PR에서 이동 시 가시성).
- **`tests/integration/rlhf-idor-runtime.test.ts`** — mock에 `withTenantScope` export 추가.

### @MX:NOTE
RLS는 **여전히 INERT** (service-role bypass). wiring해도 런타임 동작 변화 없음 — 앱 필터가 실제 isolation. Phase 3(`FORCE ROW LEVEL SECURITY`)에서 GUC가 실제 효력.

### Gate 직검 (L-007 — 에이전트 오탐 2회 직접 포착·수정)
에이전트가 "typecheck PASS / lint 통과" 보고했으나 직검에서 **2회 오탐 포착**:
1. `rlhf-idor-runtime.test.ts:236` `tx` implicit any → 타입 명시
2. `orgId` 미사용 + format 위반 → `lint:fix`

| 게이트 | 결과 |
|---|---|
| typecheck | 0 errors (오탐 수정 후) |
| lint (biome + lint:hex) | 0 errors (lint:fix 후) |
| test FULL | **4289 passed** \| 8 skipped (+4 게이트) |
| staged 범위 직검 | 6개 파일 |

### 향후 (별도 PR)
- Phase 2 나머지 도메인: pms/cyberdevice/model-governance/knowledge-gap/traceability/change-control → 정적 게이트 화이트리스트 이동
- Phase 3: `rolbypassrls` SQL 직검 → `FORCE ROW LEVEL SECURITY` + 카나리 → #239 CLOSE

Refs #239 (Phase 2/3 — 자동 close 아님)

🗿 MoAI <email@mo.ai.kr>