### PR TITLE
feat(docingest): #151 — 관리자 동기 업로드 redaction map 지속화 + Part 11 audit

### DIFF
--- a/app/api/ra/admin/documents/upload/route.ts
+++ b/app/api/ra/admin/documents/upload/route.ts
@@ -166,7 +166,10 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
   // ---------------------------------------------------------------------
   let redaction: Awaited<ReturnType<typeof redactPiiForIngest>>;
   try {
-    redaction = await redactPiiForIngest(rawText, docClass);
+    redaction = await redactPiiForIngest(rawText, docClass, {
+      documentId: existingSourceId,
+      saveMap: true,
+    });
   } catch (err) {
     return Response.json(
       { error: 'redaction_failed', detail: err instanceof Error ? err.message : 'unknown' },
@@ -265,6 +268,11 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
       layersRun: redaction.layersRun,
       redactionCount: redaction.redactionCount,
       sensitivityLevel: redaction.sensitivityLevel,
+      // 21 CFR Part 11 — record whether the reversibility map was actually
+      // persisted. mapPersisted=false means no reversible artifact exists for
+      // this document (PII_MAP_KEY unset, DB write failed, or zero pairs).
+      mapPersisted: redaction.mapPersisted,
+      mapPersistedCount: redaction.mapPersistedCount,
     },
   });
 

--- a/lib/ingest/pii/redact.ts
+++ b/lib/ingest/pii/redact.ts
@@ -15,31 +15,65 @@ export interface RedactionResult {
   layersRun: RedactionLayer[];
   redactionCount: number;
   sensitivityLevel: PiiPolicy['sensitivityLevel'];
+  // 21 CFR Part 11 — reversibility artifact persistence outcome.
+  // `mapPersisted=false` is the compliance signal that no reversible map exists
+  // for this document (PII_MAP_KEY unset, DB write failed, or no pairs to save).
+  // Audited in the `document.redact` meta_json so regulators can detect a clean
+  // redaction event with a missing reversibility artifact.
+  mapPersisted: boolean;
+  mapPersistedCount: number;
 }
 
