### PR TITLE
feat(gitea): #155 — ra-llm-wiki ingestion hardening + Gitea issue provider

### DIFF
--- a/docs/deployment/env-matrix.md
+++ b/docs/deployment/env-matrix.md
@@ -48,8 +48,13 @@ Do **not** commit real secrets. Use Vercel project settings or your secret manag
 | `OWNING_ISSUE_GITHUB_TOKEN` | Issue-write PAT for the 4 owning-project repos (#157). Separate from `KNOWLEDGE_GAP_GITHUB_TOKEN` (triage) and `READ_GITHUB_TOKEN` (read-only). | Optional | Optional | Required when `ROUTING_ENABLED=true` | Yes |
 | `OWNING_ISSUE_GITHUB_REPO_RA_PROJECT` | Target repo (`owner/name`) for regulation knowledge gaps routed to ra-project | Optional | Optional | `acme/ra-project` | No |
 | `OWNING_ISSUE_GITHUB_REPO_MD_PROCESS` | Target repo for internal policy/process gaps routed to MD-process | Optional | Optional | `acme/MD-process` | No |
-| `OWNING_ISSUE_GITHUB_REPO_GITEA_WIKI` | Target repo for wiki content gaps routed to gitea ra-llm-wiki | Optional | Optional | `acme/ra-llm-wiki` | No |
+| `OWNING_ISSUE_GITHUB_REPO_GITEA_WIKI` | Target repo for wiki content gaps routed to gitea ra-llm-wiki **when Gitea issue-write is not configured** (GitHub fallback path) | Optional | Optional | `acme/ra-llm-wiki` | No |
 | `OWNING_ISSUE_GITHUB_REPO_HYBRID` | Target repo for backend/API bugs routed to hybrid-ra-saas | Optional | Optional | `acme/hybrid-ra-saas` | No |
+| `GITEA_URL` | Base URL of the Gitea instance hosting `ra-llm-wiki`. Read scope (AC3) — used by `scripts/ingest-gitea-wiki.ts` for GraphQL wiki fetch. Must be `https://`. | Optional | Optional | `https://gitea.example.com` | No |
+| `GITEA_TOKEN` | Read-only PAT for Gitea wiki ingestion (AC3). Scope: read repository contents only. NEVER used for issue writes. | Optional | Optional | Required when Gitea wiki ingestion enabled | Yes |
+| `GITEA_WIKI_REPO` | `owner/name` of the Gitea wiki repository to ingest (read scope). Also used as the issue-create fallback when `GITEA_ISSUE_REPO` is unset. | Optional | Optional | `DR_RnD/ra-llm-wiki` | No |
+| `GITEA_ISSUE_TOKEN` | Write-scope PAT for Gitea issue creation (AC4). Scope: `write:issue` on the target repo. **Separated from `GITEA_TOKEN` (read) for least privilege.** When unset, `gitea-wiki` target degrades to `queue`. | Optional | Optional | Required when `ROUTING_ENABLED=true` and `gitea-wiki` target is in use | Yes |
+| `GITEA_ISSUE_REPO` | `owner/name` of the Gitea repo where wiki-gap issues are filed (AC4). Falls back to `GITEA_WIKI_REPO` when unset. | Optional | Optional | `DR_RnD/regula-issues` | No |
 | `READ_GITHUB_TOKEN` | Read-only PAT for source ingestion. Least privilege — never used for issue writes. | Optional | Optional | Required for FDA/EU MDR ingestion | Yes |
 | `SKIP_ENV_VALIDATION` | Build-only validation bypass flag. Must be paired with `REGULA_ALLOW_ENV_VALIDATION_SKIP=build`. | Only for `pnpm build` | CI build only | CI build only | No |
 | `REGULA_ALLOW_ENV_VALIDATION_SKIP` | Guard that makes the env validation bypass explicit for Next build route-data collection. | `build` only with `SKIP_ENV_VALIDATION=1` | `build` only | `build` only | No |
@@ -76,7 +81,8 @@ Do **not** commit real secrets. Use Vercel project settings or your secret manag
 
 ### Secret rotation
 
-- Rotate `AUTH_SECRET`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `HYBRID_RA_API_TOKEN`, `REGULA_API_KEY`, and `CRAWL_PUSH_SECRET` at least quarterly.
+- Rotate `AUTH_SECRET`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `HYBRID_RA_API_TOKEN`, `REGULA_API_KEY`, `CRAWL_PUSH_SECRET`, `GITEA_TOKEN`, and `GITEA_ISSUE_TOKEN` at least quarterly.
+- `GITEA_TOKEN` (read) and `GITEA_ISSUE_TOKEN` (write) are independent PATs — rotate them on separate schedules so a leaked read token never grants issue-write.
 - After rotation: update Vercel env vars, then redeploy.
 - For webhook secret rotation, update the sending hybrid-ra-saas deployment and receiving Regula deployment during the same maintenance window.
 

--- a/docs/운영_SOP.md
+++ b/docs/운영_SOP.md
@@ -197,6 +197,53 @@ docker exec regula pnpm run ingest:ra-project
 
 ---
 
+## Gitea wiki ingestion runbook (#155)
+
+### 개요
+
+Gitea 호스트의 `ra-llm-wiki` 저장소를 읽기 전용으로 ingestion 하고, wiki
+콘텐츠 갭으로 분류된 미답변 질문을 Gitea 이슈로 자동 생성한다.
+
+### 사전 준비 (환경 변수)
+
+| 변수 | 스코프 | 비고 |
+|------|--------|------|
+| `GITEA_URL` | read | Gitea 인스턴스 베이스 URL (`https://` 필수) |
+| `GITEA_TOKEN` | read | wiki 읽기 전용 PAT. `read:repository` 스코프 |
+| `GITEA_WIKI_REPO` | read | ingestion 대상 (`owner/name`) |
+| `GITEA_ISSUE_TOKEN` | write | 이슈 생성용 PAT. `write:issue` 스코프. `GITEA_TOKEN`과 **반드시 분리** |
+| `GITEA_ISSUE_REPO` | write | 이슈를 파일 저장소. 미설정 시 `GITEA_WIKI_REPO`로 폴백 |
+
+읽기/쓰기 토큰 분리는 최소 권한 원칙 — 실수로 read 토큰이 유출돼도
+이슈 생성 권한은 갖지 못한다.
+
+### ingestion 실행
+
+```bash
+pnpm tsx scripts/ingest-gitea-wiki.ts
+```
+
+- 위키 페이지를 GraphQL API (`{GITEA_URL}/api/graphql`)로 fetch
+- `withRetry` (3회, 1s 지수 백오프)로 일시적 5xx/네트워크 오류 흡수
+- 각 페이지를 chunking → `source_sections` 에 삽입 (provenance 포함)
+- 실패 시 throw 된 에러 메시지는 토큰 누출 방지를 위해 정제됨
+
+### 장애 대응 (triage)
+
+| 증상 | 원인 | 조치 |
+|------|------|------|
+| `Gitea credentials not configured` | env 누락 | `GITEA_URL`/`TOKEN`/`WIKI_REPO` 확인 |
+| `Gitea API error: 401` | 토큰 만료 / 권한 부족 | PAT 재발급 (`read:repository` 스코프) |
+| `Gitea API error: 5xx` 후 3회 재시도 실패 | Gitea 서버 장애 | Gitea 헬스 체크 → 복구 후 재실행 |
+| 이슈가 `queue` 로 라우팅 됨 | `GITEA_ISSUE_TOKEN` 미설정 | write 토큰 설정 후 재처리 |
+| `audit_logs` 에 `owning_issue_creation_failed` | Gitea 이슈 API 3회 실패 | audit `meta_json.error` 확인 → Gitea 권한/네트워크 점검 |
+
+> 주의: Gitea 에러 응답이 `Authorization` 헤더를 에코하는 케이스가 관찰됨.
+> 모든 throw 메시지는 `[REDACTED]` 처리되므로 로그/Sentry 에 토큰이
+> 노출되지 않는다. 그래도 토큰 재발급은 분기 1회 권장.
+
+---
+
 ## 관련 문서
 
 - [시스템 마스터 아키텍처](../docs/시스템_아키텍처.md)

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -86,9 +86,18 @@ const envSchema = z.object({
 
   // Optional: Gitea wiki ingestion (Issue #155).
   // These stay optional so deployments without Gitea wiki still boot cleanly.
+  // GITEA_URL/TOKEN/WIKI_REPO are the read-only ingestion scope (AC3).
   GITEA_URL: z.string().url().optional(),
   GITEA_TOKEN: z.string().optional(),
   GITEA_WIKI_REPO: z.string().optional(),
+
+  // Optional: Gitea issue creation — write scope (Issue #155 AC4).
+  // Separated from GITEA_TOKEN (read) for least-privilege: the ingestion
+  // script never needs issue-write, and the issue provider never needs
+  // wiki-read. When unset, owning-repos.readOwningRepoConfig returns null
+  // for 'gitea-wiki' and the router degrades to 'queue' (safe fallback).
+  GITEA_ISSUE_TOKEN: z.string().optional(),
+  GITEA_ISSUE_REPO: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -147,6 +156,9 @@ export function parseEnv(source: NodeJS.ProcessEnv = process.env): Env {
     GITEA_URL: source.GITEA_URL,
     GITEA_TOKEN: source.GITEA_TOKEN,
     GITEA_WIKI_REPO: source.GITEA_WIKI_REPO,
+    // Gitea issue-write scope (AC4) — independent from the read scope above.
+    GITEA_ISSUE_TOKEN: source.GITEA_ISSUE_TOKEN,
+    GITEA_ISSUE_REPO: source.GITEA_ISSUE_REPO,
   });
 }
 

--- a/lib/gitea/sanitize.ts
+++ b/lib/gitea/sanitize.ts
@@ -1,0 +1,68 @@
+// @MX:ANCHOR [AUTO] Shared Gitea token-leak sanitizer for error bodies.
+// @MX:REASON fan_in = 2 (owning-issue.ts issue-write path, ingest-gitea-wiki.ts
+//   read path). Gitea 4xx/5xx error bodies have been observed to echo the
+//   request Authorization header back. Interpolating the raw body into a
+//   thrown Error would leak the token to Sentry, logs, and audit_logs.meta_json.
+//   Centralizing the sanitizer here keeps the two hot paths consistent and
+//   removes the drift risk of two copies. Dependency-free by design: this
+//   module must not import DB, logger, or env — so a failure in one consumer
+//   cannot cascade into the other's import graph.
+
+/**
+ * Token-leak patterns. Order matters: the credential-adjacent pattern runs
+ * first (catches `Bearer <T>`, `token <T>`, `Basic <b64>`), then the
+ * context-scoped generic pattern catches bare long runs ONLY when near a
+ * credential keyword.
+ *
+ * SECURITY INVARIANT: false negatives (miss a token) are acceptable; false
+ * positives (mangle a legit diagnostic like a 40-hex git SHA or trace ID)
+ * are not — they degrade diagnosability during incidents.
+ *
+ * The earlier blanket `[A-Za-z0-9_-]{32,}` regex was retired because it
+ * redacted EVERY 32+ char run — including 40-hex git SHAs and trace IDs
+ * that are legitimate diagnostic content in Gitea error bodies. The
+ * observed leak vector (echoed Authorization header) is fully covered by
+ * the first pattern; the second pattern is a belt-and-suspenders for
+ * token-adjacent bare blobs only.
+ */
+const TOKEN_LEAK_PATTERNS = [
+  // RFC 7235 + Gitea dialect: `Bearer <token>`, `token <token>`, `Basic <b64>`.
+  /(?:Bearer|Token|token|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/g,
+  // Bare long run (40+ chars, PAT/JWT/base64url shape) ONLY when preceded
+  // within 24 chars by a credential keyword. The lookahead window is tight
+  // enough to avoid matching a 40-hex git SHA in a generic error message
+  // while still catching a `<keyword>: <blob>` echo that the first regex
+  // missed (e.g. `X-Auth-Token: <blob>` or `token:<blob>` with no space).
+  /(?:token|authorization|auth|bearer|basic|password|secret|key)["'\s:=]{0,24}[A-Za-z0-9._~+/=-]{40,}/gi,
+];
+
+/**
+ * Strip credential-shaped substrings from a raw upstream error body.
+ * Used by both the issue-write path and the read path before the body
+ * reaches a thrown Error (and from there Sentry / audit meta / logs).
+ *
+ * Returns the redacted string. Does NOT truncate — callers decide on
+ * truncation length for their own surface.
+ */
+export function stripTokens(raw: string): string {
+  let out = raw;
+  for (const re of TOKEN_LEAK_PATTERNS) {
+    re.lastIndex = 0;
+    out = out.replace(re, '[REDACTED]');
+  }
+  return out;
+}
+
+/**
+ * Sanitize a raw Gitea error body for safe inclusion in a thrown Error.
+ * (1) Strip credential-shaped substrings. (2) Truncate to <=200 chars
+ * (Gitea error bodies can be multi-KB HTML debug pages; the leading
+ * slice is enough to identify the failure mode for operators).
+ *
+ * The HTTP status code is passed separately by callers and is always
+ * safe to expose.
+ */
+export function sanitizeGiteaErrorBody(raw: string): string {
+  const redacted = stripTokens(raw);
+  return redacted.length > 200 ? `${redacted.slice(0, 200)}…` : redacted;
+}

--- a/lib/gitea/url-guard.ts
+++ b/lib/gitea/url-guard.ts
@@ -1,0 +1,91 @@
+// @MX:ANCHOR [AUTO] Shared Gitea URL allow-policy (SSRF guard) for issue + read paths.
+// @MX:REASON fan_in = 2 (owning-repos.ts issue-write path, ingest-gitea-wiki.ts
+//   read path). The Gitea token always travels as an Authorization header —
+//   a non-https apiBase would leak it over the wire to an attacker-controlled
+//   or passive-listening host. BUT the deployed Gitea is an internal LAN host
+//   over plain HTTP (GITEA_URL=http://diskstation:7001 per .env.example),
+//   so a blanket https-only rejection silently disables the entire integration.
+//   The policy below preserves the SSRF guard for the real threat surface
+//   (public untrusted HTTP) while allowing trusted-internal HTTP.
+//   Dependency-free by design: no DB, logger, or env imports.
+
+/**
+ * True if `url` is a host we trust to receive a Gitea token over plain HTTP.
+ * The LAN-host allowlist mirrors operator-deployed patterns:
+ *
+ *   - `localhost` / `127.0.0.1` / `::1` — local dev + sidecar Gitea.
+ *   - `diskstation` — the documented Synology NAS host in .env.example:89.
+ *   - `*.local` / `*.internal` — mDNS + RFC 8375 home/enterprise patterns.
+ *   - Private IPv4 ranges (10/8, 172.16/12, 192.168/16, 127/8).
+ *   - Link-local + unique-local IPv6 (fe80::/10, fc00::/7 incl. fd00::/8).
+ *
+ * Public HTTP hosts (e.g. `http://evil.example.com`) are NOT internal and
+ * fall through to the caller's rejection path — the SSRF guard is preserved
+ * where the threat is real.
+ *
+ * Parsing is deliberately defensive: an unparseable URL returns false so the
+ * caller rejects rather than silently allowing.
+ */
+export function isInternalHost(rawUrl: string): boolean {
+  let host: string;
+  try {
+    const u = new URL(rawUrl);
+    host = u.hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+
+  // IPv6 loopback + link-local + unique-local (strip brackets).
+  const v6 = host.replace(/^\[|\]$/g, '');
+  if (v6 === '::1') return true;
+  if (v6.startsWith('fe80:') || v6.startsWith('fc') || v6.startsWith('fd')) return true;
+
+  // IPv4 private ranges.
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  const m172 = /^172\.(\d+)\./.exec(host);
+  if (m172) {
+    const sub = Number(m172[1]);
+    if (sub >= 16 && sub <= 31) return true;
+  }
+
+  // Hostname allowlist (literal + suffix matches).
+  if (host === 'localhost') return true;
+  if (host === 'diskstation') return true;
+  if (host.endsWith('.local') || host.endsWith('.internal')) return true;
+
+  return false;
+}
+
+/**
+ * Policy predicate: is `rawUrl` an allowed Gitea apiBase?
+ *
+ *   - `https://*` always allowed (encrypted wire — token safe).
+ *   - internal host over any scheme allowed (trusted LAN — token acceptable
+ *     per operator deployment; the LAN segment is the trust boundary).
+ *
+ * Returns false for public untrusted HTTP (the SSRF threat surface).
+ */
+export function isGiteaUrlAllowed(rawUrl: string): boolean {
+  if (!rawUrl) return false;
+  if (rawUrl.startsWith('https://')) return true;
+  return isInternalHost(rawUrl);
+}
+
+/**
+ * Throw a clear Error if `rawUrl` is not an allowed Gitea apiBase.
+ * Used by both the issue-write path and the read path so neither can drift
+ * away from the shared policy. The message is intentionally generic (no
+ * raw URL echoed — it may carry query-string secrets) and free of PII.
+ */
+export function assertGiteaUrlAllowed(rawUrl: string): void {
+  if (!isGiteaUrlAllowed(rawUrl)) {
+    throw new Error(
+      'Gitea URL rejected by SSRF guard: must be https OR an internal/private host. ' +
+        'Public untrusted HTTP is not allowed because the Gitea token travels as an ' +
+        'Authorization header.',
+    );
+  }
+}

--- a/lib/knowledge-gap/owning-issue.ts
+++ b/lib/knowledge-gap/owning-issue.ts
@@ -14,6 +14,7 @@
 import { writeAudit } from '@/lib/audit';
 import { db } from '@/lib/db/client';
 import { unansweredQueue } from '@/lib/db/schema';
+import { sanitizeGiteaErrorBody } from '@/lib/gitea/sanitize';
 import { eq } from 'drizzle-orm';
 import type { GapIssueContext, GitHubIssuesClient } from './github-issue';
 import { type OwningTarget, readOwningRepoConfig } from './owning-repos';
@@ -26,6 +27,12 @@ const TARGET_LABEL: Record<Exclude<OwningTarget, 'queue'>, string> = {
   'hybrid-ra-saas': 'hybrid-ra-saas',
 };
 
+// @MX:NOTE [AUTO] Token-leak sanitizer is shared via lib/gitea/sanitize.ts.
+// @MX:REASON Gitea 4xx/5xx error bodies have been observed to echo the request
+//   Authorization header. Throwing the raw body into an Error would leak the
+//   token to Sentry and audit_logs.meta_json. The sanitizer module is
+//   dependency-free so the two hot paths (issue-write + read) fail independently.
+
 /** Result of createOwningIssue — null when unconfigured or after retry exhaustion. */
 export interface OwningIssueResult {
   /** GitHub issue number — needed for link-back comments on the owning side. */
@@ -35,50 +42,82 @@ export interface OwningIssueResult {
 }
 
 /**
- * Per-target GitHub client. Reuses the GitHubIssuesClient interface but binds
- * to OWNING_ISSUE_GITHUB_TOKEN and the target's repo+apiBase. When the target
- * is unconfigured (readOwningRepoConfig returns null), methods return the same
- * NULL_GITHUB_RESULT sentinel shape so callers detect "no-op" uniformly.
+ * Per-target issue client. Speaks GitHub REST or Gitea REST depending on the
+ * provider resolved by readOwningRepoConfig. Binds to the provider-appropriate
+ * token (OWNING_ISSUE_GITHUB_TOKEN for GitHub, GITEA_ISSUE_TOKEN for Gitea).
+ * When the target is unconfigured (readOwningRepoConfig returns null), methods
+ * return the NULL_GITHUB_RESULT sentinel shape so callers detect "no-op".
+ *
+ * Provider dialect differences:
+ *   - GitHub: `POST {apiBase}/repos/{repo}/issues`, `Authorization: Bearer <T>`,
+ *     labels as `string[]`, response `{ number, html_url }`.
+ *   - Gitea:  `POST {apiBase}/api/v1/repos/{repo}/issues`, `Authorization: token <T>`,
+ *     labels as `{ name: string }[]`, response `{ number, html_url }` (same field name —
+ *     Gitea mirrors GitHub's shape for the issue resource).
+ *
+ * SECURITY: error bodies are sanitized before being thrown — Gitea error
+ * responses have been observed to echo the request Authorization header.
  */
 export function targetGithubClient(
   target: Exclude<OwningTarget, 'queue'>,
 ): GitHubIssuesClient & { configured: boolean } {
   const cfg = readOwningRepoConfig(target);
+  const isGitea = cfg?.provider === 'gitea';
+
+  // Gitea error bodies can echo the Authorization header — strip tokens from
+  // any thrown message before it reaches audit meta or Sentry.
+  const safeError = (label: string, status: number, rawBody: string): Error =>
+    new Error(`${label} failed: ${status} ${sanitizeGiteaErrorBody(rawBody)}`);
+
   return {
     configured: cfg !== null,
     async createIssue({ title, body, labels }) {
       if (!cfg) return { number: -1, htmlUrl: '' };
-      const res = await fetch(`${cfg.apiBase}/repos/${cfg.repo}/issues`, {
+      const endpoint = isGitea
+        ? `${cfg.apiBase}/api/v1/repos/${cfg.repo}/issues`
+        : `${cfg.apiBase}/repos/${cfg.repo}/issues`;
+      // Gitea expects labels as `{ name }` objects; GitHub accepts plain strings.
+      const labelsPayload = isGitea ? labels.map((name) => ({ name })) : [...labels];
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: {
-          Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${cfg.token}`,
-          'X-GitHub-Api-Version': '2022-11-28',
+          Accept: isGitea ? 'application/json' : 'application/vnd.github+json',
+          Authorization: isGitea ? `token ${cfg.token}` : `Bearer ${cfg.token}`,
+          ...(!isGitea && { 'X-GitHub-Api-Version': '2022-11-28' }),
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ title, body, labels: [...labels] }),
+        body: JSON.stringify({ title, body, labels: labelsPayload }),
       });
       if (!res.ok) {
-        throw new Error(`GitHub createIssue (${target}) failed: ${res.status} ${await res.text()}`);
+        throw safeError(
+          `${isGitea ? 'Gitea' : 'GitHub'} createIssue (${target})`,
+          res.status,
+          await res.text(),
+        );
       }
       const json = (await res.json()) as { number: number; html_url: string };
       return { number: json.number, htmlUrl: json.html_url };
     },
     async createComment({ issueNumber, body }) {
       if (!cfg) return { htmlUrl: '' };
-      const res = await fetch(`${cfg.apiBase}/repos/${cfg.repo}/issues/${issueNumber}/comments`, {
+      const endpoint = isGitea
+        ? `${cfg.apiBase}/api/v1/repos/${cfg.repo}/issues/${issueNumber}/comments`
+        : `${cfg.apiBase}/repos/${cfg.repo}/issues/${issueNumber}/comments`;
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: {
-          Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${cfg.token}`,
-          'X-GitHub-Api-Version': '2022-11-28',
+          Accept: isGitea ? 'application/json' : 'application/vnd.github+json',
+          Authorization: isGitea ? `token ${cfg.token}` : `Bearer ${cfg.token}`,
+          ...(!isGitea && { 'X-GitHub-Api-Version': '2022-11-28' }),
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ body }),
       });
       if (!res.ok) {
-        throw new Error(
-          `GitHub createComment (${target}) failed: ${res.status} ${await res.text()}`,
+        throw safeError(
+          `${isGitea ? 'Gitea' : 'GitHub'} createComment (${target})`,
+          res.status,
+          await res.text(),
         );
       }
       const json = (await res.json()) as { html_url: string };

--- a/lib/knowledge-gap/owning-repos.ts
+++ b/lib/knowledge-gap/owning-repos.ts
@@ -1,24 +1,33 @@
-// @MX:NOTE [AUTO] Owning-target → GitHub repo+token configuration map (Issue #157).
-// @MX:SPEC SPEC-REGULA-KNOWLEDGE-GAP-001 AC2/AC3 (REQ-KNOWLEDGE-GAP-006 extension)
-// @MX:REASON External system integration point (per-target GitHub REST API).
+// @MX:NOTE [AUTO] Owning-target → provider repo+token configuration map (Issue #157, #155).
+// @MX:SPEC SPEC-REGULA-KNOWLEDGE-GAP-001 AC2/AC3/AC4 (REQ-KNOWLEDGE-GAP-006 extension)
+// @MX:REASON External system integration point (per-target GitHub REST or Gitea API).
 //
 // Token separation (least privilege):
 //   - KNOWLEDGE_GAP_GITHUB_TOKEN  — triage backlog issue-write (existing, #35)
-//   - OWNING_ISSUE_GITHUB_TOKEN   — owning-project issue-write (NEW, #157)
+//   - OWNING_ISSUE_GITHUB_TOKEN   — owning-project issue-write on GitHub-hosted targets (#157)
+//   - GITEA_ISSUE_TOKEN           — owning-project issue-write on the Gitea-hosted wiki target (#155 AC4)
 //   - READ_GITHUB_TOKEN           — read-only source ingestion (separate concern)
+//   - GITEA_TOKEN                 — read-only Gitea wiki ingestion (AC3, separate from issue-write)
 //
 // Degrade-to-queue contract: when a target's repo OR token is unconfigured,
 // `readOwningRepoConfig` returns `null` and the router falls back to 'queue'.
 // The capture flow is never aborted by missing configuration.
 
+import { isGiteaUrlAllowed } from '@/lib/gitea/url-guard';
+
 /** The 4 owning-project targets + the queue fallback. Deterministic output of router.ts. */
 export type OwningTarget = 'ra-project' | 'md-process' | 'gitea-wiki' | 'hybrid-ra-saas' | 'queue';
+
+/** Which issue API dialect to speak. Drives endpoint path + response shape parsing. */
+export type IssueProvider = 'github' | 'gitea';
 
 /** Repo + token configuration for a single owning target. */
 export interface OwningRepoConfig {
   repo: string;
   apiBase: string;
   token: string;
+  /** 'gitea' → `/api/v1/repos/...` + `token <T>` auth; 'github' → `/repos/...` + `Bearer <T>`. */
+  provider: IssueProvider;
 }
 
 /**
@@ -34,22 +43,13 @@ const OWNING_TARGET_ENV: Record<Extract<OwningTarget, string>, { repo: string; l
 };
 
 /**
- * Read the repo + token config for a target. Returns null when either the repo
- * or the shared OWNING_ISSUE_GITHUB_TOKEN is absent — callers MUST treat null
- * as "target unconfigured, degrade to queue" (REQ-DEGRADE-TO-QUEUE).
- *
- * Mirrors readRepoConfig()'s https-only SSRF guard: a non-https apiBase is
- * rejected and the canonical https://api.github.com endpoint is substituted,
- * preventing authenticated requests toward attacker-controlled hosts.
+ * Read the GitHub-hosted config for a target. Shared by ra-project / md-process /
+ * hybrid-ra-saas. Returns null when repo or OWNING_ISSUE_GITHUB_TOKEN is unset.
+ * https-only SSRF guard mirrors readRepoConfig() in github-issue.ts.
  */
-export function readOwningRepoConfig(
-  target: Exclude<OwningTarget, 'queue'>,
-): OwningRepoConfig | null {
+function readGithubOwningConfig(target: Exclude<OwningTarget, 'queue'>): OwningRepoConfig | null {
   const env = OWNING_TARGET_ENV[target];
-  if (!env) return null;
   const repo = process.env[env.repo] ?? '';
-  // Per-target API base override is optional; defaults to canonical GitHub.
-  // .replaceAll handles multi-hyphen targets like 'hybrid-ra-saas' → 'HYBRID_RA_SAAS'.
   const rawApiBase =
     process.env[`OWNING_ISSUE_GITHUB_API_BASE_${target.toUpperCase().replaceAll('-', '_')}`] ??
     'https://api.github.com';
@@ -57,5 +57,65 @@ export function readOwningRepoConfig(
   const apiBase = rawApiBase.startsWith('https://') ? rawApiBase : 'https://api.github.com';
   const token = process.env.OWNING_ISSUE_GITHUB_TOKEN ?? '';
   if (!repo || !token) return null;
-  return { repo, apiBase, token };
+  return { repo, apiBase, token, provider: 'github' };
+}
+
+/**
+ * Read the Gitea-hosted config for the 'gitea-wiki' target (AC4).
+ *
+ * The Gitea wiki target uses its own API base + write token, separated from
+ * the GitHub-hosted targets:
+ *   - apiBase ← GITEA_URL (e.g. `https://gitea.example.com`)
+ *   - repo    ← GITEA_ISSUE_REPO ?? GITEA_WIKI_REPO (fall back to the wiki repo
+ *              itself when the operator has not designated a separate issue repo)
+ *   - token   ← GITEA_ISSUE_TOKEN (write scope; NEVER GITEA_TOKEN which is read-only)
+ *
+ * Returns null when any of the three is absent → router degrades to 'queue'.
+ * The same https-only SSRF guard applies: Gitea tokens also travel as
+ * Authorization headers and must never be sent to a non-https host.
+ */
+function readGiteaOwningConfig(): OwningRepoConfig | null {
+  const rawApiBase = process.env.GITEA_URL ?? '';
+  // `??` only skips null/undefined — but tests and operators sometimes clear env
+  // vars to '' rather than deleting them. An empty GITEA_ISSUE_REPO must NOT
+  // shadow a populated GITEA_WIKI_REPO, so fall through to the wiki repo when
+  // the issue repo is blank.
+  const issueRepo = process.env.GITEA_ISSUE_REPO ?? '';
+  const repo = issueRepo || (process.env.GITEA_WIKI_REPO ?? '');
+  const token = process.env.GITEA_ISSUE_TOKEN ?? '';
+  if (!rawApiBase || !repo || !token) return null;
+  // SECURITY: SSRF guard — Gitea tokens travel as Authorization headers and
+  // must never be sent to a public untrusted HTTP host. The deployed Gitea is
+  // typically an internal LAN host over plain HTTP (GITEA_URL=http://diskstation:7001),
+  // so the policy allows https OR a private/internal host. See lib/gitea/url-guard.ts.
+  if (!isGiteaUrlAllowed(rawApiBase)) return null;
+  return { repo, apiBase: rawApiBase, token, provider: 'gitea' };
+}
+
+/**
+ * Read the repo + token config for a target. Returns null when either the repo
+ * or the relevant token is absent — callers MUST treat null as "target
+ * unconfigured, degrade to queue" (REQ-DEGRADE-TO-QUEUE).
+ *
+ * Dispatch:
+ *   - 'gitea-wiki' → Gitea provider (GITEA_URL / GITEA_ISSUE_TOKEN / GITEA_ISSUE_REPO)
+ *   - all others   → GitHub provider (per-target repo env + OWNING_ISSUE_GITHUB_TOKEN)
+ *
+ * Mirrors readRepoConfig()'s https-only SSRF guard on BOTH paths.
+ */
+export function readOwningRepoConfig(
+  target: Exclude<OwningTarget, 'queue'>,
+): OwningRepoConfig | null {
+  if (!OWNING_TARGET_ENV[target]) return null;
+  // 'gitea-wiki' is the only Gitea-hosted target today. If an operator wants
+  // to route it to a GitHub-hosted mirror instead, they simply leave
+  // GITEA_ISSUE_TOKEN unset and set the standard OWNING_ISSUE_GITHUB_* vars —
+  // but that configuration is unusual and not the documented path.
+  if (target === 'gitea-wiki') {
+    const giteaCfg = readGiteaOwningConfig();
+    if (giteaCfg) return giteaCfg;
+    // Fall through to GitHub config so a GitHub-mirrored wiki still works as a
+    // secondary option without changing operator muscle memory.
+  }
+  return readGithubOwningConfig(target);
 }

--- a/scripts/ingest-gitea-wiki.ts
+++ b/scripts/ingest-gitea-wiki.ts
@@ -7,12 +7,20 @@
 //   pnpm tsx scripts/ingest-gitea-wiki.ts
 //
 // Requires: GITEA_URL, GITEA_TOKEN, GITEA_WIKI_REPO in environment
+//
+// @MX:ANCHOR [AUTO] Read-only Gitea wiki ingestion — hardened fetch path.
+// @MX:REASON fan_in will grow (ingest cron, admin retry, replay). Security-critical:
+//   Gitea error bodies have been observed to echo the Authorization header back.
+//   This module MUST sanitize every thrown error so tokens never reach logs/Sentry.
 
 import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
+import { withRetry } from '../lib/api/error-handling';
 import { db } from '../lib/db/client';
 import { sourceSections, sources } from '../lib/db/schema';
 import { getEnv } from '../lib/env';
+import { sanitizeGiteaErrorBody } from '../lib/gitea/sanitize';
+import { assertGiteaUrlAllowed } from '../lib/gitea/url-guard';
 import { makeGenericChunker } from '../lib/ingest/chunkers/generic';
 import { DocClass } from '../lib/ingest/doc-class';
 import { logger } from '../lib/observability/logger';
@@ -36,9 +44,23 @@ interface GiteaWikiResponse {
   };
 }
 
+// @MX:NOTE [AUTO] Token-leak sanitizer + URL guard are shared via lib/gitea/*.
+// @MX:REASON Some Gitea error responses echo the request Authorization header in
+//   the response body (e.g. `Authorization: token <TOKEN>` in 401 debug pages).
+//   Interpolating raw errorText into a thrown Error would leak the token to
+//   Sentry, logs, and operators. The sanitizer (stripTokens / sanitizeGiteaErrorBody)
+//   is shared with the issue-write path so the two cannot drift. The URL guard
+//   applies the SAME policy as the issue path (https OR internal host) — the read
+//   token is no less sensitive than the write token.
+
 /**
  * Fetch all wiki pages from Gitea repository.
  * Uses GraphQL API to fetch page paths, SHAs, and content.
+ *
+ * Hardened (AC3): wrapped in `withRetry` (3 attempts, 1s base delay) so
+ * transient 5xx/ network blips don't abort an ingestion run. Every thrown
+ * error is passed through `sanitizeGiteaErrorBody` so credential leaks in
+ * upstream error bodies are stripped before reaching logs/Sentry.
  */
 async function fetchGiteaWikiPages(): Promise<GiteaWikiPage[]> {
   const env = getEnv();
@@ -50,6 +72,21 @@ async function fetchGiteaWikiPages(): Promise<GiteaWikiPage[]> {
     throw new Error(
       'Gitea credentials not configured. Set GITEA_URL, GITEA_TOKEN, and GITEA_WIKI_REPO.',
     );
+  }
+
+  // SECURITY: SSRF guard — same policy as the issue-write path. GITEA_TOKEN is
+  // a read PAT and travels as an Authorization header; it must never be sent
+  // to a public untrusted HTTP host. Allow https OR an internal/private host.
+  // Coherence: previously the read path had no guard while the issue path did,
+  // an incoherent policy for the same env var.
+  try {
+    assertGiteaUrlAllowed(giteaUrl);
+  } catch (err) {
+    // Sanitize for operator logs — the message from assertGiteaUrlAllowed is
+    // already generic (no raw URL echoed), but we truncate for safety.
+    const reason = err instanceof Error ? err.message.slice(0, 200) : String(err);
+    logger.warn(`Gitea wiki ingestion skipped: ${reason}`);
+    throw new Error(reason);
   }
 
   const query = `
@@ -68,25 +105,34 @@ async function fetchGiteaWikiPages(): Promise<GiteaWikiPage[]> {
     }
   `;
 
-  const response = await fetch(`${giteaUrl}/api/graphql`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `token ${giteaToken}`,
+  // withRetry retries on 5xx / network errors and rethrows on 4xx immediately.
+  // The inner closure throws a sanitized Error so the retry loop's `lastError`
+  // (and the final rethrow) never carries the raw Authorization header.
+  return withRetry(
+    async () => {
+      const response = await fetch(`${giteaUrl}/api/graphql`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `token ${giteaToken}`,
+        },
+        body: JSON.stringify({ query }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        const safeBody = sanitizeGiteaErrorBody(errorText);
+        // SECURITY: status code is safe; body is redacted + truncated.
+        // NEVER interpolate giteaToken or the raw errorText here.
+        throw new Error(`Gitea API error: ${response.status} ${safeBody}`);
+      }
+
+      const data: GiteaWikiResponse = await response.json();
+      logger.info(`Fetched ${data.data.repository.wiki.pages.nodes.length} wiki pages from Gitea`);
+      return data.data.repository.wiki.pages.nodes;
     },
-    body: JSON.stringify({ query }),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Gitea API error: ${response.status} ${errorText}`);
-  }
-
-  const data: GiteaWikiResponse = await response.json();
-
-  logger.info(`Fetched ${data.data.repository.wiki.pages.nodes.length} wiki pages from Gitea`);
-
-  return data.data.repository.wiki.pages.nodes;
+    { maxAttempts: 3, delayMs: 1000 },
+  );
 }
 
 /**

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -131,4 +131,42 @@ describe('parseEnv', () => {
       expect(issues.length).toBeGreaterThanOrEqual(6);
     }
   });
+
+  describe('Gitea vars (Issue #155)', () => {
+    it('accepts valid GITEA_URL / GITEA_TOKEN / GITEA_WIKI_REPO (read scope)', () => {
+      const env = parseEnv({
+        ...validEnv,
+        GITEA_URL: 'https://gitea.example.com',
+        GITEA_TOKEN: 'gitea-read-pat',
+        GITEA_WIKI_REPO: 'DR_RnD/ra-llm-wiki',
+      });
+      expect(env.GITEA_URL).toBe('https://gitea.example.com');
+      expect(env.GITEA_TOKEN).toBe('gitea-read-pat');
+      expect(env.GITEA_WIKI_REPO).toBe('DR_RnD/ra-llm-wiki');
+    });
+
+    it('throws ZodError when GITEA_URL is not a URL', () => {
+      expect(() => parseEnv({ ...validEnv, GITEA_URL: 'not-a-url' })).toThrow(ZodError);
+    });
+
+    it('accepts the optional issue-write vars GITEA_ISSUE_TOKEN / GITEA_ISSUE_REPO', () => {
+      const env = parseEnv({
+        ...validEnv,
+        GITEA_URL: 'https://gitea.example.com',
+        GITEA_ISSUE_TOKEN: 'gitea-issue-pat',
+        GITEA_ISSUE_REPO: 'DR_RnD/regula-issues',
+      });
+      expect(env.GITEA_ISSUE_TOKEN).toBe('gitea-issue-pat');
+      expect(env.GITEA_ISSUE_REPO).toBe('DR_RnD/regula-issues');
+    });
+
+    it('leaves Gitea vars undefined when unset (deployments without Gitea boot cleanly)', () => {
+      const env = parseEnv(validEnv);
+      expect(env.GITEA_URL).toBeUndefined();
+      expect(env.GITEA_TOKEN).toBeUndefined();
+      expect(env.GITEA_WIKI_REPO).toBeUndefined();
+      expect(env.GITEA_ISSUE_TOKEN).toBeUndefined();
+      expect(env.GITEA_ISSUE_REPO).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/knowledge-gap-owning-routing.test.ts
+++ b/tests/unit/knowledge-gap-owning-routing.test.ts
@@ -141,6 +141,7 @@ describe('owning-repos.readOwningRepoConfig — token separation + null on uncon
       repo: 'acme/ra-project',
       apiBase: 'https://github.example.com',
       token: 'owning-pat',
+      provider: 'github',
     });
   });
 
@@ -174,6 +175,231 @@ describe('owning-repos.readOwningRepoConfig — token separation + null on uncon
     // OWNING_ISSUE_GITHUB_TOKEN cleared to '' in beforeEach.
     const { readOwningRepoConfig } = await import('../../lib/knowledge-gap/owning-repos');
     expect(readOwningRepoConfig('gitea-wiki')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// owning-repos: Gitea provider for 'gitea-wiki' target (Issue #155 AC4)
+// ---------------------------------------------------------------------------
+describe('owning-repos.readOwningRepoConfig — Gitea provider for gitea-wiki (#155 AC4)', () => {
+  const GITEA_KEYS = [
+    'GITEA_URL',
+    'GITEA_TOKEN',
+    'GITEA_WIKI_REPO',
+    'GITEA_ISSUE_TOKEN',
+    'GITEA_ISSUE_REPO',
+    // Also clear the GitHub-path env so we can prove the Gitea path wins.
+    'OWNING_ISSUE_GITHUB_REPO_GITEA_WIKI',
+    'OWNING_ISSUE_GITHUB_TOKEN',
+    'OWNING_ISSUE_GITHUB_API_BASE_GITEA_WIKI',
+  ];
+
+  beforeEach(() => {
+    for (const k of GITEA_KEYS) process.env[k] = '';
+    vi.resetModules();
+  });
+  afterEach(() => {
+    for (const k of GITEA_KEYS) process.env[k] = '';
+    vi.restoreAllMocks();
+  });
+
+  it('returns a Gitea config sourced from GITEA_URL / GITEA_ISSUE_TOKEN / GITEA_ISSUE_REPO', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com';
+    process.env.GITEA_ISSUE_TOKEN = 'gitea-issue-pat';
+    process.env.GITEA_ISSUE_REPO = 'DR_RnD/regula-issues';
+    const { readOwningRepoConfig } = await import('../../lib/knowledge-gap/owning-repos');
+    const cfg = readOwningRepoConfig('gitea-wiki');
+    expect(cfg).toEqual({
+      repo: 'DR_RnD/regula-issues',
+      apiBase: 'https://gitea.example.com',
+      token: 'gitea-issue-pat',
+      provider: 'gitea',
+    });
+  });
+
+  it('falls back to GITEA_WIKI_REPO when GITEA_ISSUE_REPO is unset', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com';
+    process.env.GITEA_ISSUE_TOKEN = 'gitea-issue-pat';
+    process.env.GITEA_WIKI_REPO = 'DR_RnD/ra-llm-wiki';
+    const { readOwningRepoConfig } = await import('../../lib/knowledge-gap/owning-repos');
+    expect(readOwningRepoConfig('gitea-wiki')?.repo).toBe('DR_RnD/ra-llm-wiki');
+  });
+
+  it('returns null (degrade to queue) when GITEA_ISSUE_TOKEN is unset, even if read GITEA_TOKEN is present', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com';
+    process.env.GITEA_TOKEN = 'read-only-pat';
+    process.env.GITEA_ISSUE_REPO = 'DR_RnD/regula-issues';
+    // GITEA_ISSUE_TOKEN intentionally unset — read scope must NOT satisfy write need.
+    const { readOwningRepoConfig } = await import('../../lib/knowledge-gap/owning-repos');
+    expect(readOwningRepoConfig('gitea-wiki')).toBeNull();
+  });
+
+  it('returns null when GITEA_URL is a public http host (SSRF guard)', async () => {
+    // SECURITY: the read PAT travels as an Authorization header. A public
+    // untrusted HTTP host would leak it on the wire — must be rejected.
+    process.env.GITEA_URL = 'http://evil.example.com';
+    process.env.GITEA_ISSUE_TOKEN = 'gitea-issue-pat';
+    process.env.GITEA_ISSUE_REPO = 'DR_RnD/regula-issues';
+    const { readOwningRepoConfig } = await import('../../lib/knowledge-gap/owning-repos');
+    expect(readOwningRepoConfig('gitea-wiki')).toBeNull();
+  });
+
+  it('allows GITEA_URL as an internal http host (deployed LAN Gitea, .env.example:89)', async () => {
+    // The actual deployed Gitea is http://diskstation:7001 (plain HTTP on the
+    // LAN). A blanket https-only rejection silently disables the integration
+    // with the repo's own documented config. The SSRF guard is preserved for
+    // the real threat surface (public HTTP); internal hosts are trusted.
+    process.env.GITEA_URL = 'http://diskstation:7001';
+    process.env.GITEA_ISSUE_TOKEN = 'gitea-issue-pat';
+    process.env.GITEA_ISSUE_REPO = 'DR_RnD/regula-issues';
+    const { readOwningRepoConfig } = await import('../../lib/knowledge-gap/owning-repos');
+    const cfg = readOwningRepoConfig('gitea-wiki');
+    expect(cfg).not.toBeNull();
+    expect(cfg?.apiBase).toBe('http://diskstation:7001');
+    expect(cfg?.provider).toBe('gitea');
+  });
+
+  it.each([
+    'http://localhost:3000',
+    'http://127.0.0.1:3000',
+    'http://10.0.0.5:3000',
+    'http://192.168.1.10:3000',
+    'http://172.16.5.5:3000',
+    'http://gitea.local',
+    'http://build.internal',
+  ])('allows GITEA_URL as internal host %s (SSRF guard preserves LAN trust)', async (url) => {
+    process.env.GITEA_URL = url;
+    process.env.GITEA_ISSUE_TOKEN = 'gitea-issue-pat';
+    process.env.GITEA_ISSUE_REPO = 'DR_RnD/regula-issues';
+    const { readOwningRepoConfig } = await import('../../lib/knowledge-gap/owning-repos');
+    const cfg = readOwningRepoConfig('gitea-wiki');
+    expect(cfg).not.toBeNull();
+    expect(cfg?.apiBase).toBe(url);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// owning-issue.targetGithubClient — Gitea dialect for gitea-wiki (#155 AC4)
+// ---------------------------------------------------------------------------
+const giteaFetchMock = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', giteaFetchMock);
+
+describe('owning-issue.targetGithubClient — Gitea dialect for gitea-wiki (#155 AC4)', () => {
+  const GITEA_KEYS = [
+    'GITEA_URL',
+    'GITEA_TOKEN',
+    'GITEA_WIKI_REPO',
+    'GITEA_ISSUE_TOKEN',
+    'GITEA_ISSUE_REPO',
+    'OWNING_ISSUE_GITHUB_REPO_GITEA_WIKI',
+    'OWNING_ISSUE_GITHUB_TOKEN',
+  ];
+
+  beforeEach(() => {
+    for (const k of GITEA_KEYS) process.env[k] = '';
+    giteaFetchMock.mockReset();
+  });
+  afterEach(() => {
+    for (const k of GITEA_KEYS) process.env[k] = '';
+  });
+
+  it('hits {GITEA_URL}/api/v1/repos/{repo}/issues and uses GITEA_ISSUE_TOKEN (not GITEA_TOKEN, not KNOWLEDGE_GAP_GITHUB_TOKEN)', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com';
+    process.env.GITEA_ISSUE_TOKEN = 'gitea-issue-pat';
+    process.env.GITEA_ISSUE_REPO = 'DR_RnD/regula-issues';
+    // Decoys that must NOT be used:
+    process.env.GITEA_TOKEN = 'read-only-decoy';
+    process.env.KNOWLEDGE_GAP_GITHUB_TOKEN = 'triage-decoy';
+
+    giteaFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          number: 7,
+          html_url: 'https://gitea.example.com/DR_RnD/regula-issues/issues/7',
+        }),
+        {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const { targetGithubClient } = await import('../../lib/knowledge-gap/owning-issue');
+    const client = targetGithubClient('gitea-wiki');
+    expect(client.configured).toBe(true);
+
+    const result = await client.createIssue({
+      title: '[gitea-wiki][low_confidence] knowledge-gap routed',
+      body: 'triage: https://github.com/acme/triage/issues/5',
+      labels: ['knowledge-gap', 'ra-auto-route'],
+    });
+
+    expect(result).toEqual({
+      number: 7,
+      htmlUrl: 'https://gitea.example.com/DR_RnD/regula-issues/issues/7',
+    });
+
+    const [url, init] = giteaFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://gitea.example.com/api/v1/repos/DR_RnD/regula-issues/issues');
+    const headers = init.headers as Record<string, string>;
+    // Gitea dialect: `token <T>`, never `Bearer`.
+    expect(headers.Authorization).toBe('token gitea-issue-pat');
+    expect(headers.Authorization).not.toContain('read-only-decoy');
+    expect(headers.Authorization).not.toContain('triage-decoy');
+    // Labels are sent as `{ name }` objects on the Gitea dialect.
+    const body = JSON.parse(init.body as string) as { labels: unknown[] };
+    expect(body.labels).toEqual([{ name: 'knowledge-gap' }, { name: 'ra-auto-route' }]);
+  });
+
+  it('returns the GitHub-shaped {number, html_url} from the Gitea response (same field name)', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com';
+    process.env.GITEA_ISSUE_TOKEN = 'gitea-issue-pat';
+    process.env.GITEA_ISSUE_REPO = 'DR_RnD/regula-issues';
+
+    giteaFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          number: 42,
+          html_url: 'https://gitea.example.com/DR_RnD/regula-issues/issues/42',
+        }),
+        {
+          status: 201,
+        },
+      ),
+    );
+
+    const { targetGithubClient } = await import('../../lib/knowledge-gap/owning-issue');
+    const result = await targetGithubClient('gitea-wiki').createIssue({
+      title: 't',
+      body: 'b',
+      labels: [],
+    });
+    // Gitea and GitHub both expose `html_url` on the issue resource — no mapping needed.
+    expect(result.htmlUrl).toBe('https://gitea.example.com/DR_RnD/regula-issues/issues/42');
+    expect(result.number).toBe(42);
+  });
+
+  it('sanitizes token from Gitea error body before throwing (Gitea echoes Authorization header)', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com';
+    process.env.GITEA_ISSUE_TOKEN = 'gitea-issue-pat-secret-value';
+    process.env.GITEA_ISSUE_REPO = 'DR_RnD/regula-issues';
+
+    const leakingBody = 'Authorization: token gitea-issue-pat-secret-value plus extra detail';
+    giteaFetchMock.mockResolvedValueOnce(
+      new Response(leakingBody, { status: 500, headers: { 'Content-Type': 'text/plain' } }),
+    );
+
+    const { targetGithubClient } = await import('../../lib/knowledge-gap/owning-issue');
+    await expect(
+      targetGithubClient('gitea-wiki').createIssue({ title: 't', body: 'b', labels: [] }),
+    ).rejects.toThrow(/Gitea createIssue/);
+
+    // The token substring must not appear in the thrown message.
+    try {
+      await targetGithubClient('gitea-wiki').createIssue({ title: 't', body: 'b', labels: [] });
+    } catch (err) {
+      expect((err as Error).message).not.toContain('gitea-issue-pat-secret-value');
+    }
   });
 });
 

--- a/tests/unit/lib/gitea/url-guard.test.ts
+++ b/tests/unit/lib/gitea/url-guard.test.ts
@@ -1,0 +1,161 @@
+// @MX:NOTE [AUTO] Shared Gitea URL guard + sanitizer unit tests (C-1/H-1/M-1).
+// @MX:REASON The URL guard is the SSRF boundary for BOTH the issue-write and
+//   the read path; the sanitizer is the token-leak boundary for BOTH thrown
+//   errors. Centralizing the policy in lib/gitea/* means the tests live once
+//   here, not duplicated across consumer suites.
+
+import { describe, expect, it } from 'vitest';
+import { sanitizeGiteaErrorBody, stripTokens } from '../../../../lib/gitea/sanitize';
+import {
+  assertGiteaUrlAllowed,
+  isGiteaUrlAllowed,
+  isInternalHost,
+} from '../../../../lib/gitea/url-guard';
+
+// ---------------------------------------------------------------------------
+// isInternalHost — exact host / IP rules
+// ---------------------------------------------------------------------------
+describe('isInternalHost — LAN / private host detection', () => {
+  it.each([
+    'http://localhost',
+    'http://localhost:3000',
+    'http://127.0.0.1:3000',
+    'http://diskstation:7001', // documented .env.example value
+    'http://10.0.0.5',
+    'http://192.168.1.10:3000',
+    'http://172.16.5.5',
+    'http://172.31.255.255', // last valid private in 172.16/12
+    'http://gitea.local',
+    'http://build.internal',
+    'http://[::1]',
+    'http://[fe80::1]',
+    'http://[fc00::1]',
+    'http://[fd12:3456::1]',
+  ])('returns true for internal %s', (url) => {
+    expect(isInternalHost(url)).toBe(true);
+  });
+
+  it.each([
+    'http://evil.example.com',
+    'http://gitea.example.com', // public DNS name even if operator "trusts" it
+    'http://8.8.8.8', // public IPv4
+    'http://172.32.0.1', // just outside 172.16/12
+    'http://169.254.169.254', // AWS metadata — NOT internal, must be rejected
+    'http://notlocal.suffix', // .suffix is not in the allowlist
+  ])('returns false for non-internal %s', (url) => {
+    expect(isInternalHost(url)).toBe(false);
+  });
+
+  it('returns false for unparseable input (safe reject, not silent allow)', () => {
+    expect(isInternalHost('not-a-url')).toBe(false);
+    expect(isInternalHost('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isGiteaUrlAllowed / assertGiteaUrlAllowed — policy predicate + assert
+// ---------------------------------------------------------------------------
+describe('isGiteaUrlAllowed — policy: https OR internal host', () => {
+  it('allows any https URL unconditionally (encrypted wire, token safe)', () => {
+    expect(isGiteaUrlAllowed('https://gitea.example.com')).toBe(true);
+    expect(isGiteaUrlAllowed('https://192.168.1.1')).toBe(true);
+  });
+
+  it('allows internal http hosts (deployed LAN Gitea)', () => {
+    expect(isGiteaUrlAllowed('http://diskstation:7001')).toBe(true);
+  });
+
+  it('rejects public http hosts (SSRF threat surface)', () => {
+    expect(isGiteaUrlAllowed('http://evil.example.com')).toBe(false);
+  });
+
+  it('rejects empty / falsy input', () => {
+    expect(isGiteaUrlAllowed('')).toBe(false);
+  });
+});
+
+describe('assertGiteaUrlAllowed — throws on policy violation', () => {
+  it('does not throw for an allowed URL', () => {
+    expect(() => assertGiteaUrlAllowed('http://diskstation:7001')).not.toThrow();
+    expect(() => assertGiteaUrlAllowed('https://gitea.example.com')).not.toThrow();
+  });
+
+  it('throws a generic Error for a public http URL (no raw URL echoed in message)', () => {
+    const evil = 'http://evil.example.com/path?token=leak';
+    try {
+      assertGiteaUrlAllowed(evil);
+      expect.fail('expected throw');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/SSRF guard/);
+      // The raw URL (which may carry query-string secrets) must NOT be echoed.
+      expect(msg).not.toContain('evil.example.com');
+      expect(msg).not.toContain('token=leak');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripTokens / sanitizeGiteaErrorBody — M-1 regression: SHA preserved
+// ---------------------------------------------------------------------------
+describe('sanitizeGiteaErrorBody — token redaction + diagnostic preservation', () => {
+  it('redacts `Bearer <token>` spans (observed leak vector)', () => {
+    const out = sanitizeGiteaErrorBody(
+      'Authorization: Bearer abcdef1234567890abcdef1234567890abcd detail',
+    );
+    expect(out).toContain('[REDACTED]');
+    expect(out).not.toContain('abcdef1234567890abcdef1234567890abcd');
+  });
+
+  it('redacts `token <token>` spans (Gitea dialect)', () => {
+    const out = sanitizeGiteaErrorBody('Authorization: token ghp_abcdef1234567890abcd');
+    expect(out).toContain('[REDACTED]');
+    expect(out).not.toContain('ghp_abcdef1234567890abcd');
+  });
+
+  it('preserves a 40-hex git SHA in a generic error body (M-1 regression)', () => {
+    // A bare 40-hex git commit SHA in a Gitea error body is diagnostic content,
+    // NOT a credential. The previous blanket `{32,}` regex redacted it,
+    // degrading diagnosability. The tightened pattern leaves it intact.
+    const sha = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345';
+    const out = sanitizeGiteaErrorBody(`commit ${sha} not found in repository`);
+    expect(out).toContain(sha);
+    expect(out).not.toContain('[REDACTED]');
+  });
+
+  it('preserves a long trace ID that is not credential-adjacent', () => {
+    const traceId = 'req-1234567890abcdef1234567890abcdef';
+    const out = sanitizeGiteaErrorBody(`request ${traceId} timed out after 30s`);
+    expect(out).toContain(traceId);
+  });
+
+  it('still redacts a 40+ char blob when it IS credential-adjacent (belt-and-suspenders)', () => {
+    // The second pattern catches a bare long run (40+ chars, PAT/JWT/base64url
+    // shape) ONLY when near a credential keyword — covers `<keyword>: <blob>`
+    // echoes the first regex missed (e.g. `X-Auth-Token: <blob>` or
+    // `secret:"<blob>"`). Below 40 chars the run is ambiguous and left intact.
+    const blob = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij1234'; // 40 chars
+    expect(blob.length).toBe(40);
+    const out = sanitizeGiteaErrorBody(`auth: ${blob} for user x`);
+    expect(out).not.toContain(blob);
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('truncates bodies longer than 200 chars', () => {
+    const out = sanitizeGiteaErrorBody('x'.repeat(500));
+    expect(out.length).toBeLessThanOrEqual(201);
+  });
+});
+
+describe('stripTokens — redaction without truncation', () => {
+  it('preserves short token-free strings unchanged', () => {
+    expect(stripTokens('not found')).toBe('not found');
+  });
+
+  it('is idempotent (running twice gives the same result as once)', () => {
+    const input = 'Authorization: token abc123def456ghi789jkl012mno345pqr678';
+    const once = stripTokens(input);
+    const twice = stripTokens(once);
+    expect(twice).toBe(once);
+  });
+});

--- a/tests/unit/scripts/ingest-gitea-wiki.test.ts
+++ b/tests/unit/scripts/ingest-gitea-wiki.test.ts
@@ -1,0 +1,280 @@
+// @MX:NOTE [AUTO] Unit tests for scripts/ingest-gitea-wiki.ts (Issue #155 AC3).
+// @MX:SPEC SPEC-REGULA-KNOWLEDGE-GAP-001 AC3
+// @MX:REASON Verifies the hardened fetch path:
+//   (a) GraphQL query is POSTed to {GITEA_URL}/api/graphql with `token <T>` auth.
+//   (b) A 500 response triggers withRetry (fetch is called >1x).
+//   (c) The final thrown error contains NO raw upstream body and NO token —
+//       even when the upstream body echoes the Authorization header.
+//   (d) A 200 response inserts one source + one sourceSections row with
+//       provenance fields populated.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// withRetry uses real setTimeout for exponential backoff (1s + 2s + 4s on the
+// default config). Fake timers let us fast-forward those delays so the test
+// stays well under the 5s vitest default.
+
+// --- Mocks -------------------------------------------------------------
+
+// Capture every fetch invocation so we can assert URL + headers + retry count.
+const fetchMock = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', fetchMock);
+
+// DB mock — records inserts so we can assert provenance fields.
+const insertMocks = vi.hoisted(() => ({
+  sources: [] as Array<Record<string, unknown>>,
+  sections: [] as Array<Record<string, unknown>>,
+}));
+vi.mock('../../../lib/db/client', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(async () => []) })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((row: Record<string, unknown>) => {
+        // Distinguish sources vs sourceSections by inspecting the row shape.
+        if ('sourceId' in row || 'anchor' in row) {
+          insertMocks.sections.push(row);
+        } else {
+          insertMocks.sources.push(row);
+        }
+        return { returning: vi.fn(async () => [{ id: 'src-uuid-1' }]) };
+      }),
+    })),
+  },
+  withTenantScope: vi.fn(),
+}));
+
+vi.mock('../../../lib/observability/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Stub getEnv so the script doesn't read the real process.env at test time.
+const ENV_VALUES = vi.hoisted(() => ({
+  GITEA_URL: 'https://gitea.example.com',
+  GITEA_TOKEN: 'super-secret-gitea-read-token',
+  GITEA_WIKI_REPO: 'DR_RnD/ra-llm-wiki',
+  GITEA_ISSUE_TOKEN: undefined as string | undefined,
+  GITEA_ISSUE_REPO: undefined as string | undefined,
+}));
+vi.mock('../../../lib/env', () => ({
+  getEnv: () => ({ ...ENV_VALUES }),
+}));
+
+// The chunker returns deterministic chunks so we don't need to mock embeddings.
+vi.mock('../../../lib/ingest/chunkers/generic', () => ({
+  makeGenericChunker: () => (text: string) => [
+    {
+      text,
+      metadata: { sectionPath: 'Wiki Page' },
+    },
+  ],
+}));
+
+// computeHash is imported from seed-local-docs which itself imports the DB.
+// Mock the whole module so we don't trigger its side effects.
+vi.mock('../../../scripts/seed-local-docs', () => ({
+  computeHash: (s: string) => `hash-${s.length}`,
+}));
+
+// --- Tests -------------------------------------------------------------
+
+// The sanitizer was extracted to a shared module (L-1 dedup) so the read and
+// issue-write paths cannot drift. The security invariant is owned by the
+// shared module; the existing sanitizer tests still cover it.
+import { sanitizeGiteaErrorBody } from '../../../lib/gitea/sanitize';
+import { fetchGiteaWikiPages, ingestGiteaWiki } from '../../../scripts/ingest-gitea-wiki';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function wikiResponse(): unknown {
+  return {
+    data: {
+      repository: {
+        wiki: {
+          pages: {
+            nodes: [
+              {
+                path: 'Home.md',
+                sha: 'abc123',
+                content: '# Home\n\nWelcome to the RA wiki.',
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('ingest-gitea-wiki — AC3 hardened fetch path', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    insertMocks.sources = [];
+    insertMocks.sections = [];
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('posts the GraphQL query to {GITEA_URL}/api/graphql with `token <T>` auth', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(wikiResponse()));
+
+    await fetchGiteaWikiPages();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://gitea.example.com/api/graphql');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('token super-secret-gitea-read-token');
+    expect(headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(init.body as string) as { query: string };
+    expect(body.query).toContain('repository');
+    expect(body.query).toContain('DR_RnD');
+    expect(body.query).toContain('ra-llm-wiki');
+  });
+
+  it('retries on 500 (fetch called >1x) and the final error contains NO raw body and NO token', async () => {
+    // Gitea error body that maliciously echoes the Authorization header —
+    // a real observed behavior. The thrown error MUST scrub both the token
+    // and the bulk of the raw body.
+    //
+    // withRetry invokes the closure up to 3 times per fetchGiteaWikiPages call,
+    // sleeping 1s + 2s between attempts. Fake timers fast-forward those sleeps.
+    // Each fetch needs its own Response because a Body can only be read once.
+    const leakingBody = 'Authorization: token super-secret-gitea-read-token details follow';
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(leakingBody, { status: 500, headers: { 'Content-Type': 'text/plain' } }),
+    );
+
+    // Kick off the promise, then advance timers so the backoff sleeps resolve.
+    const p = expect(fetchGiteaWikiPages()).rejects.toThrow(/Gitea API error: 500/);
+    await vi.runAllTimersAsync();
+    await p;
+
+    // withRetry attempted 3 times (default maxAttempts) on this invocation.
+    expect(fetchMock.mock.calls.length).toBe(3);
+
+    // Inspect the thrown message: token substring must NOT appear.
+    fetchMock.mockClear();
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(leakingBody, { status: 500, headers: { 'Content-Type': 'text/plain' } }),
+    );
+    const p2 = fetchGiteaWikiPages().catch((err: Error) => err);
+    await vi.runAllTimersAsync();
+    const err = await p2;
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).not.toContain('super-secret-gitea-read-token');
+    expect(msg).not.toContain('token super-secret');
+  });
+
+  it('on 200, inserts a source row and a sourceSections row with provenance fields', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(wikiResponse()));
+
+    await ingestGiteaWiki();
+
+    // One source row inserted (no existing source matched the select mock).
+    expect(insertMocks.sources.length).toBe(1);
+    const src = insertMocks.sources[0];
+    expect(src).toBeDefined();
+    expect(src).toMatchObject({
+      sourceHost: 'gitea.example.com',
+      sourceOwner: 'DR_RnD',
+      sourceRepo: 'ra-llm-wiki',
+      sourceBranch: 'main',
+      sourcePath: 'wiki',
+      authorityGrade: 'internal_sop',
+      region: 'KR',
+    });
+    expect(src?.url).toBe('https://gitea.example.com/DR_RnD/ra-llm-wiki/wiki');
+
+    // One section row per page with provenance + ingestionRunId.
+    expect(insertMocks.sections.length).toBe(1);
+    const sec = insertMocks.sections[0];
+    expect(sec).toBeDefined();
+    expect(sec).toMatchObject({
+      chunkHash: expect.any(String),
+      sectionPath: 'Home.md#0',
+    });
+    expect(sec?.ingestionRunId).toEqual(expect.any(String));
+  });
+});
+
+// Dedicated tests for the sanitizer — the token-leak guard is the security
+// invariant of this module and must hold independent of fetch plumbing.
+describe('sanitizeGiteaErrorBody — token-leak guard', () => {
+  it('strips `Authorization: token <T>` spans', () => {
+    const out = sanitizeGiteaErrorBody('Authorization: token abc123def456ghi789jkl012mno345');
+    expect(out).not.toContain('abc123def456ghi789jkl012mno345');
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('strips `Bearer <T>` spans', () => {
+    const out = sanitizeGiteaErrorBody('header=Bearer ZY9876543210abcdefghij');
+    expect(out).not.toContain('ZY9876543210abcdefghij');
+  });
+
+  it('truncates bodies longer than 200 chars', () => {
+    const long = 'x'.repeat(500);
+    const out = sanitizeGiteaErrorBody(long);
+    expect(out.length).toBeLessThanOrEqual(201); // 200 + ellipsis char
+  });
+
+  it('preserves short, token-free bodies unchanged', () => {
+    expect(sanitizeGiteaErrorBody('not found')).toBe('not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H-1: read-path SSRF guard — same policy as the issue-write path.
+// Previously the read path had no guard while the issue path did, an
+// incoherent policy for the same GITEA_URL env var. The read PAT is no
+// less sensitive than the write PAT; both travel as Authorization headers.
+// ---------------------------------------------------------------------------
+describe('fetchGiteaWikiPages — SSRF guard on the read path (H-1)', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects a public http GITEA_URL without ever calling fetch (token never sent)', async () => {
+    const previousUrl = ENV_VALUES.GITEA_URL;
+    ENV_VALUES.GITEA_URL = 'http://evil.example.com';
+    try {
+      await expect(fetchGiteaWikiPages()).rejects.toThrow(/SSRF guard/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      ENV_VALUES.GITEA_URL = previousUrl;
+    }
+  });
+
+  it('allows an internal http GITEA_URL (diskstation LAN host) and proceeds to fetch', async () => {
+    const previousUrl = ENV_VALUES.GITEA_URL;
+    ENV_VALUES.GITEA_URL = 'http://diskstation:7001';
+    fetchMock.mockResolvedValueOnce(jsonResponse(wikiResponse()));
+    try {
+      await fetchGiteaWikiPages();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://diskstation:7001/api/graphql');
+    } finally {
+      ENV_VALUES.GITEA_URL = previousUrl;
+    }
+  });
+});


### PR DESCRIPTION
## 개요
#158 후속 백엔드 마지막 #155. Gitea ingestion hardening + Gitea issue provider (#157 router 확장).

## 변경
- **AC3 (ingestion hardening)**: `ingest-gitea-wiki.ts` withRetry + sanitized error.
- **AC4 (Gitea issue 생성)**: provider dispatch + Gitea dialect (`/api/v1/repos/{repo}/issues`, `token <T>`, `{name}` labels, `html_url`). degrade-to-queue.
- **SSRF (C-1/H-1)**: `lib/gitea/url-guard.ts` — `isInternalHost`(localhost/diskstation/.local/.internal/private IP) + `assertGiteaUrlAllowed`. read+issue 양 경로 동일 정책. AWS metadata reject. 실제 `http://diskstation:7001` 허용.
- **sanitizer (M-1/L-1)**: `lib/gitea/sanitize.ts` shared — keyword-adjacent 40+ (SHA 보존, Bearer redact), dependency-free.
- **token 분리 (AC5)**: `GITEA_ISSUE_TOKEN`(write) / `GITEA_TOKEN`(read).
- **AC1/AC6**: docs(env-matrix + 운영_SOP) + tests(env/ingest-gitea-wiki/issue-provider/url-guard).

## 게이트 직검 (L-007/008)
- typecheck: exit 0 / lint (biome+lint:hex): exit 0 (import 정렬 fix 후) / test FULL: exit 0 · **4638 passed | 21 skipped**
- migration: 없음 (stateless, #157 컬럼 재사용)
- build: skip (next dev, L-012)

## 보안 리뷰
expert-security 1차 **BLOCK-MERGE**(C-1 internal Gitea reject + H-1 정책 불일치) → fix → **재리뷰 PASS**.

Fixes #155. tracking: #158