### PR TITLE
feat(rls): #239 Phase 2 완료 — cyberdevice/model-governance/traceability withTenantScope wiring

### DIFF
--- a/app/api/cyberdevice/cve-analysis/route.ts
+++ b/app/api/cyberdevice/cve-analysis/route.ts
@@ -11,7 +11,7 @@ import {
 import { mapCvesToComponents } from '@/lib/cyberdevice/cve-mapper';
 import { linkCveImpactToRiskItem, shouldTriggerReassessment } from '@/lib/cyberdevice/risk-linkage';
 import { cveAnalysisInputSchema } from '@/lib/cyberdevice/types';
-import { db } from '@/lib/db/client';
+import { db, withTenantScope } from '@/lib/db/client';
 import { cveImpact, sbom } from '@/lib/db/schema';
 import { assertPmsProjectAccess } from '@/lib/pms/project-ownership';
 import { eq } from 'drizzle-orm';
@@ -80,7 +80,8 @@ export const POST = withPermission('cyberdevice.manage', async (req, _ctx, sessi
     matched: boolean;
   }> = [];
   try {
-    await db.transaction(async (tx) => {
+    // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+    await withTenantScope(organizationId, async (tx) => {
       for (const result of mapped) {
         const [created] = await tx
           .insert(cveImpact)

--- a/app/api/cyberdevice/evidence-bundle/route.ts
+++ b/app/api/cyberdevice/evidence-bundle/route.ts
@@ -6,7 +6,7 @@ import { auditCyberAccessDenied, auditEvidenceBundled } from '@/lib/cyberdevice/
 import { assembleEvidenceBundle } from '@/lib/cyberdevice/evidence-bundle';
 import { verifyLinkedReferentExists } from '@/lib/cyberdevice/linkage';
 import { evidenceBundleInputSchema } from '@/lib/cyberdevice/types';
-import { db } from '@/lib/db/client';
+import { db, withTenantScope } from '@/lib/db/client';
 import { cyberEvidenceBundle, sbom, threatModel } from '@/lib/db/schema';
 import { assertPmsProjectAccess } from '@/lib/pms/project-ownership';
 import { eq } from 'drizzle-orm';
@@ -118,7 +118,8 @@ export const POST = withPermission('cyberdevice.manage', async (req, _ctx, sessi
 
   let bundleId = '';
   try {
-    await db.transaction(async (tx) => {
+    // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+    await withTenantScope(organizationId, async (tx) => {
       const [created] = await tx
         .insert(cyberEvidenceBundle)
         .values({

--- a/app/api/cyberdevice/sbom/diff/route.ts
+++ b/app/api/cyberdevice/sbom/diff/route.ts
@@ -5,7 +5,7 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { auditSbomDiffed } from '@/lib/cyberdevice/audit';
 import { diffSbomVersions } from '@/lib/cyberdevice/sbom-diff';
 import type { SbomComponent } from '@/lib/cyberdevice/types';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { sbom } from '@/lib/db/schema';
 import { assertPmsProjectAccess } from '@/lib/pms/project-ownership';
 import { and, eq } from 'drizzle-orm';
@@ -29,10 +29,13 @@ export const GET = withPermission('cyberdevice.view', async (req, _ctx, session)
   const denied = await assertPmsProjectAccess(projectId, organizationId);
   if (denied) return denied;
 
-  const rows = await db
-    .select({ version: sbom.version, components: sbom.components })
-    .from(sbom)
-    .where(and(eq(sbom.projectId, projectId), eq(sbom.orgId, organizationId)));
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  const rows = await withTenantScope(organizationId, async (dbs) =>
+    dbs
+      .select({ version: sbom.version, components: sbom.components })
+      .from(sbom)
+      .where(and(eq(sbom.projectId, projectId), eq(sbom.orgId, organizationId))),
+  );
   const a = rows.find((r) => r.version === versionA);
   const b = rows.find((r) => r.version === versionB);
   if (!a || !b) {

--- a/app/api/cyberdevice/sbom/route.ts
+++ b/app/api/cyberdevice/sbom/route.ts
@@ -5,7 +5,7 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { auditSbomImported, auditSbomValidated } from '@/lib/cyberdevice/audit';
 import { SbomParseError, parseSbom } from '@/lib/cyberdevice/sbom-parser';
 import { sbomImportInputSchema } from '@/lib/cyberdevice/types';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { sbom } from '@/lib/db/schema';
 import { assertPmsProjectAccess } from '@/lib/pms/project-ownership';
 import { and, desc, eq } from 'drizzle-orm';
@@ -40,7 +40,8 @@ export const POST = withPermission('cyberdevice.manage', async (req, _ctx, sessi
 
   let sbomId = '';
   try {
-    await db.transaction(async (tx) => {
+    // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+    await withTenantScope(organizationId, async (tx) => {
       const [created] = await tx
         .insert(sbom)
         .values({
@@ -108,19 +109,22 @@ export const GET = withPermission('cyberdevice.view', async (req, _ctx, session)
   const denied = await assertPmsProjectAccess(projectId, organizationId);
   if (denied) return denied;
 
-  const rows = await db
-    .select({
-      id: sbom.id,
-      format: sbom.format,
-      version: sbom.version,
-      componentCount: sbom.components,
-      validated: sbom.validated,
-      contentHash: sbom.contentHash,
-      createdAt: sbom.createdAt,
-    })
-    .from(sbom)
-    .where(and(eq(sbom.projectId, projectId), eq(sbom.orgId, organizationId)))
-    .orderBy(desc(sbom.createdAt));
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  const rows = await withTenantScope(organizationId, async (dbs) =>
+    dbs
+      .select({
+        id: sbom.id,
+        format: sbom.format,
+        version: sbom.version,
+        componentCount: sbom.components,
+        validated: sbom.validated,
+        contentHash: sbom.contentHash,
+        createdAt: sbom.createdAt,
+      })
+      .from(sbom)
+      .where(and(eq(sbom.projectId, projectId), eq(sbom.orgId, organizationId)))
+      .orderBy(desc(sbom.createdAt)),
+  );
   // componentCount is jsonb; surface length without sending full payload in list view.
   const items = rows.map((r) => ({
     ...r,

--- a/app/api/cyberdevice/threat-model/route.ts
+++ b/app/api/cyberdevice/threat-model/route.ts
@@ -6,7 +6,7 @@ import { auditThreatModeled } from '@/lib/cyberdevice/audit';
 import { mapThreatsToGspr } from '@/lib/cyberdevice/gspr-mapping';
 import { generateThreatModel } from '@/lib/cyberdevice/threat-model-generator';
 import { architectureInputSchema } from '@/lib/cyberdevice/types';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { threatModel } from '@/lib/db/schema';
 import { assertPmsProjectAccess } from '@/lib/pms/project-ownership';
 import { eq } from 'drizzle-orm';
@@ -40,7 +40,8 @@ export const POST = withPermission('cyberdevice.manage', async (req, _ctx, sessi
 
   let threatModelId = '';
   try {
-    await db.transaction(async (tx) => {
+    // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+    await withTenantScope(organizationId, async (tx) => {
       const [created] = await tx
         .insert(threatModel)
         .values({
@@ -88,6 +89,9 @@ export const GET = withPermission('cyberdevice.view', async (req, _ctx, session)
   const denied = await assertPmsProjectAccess(projectId, organizationId);
   if (denied) return denied;
 
-  const rows = await db.select().from(threatModel).where(eq(threatModel.projectId, projectId));
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  const rows = await withTenantScope(organizationId, async (dbs) =>
+    dbs.select().from(threatModel).where(eq(threatModel.projectId, projectId)),
+  );
   return Response.json({ items: rows });
 });

--- a/app/api/cyberdevice/update-plan/route.ts
+++ b/app/api/cyberdevice/update-plan/route.ts
@@ -5,7 +5,7 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { auditUpdatePlanCreated } from '@/lib/cyberdevice/audit';
 import { updatePlanInputSchema } from '@/lib/cyberdevice/types';
 import { generateUpdatePlan } from '@/lib/cyberdevice/update-plan';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { cyberEvidenceBundle } from '@/lib/db/schema';
 import { assertPmsProjectAccess } from '@/lib/pms/project-ownership';
 
@@ -31,7 +31,8 @@ export const POST = withPermission('cyberdevice.manage', async (req, _ctx, sessi
 
   let bundleId = '';
   try {
-    await db.transaction(async (tx) => {
+    // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+    await withTenantScope(organizationId, async (tx) => {
       const [created] = await tx
         .insert(cyberEvidenceBundle)
         .values({

--- a/app/api/model-governance/change-request/route.ts
+++ b/app/api/model-governance/change-request/route.ts
@@ -2,7 +2,7 @@
 // @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (Issue 71, REQ-MODELGOV-004/005)
 
 import { withPermission } from '@/lib/auth/with-permission';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { changeRequest } from '@/lib/db/schema';
 import { assertModelPinAccess, assertPromptAccess } from '@/lib/model-governance/access';
 import { createChangeRequest } from '@/lib/model-governance/change-workflow';
@@ -54,6 +54,9 @@ export const GET = withPermission('modelgov.view', async (_req, _ctx, session) =
     return Response.json({ error: 'Organization context required' }, { status: 403 });
   }
 
-  const rows = await db.select().from(changeRequest).where(eq(changeRequest.orgId, organizationId));
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  const rows = await withTenantScope(organizationId, async (dbs) =>
+    dbs.select().from(changeRequest).where(eq(changeRequest.orgId, organizationId)),
+  );
   return Response.json({ changeRequests: rows });
 });

--- a/app/api/traceability/[deliverableId]/export/route.ts
+++ b/app/api/traceability/[deliverableId]/export/route.ts
@@ -3,7 +3,7 @@
 
 import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { getEvidencePacket } from '@/lib/traceability/evidence-packet';
 import { exportPacket, sanitizeFilename } from '@/lib/traceability/export-packet';
 import { listStaleNodeIds } from '@/lib/traceability/stale-propagation';
@@ -35,11 +35,16 @@ export const GET = withPermission('traceability.view', async (req, ctx, session)
   }
   const format = parsed.data.format;
 
-  const staleNodeIds = await listStaleNodeIds(db, organizationId);
-  const packet = await getEvidencePacket(db, {
-    orgId: organizationId,
-    deliverableId,
-    staleNodeIds,
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  // listStaleNodeIds + getEvidencePacket issue org-scoped reads via the passed
+  // handle; wrapping them sets the GUC so Phase 3 FORCE RLS will enforce isolation.
+  const packet = await withTenantScope(organizationId, async (dbs) => {
+    const staleNodeIds = await listStaleNodeIds(dbs, organizationId);
+    return getEvidencePacket(dbs, {
+      orgId: organizationId,
+      deliverableId,
+      staleNodeIds,
+    });
   });
   if (!packet) {
     return Response.json({ error: 'not_found' }, { status: 404 });

--- a/app/api/traceability/[deliverableId]/packet/route.ts
+++ b/app/api/traceability/[deliverableId]/packet/route.ts
@@ -2,7 +2,7 @@
 // @MX:SPEC SPEC-REGULA-TRACEABILITY-001 (REQ-TRACEABILITY-006, REQ-TRACEABILITY-007)
 
 import { withPermission } from '@/lib/auth/with-permission';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { getEvidencePacket } from '@/lib/traceability/evidence-packet';
 import { listStaleNodeIds } from '@/lib/traceability/stale-propagation';
 
@@ -18,11 +18,16 @@ export const GET = withPermission('traceability.view', async (_req, ctx, session
     return Response.json({ error: 'deliverableId required' }, { status: 400 });
   }
 
-  const staleNodeIds = await listStaleNodeIds(db, organizationId);
-  const packet = await getEvidencePacket(db, {
-    orgId: organizationId,
-    deliverableId,
-    staleNodeIds,
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  // listStaleNodeIds + getEvidencePacket issue org-scoped reads via the passed
+  // handle; wrapping them sets the GUC so Phase 3 FORCE RLS will enforce isolation.
+  const packet = await withTenantScope(organizationId, async (dbs) => {
+    const staleNodeIds = await listStaleNodeIds(dbs, organizationId);
+    return getEvidencePacket(dbs, {
+      orgId: organizationId,
+      deliverableId,
+      staleNodeIds,
+    });
   });
   if (!packet) {
     // 404 (not 403) — avoid leaking deliverable existence across orgs.

--- a/app/api/traceability/edges/route.ts
+++ b/app/api/traceability/edges/route.ts
@@ -8,7 +8,7 @@
 
 import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
-import { db } from '@/lib/db/client';
+import { db, withTenantScope } from '@/lib/db/client';
 import {
   EdgeIdorError,
   type EvidenceEdgeRelation,
@@ -59,7 +59,8 @@ export const POST = withPermission('traceability.manage', async (req, _ctx, sess
       // H2 fix (21 CFR Part 11): edge create + audit commit atomically. A
       // transient failure between the INSERT and the audit write rolls back
       // BOTH — the edge must never persist without its audit record.
-      const res = await db.transaction(async (tx) => {
+      // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+      const res = await withTenantScope(organizationId, async (tx) => {
         const txDb = tx as unknown as TraceabilityDb;
         const result = await createEdge(txDb, {
           orgId: organizationId,
@@ -125,7 +126,8 @@ export const POST = withPermission('traceability.manage', async (req, _ctx, sess
     }
 
     // action === 'delete' — H2: delete + audit in one transaction.
-    const deleted = await db.transaction(async (tx) => {
+    // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+    const deleted = await withTenantScope(organizationId, async (tx) => {
       const txDb = tx as unknown as TraceabilityDb;
       const result = await deleteEdgeByKey(txDb, {
         orgId: organizationId,

--- a/app/api/traceability/route.ts
+++ b/app/api/traceability/route.ts
@@ -6,7 +6,7 @@
 
 import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { buildMatrix } from '@/lib/traceability/matrix';
 import { listStaleNodeIds } from '@/lib/traceability/stale-propagation';
 import { z } from 'zod';
@@ -36,8 +36,13 @@ export const GET = withPermission('traceability.view', async (req, _ctx, session
     );
   }
 
-  const staleNodeIds = await listStaleNodeIds(db, organizationId);
-  const result = await buildMatrix(db, { ...parsed.data, orgId: organizationId }, { staleNodeIds });
+  // #239 Phase 2: withTenantScope sets app.current_org_id GUC for RLS enforce.
+  // listStaleNodeIds + buildMatrix issue org-scoped reads via the passed handle;
+  // wrapping them sets the GUC so Phase 3 FORCE RLS will enforce isolation.
+  const result = await withTenantScope(organizationId, async (dbs) => {
+    const staleNodeIds = await listStaleNodeIds(dbs, organizationId);
+    return buildMatrix(dbs, { ...parsed.data, orgId: organizationId }, { staleNodeIds });
+  });
 
   // Read-only view — no edge mutation, so we audit only at trace.debug granularity.
   // Keep the audit row minimal (non-PII) and scoped to the project.

--- a/tests/integration/cyberdevice.test.ts
+++ b/tests/integration/cyberdevice.test.ts
@@ -114,7 +114,8 @@ describe('AC-01: SBOM import + version diff (REQ-003/004)', () => {
     expect(src).toContain('assertPmsProjectAccess');
     expect(src).toContain('auditSbomImported');
     expect(src).toContain('auditSbomValidated');
-    expect(src).toContain('db.transaction');
+    // #239 Phase 2: withTenantScope wraps db.transaction (sets GUC + preserves atomicity).
+    expect(src).toContain('withTenantScope');
   });
 
   it('sbom/diff route enforces withPermission + IDOR + audit (source-level)', () => {
@@ -226,7 +227,8 @@ describe('AC-03: CVE impact → component mapping (REQ-005/006)', () => {
     expect(src).toContain("withPermission('cyberdevice.manage'");
     expect(src).toContain('assertPmsProjectAccess');
     expect(src).toContain('auditCveAnalyzed');
-    expect(src).toContain('db.transaction');
+    // #239 Phase 2: withTenantScope wraps db.transaction (sets GUC + preserves atomicity).
+    expect(src).toContain('withTenantScope');
     expect(src).toContain('shouldTriggerReassessment');
   });
 });
@@ -487,7 +489,8 @@ describe('AC-05: evidence bundle assembly (REQ-009/012/014)', () => {
     expect(src).toContain('threat_model_not_found');
     expect(src).toContain('sbom_not_found');
     expect(src).toContain('auditEvidenceBundled');
-    expect(src).toContain('db.transaction');
+    // #239 Phase 2: withTenantScope wraps db.transaction (sets GUC + preserves atomicity).
+    expect(src).toContain('withTenantScope');
   });
 
   it('update-plan route generates signed staged plan', () => {

--- a/tests/integration/model-governance.test.ts
+++ b/tests/integration/model-governance.test.ts
@@ -22,6 +22,12 @@ vi.mock('@/lib/db/client', () => ({
     delete: () => ({ where: () => Promise.resolve([]) }),
     query: {},
   },
+  // #239 Phase 2: withTenantScope stub — delegates to an inline transaction
+  // so any transitive route import that calls withTenantScope does not crash.
+  // This file tests pure functions only; the fn receives the same mock db.
+  withTenantScope: vi.fn(
+    async <T>(_orgId: string, fn: (db: unknown) => Promise<T>): Promise<T> => fn({}),
+  ),
 }));
 
 import { buildAnswerVersionMetadata } from '@/lib/model-governance/audit-metadata';

--- a/tests/regression/traceability.test.ts
+++ b/tests/regression/traceability.test.ts
@@ -14,6 +14,11 @@ vi.mock('@/lib/db/client', () => ({
     })),
     insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
   },
+  // #239 Phase 2: withTenantScope stub — delegates to an inline transaction
+  // so any transitive route import that calls withTenantScope does not crash.
+  withTenantScope: vi.fn(
+    async <T>(_orgId: string, fn: (db: unknown) => Promise<T>): Promise<T> => fn({}),
+  ),
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/tests/unit/api/traceability-edges-route.test.ts
+++ b/tests/unit/api/traceability-edges-route.test.ts
@@ -89,7 +89,15 @@ const dbStub = {
 // vi.mock: hoisted, replaces modules before any import. The factory controls
 // behavior via the mutable state above. This is the ONLY way to mock @/lib/db
 // for a route handler that imports it at module-load time.
-vi.mock('@/lib/db/client', () => ({ db: dbStub }));
+// #239 Phase 2: withTenantScope delegates to dbStub.transaction so the GUC-wrap
+// path in the route is exercised; the fn receives dbStub as the scoped tx handle.
+vi.mock('@/lib/db/client', () => ({
+  db: dbStub,
+  withTenantScope: vi.fn(
+    async <T>(_orgId: string, fn: (db: typeof dbStub) => Promise<T>): Promise<T> =>
+      dbStub.transaction(async (tx: unknown) => fn(tx as typeof dbStub)) as Promise<T>,
+  ),
+}));
 vi.mock('@/lib/auth', () => ({ auth: async () => SESSION }));
 vi.mock('@/lib/auth/acl', () => ({
   isOrgMember: async () => true,

--- a/tests/unit/db/with-tenant-scope-coverage.test.ts
+++ b/tests/unit/db/with-tenant-scope-coverage.test.ts
@@ -1,12 +1,13 @@
 // @MX:NOTE [AUTO] Static coverage gate for withTenantScope wiring.
-// @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 (Phase 2 — rlhf + knowledge-gap + pms + change-control wiring)
+// @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 (Phase 2 — all 7 org-scoped domains wired)
 // @MX:REASON #239 Phase 2 enforces that every DB mutation/select in a wired
 //           domain route runs inside withTenantScope(...) so the
 //           app.current_org_id GUC is set for RLS policies. The gate scans
 //           route files statically: any file containing db.select|insert|
 //           update|delete|transaction MUST also contain a withTenantScope
-//           call. Wired domains: rlhf, knowledge-gap, pms, change-control;
-//           other domains are listed as pending wiring and explicitly skipped.
+//           call. Wired domains: rlhf, knowledge-gap, pms, change-control,
+//           cyberdevice, model-governance, traceability (all org-scoped
+//           domains under app/api/ are now wired).
 
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -19,24 +20,41 @@ const ROOT = process.cwd();
  * its routes are wired in a follow-up PR. Each entry is a subdirectory under
  * app/api/.
  *
- * Phase 2 scope: rlhf, knowledge-gap, pms, change-control.
+ * Phase 2 scope (complete): rlhf, knowledge-gap, pms, change-control,
+ * cyberdevice, model-governance, traceability — all 7 org-scoped domains.
  */
-const WIRED_DOMAINS = ['rlhf', 'knowledge-gap', 'pms', 'change-control'];
+const WIRED_DOMAINS = [
+  'rlhf',
+  'knowledge-gap',
+  'pms',
+  'change-control',
+  'cyberdevice',
+  'model-governance',
+  'traceability',
+];
 
 /**
- * Domains NOT yet wired. Listed for explicit tracking; the gate does NOT
- * scan these. Remove a domain from this list when you add it to WIRED_DOMAINS.
- *
- * Pending: cyberdevice, model-governance, traceability (and any other
- * org-scoped domain under app/api/).
+ * Domains NOT yet wired. All 7 org-scoped domains are wired as of this PR,
+ * so the pending list is empty. Add a domain here only if a new org-scoped
+ * domain is introduced under app/api/ before its routes are wired.
  */
-const PENDING_DOMAINS = ['cyberdevice', 'model-governance', 'traceability'];
+const PENDING_DOMAINS: string[] = [];
 
 /** Pattern that flags a file as performing DB operations. */
 const DB_OP_PATTERN = /\b(?:db|tx|dbs)\s*\.(?:select|insert|update|delete|transaction)\s*\(/;
 
 /** Pattern confirming the file routes DB ops through withTenantScope. */
 const TENANT_SCOPE_PATTERN = /\bwithTenantScope\s*\(/;
+
+/**
+ * Strip `//` line comments so the DB_OP_PATTERN only matches real code, not
+ * prose mentions like "all in one db.transaction" in an @MX:REASON comment.
+ * Without this, a route that only documents db.transaction in a comment would
+ * be flagged as performing a DB op (false positive).
+ */
+function stripLineComments(source: string): string {
+  return source.replace(/^\s*\/\/.*$/gm, '');
+}
 
 /**
  * Recursively collect route.ts files under a given directory.
@@ -74,7 +92,8 @@ describe('withTenantScope static coverage gate (SPEC-REGULA-RLS-ENFORCE-001 Phas
           const rel = file.replace(`${ROOT}/`, '');
           it(`${rel}: every DB op runs inside withTenantScope`, () => {
             const source = readFileSync(file, 'utf8');
-            const hasDbOp = DB_OP_PATTERN.test(source);
+            const code = stripLineComments(source);
+            const hasDbOp = DB_OP_PATTERN.test(code);
             if (!hasDbOp) {
               // No DB ops in this file — nothing to enforce.
               return;
@@ -98,9 +117,8 @@ describe('withTenantScope static coverage gate (SPEC-REGULA-RLS-ENFORCE-001 Phas
       // This assertion exists to surface the pending list in test output.
       expect(PENDING_DOMAINS.length).toBeGreaterThanOrEqual(0);
       // Snapshot for visibility — update freely when wiring a domain.
-      expect(PENDING_DOMAINS).toEqual(
-        expect.arrayContaining(['cyberdevice', 'model-governance', 'traceability']),
-      );
+      // All 7 org-scoped domains are wired; pending list is empty.
+      expect(PENDING_DOMAINS).toEqual(expect.arrayContaining([]));
     });
   });
 });


### PR DESCRIPTION
## Summary

SPEC-REGULA-RLS-ENFORCE-001 **Phase 2 최종 완료**. PR #268(rlhf)·#269(kg/pms/cc)에 이어 마지막 3도메인 wiring → **전 7개 org-scoped 도메인 withTenantScope wiring 종료**.

> RLS는 여전히 **INERT**(service-role bypass). wiring은 GUC 설정만, 런타임 동작 변화 없음. Phase 3(별도 PR)에서 FORCE RLS.

## Changes (16 files)
- **11 route files wired**: cyberdevice(6)·model-governance/change-request(1)·traceability(4)
- **5 model-governance routes no-op**: approve/eval/model-pinning/prompt-registry/rollback은 DB op가 lib에 위임 → route 변경 없음 (coverage gate \`stripLineComments\`로 주석 prose 오탐 방지)
- **coverage gate**: \`WIRED_DOMAINS\` 7개 완성, \`PENDING_DOMAINS\` 비움(Phase 2 종료), \`stripLineComments\` 헬퍼 추가
- **4 test files**: 3 mock factory(model-governance/traceability/traceability-edges) + cyberdevice source-regex(\`db.transaction\`→\`withTenantScope\`)

## 직검 (L-007/008/009)

| Gate | 결과 |
|---|---|
| typecheck | EXIT 0 |
| lint (biome + lint:hex) | EXIT 0 (2 pre-existing warnings) |
| **test FULL** | **4315 passed \| 0 failed \| 8 skipped** (베이스라인 4299 → +16) |
| migration | 0 (코드만) |

## 보안 리뷰 (sync Phase 0.55 병렬) — 리뷰 불일치 직검 판정
- **expert-security: PASS** (BLOCK-MERGE 0건) — 채택
- **evaluator-active: BLOCK-MERGE** — 3개 audit write scope 밖 CRITICAL 주장 → **직검으로 과잉 판정**: 3개 모두 **read-only route**(mutation 없음)로 C-3/H2 atomicity 대상 아님 + RLS INERT로 현재 bypass 아님 + PR #269 동일 패턴
- **단, audit_logs에 RLS 정책 존재**(migration 0001) → Phase 3 FORCE RLS 시 scope 밖 audit write GUC 보장 필요 → **Phase 3 prerequisite으로 이관**

## ★ 핵심 교훈 (L-007 — 본 세션 누적)
PR #269의 11 failures(test mock \`withTenantScope\` 누락) 교훈 반영 → 이번엔 에이전트에게 **test mock 갱신을 명시적 지시** + \`stripLineComments\`로 gate false-positive 차단 → test FULL 4315 passed 첫 통과. 보안 리뷰 불일치 시 **오케스트레이터 직검(route mutation 여부 + RLS 상태 + 기존 패턴)** 으로 판정.

## Phase 2 종료 → Phase 3 (별도 PR)
- **Phase 3 prerequisites (직검 파악)**:
  1. \`rolbypassrls\` 직검 → migration FORCE RLS (Option A) 또는 이중 클라이언트 (Option B)
  2. **lib GUC wiring 선행**: 다수 lib 함수(model-governance/cyberdevice/ai/source-governance 등)가 global db로 org-scoped 쿼리 → FORCE RLS 시 GUC 미설정으로 행 누락
  3. **audit write GUC 보장**: read-only route의 scope 밖 audit도 Phase 3 시 GUC 필요
  4. 카나리(전 도메인) + GUC 미설정 0행 단언

Closes #239 Phase 2. Phase 3 → #239 CLOSE (별도 PR).

🗿 MoAI <email@mo.ai.kr>