-export function redactRegexPii(text: string): { text: string; redactionCount: number } {
+// Per-match tuple collected for optional persistence to private.redaction_maps.
+// 21 CFR Part 11: the original→placeholder mapping must be recoverable for audit.
+interface RedactionPair {
+  original: string;
+  placeholder: string;
+  piiType: string;
+  confidence: number;
+}
+
+export interface RedactionOptions {
+  documentId?: string;
+  saveMap?: boolean;
+}
+
+export function redactRegexPii(text: string): {
+  text: string;
+  redactionCount: number;
+  pairs: RedactionPair[];
+} {
   const matches = detectPii(text);
   return {
     text: redactRegexText(text, matches),
     redactionCount: matches.length,
+    pairs: matches.map((m) => ({
+      original: m.value,
+      placeholder: `[REDACTED:${m.type.toUpperCase()}]`,
+      piiType: m.type,
+      confidence: m.confidence,
+    })),
   };
 }
 
 export async function redactPiiForIngest(
   text: string,
   docClass: DocClass,
-  _options?: { documentId?: string; saveMap?: boolean },
+  options?: RedactionOptions,
 ): Promise<RedactionResult> {
   const policy = PII_POLICY_BY_CLASS[docClass];
   let redacted = text;
   let redactionCount = 0;
   const layersRun: RedactionLayer[] = [];
+  // Collected for optional persistence to private.redaction_maps (21 CFR Part 11).
+  const pairs: RedactionPair[] = [];
 
   // Layer 1: Regex-based redaction (fast-path for common PII)
   if (policy.layers.includes('regex')) {
     const result = redactRegexPii(redacted);
     redacted = result.text;
     redactionCount += result.redactionCount;
+    pairs.push(...result.pairs);
     layersRun.push('regex');
   }
 
@@ -49,6 +83,7 @@ export async function redactPiiForIngest(
       const spans = await detectPiiWorkersAi(redacted);
       redacted = applySpanRedaction(redacted, spans);
       redactionCount += spans.length;
+      collectSpanPairs(spans, pairs);
       layersRun.push('workers_ai');
     } catch (err) {
       // Fail-closed: log error but continue to next layer
@@ -66,6 +101,7 @@ export async function redactPiiForIngest(
       const spans = await detectPiiPresidio(redacted);
       redacted = applySpanRedaction(redacted, spans);
       redactionCount += spans.length;
+      collectSpanPairs(spans, pairs);
       layersRun.push('presidio');
     } catch (err) {
       // Fail-closed: Layer 3 failure is critical for PHI documents
@@ -89,6 +125,14 @@ export async function redactPiiForIngest(
       : new RegExp(pattern.source, `${pattern.flags}g`);
     const matches = Array.from(redacted.matchAll(globalPattern));
     if (matches.length === 0) continue;
+    for (const m of matches) {
+      pairs.push({
+        original: m[0],
+        placeholder: '[REDACTED:CUSTOM]',
+        piiType: 'custom',
+        confidence: 1.0,
+      });
+    }
     redacted = redacted.replace(globalPattern, '[REDACTED:CUSTOM]');
     redactionCount += matches.length;
     if (!layersRun.includes('custom')) layersRun.push('custom');
@@ -104,12 +148,61 @@ export async function redactPiiForIngest(
     );
   }
 
+  // 21 CFR Part 11 — persist original→placeholder map for audit reversibility.
+  // Non-fatal: a map-write failure MUST NOT roll back ingestion; the redacted
+  // text above is already safe to embed and persist. PII_MAP_KEY may be unset
+  // in CI / non-production environments — encryptPii throws there, so swallow.
+  // Orphan tradeoff (accepted): if the downstream source_sections transaction
+  // rolls back, map rows may persist for a document_id without a corresponding
+  // source. Data is encrypted + RLS-isolated, so non-fatal by design.
+  let mapPersisted = false;
+  let mapPersistedCount = 0;
+  if (options?.saveMap && options.documentId && pairs.length > 0) {
+    try {
+      const { saveRedactionMap, encryptPii } = await import('@/lib/ingest/pii/redaction-map');
+      for (const pair of pairs) {
+        const { iv, ciphertext } = encryptPii(pair.original);
+        await saveRedactionMap({
+          documentId: options.documentId,
+          iv,
+          encryptedOriginal: ciphertext,
+          redactedPlaceholder: pair.placeholder,
+          piiType: pair.piiType,
+          confidence: pair.confidence,
+        });
+        mapPersistedCount += 1;
+      }
+      mapPersisted = true;
+    } catch (mapErr) {
+      // mapPersisted stays false — audited upstream so the compliance signal is
+      // visible. Do NOT rethrow: ingestion must succeed with a failed map write.
+      console.error('[PII Redaction] redaction_maps persistence failed (non-fatal):', mapErr);
+    }
+  }
+
   return {
     text: redacted,
     layersRun,
     redactionCount,
     sensitivityLevel: policy.sensitivityLevel,
+    mapPersisted,
+    mapPersistedCount,
   };
+}
+
+// Append workers-ai/presidio spans to the pairs collector.
+// Placeholder mirrors applySpanRedaction's `[REDACTED:${entity}]` format so the
+// persisted entry matches what actually landed in the redacted text.
+function collectSpanPairs(spans: PIISpan[], pairs: RedactionPair[]): void {
+  for (const span of spans) {
+    if (span.start < 0 || span.end <= span.start) continue;
+    pairs.push({
+      original: span.text,
+      placeholder: `[REDACTED:${span.entity}]`,
+      piiType: span.entity,
+      confidence: span.score,
+    });
+  }
 }
 
 export function applySpanRedaction(text: string, spans: PIISpan[]): string {

--- a/tests/integration/docingest-e2e.test.ts
+++ b/tests/integration/docingest-e2e.test.ts
@@ -132,6 +132,11 @@ describe('Document Ingestion E2E (REQ-QUAL-015..019)', () => {
   });
 
   afterEach(() => {
+    // resetModules clears the cached route module so the next test re-evaluates
+    // vi.mock/vi.doUnmock bindings (e.g. workers-ai). Without this, tests after
+    // AC5 inherit its doUnmock'd module and the stub stays bound, masking
+    // redaction regressions behind RBAC-passing assertions.
+    vi.resetModules();
     vi.unstubAllEnvs();
   });
 
@@ -203,6 +208,70 @@ describe('Document Ingestion E2E (REQ-QUAL-015..019)', () => {
         meta_json: expect.not.objectContaining({ filename: expect.any(String) }),
       }),
     );
+  });
+
+  it('redacts phone, URL, MRN identifiers and patient names across layers (AC5)', async () => {
+    authMock.mockResolvedValue({
+      user: { id: 'user-1', role: 'admin', organizationId: 'org-1' },
+    });
+
+    // Layer 2 (Workers AI) returns [] in CI because CF_WORKERS_AI_TOKEN is
+    // unset. To exercise name redaction + redaction_maps pair collection on the
+    // span path, stub the module to surface a PERSON span for "John Smith".
+    vi.doMock('@/lib/ingest/pii/workers-ai', () => ({
+      detectPiiWorkersAi: vi.fn(async (text: string) => {
+        const idx = text.indexOf('John Smith');
+        if (idx < 0) return [];
+        return [
+          {
+            entity: 'PERSON',
+            start: idx,
+            end: idx + 'John Smith'.length,
+            text: 'John Smith',
+            score: 0.92,
+          },
+        ];
+      }),
+    }));
+    vi.resetModules();
+
+    const piiText = Buffer.from(
+      'Patient John Smith called from (555) 123-4567. ' +
+        'Portal: https://patient-portal.example.org/x. ' +
+        'MRN: 12345678.',
+    );
+    const res = await callPost(
+      buildFormData({
+        bytes: piiText,
+        filename: 'phi-multi-identifier.txt',
+        docClass: 'internal_sop',
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const embeddedTexts = embedChunksMock.mock.calls[0]?.[0] as string[];
+    const embedded = embeddedTexts.join('\n');
+
+    // AC5: each raw identifier is absent from the embedded text.
+    expect(embedded).not.toContain('(555) 123-4567');
+    expect(embedded).not.toContain('https://patient-portal.example.org/x');
+    expect(embedded).not.toContain('MRN: 12345678');
+    expect(embedded).not.toContain('John Smith');
+
+    // AC5: each layer produced its corresponding placeholder.
+    expect(embedded).toContain('[REDACTED:PHONE]');
+    expect(embedded).toContain('[REDACTED:URL]');
+    expect(embedded).toContain('[REDACTED:MRN]');
+    expect(embedded).toContain('[REDACTED:PERSON]');
+
+    // source_sections persistence must also be free of raw identifiers.
+    const sectionRows = insertedSections.at(-1) as Array<{ text: string }>;
+    const persistedText = sectionRows.map((row) => row.text).join('\n');
+    expect(persistedText).not.toContain('(555) 123-4567');
+    expect(persistedText).not.toContain('John Smith');
+    expect(persistedText).not.toContain('MRN: 12345678');
+
+    vi.doUnmock('@/lib/ingest/pii/workers-ai');
   });
 
   it('returns 403 for non-admin role (REQ-QUAL-018)', async () => {


### PR DESCRIPTION
## 개요
#158 후속 백엔드 그룹 중 #151. 이슈 기준 커밋(`243fcda`, 2주 전) 대비 현재 main(`6295232`)에서 **AC1/AC2/AC4는 이미 MET** — 정밀 조사(read-only 5에이전트 워크플로우)로 **AC3/AC5만 잔존** 확인 후 최소 변경.

## 변경
- **AC3 (redaction map 지속화)**: `saveRedactionMap()`이 구현·테이블(`private.redaction_maps`)·AES-256-GCM crypto 모두 존재했으나 **호출부 0**(dead `_options`)이던 것 활성화. 3개 레이어(regex/workers-ai/presidio)에서 redaction pairs 수집 → 암호화 저장. try/catch non-fatal(ingest 롤백 안 함).
- **Part 11 audit (M-1)**: `document.redact` audit에 `mapPersisted`/`mapPersistedCount` 추가 — map persist 실패 시 compliance signal (21 CFR Part 11 §11.10).
- **AC5 (테스트)**: phone/patient-name/URL/MRN 케이스 + `embedChunks` raw PII 없음 단언. test isolation(L-2, afterEach resetModules).

## 게이트 직검 (오케스트레이터, L-007/008/009)
- typecheck: exit 0
- lint (biome + lint:hex): exit 0
- test FULL: exit 0 · **4528 passed | 21 skipped** (+1 vs main 4527)
- build: skip (`next dev` 구동 중, L-012)

## 보안 리뷰
expert-security **PASS-WITH-CONDITIONS** (CRITICAL/HIGH 0). M-1(Part 11 audit)/L-1(orphan 주석)/L-2(test isolation) hardening 반영. migration 불필요(`0015` 이미 `private.redaction_maps` 생성).

Fixes #151. tracking: #158