### PR TITLE
feat(rls): #239 Phase 4 — FORCE RLS + regula_app role + runbook

### DIFF
--- a/docs/phase-4-rls-enforce-runbook.md
+++ b/docs/phase-4-rls-enforce-runbook.md
@@ -1,0 +1,125 @@
+# Phase 4 — RLS Enforce Runbook (SPEC-REGULA-RLS-ENFORCE-001, Issue #239)
+
+Operational runbook for enforcing Row-Level Security at runtime. Applies after
+migrations `0084_force_rls.sql` and `0085_app_role.sql` land. The actual cutover
+(migration application + env switch + canary) is an **ops action**, not a code
+change — this document is the single source of truth for that action.
+
+## 1. Prerequisites (already merged)
+
+- **Phase 1 (migration 0083)**: 20 org-scoped policies carry `WITH CHECK` equal
+  to `USING`. INSERT/UPDATE now gated.
+- **Phase 2 (PR #271)**: All org-scoped DB ops in routes wired through
+  `withTenantScope` (`lib/db/with-tenant-scope.ts`), which sets the
+  `app.current_org_id` GUC.
+- **Phase 3 (PR #271)**: `lib/*` wiring complete. Coverage gate at
+  `tests/unit/db/with-tenant-scope-coverage.test.ts` is green.
+- **M-1 (PR #272)**: `auth.ts` uses `SERVICE_DATABASE_URL` (superuser / bypass).
+  `serviceDb` is the **only** bypass client and is confined to `auth.ts`.
+
+## 2. Pre-flight checks (before cutover)
+
+1. `pnpm test tests/unit/db/with-tenant-scope-coverage.test.ts` is green.
+2. Grep audit: `serviceDb` appears **only** in `lib/auth.ts` (and its own
+   definition site). Run:
+   `grep -rn "serviceDb" app lib --include="*.ts" | grep -v "lib/db/service-client.ts"`
+   Expected: zero hits outside `lib/auth.ts`.
+3. No route handler or lib function issues an org-scoped query without
+   `withTenantScope`. The coverage gate enforces this statically.
+
+## 3. Step 1 — Set the real password (ops)
+
+The password in `0085_app_role.sql` is a placeholder. After applying 0085, set
+the real password from the secrets manager — **never commit it**:
+
+```sql
+ALTER ROLE regula_app WITH PASSWORD '<from-secrets-manager>';
+```
+
+## 4. Step 2 — Set environment variables
+
+Both URLs must be set. `DATABASE_URL` is the RLS-subject connection the app runs
+on; `SERVICE_DATABASE_URL` is the superuser bypass used only by `auth.ts`.
+
+```
+DATABASE_URL=postgresql://regula_app:<pwd>@host:5432/regula
+SERVICE_DATABASE_URL=postgresql://postgres:<superuser_pwd>@host:5432/regula
+```
+
+If `SERVICE_DATABASE_URL` is unset, `auth.ts` bootstrap (session lookup, user
+provisioning) fails. If `DATABASE_URL` is not switched to `regula_app`, RLS
+remains a no-op (superuser bypass).
+
+## 5. Step 3 — Apply migrations 0084 + 0085
+
+Run via the project's migration tool (drizzle-kit or the existing migration
+runner). Order matters only in that 0085 creates the role that 0001's
+GRANT/REVOKE references — but since 0001 already ran historically, apply in
+numeric order: **0084 then 0085**.
+
+- `0085` creates `regula_app` (NOBYPASSRLS) + grants.
+- `0084` sets `FORCE ROW LEVEL SECURITY` on the 20 tables.
+
+## 6. Step 4 — Canary verification
+
+With the app running as `regula_app` + FORCE RLS applied, run a canary that
+asserts both the positive and negative isolation paths.
+
+**Suggested vitest integration test**:
+
+```ts
+// tests/integration/rls-enforce.canary.spec.ts
+describe('RLS enforce canary (Phase 4)', () => {
+  it('returns only the caller org rows when GUC is set', async () => {
+    // 1. Seed two orgs (A, B) with one row each in e.g. organization_documents.
+    // 2. Inside withTenantScope({ orgId: A, userId }, () => db.select()...)
+    // 3. Assert: only org A rows returned.
+  });
+
+  it('returns 0 rows (fail-closed) when GUC is unset outside withTenantScope', async () => {
+    // 1. Same seed.
+    // 2. Issue a raw query on organization_documents WITHOUT withTenantScope,
+    //    using the app role (regula_app) connection.
+    // 3. Assert: current_setting('app.current_org_id', true) IS NULL.
+    // 4. Assert: query returns 0 rows (policy's USING evaluates to NULL = false).
+  });
+});
+```
+
+Assertion shape: `current_setting('app.current_org_id', true)` must be `NULL`
+outside a `withTenantScope` call, and any org-scoped `SELECT` must return 0 rows
+in that state (fail-closed). This is the guarantee that an forgotten
+`withTenantScope` wiring does not leak cross-org data.
+
+## 7. Rollback
+
+FORCE RLS and the role switch are both **additive and reversible**.
+
+- Disable FORCE on a specific table (keeps policies, just removes FORCE flag):
+  `ALTER TABLE <table> NO FORCE ROW LEVEL SECURITY;`
+- Full disable across all 20 tables: issue `NO FORCE` for each (a rollback
+  migration `0086_unforce_rls.sql` can be authored on demand).
+- Revert the env switch: set `DATABASE_URL` back to the superuser connection.
+  RLS policies remain attached but become inert again (superuser bypass).
+
+Neither action drops data or policies. The role `regula_app` can be left in
+place (it is harmless if unused).
+
+## 8. Known limits / Phase 4 follow-ups
+
+- **M-2 (sources / source_sections catalog policy)**: these are global catalog
+  tables read cross-org (e.g. the FDA/EU MDR/MFDS corpus). If their RLS policy
+  requires `org_id` match, a `regula_app` connection without a GUC set will see
+  0 rows — breaking global catalog reads. Confirm the policy allows
+  `org_id IS NULL` rows to be visible without a GUC, or exempt the catalog read
+  path. This is a **policy-shape** question, not addressed by 0084/0085.
+- **Weekly-digest cron (cross-org admin enumeration)**: any job that enumerates
+  across all orgs (e.g. a weekly digest) cannot use the `regula_app`
+  connection — RLS would restrict it to one org. It must use
+  `SERVICE_DATABASE_URL` (superuser bypass) or a dedicated bypass role. Confirm
+  the cron's DB client before cutover.
+- **`audit_logs` is intentionally NOT in the 20 FORCE tables**: it is
+  append-only (trigger-enforced, migration 0001) and append access must not be
+  blocked by tenant GUC. Audit writes go through `writeAudit` which uses the
+  caller's connection — confirm `audit_logs` has no `org_id` policy or is
+  exempted.

--- a/migrations/0084_force_rls.sql
+++ b/migrations/0084_force_rls.sql
@@ -1,0 +1,78 @@
+-- 0084_force_rls.sql
+-- SPEC-REGULA-RLS-ENFORCE-001 (Issue #239) — Phase 4 (migration piece)
+--
+-- 20개 org-scoped 테이블에 FORCE ROW LEVEL SECURITY 를 부여한다.
+-- FORCE 를 부여하면 테이블 소유자(owner) 도 RLS 정책의 대상이 된다.
+-- 일반적인 ENABLE ROW LEVEL SECURITY 는 소유자를 RLS 에서 제외하지만,
+-- FORCE 는 그 예외를 제거한다.
+--
+-- @MX:WARN 본 migration 만으로는 RLS 가 런타임에 enforce 되지 않는다.
+--   이유: (1) superuser 는 항상 RLS 를 bypass (BYPASSRLS); (2) BYPASSRLS 속성을
+--   가진 role 도 bypass. 현재 앱 DB role = postgres (superuser) 이므로
+--   FORCE 적용 직후에도 모든 쿼리가 정책을 우회한다.
+--   실제 enforce 는 migration 0085 로 생성되는 non-superuser role
+--   `regula_app` (NOBYPASSRLS) 로 DATABASE_URL 을 전환한 후에야 발생한다.
+--   적용 순서: 0084 (본 파일) → 0085 (app role) → ops 가 DATABASE_URL 전환.
+--   superuser role 로 본 migration 을 미리 적용하는 것은 no-op 이며 무해하다.
+--
+-- @MX:NOTE 대상 20개 테이블은 migration 0083 (WITH CHECK clauses) 과 동일.
+--   0015(4) · 0066(1) · 0067(1) · 0068(3) · 0077(4) · 0078(4) · 0080(2) · 0082(1) = 20.
+--   직검 2026-06-26: 아래 ALTER TABLE 목록이 0083 의 ALTER POLICY 대상과
+--   정확히 일치하는지 대조 완료.
+--
+-- @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 Phase 4
+-- @MX:REASON RLS 는 21 CFR Part 11 §11.10(c) 감사 추적성과 tenant isolation의
+--   이중 안전망. superuser 버그나 privilege escalation 시에도 org-scope 가
+--   유지되어야 규제 위반이 발생하지 않는다.
+
+-- ============================================================
+-- 0015_docingest_rls — organization_id 기반 (org_id 아님)
+-- ============================================================
+ALTER TABLE organization_documents FORCE ROW LEVEL SECURITY;
+ALTER TABLE document_chunks FORCE ROW LEVEL SECURITY;
+ALTER TABLE document_access_policies FORCE ROW LEVEL SECURITY;
+ALTER TABLE ingest_jobs FORCE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 0066_knowledge_gap
+-- ============================================================
+ALTER TABLE unanswered_queue FORCE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 0067_classify
+-- ============================================================
+ALTER TABLE device_classifications FORCE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 0068_traceability
+-- ============================================================
+ALTER TABLE evidence_nodes FORCE ROW LEVEL SECURITY;
+ALTER TABLE evidence_edges FORCE ROW LEVEL SECURITY;
+ALTER TABLE stale_flags FORCE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 0077_lifecycle
+-- ============================================================
+ALTER TABLE prompt_registry FORCE ROW LEVEL SECURITY;
+ALTER TABLE model_pin FORCE ROW LEVEL SECURITY;
+ALTER TABLE change_request FORCE ROW LEVEL SECURITY;
+ALTER TABLE approved_combination FORCE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 0078_cyberdevice
+-- ============================================================
+ALTER TABLE threat_model FORCE ROW LEVEL SECURITY;
+ALTER TABLE sbom FORCE ROW LEVEL SECURITY;
+ALTER TABLE cve_impact FORCE ROW LEVEL SECURITY;
+ALTER TABLE cyber_evidence_bundle FORCE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 0080_corpus_license
+-- ============================================================
+ALTER TABLE source_license FORCE ROW LEVEL SECURITY;
+ALTER TABLE entitlement FORCE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 0082_rlhf
+-- ============================================================
+ALTER TABLE answer_feedback FORCE ROW LEVEL SECURITY;

--- a/migrations/0085_app_role.sql
+++ b/migrations/0085_app_role.sql
@@ -1,0 +1,57 @@
+-- 0085_app_role.sql
+-- SPEC-REGULA-RLS-ENFORCE-001 (Issue #239) — Phase 4 (migration piece)
+--
+-- Non-superuser application DB role `regula_app` 생성.
+-- 이 role 은 NOBYPASSRLS 이므로 RLS 정책의 대상이 되며, migration 0084 의
+-- FORCE ROW LEVEL SECURITY 와 함께 적용될 때 비로소 tenant isolation 이
+-- 런타임에 enforce 된다.
+--
+-- @MX:WARN 비밀번호는 placeholder 이다. ops 는 본 migration 적용 후 즉시
+--   `ALTER ROLE regula_app WITH PASSWORD '<secrets-manager 값>';` 으로
+--   실제 비밀번호를 설정해야 한다. 실제 비밀번호를 본 파일에 기록하지 마십시오.
+--   DATABASE_URL 도 같은 비밀번호로 설정된다 (runbook §3-4 참조).
+--
+-- @MX:NOTE 최초의 CREATE ROLE migration. 이전까지 regula_app role 은
+--   migration 0001_audit_append_only.sql 주석에 "사전 존재해야 함"으로
+--   명시되었으나 실제 생성 스크립트는 본 파일이 최초다. 0001 의
+--   GRANT/REVOKE 는 role 부재 시 no-op 이므로 순서 역전은 무해하다.
+--
+-- @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 Phase 4
+-- @MX:REASON superuser 또는 BYPASSRLS role 로는 FORCE RLS 를 걸어도 정책이
+--   우회된다. 앱 코드가 실행되는 role 이 NOBYPASSRLS + NOSUPERUSER 여야
+--   app.current_org_id GUC 기반 tenant filtering 이 실제로 동작한다.
+
+-- ============================================================
+-- 1. Role creation (idempotent via DO block)
+-- ============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'regula_app') THEN
+    CREATE ROLE regula_app
+      WITH LOGIN
+      PASSWORD 'CHANGE_ME_SET_VIA_ALTER_ROLE'
+      NOSUPERUSER
+      NOCREATEDB
+      NOCREATEROLE
+      NOREPLICATION
+      NOBYPASSRLS;
+  END IF;
+END
+$$;
+
+-- ============================================================
+-- 2. Schema + table privileges
+-- ============================================================
+GRANT USAGE ON SCHEMA public TO regula_app;
+
+-- 기존 테이블에 대한 DML 권한
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO regula_app;
+
+-- 시퀀스 사용 권한
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO regula_app;
+
+-- 이후 migration 으로 생성되는 테이블에도 동일 권한 자동 부여
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO regula_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO regula_app;

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -1373,6 +1373,101 @@ describe('Migration 0083: RLS WITH CHECK clauses project-wide (Issue #239)', () 
   });
 });
 
