### PR TITLE
feat(rls): #239 Phase 4 prep — M-1 service-role bypass client (auth.ts)

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -18,7 +18,7 @@ import Google from 'next-auth/providers/google';
 import MicrosoftEntraID from 'next-auth/providers/microsoft-entra-id';
 import { writeAudit } from './audit';
 import { buildLoginAuditEvent, buildLogoutAuditEvent } from './auth/audit-callbacks';
-import { db } from './db/client';
+import { db, serviceDb } from './db/client';
 import { accounts, orgMembers, sessions, users, verificationTokens } from './db/schema';
 import { getEnv } from './env';
 
@@ -91,13 +91,18 @@ export const { handlers, auth, signIn, signOut } = NextAuth(() => {
       session: async ({ session, user, token }) => {
         const userId = user?.id ?? (token?.sub as string | undefined);
         if (!userId) return session;
+        // users = global identity table (not org-scoped) → safe on `db` under RLS.
+        // org_members = org-scoped → MUST use serviceDb. The orgId is derived FROM
+        // this read, so the GUC cannot be set yet — under FORCE RLS the non-superuser
+        // app role would get ZERO rows here and every user would lose org context.
+        // M-1: serviceDb bypasses RLS — bootstrap orgId derivation (chicken-and-egg).
         const [[dbUser], [membership]] = await Promise.all([
           db
             .select({ mustChangePassword: users.mustChangePassword, role: users.role })
             .from(users)
             .where(eq(users.id, userId))
             .limit(1),
-          db
+          serviceDb
             .select({ orgId: orgMembers.orgId })
             .from(orgMembers)
             .where(eq(orgMembers.userId, userId))

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -25,6 +25,22 @@ export type Database = typeof db;
 // Drizzle client type inferred from the db instance — exported for radar crawlers
 export type DrizzleClient = typeof db;
 
+// Service-role client: bypasses RLS for bootstrap queries that cannot have a
+// tenant GUC (Auth.js session callback derives orgId FROM this read).
+// Falls back to DATABASE_URL when SERVICE_DATABASE_URL is unset (local dev
+// with a single superuser role). Phase 4 sets SERVICE_DATABASE_URL to a
+// BYPASSRLS role while DATABASE_URL moves to the non-superuser app role.
+// @MX:WARN Service client bypasses RLS — use ONLY for org-membership bootstrap.
+// @MX:REASON Without this, the session callback would get ZERO rows from
+// org_members under FORCE RLS (GUC is derived FROM this read → chicken-and-egg).
+// @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 Phase 4 (M-1)
+const serviceQueryClient = postgres(env.SERVICE_DATABASE_URL ?? env.DATABASE_URL, {
+  max: 10,
+  idle_timeout: 30,
+  connect_timeout: 10,
+});
+export const serviceDb = drizzle(serviceQueryClient, { schema });
+
 /**
  * Execute a function within a tenant-scoped transaction.
  * Sets `app.current_org_id` GUC so RLS policies can enforce org isolation.

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -21,7 +21,18 @@ const devPlaceholderMessage = (label: string): string =>
 // and stay optional in `.env.example` until then.
 const envSchema = z.object({
   // Database connection — Drizzle + postgres-js consume this directly.
+  // After SPEC-REGULA-RLS-ENFORCE-001 Phase 4 this is the non-superuser
+  // `regula_app` role (BYPASSRLS=false); all org-scoped reads rely on the
+  // `app.current_org_id` GUC set by withTenantScope.
   DATABASE_URL: z.string().url('DATABASE_URL must be a valid URL'),
+
+  // Optional service-role DB URL — connects with a BYPASSRLS role for
+  // bootstrap queries that cannot have a tenant GUC (Auth.js session
+  // callback derives orgId FROM this read, so it must see rows regardless
+  // of RLS). Falls back to DATABASE_URL when unset, so local dev with a
+  // single superuser role keeps working unchanged.
+  // @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 Phase 4 (M-1)
+  SERVICE_DATABASE_URL: z.string().url('SERVICE_DATABASE_URL must be a valid URL').optional(),
 
   // Auth.js v5 — AUTH_SECRET replaces the legacy NEXTAUTH_SECRET name.
   AUTH_SECRET: z
@@ -117,6 +128,7 @@ export function parseEnv(source: NodeJS.ProcessEnv = process.env): Env {
 
   return envSchema.parse({
     DATABASE_URL: source.DATABASE_URL,
+    SERVICE_DATABASE_URL: source.SERVICE_DATABASE_URL,
     AUTH_SECRET: source.AUTH_SECRET,
     NEXTAUTH_URL: source.NEXTAUTH_URL,
     AUTH_MICROSOFT_ID: microsoftId,

--- a/tests/unit/db/client.test.ts
+++ b/tests/unit/db/client.test.ts
@@ -24,7 +24,7 @@ vi.mock('../../../lib/db/client', () => {
     });
   }
 
-  return { db: mockDb, withTenantScope };
+  return { db: mockDb, serviceDb: mockDb, withTenantScope };
 });
 
 import { withTenantScope } from '../../../lib/db/client';


### PR DESCRIPTION
## Summary
SPEC-REGULA-RLS-ENFORCE-001 **Phase 4 prep — M-1 해결**. auth.ts session callback의 \`org_members\` chicken-and-egg(orgId를 이 조회로 획득)를 service-role bypass client로 해결. Phase 4(non-superuser role + FORCE RLS) 전환 전제 조건.

## Changes (4 files)
- \`lib/env.ts\`: \`SERVICE_DATABASE_URL\` optional (fallback \`DATABASE_URL\`)
- \`lib/db/client.ts\`: \`serviceDb\` (superuser bypass) — fallback으로 현재 \`db\`와 동일
- \`lib/auth.ts\`: session callback \`org_members\` → \`serviceDb\` (users/accounts 등 global은 \`db\` 유지)
- \`tests/unit/db/client.test.ts\`: \`serviceDb: mockDb\` 추가

## 직검 (L-007)
| Gate | 결과 |
|---|---|
| typecheck | EXIT 0 |
| lint (biome + lint:hex) | EXIT 0 (1 pre-existing warning) |
| **test FULL** | **4315 passed \| 0 failed** |
| serviceDb 사용처 | **auth.ts org_members 1곳만** (bypass 남용 0) |

## ★ 영향 없음 확인
\`SERVICE_DATABASE_URL\` 미설정(현재) → \`serviceDb\` === \`db\`(동일 superuser 연결). 본 PR은 순수 Phase 4 준비, 런타임 동작 변화 0. Phase 4 시 \`SERVICE_DATABASE_URL\` = BYPASSRLS role, \`DATABASE_URL\` = \`regula_app\`(non-superuser)로 분리.

## Phase 4 잔류 (runbook 이관)
- migration 0084 FORCE RLS (org-scoped 테이블)
- migration 0085 DB role \`regula_app\`(BYPASSRLS=false) + GRANT (password 환경변수)
- 운영 DATABASE_URL/SERVICE_DATABASE_URL 전환
- 카나리(GUC 0행 단언)

🗿 MoAI <email@mo.ai.kr>