### PR TITLE
fix(seed): #284 — viewer@example.test password_hash 누락 복구 (Credentials 로그인)

### DIFF
--- a/scripts/seed-test-db.ts
+++ b/scripts/seed-test-db.ts
@@ -51,7 +51,7 @@ async function main(): Promise<void> {
           ),
           (
             ${VIEWER_ID}, 'viewer@example.test', 'Viewer', 'viewer', 'en', 'system', 'External',
-            null, 'active', false
+            ${passwordHash}, 'active', false
           ),
           (
             ${ADMIN_ID}, 'admin@example.test', 'Admin', 'admin', 'ko', 'system', 'RA',


### PR DESCRIPTION
## #284 — viewer@example.test password_hash 누락 복구

### 원인
`scripts/seed-test-db.ts` viewer INSERT에서 `password_hash`가 `null` 하드코딩. `lib/auth.ts:54-56` Credentials provider가 `!password_hash` 시 로그인 거부 → viewer Credentials 로그인 불가 (ra.lead/admin/evaluator는 정상).

### 수정
1줄: `null` → `${passwordHash}` (E2E 공통 해시). `ON CONFLICT` 재실행으로 기존 DB도 자동 복원.

### 게이트 직견 (L-007/008/009/012)
- typecheck: exit 0
- lint (biome + lint:hex): error 0 (warnings 2 pre-existing)
- full test: **4638 passed | 21 skipped · 0 failed** (회귀 0)
- build: skip (next dev 구동 중, L-012)

### 회귀 리스크
매우 낮음 — seed 스크립트 1줄, 프로덕션 코드 변경 0.

Fixes #284