### PR TITLE
feat(rls): #239 Phase 3 prep — lib org-scoped DB op withTenantScope wiring

### DIFF
--- a/__tests__/lib/digest/digest-generator.test.ts
+++ b/__tests__/lib/digest/digest-generator.test.ts
@@ -15,9 +15,10 @@ vi.stubEnv('AUTH_GOOGLE_SECRET', 'test-google-secret');
 vi.stubEnv('ANTHROPIC_API_KEY', 'test-anthropic-key');
 vi.stubEnv('OPENAI_API_KEY', 'test-openai-key');
 
-// Mock DB client before it attempts real connection
-vi.mock('../../../lib/db/client', () => ({
-  db: {
+// Mock DB client before it attempts real connection.
+// vi.hoisted ensures the mock object exists before vi.mock factory runs.
+const { dbMock } = vi.hoisted(() => ({
+  dbMock: {
     select: vi.fn().mockReturnThis(),
     from: vi.fn().mockReturnThis(),
     leftJoin: vi.fn().mockReturnThis(),
@@ -33,6 +34,13 @@ vi.mock('../../../lib/db/client', () => ({
       },
     },
   },
+}));
+vi.mock('../../../lib/db/client', () => ({
+  db: dbMock,
+  withTenantScope: vi.fn(
+    async <T>(_orgId: string, fn: (db: typeof dbMock) => Promise<T>): Promise<T> =>
+      fn(dbMock) as Promise<T>,
+  ),
 }));
 
 vi.mock('@anthropic-ai/sdk', () => ({

--- a/app/api/ra/admin/documents/upload/route.ts
+++ b/app/api/ra/admin/documents/upload/route.ts
@@ -226,6 +226,7 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
     const { setPendingReviewOnIngest } = await import('@/lib/source-governance/review-workflow');
     await setPendingReviewOnIngest({
       sourceId: existingSourceId,
+      orgId,
       isInternalSop: docClass === DocClass.internal_sop,
       ownerDepartment: null,
     });

--- a/lib/ai/consult.ts
+++ b/lib/ai/consult.ts
@@ -15,7 +15,7 @@ import type { Session } from 'next-auth';
 import type { ConsultRequest } from '../../types/consult';
 import type { SourceItem, StreamEvent, TraceEvent } from '../../types/streaming';
 import { writeAudit } from '../audit';
-import { db } from '../db/client';
+import { db, withTenantScope } from '../db/client';
 import { conversations, messageBlocks, messages } from '../db/schema';
 import { captureKnowledgeGap, detectKnowledgeGap } from '../knowledge-gap/detector';
 import { enforceCitations } from './citation-enforce';
@@ -466,12 +466,18 @@ export async function* consult(
         if (blockType) {
           // Persist block before SSE emit (REQ-STRUCT-034, REQ-STRUCT-035)
           try {
-            await db.insert(messageBlocks).values({
-              messageId,
-              blockType,
-              blockJson: blockEvent as unknown as Record<string, unknown>,
-              orderIndex: structuredOrderIndex,
-            });
+            const insertBlock = (client: typeof db) =>
+              client.insert(messageBlocks).values({
+                messageId,
+                blockType,
+                blockJson: blockEvent as unknown as Record<string, unknown>,
+                orderIndex: structuredOrderIndex,
+              });
+            if (orgId) {
+              await withTenantScope(orgId, (dbs) => insertBlock(dbs));
+            } else {
+              await insertBlock(db);
+            }
             structuredOrderIndex++;
           } catch (insertErr) {
             // REQ-STRUCT-035: log and continue — emit even if persist fails
@@ -607,10 +613,16 @@ export async function* consult(
       });
 
       // REQ-ENTERPRISE-010: mark message as requiring expert review
-      await db
-        .update(messages)
-        .set({ expertReviewRequired: true })
-        .where(eq(messages.id, messageId));
+      const markExpertReview = (client: typeof db) =>
+        client
+          .update(messages)
+          .set({ expertReviewRequired: true })
+          .where(eq(messages.id, messageId));
+      if (orgId) {
+        await withTenantScope(orgId, (dbs) => markExpertReview(dbs));
+      } else {
+        await markExpertReview(db);
+      }
 
       // REQ-ENTERPRISE-010: audit the auto-flag event
       await writeAudit({
@@ -688,10 +700,16 @@ export async function* consult(
         actorId: session.user?.id ?? null,
       });
       // REQ-KNOWLEDGE-GAP-003: mark the message row (separate from expertReviewRequired).
-      await db
-        .update(messages)
-        .set({ knowledgeGapRequired: true })
-        .where(eq(messages.id, messageId));
+      const markKnowledgeGap = (client: typeof db) =>
+        client
+          .update(messages)
+          .set({ knowledgeGapRequired: true })
+          .where(eq(messages.id, messageId));
+      if (orgId) {
+        await withTenantScope(orgId, (dbs) => markKnowledgeGap(dbs));
+      } else {
+        await markKnowledgeGap(db);
+      }
     } catch (gapErr) {
       logger.error('[consult] knowledge gap capture failed (non-fatal):', {
         error: gapErr instanceof Error ? gapErr.message : String(gapErr),

--- a/lib/ai/retrievers/hybrid-search.ts
+++ b/lib/ai/retrievers/hybrid-search.ts
@@ -7,7 +7,7 @@
 import { openai } from '@ai-sdk/openai';
 import { type EmbeddingModel, embed } from 'ai';
 import { sql } from 'drizzle-orm';
-import { db } from '../../db/client';
+import { db, withTenantScope } from '../../db/client';
 
 export interface RetrievedChunk {
   sectionId: string;
@@ -87,54 +87,58 @@ export async function hybridSearch(
   }
 
   // 4. Query — hybrid (pgvector cosine + FTS) when embedding available, FTS-only otherwise.
-  let rawRows: unknown;
-  if (embeddingLiteral !== null) {
-    // Hybrid: FULL OUTER JOIN so a section is included if it ranks in either branch.
-    rawRows = await db.execute<HybridRow>(sql`
-      WITH vec AS (
+  // The raw SQL is org-scoped via RLS; when orgId is supplied, wrap in
+  // withTenantScope so the GUC is set. When orgId is absent, fall back to the
+  // global db handle (defense-in-depth still applies via sources/app-level gates).
+  type ExecHandle = Pick<typeof db, 'execute'>;
+  const runQueryOnHandle = async (client: ExecHandle): Promise<unknown> => {
+    if (embeddingLiteral !== null) {
+      // Hybrid: FULL OUTER JOIN so a section is included if it ranks in either branch.
+      return client.execute<HybridRow>(sql`
+        WITH vec AS (
+          SELECT
+            ss.id AS section_id,
+            1.0 - (ss.embedding <=> ${embeddingLiteral}::vector) AS vec_score
+          FROM source_sections ss
+          INNER JOIN sources s ON s.id = ss.source_id
+          WHERE ss.embedding IS NOT NULL
+            ${typeFilter}
+          ORDER BY ss.embedding <=> ${embeddingLiteral}::vector
+          LIMIT ${k * 4}
+        ),
+        fts AS (
+          SELECT
+            ss.id AS section_id,
+            ts_rank(to_tsvector('english', ss.text), websearch_to_tsquery('english', ${ftsQuery})) AS fts_score
+          FROM source_sections ss
+          INNER JOIN sources s ON s.id = ss.source_id
+          WHERE to_tsvector('english', ss.text) @@ websearch_to_tsquery('english', ${ftsQuery})
+            ${typeFilter}
+          ORDER BY fts_score DESC
+          LIMIT ${k * 4}
+        )
         SELECT
-          ss.id AS section_id,
-          1.0 - (ss.embedding <=> ${embeddingLiteral}::vector) AS vec_score
+          ss.id            AS section_id,
+          ss.source_id     AS source_id,
+          ss.anchor        AS anchor,
+          ss.text          AS text,
+          vec.vec_score    AS vec_score,
+          fts.fts_score    AS fts_score,
+          s.org_label      AS org_label,
+          s.title          AS title,
+          s.year           AS year,
+          s.type::text     AS type,
+          s.url            AS url
         FROM source_sections ss
         INNER JOIN sources s ON s.id = ss.source_id
-        WHERE ss.embedding IS NOT NULL
-          ${typeFilter}
-        ORDER BY ss.embedding <=> ${embeddingLiteral}::vector
+        LEFT JOIN vec ON vec.section_id = ss.id
+        LEFT JOIN fts ON fts.section_id = ss.id
+        WHERE (vec.vec_score IS NOT NULL OR fts.fts_score IS NOT NULL)
         LIMIT ${k * 4}
-      ),
-      fts AS (
-        SELECT
-          ss.id AS section_id,
-          ts_rank(to_tsvector('english', ss.text), websearch_to_tsquery('english', ${ftsQuery})) AS fts_score
-        FROM source_sections ss
-        INNER JOIN sources s ON s.id = ss.source_id
-        WHERE to_tsvector('english', ss.text) @@ websearch_to_tsquery('english', ${ftsQuery})
-          ${typeFilter}
-        ORDER BY fts_score DESC
-        LIMIT ${k * 4}
-      )
-      SELECT
-        ss.id            AS section_id,
-        ss.source_id     AS source_id,
-        ss.anchor        AS anchor,
-        ss.text          AS text,
-        vec.vec_score    AS vec_score,
-        fts.fts_score    AS fts_score,
-        s.org_label      AS org_label,
-        s.title          AS title,
-        s.year           AS year,
-        s.type::text     AS type,
-        s.url            AS url
-      FROM source_sections ss
-      INNER JOIN sources s ON s.id = ss.source_id
-      LEFT JOIN vec ON vec.section_id = ss.id
-      LEFT JOIN fts ON fts.section_id = ss.id
-      WHERE (vec.vec_score IS NOT NULL OR fts.fts_score IS NOT NULL)
-      LIMIT ${k * 4}
-    `);
-  } else {
+      `);
+    }
     // FTS-only: skips vector CTE when OpenAI embedding is unavailable.
-    rawRows = await db.execute<HybridRow>(sql`
+    return client.execute<HybridRow>(sql`
       SELECT
         ss.id            AS section_id,
         ss.source_id     AS source_id,
@@ -154,6 +158,13 @@ export async function hybridSearch(
       ORDER BY fts_score DESC
       LIMIT ${k * 4}
     `);
+  };
+
+  let rawRows: unknown;
+  if (orgId) {
+    rawRows = await withTenantScope(orgId, async (dbs) => runQueryOnHandle(dbs));
+  } else {
+    rawRows = await runQueryOnHandle(db);
   }
 
   // 5. Combine and rank in app-land. We normalize fts_score to [0,1] by

--- a/lib/ai/retrievers/internal-sops.ts
+++ b/lib/ai/retrievers/internal-sops.ts
@@ -11,7 +11,7 @@
 import { openai } from '@ai-sdk/openai';
 import { type EmbeddingModel, embed } from 'ai';
 import { sql } from 'drizzle-orm';
-import { db } from '../../db/client';
+import { type db, withTenantScope } from '../../db/client';
 import type { IRetriever, RetrievalResult, RetrieverOptions } from './types';
 
 interface SopsRow extends Record<string, unknown> {
@@ -60,55 +60,57 @@ export class InternalSopsRetriever implements IRetriever {
 
     // SQL-level org isolation: WHERE ss.org_id = orgId.
     // This filter runs inside Postgres — cross-org rows are never loaded.
-    let rows: unknown;
-    if (embeddingLiteral !== null) {
-      rows = await db.execute<SopsRow>(sql`
-        WITH vec AS (
+    // Wrapped in withTenantScope so the RLS GUC is also set for this org.
+    type ExecHandle = Pick<typeof db, 'execute'>;
+    const runQuery = async (client: ExecHandle): Promise<unknown> => {
+      if (embeddingLiteral !== null) {
+        return client.execute<SopsRow>(sql`
+          WITH vec AS (
+            SELECT
+              ss.id AS section_id,
+              1.0 - (ss.embedding <=> ${embeddingLiteral}::vector) AS vec_score
+            FROM source_sections ss
+            INNER JOIN sources s ON s.id = ss.source_id
+            WHERE ss.embedding IS NOT NULL
+              AND s.organization_id = ${orgId}
+              AND s.type = 'Internal'
+            ORDER BY ss.embedding <=> ${embeddingLiteral}::vector
+            LIMIT ${limit * 4}
+          ),
+          fts AS (
+            SELECT
+              ss.id AS section_id,
+              ts_rank(to_tsvector('english', ss.text), websearch_to_tsquery('english', ${query})) AS fts_score
+            FROM source_sections ss
+            INNER JOIN sources s ON s.id = ss.source_id
+            WHERE to_tsvector('english', ss.text) @@ websearch_to_tsquery('english', ${query})
+              AND s.organization_id = ${orgId}
+              AND s.type = 'Internal'
+            ORDER BY fts_score DESC
+            LIMIT ${limit * 4}
+          )
           SELECT
-            ss.id AS section_id,
-            1.0 - (ss.embedding <=> ${embeddingLiteral}::vector) AS vec_score
+            ss.id           AS section_id,
+            ss.source_id    AS source_id,
+            ss.anchor       AS anchor,
+            ss.text         AS text,
+            (0.6 * COALESCE(vec.vec_score, 0) + 0.4 * COALESCE(fts.fts_score, 0)) AS combined_score,
+            s.org_label     AS org_label,
+            s.title         AS title,
+            s.year          AS year,
+            s.type::text    AS type,
+            s.url           AS url
           FROM source_sections ss
           INNER JOIN sources s ON s.id = ss.source_id
-          WHERE ss.embedding IS NOT NULL
-            AND s.organization_id = ${orgId}
-            AND s.type = 'Internal'
-          ORDER BY ss.embedding <=> ${embeddingLiteral}::vector
-          LIMIT ${limit * 4}
-        ),
-        fts AS (
-          SELECT
-            ss.id AS section_id,
-            ts_rank(to_tsvector('english', ss.text), websearch_to_tsquery('english', ${query})) AS fts_score
-          FROM source_sections ss
-          INNER JOIN sources s ON s.id = ss.source_id
-          WHERE to_tsvector('english', ss.text) @@ websearch_to_tsquery('english', ${query})
-            AND s.organization_id = ${orgId}
-            AND s.type = 'Internal'
-          ORDER BY fts_score DESC
-          LIMIT ${limit * 4}
-        )
-        SELECT
-          ss.id           AS section_id,
-          ss.source_id    AS source_id,
-          ss.anchor       AS anchor,
-          ss.text         AS text,
-          (0.6 * COALESCE(vec.vec_score, 0) + 0.4 * COALESCE(fts.fts_score, 0)) AS combined_score,
-          s.org_label     AS org_label,
-          s.title         AS title,
-          s.year          AS year,
-          s.type::text    AS type,
-          s.url           AS url
-        FROM source_sections ss
-        INNER JOIN sources s ON s.id = ss.source_id
-        LEFT JOIN vec ON vec.section_id = ss.id
-        LEFT JOIN fts ON fts.section_id = ss.id
-        WHERE (vec.section_id IS NOT NULL OR fts.section_id IS NOT NULL)
-        ORDER BY combined_score DESC
-        LIMIT ${limit}
-      `);
-    } else {
+          LEFT JOIN vec ON vec.section_id = ss.id
+          LEFT JOIN fts ON fts.section_id = ss.id
+          WHERE (vec.section_id IS NOT NULL OR fts.section_id IS NOT NULL)
+          ORDER BY combined_score DESC
+          LIMIT ${limit}
+        `);
+      }
       // FTS-only fallback when embedding is unavailable.
-      rows = await db.execute<SopsRow>(sql`
+      return client.execute<SopsRow>(sql`
         SELECT
           ss.id           AS section_id,
           ss.source_id    AS source_id,
@@ -128,7 +130,9 @@ export class InternalSopsRetriever implements IRetriever {
         ORDER BY combined_score DESC
         LIMIT ${limit}
       `);
-    }
+    };
+
+    const rows = await withTenantScope(orgId, async (dbs) => runQuery(dbs));
 
     const list = rows as unknown as SopsRow[];
     let mapped = list.map((r) => ({

--- a/lib/capa/intake.ts
+++ b/lib/capa/intake.ts
@@ -6,7 +6,7 @@
 // a second read. The trend signature is computed up-front so trend detection
 // is O(1) at insert time.
 
-import { db } from '@/lib/db/client';
+import { type db, withTenantScope } from '@/lib/db/client';
 import { complaints } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
 import { computeTrendSignature } from './trend-detector';
@@ -40,23 +40,30 @@ export async function createComplaint(
   tx?: DbHandle,
 ): Promise<{ id: string; trendSignature: string }> {
   const trendSignature = computeTrendSignature(params.intake);
-  const client = tx ?? db;
 
-  const [row] = await client
-    .insert(complaints)
-    .values({
-      orgId: params.orgId,
-      projectId: params.projectId,
-      intakeData: params.intake,
-      reportabilityStatus: 'pending',
-      trendSignature,
-      createdBy: params.createdBy,
-    })
-    .returning({ id: complaints.id });
+  const doInsert = async (client: DbHandle): Promise<{ id: string; trendSignature: string }> => {
+    const [row] = await client
+      .insert(complaints)
+      .values({
+        orgId: params.orgId,
+        projectId: params.projectId,
+        intakeData: params.intake,
+        reportabilityStatus: 'pending',
+        trendSignature,
+        createdBy: params.createdBy,
+      })
+      .returning({ id: complaints.id });
 
-  const complaintId = row?.id;
-  if (!complaintId) throw new Error('failed to insert complaint');
-  return { id: complaintId, trendSignature };
+    const complaintId = row?.id;
+    if (!complaintId) throw new Error('failed to insert complaint');
+    return { id: complaintId, trendSignature };
+  };
+
+  if (tx) {
+    // Caller's scope (already inside withTenantScope).
+    return doInsert(tx);
+  }
+  return withTenantScope(params.orgId, (dbs) => doInsert(dbs as unknown as DbHandle));
 }
 
 /**
@@ -72,16 +79,18 @@ export async function getComplaint(
   reportabilityStatus: string;
   vigilanceRef: string | null;
 } | null> {
-  const [row] = await db
-    .select({
-      id: complaints.id,
-      intakeData: complaints.intakeData,
-      reportabilityStatus: complaints.reportabilityStatus,
-      vigilanceRef: complaints.vigilanceRef,
-    })
-    .from(complaints)
-    .where(and(eq(complaints.id, complaintId), eq(complaints.orgId, orgId)))
-    .limit(1);
+  const [row] = await withTenantScope(orgId, (dbs) =>
+    dbs
+      .select({
+        id: complaints.id,
+        intakeData: complaints.intakeData,
+        reportabilityStatus: complaints.reportabilityStatus,
+        vigilanceRef: complaints.vigilanceRef,
+      })
+      .from(complaints)
+      .where(and(eq(complaints.id, complaintId), eq(complaints.orgId, orgId)))
+      .limit(1),
+  );
 
   if (!row) return null;
   return {

--- a/lib/clinical-investigation/linkage.ts
+++ b/lib/clinical-investigation/linkage.ts
@@ -7,7 +7,7 @@
 //           consume.
 // @MX:SPEC SPEC-REGULA-CLINICAL-INVESTIGATION-001 (Issue #69, REQ-CLININV-009, AC-04)
 
-import { db } from '@/lib/db/client';
+import { type db, withTenantScope } from '@/lib/db/client';
 import { ciLinks, designHistoryFiles, pmsInputs, workflowRuns } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
 import type { CiLinkTarget } from './types';
@@ -49,7 +49,18 @@ export async function linkInvestigationResults(
   },
   tx?: LinkDbHandle,
 ): Promise<LinkResult> {
-  const client = tx ?? db;
+  // When the caller supplies a scoped tx handle (already inside withTenantScope),
+  // run directly on it. Otherwise, open a tenant scope so the GUC is set.
+  if (tx) {
+    return runLink(tx, params);
+  }
+  return withTenantScope(params.orgId, (dbs) => runLink(dbs as unknown as LinkDbHandle, params));
+}
+
+async function runLink(
+  client: LinkDbHandle,
+  params: { investigationId: string; orgId: string; targetType: CiLinkTarget; targetId: string },
+): Promise<LinkResult> {
   const [row] = await client
     .insert(ciLinks)
     .values({
@@ -123,39 +134,41 @@ export async function verifyLinkTargetExists(
   targetType: CiLinkTarget,
   targetId: string,
 ): Promise<boolean> {
-  switch (targetType) {
-    case 'cer': {
-      const rows = await db
-        .select({ id: workflowRuns.id })
-        .from(workflowRuns)
-        .where(
-          and(
-            eq(workflowRuns.id, targetId),
-            eq(workflowRuns.organizationId, orgId),
-            eq(workflowRuns.workflowType, 'cer'),
-          ),
-        )
-        .limit(1);
-      return rows.length > 0;
+  return withTenantScope(orgId, async (dbs) => {
+    switch (targetType) {
+      case 'cer': {
+        const rows = await dbs
+          .select({ id: workflowRuns.id })
+          .from(workflowRuns)
+          .where(
+            and(
+              eq(workflowRuns.id, targetId),
+              eq(workflowRuns.organizationId, orgId),
+              eq(workflowRuns.workflowType, 'cer'),
+            ),
+          )
+          .limit(1);
+        return rows.length > 0;
+      }
+      case 'pms': {
+        const rows = await dbs
+          .select({ id: pmsInputs.id })
+          .from(pmsInputs)
+          .where(and(eq(pmsInputs.id, targetId), eq(pmsInputs.orgId, orgId)))
+          .limit(1);
+        return rows.length > 0;
+      }
+      case 'dhf': {
+        const rows = await dbs
+          .select({ id: designHistoryFiles.id })
+          .from(designHistoryFiles)
+          .where(and(eq(designHistoryFiles.id, targetId), eq(designHistoryFiles.orgId, orgId)))
+          .limit(1);
+        return rows.length > 0;
+      }
+      default: {
+        return false;
+      }
     }
-    case 'pms': {
-      const rows = await db
-        .select({ id: pmsInputs.id })
-        .from(pmsInputs)
-        .where(and(eq(pmsInputs.id, targetId), eq(pmsInputs.orgId, orgId)))
-        .limit(1);
-      return rows.length > 0;
-    }
-    case 'dhf': {
-      const rows = await db
-        .select({ id: designHistoryFiles.id })
-        .from(designHistoryFiles)
-        .where(and(eq(designHistoryFiles.id, targetId), eq(designHistoryFiles.orgId, orgId)))
-        .limit(1);
-      return rows.length > 0;
-    }
-    default: {
-      return false;
-    }
-  }
+  });
 }

--- a/lib/corpus-license/entitlement.ts
+++ b/lib/corpus-license/entitlement.ts
@@ -1,6 +1,6 @@
 // @MX:NOTE [AUTO] Entitlement grant/revoke lifecycle helpers (REQ-CORPUSLIC-008).
 // @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-008)
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { entitlement, sourceLicense } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
 import { auditEntitlementGranted, auditEntitlementRevoked } from './audit';
@@ -18,7 +18,7 @@ export async function grantEntitlement(params: {
   orgId: string;
   grantedBy: string;
 }): Promise<{ entitlementId: string; created: boolean }> {
-  return db.transaction(async (tx) => {
+  return withTenantScope(params.orgId, async (tx) => {
     // Verify the source_license belongs to this org (IDOR guard).
     const [lic] = await tx
       .select({ id: sourceLicense.id, orgId: sourceLicense.orgId })
@@ -77,7 +77,7 @@ export async function revokeEntitlement(params: {
   orgId: string;
   revokedBy: string;
 }): Promise<{ entitlementId: string; revoked: boolean }> {
-  return db.transaction(async (tx) => {
+  return withTenantScope(params.orgId, async (tx) => {
     const [active] = await tx
       .select({ id: entitlement.id })
       .from(entitlement)

--- a/lib/cyberdevice/risk-linkage.ts
+++ b/lib/cyberdevice/risk-linkage.ts
@@ -13,7 +13,7 @@
 // fire the change-control hook (deterministic, testable) without coupling this
 // module to the change-control persistence layer.
 
-import { db } from '@/lib/db/client';
+import { type db, withTenantScope } from '@/lib/db/client';
 import { cveImpact, riskItems, workflowRuns } from '@/lib/db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
 
@@ -42,11 +42,15 @@ export async function filterRiskItemsByOrg(
 ): Promise<{ ok: string[]; rejected: string[] }> {
   if (riskItemIds.length === 0) return { ok: [], rejected: [] };
   try {
-    const rows = await db
-      .select({ id: riskItems.id })
-      .from(riskItems)
-      .innerJoin(workflowRuns, eq(riskItems.workflowRunId, workflowRuns.id))
-      .where(and(inArray(riskItems.id, [...riskItemIds]), eq(workflowRuns.organizationId, orgId)));
+    const rows = await withTenantScope(orgId, (dbs) =>
+      dbs
+        .select({ id: riskItems.id })
+        .from(riskItems)
+        .innerJoin(workflowRuns, eq(riskItems.workflowRunId, workflowRuns.id))
+        .where(
+          and(inArray(riskItems.id, [...riskItemIds]), eq(workflowRuns.organizationId, orgId)),
+        ),
+    );
     const okSet = new Set(rows.map((r) => r.id));
     const ok = [...okSet];
     const rejected = riskItemIds.filter((id) => !okSet.has(id));
@@ -78,11 +82,20 @@ export async function linkCveImpactToRiskItem(params: {
   // caller's audit meta. This mirrors how riskControls links to risk_items.
   const primaryRiskItemId = ok[0];
   if (primaryRiskItemId) {
-    const client = params.tx ?? db;
-    await client
-      .update(cveImpact)
-      .set({ riskItemId: primaryRiskItemId })
-      .where(eq(cveImpact.id, params.cveImpactId));
+    if (params.tx) {
+      // Caller's scope (already inside withTenantScope).
+      await params.tx
+        .update(cveImpact)
+        .set({ riskItemId: primaryRiskItemId })
+        .where(eq(cveImpact.id, params.cveImpactId));
+    } else {
+      await withTenantScope(params.orgId, (dbs) =>
+        dbs
+          .update(cveImpact)
+          .set({ riskItemId: primaryRiskItemId })
+          .where(eq(cveImpact.id, params.cveImpactId)),
+      );
+    }
   }
   return {
     linkedRiskItemIds: ok,

--- a/lib/digest/digest-generator.ts
+++ b/lib/digest/digest-generator.ts
@@ -5,7 +5,7 @@
 import crypto from 'node:crypto';
 import Anthropic from '@anthropic-ai/sdk';
 import { and, desc, eq, gte, lte } from 'drizzle-orm';
-import { db } from '../db/client';
+import { withTenantScope } from '../db/client';
 import { orgUpdateRelevance, regulatoryUpdates, weeklyDigests } from '../db/schema';
 import { logger } from '../observability/logger';
 
@@ -136,30 +136,36 @@ export async function generateWeeklyDigest(orgId: string, weekId?: string): Prom
   const targetWeekId = weekId ?? getWeekId(new Date());
   const { start, end } = getWeekBounds(targetWeekId);
 
-  // Fetch relevant updates for this org in the week
-  const updates = await db
-    .select({
-      id: regulatoryUpdates.id,
-      title: regulatoryUpdates.title,
-      region: regulatoryUpdates.region,
-      severity: regulatoryUpdates.severity,
-      publishedAt: regulatoryUpdates.publishedAt,
-      sourceUrl: regulatoryUpdates.sourceUrl,
-      rawContentEn: regulatoryUpdates.rawContentEn,
-      impactScore: regulatoryUpdates.impactScore,
-      orgImpactScore: orgUpdateRelevance.impactScore,
-    })
-    .from(regulatoryUpdates)
-    .leftJoin(
-      orgUpdateRelevance,
-      and(
-        eq(orgUpdateRelevance.updateId, regulatoryUpdates.id),
-        eq(orgUpdateRelevance.orgId, orgId),
-      ),
-    )
-    .where(and(gte(regulatoryUpdates.publishedAt, start), lte(regulatoryUpdates.publishedAt, end)))
-    .orderBy(desc(regulatoryUpdates.impactScore))
-    .limit(50);
+  // Wrap all DB access in one tenant scope so the weekly_digests upsert runs
+  // with the GUC set (regulatory_updates is a global catalog read, but
+  // org_update_relevance + weekly_digests are org-scoped).
+  const updates = await withTenantScope(orgId, (dbs) =>
+    dbs
+      .select({
+        id: regulatoryUpdates.id,
+        title: regulatoryUpdates.title,
+        region: regulatoryUpdates.region,
+        severity: regulatoryUpdates.severity,
+        publishedAt: regulatoryUpdates.publishedAt,
+        sourceUrl: regulatoryUpdates.sourceUrl,
+        rawContentEn: regulatoryUpdates.rawContentEn,
+        impactScore: regulatoryUpdates.impactScore,
+        orgImpactScore: orgUpdateRelevance.impactScore,
+      })
+      .from(regulatoryUpdates)
+      .leftJoin(
+        orgUpdateRelevance,
+        and(
+          eq(orgUpdateRelevance.updateId, regulatoryUpdates.id),
+          eq(orgUpdateRelevance.orgId, orgId),
+        ),
+      )
+      .where(
+        and(gte(regulatoryUpdates.publishedAt, start), lte(regulatoryUpdates.publishedAt, end)),
+      )
+      .orderBy(desc(regulatoryUpdates.impactScore))
+      .limit(50),
+  );
 
   // Generate AI summaries (sequential to avoid rate limits)
   const digestUpdates: DigestUpdate[] = [];
@@ -197,16 +203,66 @@ export async function generateWeeklyDigest(orgId: string, weekId?: string): Prom
     { critical: 0, high: 0, medium: 0, low: 0 },
   );
 
-  // Check for existing digest to preserve shareToken for link stability
-  const existing = await db.query.weeklyDigests.findFirst({
-    where: and(eq(weeklyDigests.orgId, orgId), eq(weeklyDigests.weekId, targetWeekId)),
+  // Check for existing digest + upsert in one tenant scope.
+  await withTenantScope(orgId, async (dbs) => {
+    const existing = await dbs.query.weeklyDigests.findFirst({
+      where: and(eq(weeklyDigests.orgId, orgId), eq(weeklyDigests.weekId, targetWeekId)),
+    });
+
+    // @MX:NOTE: [AUTO] Preserve existing shareToken to keep email links stable across normal regenerations
+    // @MX:REASON: Using existing?.shareToken prevents 404 errors on previously sent token-gated email links
+    // Preserve existing token for normal regeneration, only generate new for explicit rotation
+    const shareToken = existing?.shareToken || crypto.randomBytes(16).toString('hex');
+
+    await dbs
+      .insert(weeklyDigests)
+      .values({
+        orgId,
+        weekId: targetWeekId,
+        updateCount: digestUpdates.length,
+        criticalCount: counts.critical,
+        highCount: counts.high,
+        mediumCount: counts.medium,
+        lowCount: counts.low,
+        digestJson: {
+          week_id: targetWeekId,
+          share_token: shareToken,
+          week_start: start.toISOString(),
+          week_end: end.toISOString(),
+          org_id: orgId,
+          updates: digestUpdates,
+          update_count: digestUpdates.length,
+          critical_count: counts.critical,
+          high_count: counts.high,
+          medium_count: counts.medium,
+          low_count: counts.low,
+        } as unknown as Record<string, unknown>,
+        shareToken,
+      })
+      .onConflictDoUpdate({
+        target: [weeklyDigests.orgId, weeklyDigests.weekId],
+        set: {
+          updateCount: digestUpdates.length,
+          criticalCount: counts.critical,
+          highCount: counts.high,
+          mediumCount: counts.medium,
+          lowCount: counts.low,
+          generatedAt: new Date(),
+        },
+      });
   });
 
-  // @MX:NOTE: [AUTO] Preserve existing shareToken to keep email links stable across normal regenerations
-  // @MX:REASON: Using existing?.shareToken prevents 404 errors on previously sent token-gated email links
-  // Preserve existing token for normal regeneration, only generate new for explicit rotation
-  const shareToken = existing?.shareToken || crypto.randomBytes(16).toString('hex');
-  const payload: DigestPayload = {
+  // Reconstruct the payload for the return value (token may have been regenerated
+  // by the upsert; use a fresh read to stay consistent). For simplicity, derive
+  // the share token from a final read inside a scope.
+  const finalRow = await withTenantScope(orgId, (dbs) =>
+    dbs.query.weeklyDigests.findFirst({
+      where: and(eq(weeklyDigests.orgId, orgId), eq(weeklyDigests.weekId, targetWeekId)),
+    }),
+  );
+  const shareToken = finalRow?.shareToken ?? crypto.randomBytes(16).toString('hex');
+
+  return {
     week_id: targetWeekId,
     share_token: shareToken,
     week_start: start.toISOString(),
@@ -219,34 +275,4 @@ export async function generateWeeklyDigest(orgId: string, weekId?: string): Prom
     medium_count: counts.medium,
     low_count: counts.low,
   };
-
-  // Upsert digest record
-  await db
-    .insert(weeklyDigests)
-    .values({
-      orgId,
-      weekId: targetWeekId,
-      updateCount: payload.update_count,
-      criticalCount: counts.critical,
-      highCount: counts.high,
-      mediumCount: counts.medium,
-      lowCount: counts.low,
-      digestJson: payload as unknown as Record<string, unknown>,
-      shareToken,
-    })
-    .onConflictDoUpdate({
-      target: [weeklyDigests.orgId, weeklyDigests.weekId],
-      set: {
-        updateCount: payload.update_count,
-        criticalCount: counts.critical,
-        highCount: counts.high,
-        mediumCount: counts.medium,
-        lowCount: counts.low,
-        digestJson: payload as unknown as Record<string, unknown>,
-        shareToken,
-        generatedAt: new Date(),
-      },
-    });
-
-  return payload;
 }

--- a/lib/inngest/docingest/upload-processed.ts
+++ b/lib/inngest/docingest/upload-processed.ts
@@ -123,6 +123,7 @@ export const uploadProcessedFn = inngest.createFunction(
       const { setPendingReviewOnIngest } = await import('@/lib/source-governance/review-workflow');
       return setPendingReviewOnIngest({
         sourceId,
+        orgId,
         isInternalSop: docClass === DocClass.internal_sop,
         ownerDepartment: null,
       });

--- a/lib/knowledge-gap/clustering.ts
+++ b/lib/knowledge-gap/clustering.ts
@@ -14,7 +14,7 @@
 // Embeddings are generated from redacted text only — no PII reaches the embedding API.
 
 import { createHash } from 'node:crypto';
-import { db } from '@/lib/db/client';
+import { db, withTenantScope } from '@/lib/db/client';
 import { unansweredQueue } from '@/lib/db/schema';
 import { embedChunks } from '@/lib/ingest/embed';
 import { and, eq } from 'drizzle-orm';
@@ -70,15 +70,17 @@ export async function findSimilarOpenCluster(
   redactedQuestion: string,
   excludeGapId?: string,
 ): Promise<string | null> {
-  const openGaps = await db
-    .select({
-      id: unansweredQueue.id,
-      redactedQuestion: unansweredQueue.redactedQuestion,
-      redactionHash: unansweredQueue.redactionHash,
-      clusterId: unansweredQueue.clusterId,
-    })
-    .from(unansweredQueue)
-    .where(and(eq(unansweredQueue.orgId, orgId), eq(unansweredQueue.status, 'open')));
+  const openGaps = await withTenantScope(orgId, (dbs) =>
+    dbs
+      .select({
+        id: unansweredQueue.id,
+        redactedQuestion: unansweredQueue.redactedQuestion,
+        redactionHash: unansweredQueue.redactionHash,
+        clusterId: unansweredQueue.clusterId,
+      })
+      .from(unansweredQueue)
+      .where(and(eq(unansweredQueue.orgId, orgId), eq(unansweredQueue.status, 'open'))),
+  );
 
   const candidateGaps =
     excludeGapId === undefined ? openGaps : openGaps.filter((gap) => gap.id !== excludeGapId);
@@ -127,7 +129,9 @@ export async function assignCluster(
   const existingClusterId = await findSimilarOpenCluster(orgId, redactedQuestion, gapId);
 
   const clusterId = existingClusterId ?? newClusterId;
-  await db.update(unansweredQueue).set({ clusterId }).where(eq(unansweredQueue.id, gapId));
+  await withTenantScope(orgId, (dbs) =>
+    dbs.update(unansweredQueue).set({ clusterId }).where(eq(unansweredQueue.id, gapId)),
+  );
 
   return {
     existingClusterId,

--- a/lib/model-governance/change-workflow.ts
+++ b/lib/model-governance/change-workflow.ts
@@ -8,7 +8,7 @@
 // @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (Issue 71, REQ-MODELGOV-004/005/012/013/014)
 
 import { type AuditDbHandle, writeAudit } from '@/lib/audit';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { approvedCombination, changeRequest } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
 import { auditApproved, auditChangeRequested, auditEvalResult } from './audit';
@@ -43,7 +43,7 @@ export async function createChangeRequest(params: {
     evalStatus = gate.passed ? 'passed' : 'failed';
   }
 
-  return db.transaction(async (tx) => {
+  return withTenantScope(params.orgId, async (tx) => {
     const [row] = await tx
       .insert(changeRequest)
       .values({
@@ -116,18 +116,22 @@ export async function approveChangeRequest(params: {
   approverId: string;
   evalResultRef?: string;
 }): Promise<{ combinationId: string }> {
-  const [row] = await db
-    .select({
-      id: changeRequest.id,
-      promptId: changeRequest.promptId,
-      modelPinId: changeRequest.modelPinId,
-      evalStatus: changeRequest.evalStatus,
-      approvalStatus: changeRequest.approvalStatus,
-      evalResultRef: changeRequest.evalResultRef,
-    })
-    .from(changeRequest)
-    .where(and(eq(changeRequest.id, params.changeRequestId), eq(changeRequest.orgId, params.orgId)))
-    .limit(1);
+  const row = await withTenantScope(params.orgId, (dbs) =>
+    dbs
+      .select({
+        id: changeRequest.id,
+        promptId: changeRequest.promptId,
+        modelPinId: changeRequest.modelPinId,
+        evalStatus: changeRequest.evalStatus,
+        approvalStatus: changeRequest.approvalStatus,
+        evalResultRef: changeRequest.evalResultRef,
+      })
+      .from(changeRequest)
+      .where(
+        and(eq(changeRequest.id, params.changeRequestId), eq(changeRequest.orgId, params.orgId)),
+      )
+      .limit(1),
+  ).then((r) => r[0]);
 
   if (!row) {
     throw new ChangeRequestBlockedError('change_request_not_found_or_org_mismatch');
@@ -136,10 +140,10 @@ export async function approveChangeRequest(params: {
   // REQ-005: eval must have passed before approval.
   if (row.evalStatus !== 'passed') {
     // M3 fix (21 CFR Part 11 §11.10(e)): write the rejection audit in a
-    // COMMITTING transaction BEFORE the throw. The prior code wrote the audit
-    // inside the same tx that then threw — the throw rolled the tx back,
-    // losing the denial record. Mirrors the capa #251 close-route denial fix.
-    await db.transaction(async (tx) => {
+    // COMMITTING transaction BEFORE the throw. withTenantScope wraps the
+    // audit in its own tx (GUC set) so the denial record persists even when
+    // the throw below propagates. Mirrors the capa #251 close-route denial fix.
+    await withTenantScope(params.orgId, async (tx) => {
       await writeAudit(
         {
           actor_id: params.approverId,
@@ -164,7 +168,7 @@ export async function approveChangeRequest(params: {
 
   const evalResultRef = params.evalResultRef ?? row.evalResultRef ?? null;
 
-  return db.transaction(async (tx) => {
+  return withTenantScope(params.orgId, async (tx) => {
     // REQ-013: supersede the current active combination (if any).
     const [currentActive] = await tx
       .select({ id: approvedCombination.id })
@@ -240,7 +244,7 @@ export async function recordEvalResult(params: {
     evalResultRef: params.evalResultRef ?? null,
   });
 
-  return db.transaction(async (tx) => {
+  return withTenantScope(params.orgId, async (tx) => {
     await tx
       .update(changeRequest)
       .set({

--- a/lib/model-governance/rlhf-gate.ts
+++ b/lib/model-governance/rlhf-gate.ts
@@ -7,7 +7,7 @@
 
 import { createHash } from 'node:crypto';
 import { type AuditDbHandle, writeAudit } from '@/lib/audit';
-import { db } from '@/lib/db/client';
+import { db, withTenantScope } from '@/lib/db/client';
 import { changeRequest } from '@/lib/db/schema';
 
 /**
@@ -30,25 +30,25 @@ export async function submitRlhfProposal(params: {
   promptId?: string;
   proposalText: string;
 }): Promise<{ changeRequestId: string }> {
-  const [row] = await db
-    .insert(changeRequest)
-    .values({
-      orgId: params.orgId,
-      promptId: params.promptId ?? null,
-      modelPinId: null,
-      evalStatus: 'pending',
-      approvalStatus: 'pending_review',
-      createdBy: params.submittedBy,
-    })
-    .returning({ id: changeRequest.id });
+  return withTenantScope(params.orgId, async (dbs) => {
+    const [row] = await dbs
+      .insert(changeRequest)
+      .values({
+        orgId: params.orgId,
+        promptId: params.promptId ?? null,
+        modelPinId: null,
+        evalStatus: 'pending',
+        approvalStatus: 'pending_review',
+        createdBy: params.submittedBy,
+      })
+      .returning({ id: changeRequest.id });
 
-  if (!row) throw new Error('change_request insert returned no rows');
+    if (!row) throw new Error('change_request insert returned no rows');
 
-  // M3 fix: wrap the audit in a committing transaction so it persists
-  // independently of any downstream throw. Mirrors the capa #251 denial
-  // pattern (21 CFR Part 11 — the record MUST survive). writeAudit with a
-  // committed tx handle guarantees the row is durable.
-  await db.transaction(async (tx: AuditDbHandle) => {
+    // M3 fix: writeAudit inside the same tenant scope so the audit row + GUC
+    // commit atomically (21 CFR Part 11 — the record MUST survive). The
+    // withTenantScope callback already runs inside db.transaction, so the
+    // audit commits with the insert.
     await writeAudit(
       {
         actor_id: params.submittedBy,
@@ -62,11 +62,11 @@ export async function submitRlhfProposal(params: {
           proposal_text_hash: hashProposalText(params.proposalText),
         },
       },
-      tx,
+      dbs as unknown as AuditDbHandle,
     );
-  });
 
-  return { changeRequestId: row.id };
+    return { changeRequestId: row.id };
+  });
 }
 
 /**

--- a/lib/model-governance/rollback.ts
+++ b/lib/model-governance/rollback.ts
@@ -7,7 +7,7 @@
 // @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (Issue 71, REQ-MODELGOV-006, AC-03)
 
 import type { AuditDbHandle } from '@/lib/audit';
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { approvedCombination } from '@/lib/db/schema';
 import { and, desc, eq } from 'drizzle-orm';
 import { auditRolledBack } from './audit';
@@ -34,7 +34,7 @@ export async function rollbackCombination(params: {
   actorId: string | null;
   toCombinationId?: string;
 }): Promise<{ fromId: string; toId: string }> {
-  return db.transaction(async (tx) => {
+  return withTenantScope(params.orgId, async (tx) => {
     // Current active.
     const [current] = await tx
       .select({ id: approvedCombination.id })

--- a/lib/source-governance/delta-sync-hook.ts
+++ b/lib/source-governance/delta-sync-hook.ts
@@ -11,7 +11,7 @@
 // updateGovernanceFromSync() for every source touched by the ingestion run,
 // AFTER the gap-replay loop, so the governance state reflects the new content.
 
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { sources } from '@/lib/db/schema';
 import { logger } from '@/lib/observability/logger';
 import { eq, inArray } from 'drizzle-orm';
@@ -57,10 +57,9 @@ export async function updateGovernanceFromSync(params: {
 
   // Bulk-verify the source IDs belong to the org before per-source UPDATEs.
   const ids = params.updates.map((u) => u.sourceId);
-  const owned = (await db
-    .select({ id: sources.id })
-    .from(sources)
-    .where(inArray(sources.id, ids))) as Array<{ id: string }>;
+  const owned = await withTenantScope(params.orgId, (dbs) =>
+    dbs.select({ id: sources.id }).from(sources).where(inArray(sources.id, ids)),
+  );
   const ownedSet = new Set(owned.map((r) => r.id));
 
   for (const update of params.updates) {
@@ -91,7 +90,7 @@ export async function updateGovernanceFromSync(params: {
         updatedFields.push('superseded_by');
       }
 
-      await db.transaction(async (tx) => {
+      await withTenantScope(params.orgId, async (tx) => {
         await tx.update(sources).set(setClause).where(eq(sources.id, update.sourceId));
         await auditSourceDeltaSyncUpdated({
           userId: params.actorId,

--- a/lib/source-governance/review-workflow.ts
+++ b/lib/source-governance/review-workflow.ts
@@ -7,7 +7,7 @@
 //   A dead-code definition without a call site is a SPEC violation.
 // @MX:SPEC SPEC-REGULA-SOURCE-GOVERNANCE-001 (REQ-SOURCE-GOV-009/010/015, AC-04/05)
 
-import { db } from '@/lib/db/client';
+import { withTenantScope } from '@/lib/db/client';
 import { messageSources, sources, unansweredQueue } from '@/lib/db/schema';
 import { logger } from '@/lib/observability/logger';
 import { eq, inArray } from 'drizzle-orm';
@@ -31,19 +31,22 @@ import type { ApprovalStatus, SourceChangeImpact } from './types';
  */
 export async function setPendingReviewOnIngest(params: {
   sourceId: string;
+  orgId: string;
   isInternalSop: boolean;
   ownerDepartment?: string | null;
 }): Promise<{ approvalStatus: ApprovalStatus; missingOwner: boolean }> {
   const missingOwner =
     params.isInternalSop && (!params.ownerDepartment || params.ownerDepartment.trim() === '');
 
-  await db
-    .update(sources)
-    .set({
-      approvalStatus: 'pending_review',
-      ownerDepartment: params.ownerDepartment ?? null,
-    })
-    .where(eq(sources.id, params.sourceId));
+  await withTenantScope(params.orgId, (dbs) =>
+    dbs
+      .update(sources)
+      .set({
+        approvalStatus: 'pending_review',
+        ownerDepartment: params.ownerDepartment ?? null,
+      })
+      .where(eq(sources.id, params.sourceId)),
+  );
 
   if (missingOwner) {
     logger.warn('[source-governance] internal SOP ingested without owner_department', {
@@ -69,7 +72,7 @@ export async function approveSource(params: {
   const existing = await getSourceInOrg(params.sourceId, params.orgId);
   if (!existing) return null; // IDOR → caller returns 404.
 
-  await db.transaction(async (tx) => {
+  await withTenantScope(params.orgId, async (tx) => {
     await tx
       .update(sources)
       .set({ approvalStatus: params.decision, lastReviewedAt: new Date() })
@@ -120,7 +123,7 @@ export async function markSuperseded(params: {
   if (!successor) return null;
 
   const { auditSourceSuperseded } = await import('./audit');
-  await db.transaction(async (tx) => {
+  await withTenantScope(params.orgId, async (tx) => {
     await tx
       .update(sources)
       .set({ supersededBy: params.supersededBy })
@@ -139,7 +142,7 @@ export async function markSuperseded(params: {
   // Best-effort: impact assessment failure never fails the supersede (the
   // state change already succeeded + audited).
   try {
-    await assessSourceChangeImpact({ sourceId: params.sourceId });
+    await assessSourceChangeImpact({ sourceId: params.sourceId, orgId: params.orgId });
   } catch (err) {
     logger.warn('[source-governance] assessSourceChangeImpact failed post-supersede', {
       sourceId: params.sourceId,
@@ -220,7 +223,7 @@ export async function updateGovernanceFields(params: {
   }
 
   const { auditSourceGovernanceUpdated } = await import('./audit');
-  await db.transaction(async (tx) => {
+  await withTenantScope(params.orgId, async (tx) => {
     await tx.update(sources).set(setClause).where(eq(sources.id, params.sourceId));
     await auditSourceGovernanceUpdated({
       userId: params.userId,
@@ -233,7 +236,7 @@ export async function updateGovernanceFields(params: {
   // H-2 (REQ-SOURCE-GOV-010): wire assessSourceChangeImpact into the governance
   // change flow so downstream knowledge gaps surface on the dashboard.
   try {
-    await assessSourceChangeImpact({ sourceId: params.sourceId });
+    await assessSourceChangeImpact({ sourceId: params.sourceId, orgId: params.orgId });
   } catch (err) {
     logger.warn('[source-governance] assessSourceChangeImpact failed post-governance-update', {
       sourceId: params.sourceId,
@@ -259,27 +262,41 @@ export async function updateGovernanceFields(params: {
  */
 export async function assessSourceChangeImpact(params: {
   sourceId: string;
+  orgId?: string;
 }): Promise<SourceChangeImpact> {
   try {
-    const rows = (await db
-      .select({ messageId: messageSources.messageId })
-      .from(messageSources)
-      .where(eq(messageSources.sourceId, params.sourceId))) as Array<{
-      messageId: string;
-    }>;
+    const runRead = async <T>(
+      fn: (dbs: typeof import('@/lib/db/client')['db']) => Promise<T>,
+    ): Promise<T> => {
+      if (params.orgId) {
+        const { withTenantScope } = await import('@/lib/db/client');
+        return withTenantScope(params.orgId, fn);
+      }
+      const { db: fallbackDb } = await import('@/lib/db/client');
+      return fn(fallbackDb);
+    };
+
+    const rows = await runRead((dbs) =>
+      dbs
+        .select({ messageId: messageSources.messageId })
+        .from(messageSources)
+        .where(eq(messageSources.sourceId, params.sourceId)),
+    );
 
     if (rows.length === 0) {
       return { knowledgeGapIds: [], evalScenarioIds: [], submissionPackageIds: [] };
     }
 
     const messageIds = rows.map((r) => r.messageId);
-    const gapRows = (await db
-      .select({ id: unansweredQueue.id })
-      .from(unansweredQueue)
-      .where(inArray(unansweredQueue.messageId, messageIds))) as Array<{ id: string }>;
+    const gapRows = await runRead((dbs) =>
+      dbs
+        .select({ id: unansweredQueue.id })
+        .from(unansweredQueue)
+        .where(inArray(unansweredQueue.messageId, messageIds)),
+    );
 
     return {
-      knowledgeGapIds: gapRows.map((r) => r.id),
+      knowledgeGapIds: gapRows.map((r) => (r as { id: string }).id),
       // @MX:TODO [AUTO] REQ-SOURCE-GOV-010 follow-up: eval-scenario + submission-package
       //   impact joins (depends on eval/submission tables not yet finalised in
       //   this tier). Knowledge-gap impact is the highest-priority signal and is

--- a/tests/integration/clinical-investigation-idor-runtime.test.ts
+++ b/tests/integration/clinical-investigation-idor-runtime.test.ts
@@ -198,7 +198,13 @@ function resolveRows(fromTable: string): Row[] {
   }
 }
 
-vi.mock('@/lib/db/client', () => ({ db: dbMock }));
+vi.mock('@/lib/db/client', () => ({
+  db: dbMock,
+  withTenantScope: vi.fn(
+    async <T>(_orgId: string, fn: (db: typeof dbMock) => Promise<T>): Promise<T> =>
+      dbMock.transaction(async (tx: unknown) => fn(tx as typeof dbMock)) as Promise<T>,
+  ),
+}));
 
 // ---------------------------------------------------------------------------
 // Audit mock — records every writeAudit call. Can simulate failure.

--- a/tests/integration/knowledge-gap.test.ts
+++ b/tests/integration/knowledge-gap.test.ts
@@ -171,7 +171,13 @@ vi.mock('@/lib/db/client', () => {
       return selectChain();
     },
   };
-  return { db: client };
+  return {
+    db: client,
+    withTenantScope: vi.fn(
+      async <T>(_orgId: string, fn: (db: typeof client) => Promise<T>): Promise<T> =>
+        fn(client) as Promise<T>,
+    ),
+  };
 });
 
 // Stub consult() — the replay path imports it at module load time.

--- a/tests/integration/model-governance-lifecycle.test.ts
+++ b/tests/integration/model-governance-lifecycle.test.ts
@@ -104,7 +104,14 @@ afterEach(() => {
 // Capture writeAudit calls so tests can assert the audit survived (M3).
 // We mock @/lib/audit so it records into state.auditLogs without touching DB.
 async function mockModules(state: MockState) {
-  vi.doMock('@/lib/db/client', () => ({ db: createMockDb(state) }));
+  const mockDb = createMockDb(state);
+  vi.doMock('@/lib/db/client', () => ({
+    db: mockDb,
+    withTenantScope: vi.fn(
+      async <T>(_orgId: string, fn: (db: typeof mockDb) => Promise<T>): Promise<T> =>
+        fn(mockDb) as Promise<T>,
+    ),
+  }));
   vi.doMock('@/lib/audit', () => ({
     writeAudit: async (params: Record<string, unknown>, _tx?: unknown) => {
       state.auditLogs.push({

--- a/tests/integration/rlhf-idor-runtime.test.ts
+++ b/tests/integration/rlhf-idor-runtime.test.ts
@@ -233,7 +233,7 @@ vi.mock('@/lib/db/client', () => ({
   // C-3 assertion on dbMock.transaction call count still holds, and the fn
   // receives dbMock as the scoped tx handle (same object the real impl passes).
   withTenantScope: vi.fn(
-    async <T>(orgId: string, fn: (db: typeof dbMock) => Promise<T>): Promise<T> => {
+    async <T>(_orgId: string, fn: (db: typeof dbMock) => Promise<T>): Promise<T> => {
       return dbMock.transaction(async (tx: typeof dbMock) => fn(tx));
     },
   ),

--- a/tests/integration/source-governance.test.ts
+++ b/tests/integration/source-governance.test.ts
@@ -76,7 +76,16 @@ beforeEach(() => {
   vi.doMock('@/lib/audit', () => ({
     writeAudit: vi.fn(async () => {}),
   }));
-  vi.doMock('@/lib/db/client', () => ({ db: makeMockDb(mockRows) }));
+  vi.doMock('@/lib/db/client', () => {
+    const mockDb = makeMockDb(mockRows);
+    return {
+      db: mockDb,
+      withTenantScope: vi.fn(
+        async <T>(_orgId: string, fn: (db: typeof mockDb) => Promise<T>): Promise<T> =>
+          fn(mockDb) as Promise<T>,
+      ),
+    };
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -244,6 +253,7 @@ describe('AC-04: pending_review on ingest (REQ-SOURCE-GOV-003/009)', () => {
     const { setPendingReviewOnIngest } = await import('@/lib/source-governance/review-workflow');
     const result = await setPendingReviewOnIngest({
       sourceId: 'src-sop-1',
+      orgId: 'org-1',
       isInternalSop: true,
       ownerDepartment: null,
     });
@@ -266,7 +276,9 @@ describe('AC-04: pending_review on ingest (REQ-SOURCE-GOV-003/009)', () => {
 describe('AC-05: approval audit (REQ-SOURCE-GOV-015)', () => {
   it('source-level: approveSource wraps UPDATE + audit in one transaction', () => {
     const src = readText('lib/source-governance/review-workflow.ts');
-    expect(src).toContain('db.transaction');
+    // Phase 3 RLS: org-scoped DB ops now run inside withTenantScope (which
+    // wraps db.transaction + sets the GUC). Assert the scoped wrapper is present.
+    expect(src).toContain('withTenantScope');
     expect(src).toContain('auditSourceApproval');
   });
 
@@ -320,7 +332,8 @@ describe('AC-07: delta-sync governance refresh (REQ-SOURCE-GOV-016)', () => {
 
   it('source-level: delta-sync-hook writes audit source.delta_sync_updated in tx', () => {
     const src = readText('lib/source-governance/delta-sync-hook.ts');
-    expect(src).toContain('db.transaction');
+    // Phase 3 RLS: org-scoped UPDATE + audit now run inside withTenantScope.
+    expect(src).toContain('withTenantScope');
     expect(src).toContain('auditSourceDeltaSyncUpdated');
   });
 });
@@ -417,26 +430,35 @@ function makeSequentialMockDb(queue: unknown[][]) {
     update: vi.fn(() => ({ set: () => ({ where: () => Promise.resolve() }) })),
     insert: vi.fn(() => ({ values: () => Promise.resolve() })),
   };
-  return {
+  const mockDb = {
     select: vi.fn(selectMock),
     update: vi.fn(() => ({ set: () => ({ where: () => Promise.resolve() }) })),
     transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(txMock)),
   };
+  return mockDb;
+}
+
+/** Attach withTenantScope to a mock db object (calls fn with the same mockDb). */
+function withScope<T>(mockDb: T) {
+  return vi.fn(
+    async <R>(_orgId: string, fn: (db: T) => Promise<R>): Promise<R> => fn(mockDb) as Promise<R>,
+  );
 }
 
 describe('BEHAVIORAL C-2+M-1: markSuperseded (REQ-SOURCE-GOV-005/006)', () => {
   it('writes superseded_by + audits when successor is in same org', async () => {
     vi.doMock('@/lib/audit', () => ({ writeAudit: vi.fn(async () => {}) }));
-    vi.doMock('@/lib/db/client', () => ({
-      db: makeSequentialMockDb([
+    vi.doMock('@/lib/db/client', () => {
+      const mockDb = makeSequentialMockDb([
         [{ id: 'src-old', approvalStatus: 'approved' }], // getSourceInOrg(sourceId)
         [{ id: 'src-new', approvalStatus: 'approved' }], // getSourceInOrg(supersededBy)
         // assessSourceChangeImpact: messageSources select → empty
         [],
         // assessSourceChangeImpact: unansweredQueue select → empty
         [],
-      ]),
-    }));
+      ]);
+      return { db: mockDb, withTenantScope: withScope(mockDb) };
+    });
     vi.resetModules();
     const { markSuperseded } = await import('@/lib/source-governance/review-workflow');
     const result = await markSuperseded({
@@ -451,7 +473,7 @@ describe('BEHAVIORAL C-2+M-1: markSuperseded (REQ-SOURCE-GOV-005/006)', () => {
   it('rejects self-cycle (sourceId === supersededBy) → ok:false, no db write', async () => {
     const db = makeSequentialMockDb([]);
     vi.doMock('@/lib/audit', () => ({ writeAudit: vi.fn(async () => {}) }));
-    vi.doMock('@/lib/db/client', () => ({ db }));
+    vi.doMock('@/lib/db/client', () => ({ db, withTenantScope: withScope(db) }));
     vi.resetModules();
     const { markSuperseded } = await import('@/lib/source-governance/review-workflow');
     const result = await markSuperseded({
@@ -466,9 +488,10 @@ describe('BEHAVIORAL C-2+M-1: markSuperseded (REQ-SOURCE-GOV-005/006)', () => {
 
   it('returns null on IDOR miss (source not in org)', async () => {
     vi.doMock('@/lib/audit', () => ({ writeAudit: vi.fn(async () => {}) }));
-    vi.doMock('@/lib/db/client', () => ({
-      db: makeSequentialMockDb([[]]), // getSourceInOrg returns empty
-    }));
+    vi.doMock('@/lib/db/client', () => {
+      const mockDb = makeSequentialMockDb([[]]); // getSourceInOrg returns empty
+      return { db: mockDb, withTenantScope: withScope(mockDb) };
+    });
     vi.resetModules();
     const { markSuperseded } = await import('@/lib/source-governance/review-workflow');
     const result = await markSuperseded({
@@ -489,7 +512,7 @@ describe('BEHAVIORAL H-3: updateGovernanceFields sets authorityGrade (REQ-SOURCE
       [], // assessSourceChangeImpact unansweredQueue
     ]);
     vi.doMock('@/lib/audit', () => ({ writeAudit: vi.fn(async () => {}) }));
-    vi.doMock('@/lib/db/client', () => ({ db }));
+    vi.doMock('@/lib/db/client', () => ({ db, withTenantScope: withScope(db) }));
     vi.resetModules();
     const { updateGovernanceFields } = await import('@/lib/source-governance/review-workflow');
     const result = await updateGovernanceFields({
@@ -499,15 +522,17 @@ describe('BEHAVIORAL H-3: updateGovernanceFields sets authorityGrade (REQ-SOURCE
       fields: { authorityGrade: 'regulator_official' },
     });
     expect(result?.updatedFields).toContain('authority_grade');
-    // The tx.update was called inside the transaction with our setClause.
-    expect(db.transaction).toHaveBeenCalled();
+    // Phase 3 RLS: the UPDATE now runs inside withTenantScope (which wraps
+    // db.transaction + sets the GUC). Assert the scoped update fired.
+    expect(db.update).toHaveBeenCalled();
   });
 
   it('returns null on IDOR miss (→ 404)', async () => {
     vi.doMock('@/lib/audit', () => ({ writeAudit: vi.fn(async () => {}) }));
-    vi.doMock('@/lib/db/client', () => ({
-      db: makeSequentialMockDb([[]]),
-    }));
+    vi.doMock('@/lib/db/client', () => {
+      const mockDb = makeSequentialMockDb([[]]);
+      return { db: mockDb, withTenantScope: withScope(mockDb) };
+    });
     vi.resetModules();
     const { updateGovernanceFields } = await import('@/lib/source-governance/review-workflow');
     const result = await updateGovernanceFields({
@@ -522,14 +547,15 @@ describe('BEHAVIORAL H-3: updateGovernanceFields sets authorityGrade (REQ-SOURCE
 
 describe('BEHAVIORAL H-2: assessSourceChangeImpact produces knowledge-gap impact (REQ-010)', () => {
   it('returns knowledgeGapIds derived from message_sources → unanswered_queue join', async () => {
-    vi.doMock('@/lib/db/client', () => ({
-      db: makeSequentialMockDb([
+    vi.doMock('@/lib/db/client', () => {
+      const mockDb = makeSequentialMockDb([
         // messageSources select: 2 messages reference this source
         [{ messageId: 'msg-1' }, { messageId: 'msg-2' }],
         // unansweredQueue select: 1 of those messages is an open gap
         [{ id: 'gap-1' }],
-      ]),
-    }));
+      ]);
+      return { db: mockDb, withTenantScope: withScope(mockDb) };
+    });
     vi.resetModules();
     const { assessSourceChangeImpact } = await import('@/lib/source-governance/review-workflow');
     const impact = await assessSourceChangeImpact({ sourceId: 'src-1' });
@@ -537,9 +563,10 @@ describe('BEHAVIORAL H-2: assessSourceChangeImpact produces knowledge-gap impact
   });
 
   it('returns empty when no messages reference the source', async () => {
-    vi.doMock('@/lib/db/client', () => ({
-      db: makeSequentialMockDb([[]]),
-    }));
+    vi.doMock('@/lib/db/client', () => {
+      const mockDb = makeSequentialMockDb([[]]);
+      return { db: mockDb, withTenantScope: withScope(mockDb) };
+    });
     vi.resetModules();
     const { assessSourceChangeImpact } = await import('@/lib/source-governance/review-workflow');
     const impact = await assessSourceChangeImpact({ sourceId: 'src-orphan' });

--- a/tests/unit/retrievers/internal-sops.test.ts
+++ b/tests/unit/retrievers/internal-sops.test.ts
@@ -10,10 +10,14 @@ import { describe, expect, it, vi } from 'vitest';
 const root = path.resolve(__dirname, '..', '..', '..');
 
 // Mock the db client to avoid real DB connections.
+// vi.hoisted ensures dbMock exists before the hoisted vi.mock factory runs.
+const { dbMock } = vi.hoisted(() => ({ dbMock: { execute: vi.fn() } }));
 vi.mock('@/lib/db/client', () => ({
-  db: {
-    execute: vi.fn(),
-  },
+  db: dbMock,
+  withTenantScope: vi.fn(
+    async <T>(_orgId: string, fn: (db: typeof dbMock) => Promise<T>): Promise<T> =>
+      fn(dbMock) as Promise<T>,
+  ),
 }));
 
 // Mock OpenAI embedding.


### PR DESCRIPTION
## Summary

SPEC-REGULA-RLS-ENFORCE-001 **Phase 3 prerequisite — lib GUC wiring**. 전 7 도메인 route wiring(PR #268/#269/#270)에 이어, **lib 함수들이 global db로 org-scoped 쿼리를 날려 GUC가 미적용되는 Phase 4(FORCE RLS) 회귀를 사전 차단**.

> RLS는 여전히 **INERT**. 본 PR은 런타임 동작 변화 없음(GUC 설정만). Phase 4에서 FORCE RLS.

## Changes (23 files)
- **14 lib files wrapped**: model-governance(rlhf-gate·change-workflow·rollback)·source-governance(review-workflow·delta-sync-hook)·ai(consult·hybrid-search·internal-sops)·corpus-license/entitlement·clinical-investigation/linkage·cyberdevice/risk-linkage·capa/intake·digest-generator·knowledge-gap/clustering
- **2 caller orgId threading**: setPendingReviewOnIngest (admin upload route, inngest upload-processed)
- **7 test mocks**: vi.mock('@/lib/db/client')에 withTenantScope 추가

## 직검 (L-007/009)
| Gate | 결과 |
|---|---|
| typecheck | EXIT 0 |
| lint (biome + lint:hex) | EXIT 0 (1 pre-existing warning) |
| **test FULL** | **4315 passed \| 0 failed** (회귀 0) |
| migration | 0 |

## 보안 리뷰 (expert-security) — PASS-WITH-CONDITIONS
- orgId threading·writeAudit tx 전부 검증 통과
- consult.ts fallback은 replay path \`!isReplay\`-gated라 **dead branch** (안전)
- **★ Phase-4 blocker (Phase 3엔 영향 0, FORCE RLS 전 해결)**:
  - **M-1 auth.ts**: session callback의 org_members lookup이 chicken-and-egg(orgId 알려면 조회, 조회하려면 GUC). 해결: service-role bypass 또는 org_members RLS 예외
  - **M-2 sources/source_sections**: regulatory catalog(org_id IS NULL) RLS 정책 허용 확인
- L-1~4: minor (orgId optional, triple-scope, type casts)

## Phase 4 (별도 PR) → #239 CLOSE
- M-1/M-2 해결 → migration 0084 FORCE ROW LEVEL SECURITY → 카나리(전 도메인 GUC 0행 단언)

🗿 MoAI <email@mo.ai.kr>