+// Migration 0084: FORCE ROW LEVEL SECURITY (SPEC-REGULA-RLS-ENFORCE-001, Issue #239, Phase 4)
+// Forces RLS on the 20 org-scoped tables so even owners are subject to policies.
+// Runtime enforcement still requires the app role switch (migration 0085) because
+// superuser + BYPASSRLS roles bypass RLS regardless of FORCE.
+describe('Migration 0084: FORCE ROW LEVEL SECURITY (Issue #239, Phase 4)', () => {
+  it('migration file 0084_force_rls.sql exists', () => {
+    expect(fileExists('migrations/0084_force_rls.sql')).toBe(true);
+  });
+
+  it('issues exactly 20 ALTER TABLE ... FORCE ROW LEVEL SECURITY statements', () => {
+    const sql = readText('migrations/0084_force_rls.sql');
+    const forceMatches = sql.match(/ALTER TABLE \w+ FORCE ROW LEVEL SECURITY/g) ?? [];
+    expect(forceMatches).toHaveLength(20);
+  });
+
+  it('includes @MX:WARN noting FORCE alone does not enforce (app role switch required)', () => {
+    const sql = readText('migrations/0084_force_rls.sql');
+    expect(sql).toMatch(/@MX:WARN/);
+    expect(sql).toMatch(/NOBYPASSRLS|regula_app/);
+    expect(sql).toMatch(/superuser|BYPASSRLS/);
+  });
+
+  it.each([
+    'organization_documents',
+    'document_chunks',
+    'document_access_policies',
+    'ingest_jobs',
+    'unanswered_queue',
+    'device_classifications',
+    'evidence_nodes',
+    'evidence_edges',
+    'stale_flags',
+    'prompt_registry',
+    'model_pin',
+    'change_request',
+    'approved_combination',
+    'threat_model',
+    'sbom',
+    'cve_impact',
+    'cyber_evidence_bundle',
+    'source_license',
+    'entitlement',
+    'answer_feedback',
+  ])('forces RLS on %s', (table) => {
+    const sql = readText('migrations/0084_force_rls.sql');
+    expect(sql).toContain(`ALTER TABLE ${table} FORCE ROW LEVEL SECURITY`);
+  });
+});
+
+// Migration 0085: non-superuser app role (SPEC-REGULA-RLS-ENFORCE-001, Issue #239, Phase 4)
+// Creates regula_app (NOBYPASSRLS) — the role that makes FORCE RLS actually enforce.
+describe('Migration 0085: non-superuser app role regula_app (Issue #239, Phase 4)', () => {
+  it('migration file 0085_app_role.sql exists', () => {
+    expect(fileExists('migrations/0085_app_role.sql')).toBe(true);
+  });
+
+  it('creates regula_app role via idempotent DO block (CREATE ROLE has no IF NOT EXISTS)', () => {
+    const sql = readText('migrations/0085_app_role.sql');
+    expect(sql).toMatch(/DO \$\$[\s\S]*pg_roles[\s\S]*regula_app[\s\S]*\$\$/);
+    expect(sql).toMatch(/CREATE ROLE regula_app/);
+  });
+
+  it('sets NOBYPASSRLS and NOSUPERUSER (RLS applies to this role)', () => {
+    const sql = readText('migrations/0085_app_role.sql');
+    expect(sql).toMatch(/NOBYPASSRLS/);
+    expect(sql).toMatch(/NOSUPERUSER/);
+  });
+
+  it('uses a placeholder password (never a real password in the repo)', () => {
+    const sql = readText('migrations/0085_app_role.sql');
+    expect(sql).toMatch(/CHANGE_ME_SET_VIA_ALTER_ROLE/);
+    expect(sql).toMatch(/ALTER ROLE regula_app WITH PASSWORD/i);
+  });
+
+  it('includes @MX:WARN about placeholder password + ops ALTER ROLE requirement', () => {
+    const sql = readText('migrations/0085_app_role.sql');
+    expect(sql).toMatch(/@MX:WARN/);
+    expect(sql).toMatch(/placeholder|CHANGE_ME/i);
+  });
+
+  it('grants schema + DML + sequence privileges on public', () => {
+    const sql = readText('migrations/0085_app_role.sql');
+    expect(sql).toMatch(/GRANT USAGE ON SCHEMA public TO regula_app/);
+    expect(sql).toMatch(
+      /GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO regula_app/,
+    );
+    expect(sql).toMatch(/GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO regula_app/);
+  });
+
+  it('sets ALTER DEFAULT PRIVILEGES so future tables also grant regula_app', () => {
+    const sql = readText('migrations/0085_app_role.sql');
+    expect(sql).toMatch(/ALTER DEFAULT PRIVILEGES IN SCHEMA public[\s\S]*regula_app/);
+  });
+});
+
 // Migration 0076: clinical investigation planner (SPEC-REGULA-CLINICAL-INVESTIGATION-001, Issue #69)
 describe('Migration 0076: clinical investigation planner (Issue #69)', () => {
   it('migration file 0076_clinical_investigation.sql exists', () => {


### PR DESCRIPTION
## Summary
SPEC-REGULA-RLS-ENFORCE-001 **Phase 4 — migration + runbook**. Phase 1·2·3·M-1(PR #272) 완료에 이어 실제 RLS enforce를 위한 migration과 운영 적용 runbook. **#239 코드 작업 종료** (실제 enforce는 runbook 운영 절차).

## Changes
- **migration 0084**: 20개 org-scoped 테이블 \`FORCE ROW LEVEL SECURITY\` (table owner도 RLS 적용; superuser/BYPASSRLS는 여전히 bypass → 앱 role 전환 선행)
- **migration 0085**: \`regula_app\` non-superuser role (NOBYPASSRLS, placeholder password + ops ALTER ROLE 의무화, GRANT 3종 + ALTER DEFAULT PRIVILEGES)
- **enterprise-migrations.test.ts**: 0084(20 FORCE RLS 정밀 매칭) + 0085(role 속성/GRANT/placeholder) describe
- **docs/phase-4-rls-enforce-runbook.md**: 8 섹션 운영 적용 절차

## 직검 (L-007)
| Gate | 결과 |
|---|---|
| typecheck | EXIT 0 |
| lint (biome + lint:hex) | EXIT 0 (1 pre-existing warning) |
| **test FULL** | **4345 passed \| 0 failed** (+30) |
| 0084 FORCE RLS | **20개 정확** (missing/extra 0) |
| 0085 보안 | **real password 0** (placeholder + ALTER ROLE note) |

## ★ Phase 4 운영 적용 (runbook 이관)
RLS 실제 enforce = 코드 외 인프라 작업:
1. ops: \`ALTER ROLE regula_app WITH PASSWORD '<secrets>';\`
2. env: \`DATABASE_URL=...regula_app...\` (app, RLS-subject) + \`SERVICE_DATABASE_URL=...postgres...\` (bypass, auth.ts)
3. apply 0084 + 0085 (drizzle-kit)
4. 카나리: GUC set→자기 org만 / GUC unset→0 rows fail-closed
5. Rollback: \`NO FORCE ROW LEVEL SECURITY\` (가역)

## Known limits (runbook §8)
- M-2: sources/source_sections catalog(org_id IS NULL) 정책 점검
- weekly-digest cron cross-org enum: serviceDb bypass 필요
- audit_logs: RLS 대상 20개 외 (본 migration 영향 없음)

Closes #239 (코드 작업 종료 — Phase 1·2·3·4-prep 완료, 운영 enforce는 runbook).

🗿 MoAI <email@mo.ai.kr>