### PR TITLE
fix(migrations): #280 — dhf/esubmit org_id text→uuid FK fix-up (6 테이블)

### DIFF
--- a/migrations/0092_fixup_dhf_esubmit_text_uuid.sql
+++ b/migrations/0092_fixup_dhf_esubmit_text_uuid.sql
@@ -1,0 +1,168 @@
+-- Migration: Fix-up — design_history_files + submission_packages text-vs-uuid FK mismatch
+-- SPEC: SPEC-REGULA-MIGRATION-FIXUP-0092 (Issue #280 follow-up; L-010/L-011)
+-- Scope:
+--   1. design_history_files.org_id: text -> uuid (FK to organizations.id which is uuid)
+--   2. design_history_files.created_by: text -> uuid (FK to users.id which is uuid)
+--   3. submission_packages.org_id: text -> uuid (FK to organizations.id which is uuid)
+--   4. submission_packages.created_by: text -> uuid (FK to users.id which is uuid)
+--
+-- Background:
+--   Original migrations 0055 (DHF) and 0056 (eSubmit) both declared their
+--   org-scoping FK columns as `text` while the referent PKs (`organizations.id`,
+--   `users.id`) are `uuid`. PostgreSQL refuses a `text` -> `uuid` FK (type
+--   mismatch), so both CREATE TABLE statements rolled back at runtime, leaving
+--   all 6 tables ABSENT from the production-shaped DB. The textual
+--   enterprise-migrations.test.ts could not catch this because it never
+--   applied the DDL to a real Postgres. This is the SAME bug class as #279
+--   (migrations 0086/0087 fixed by 0089) and #281 (migrations 0082/0054
+--   fixed by 0090). L-010 / L-011 codify the pattern.
+--
+-- Approach:
+--   CREATE TABLE IF NOT EXISTS with the CORRECTED schema only. We do NOT
+--   edit merged migrations 0055/0056. If the tables somehow already exist
+--   (partial apply on a dev DB), the IF NOT EXISTS guard leaves them as-is —
+--   the operator is responsible for dropping the bad tables first. The
+--   canonical schema reproduced below mirrors 0055/0056 verbatim except for
+--   the FK column type fixes, so existing application code and indexes/RLS
+--   policies continue to work unchanged. RLS policies are NOT included in
+--   0055/0056 (applied in later migrations 0083/0084), so this migration
+--   only reproduces the base DDL.
+--
+-- Idempotent: all CREATE INDEX statements use IF NOT EXISTS. Enum values from
+-- 0055 already exist in the DB (ALTER TYPE audit_action ADD VALUE IF NOT EXISTS).
+
+-- -------------------------------------
+-- §1 design_history_files (DHF) — org_id + created_by FIXED to uuid
+-- -------------------------------------
+-- Reproduces 0055_design_history_files.sql §2 verbatim with type fixes.
+-- id stays TEXT (gen_random_uuid()::text) per schema.ts.
+
+CREATE TABLE IF NOT EXISTS design_history_files (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  device_name TEXT NOT NULL,
+  device_model TEXT,
+  intended_use TEXT NOT NULL,
+  jurisdiction TEXT NOT NULL DEFAULT 'FDA' CHECK (jurisdiction IN ('FDA','EU','MFDS','NMPA','PMDA')),
+  regulatory_framework TEXT NOT NULL DEFAULT 'QSR_QMSR' CHECK (regulatory_framework IN ('QSR_QMSR','ISO_13485','EU_MDR')),
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','in_review','design_freeze','archived')),
+  completeness_score INTEGER NOT NULL DEFAULT 0 CHECK (completeness_score >= 0 AND completeness_score <= 100),
+  design_freeze_date DATE,
+  created_by uuid NOT NULL REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dhf_org ON design_history_files(org_id);
+
+-- -------------------------------------
+-- §2 design_inputs — unchanged (dhf_id TEXT matches design_history_files.id TEXT)
+-- -------------------------------------
+-- Reproduces 0055_design_history_files.sql §3 verbatim.
+
+CREATE TABLE IF NOT EXISTS design_inputs (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  dhf_id TEXT NOT NULL REFERENCES design_history_files(id) ON DELETE CASCADE,
+  input_type TEXT NOT NULL CHECK (input_type IN ('user_need','regulatory','standards','risk')),
+  requirement_id TEXT,
+  description TEXT NOT NULL,
+  source TEXT,
+  priority TEXT NOT NULL DEFAULT 'must' CHECK (priority IN ('must','should','nice_to_have')),
+  verification_status TEXT NOT NULL DEFAULT 'pending' CHECK (verification_status IN ('pending','verified','not_applicable')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_design_inputs_dhf ON design_inputs(dhf_id);
+
+-- -------------------------------------
+-- §3 design_verifications — unchanged (dhf_id TEXT, design_input_id TEXT)
+-- -------------------------------------
+-- Reproduces 0055_design_history_files.sql §4 verbatim.
+
+CREATE TABLE IF NOT EXISTS design_verifications (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  dhf_id TEXT NOT NULL REFERENCES design_history_files(id) ON DELETE CASCADE,
+  design_input_id TEXT REFERENCES design_inputs(id),
+  verification_type TEXT NOT NULL CHECK (verification_type IN ('analysis','test','inspection','demonstration')),
+  protocol_title TEXT NOT NULL,
+  result TEXT CHECK (result IN ('pass','fail','pending','not_started')),
+  test_date DATE,
+  performed_by TEXT,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_design_verifications_dhf ON design_verifications(dhf_id);
+
+-- -------------------------------------
+-- §4 design_reviews — unchanged (dhf_id TEXT)
+-- -------------------------------------
+-- Reproduces 0055_design_history_files.sql §5 verbatim.
+
+CREATE TABLE IF NOT EXISTS design_reviews (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  dhf_id TEXT NOT NULL REFERENCES design_history_files(id) ON DELETE CASCADE,
+  review_stage TEXT NOT NULL CHECK (review_stage IN ('concept','preliminary','critical','final','design_freeze')),
+  review_date DATE NOT NULL,
+  attendees TEXT[] NOT NULL DEFAULT '{}',
+  decisions TEXT,
+  open_actions TEXT,
+  approved_by TEXT,
+  approved_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_design_reviews_dhf ON design_reviews(dhf_id);
+
+-- -------------------------------------
+-- §5 submission_packages (eSubmit) — org_id + created_by FIXED to uuid
+-- -------------------------------------
+-- Reproduces 0056_submission_packages.sql verbatim with type fixes.
+-- id stays TEXT (gen_random_uuid()::text) per schema.ts.
+
+CREATE TABLE IF NOT EXISTS submission_packages (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  submission_type TEXT NOT NULL CHECK (submission_type IN ('510k','de_novo','pma','cer','pccp','mfds_import','nmpa_ecdt')),
+  jurisdiction TEXT NOT NULL CHECK (jurisdiction IN ('FDA','EU','MFDS','NMPA','PMDA')),
+  device_name TEXT NOT NULL,
+  submission_number TEXT,
+  version TEXT NOT NULL DEFAULT '1.0',
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','validating','validated','submitted','rta','accepted','rejected')),
+  package_manifest JSONB NOT NULL DEFAULT '{}',
+  validation_results JSONB NOT NULL DEFAULT '[]',
+  created_by uuid NOT NULL REFERENCES users(id),
+  submitted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_submission_packages_org ON submission_packages(org_id);
+
+-- -------------------------------------
+-- §6 submission_interactions — unchanged (package_id TEXT matches submission_packages.id TEXT)
+-- -------------------------------------
+-- Reproduces 0056_submission_packages.sql verbatim.
+
+CREATE TABLE IF NOT EXISTS submission_interactions (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  package_id TEXT NOT NULL REFERENCES submission_packages(id) ON DELETE CASCADE,
+  interaction_type TEXT NOT NULL CHECK (interaction_type IN ('rta','ai_request','deficiency','approval','rejection')),
+  reference_number TEXT,
+  description TEXT NOT NULL,
+  due_date DATE,
+  resolved_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_submission_interactions_pkg ON submission_interactions(package_id);
+
+-- -------------------------------------
+-- §7 DHF audit_action enum values (idempotent)
+-- -------------------------------------
+-- Reproduces 0055_design_history_files.sql §1 verbatim.
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'dhf_created';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'dhf_updated';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'dhf_design_freeze';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'dhf_review_approved';

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -2089,3 +2089,118 @@ describe('Migration 0091: owning-project issue routing (Issue #157)', () => {
     expect(typeValues).toContain('owning_issue_creation_failed');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Migration 0092: design_history_files + submission_packages text-vs-uuid FK fix (Issue #280)
+// ---------------------------------------------------------------------------
+describe('Migration 0092: DHF + eSubmit text-vs-uuid FK fix (Issue #280)', () => {
+  it('migration file 0092_fixup_dhf_esubmit_text_uuid.sql exists', () => {
+    expect(fileExists('migrations/0092_fixup_dhf_esubmit_text_uuid.sql')).toBe(true);
+  });
+
+  it('creates design_history_files with org_id uuid (not text)', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS design_history_files/);
+    expect(sql).toMatch(/org_id uuid NOT NULL REFERENCES organizations\(id\) ON DELETE CASCADE/);
+  });
+
+  it('creates design_history_files with created_by uuid (not text)', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/created_by uuid NOT NULL REFERENCES users\(id\)/);
+  });
+
+  it('creates design_inputs table (dhf_id TEXT matches design_history_files.id TEXT)', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS design_inputs/);
+    expect(sql).toMatch(
+      /dhf_id TEXT NOT NULL REFERENCES design_history_files\(id\) ON DELETE CASCADE/,
+    );
+  });
+
+  it('creates design_verifications table', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS design_verifications/);
+    expect(sql).toMatch(
+      /dhf_id TEXT NOT NULL REFERENCES design_history_files\(id\) ON DELETE CASCADE/,
+    );
+    expect(sql).toMatch(/design_input_id TEXT REFERENCES design_inputs\(id\)/);
+  });
+
+  it('creates design_reviews table', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS design_reviews/);
+    expect(sql).toMatch(
+      /dhf_id TEXT NOT NULL REFERENCES design_history_files\(id\) ON DELETE CASCADE/,
+    );
+  });
+
+  it('creates submission_packages with org_id uuid (not text)', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS submission_packages/);
+    expect(sql).toMatch(/org_id uuid NOT NULL REFERENCES organizations\(id\) ON DELETE CASCADE/);
+  });
+
+  it('creates submission_packages with created_by uuid (not text)', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/created_by uuid NOT NULL REFERENCES users\(id\)/);
+  });
+
+  it('creates submission_interactions table (package_id TEXT matches submission_packages.id TEXT)', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS submission_interactions/);
+    expect(sql).toMatch(
+      /package_id TEXT NOT NULL REFERENCES submission_packages\(id\) ON DELETE CASCADE/,
+    );
+  });
+
+  it('creates all 6 required indexes with IF NOT EXISTS', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_dhf_org ON design_history_files\(org_id\)/);
+    expect(sql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_design_inputs_dhf ON design_inputs\(dhf_id\)/,
+    );
+    expect(sql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_design_verifications_dhf ON design_verifications\(dhf_id\)/,
+    );
+    expect(sql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_design_reviews_dhf ON design_reviews\(dhf_id\)/,
+    );
+    expect(sql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_submission_packages_org ON submission_packages\(org_id\)/,
+    );
+    expect(sql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_submission_interactions_pkg ON submission_interactions\(package_id\)/,
+    );
+  });
+
+  it('adds 4 DHF audit_action enum values with IF NOT EXISTS', () => {
+    const sql = readText('migrations/0092_fixup_dhf_esubmit_text_uuid.sql');
+    expect(sql).toMatch(/ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'dhf_created'/);
+    expect(sql).toMatch(/ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'dhf_updated'/);
+    expect(sql).toMatch(/ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'dhf_design_freeze'/);
+    expect(sql).toMatch(/ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'dhf_review_approved'/);
+  });
+
+  it('schema.ts designHistoryFiles matches migration (org_id uuid, created_by uuid)', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain("orgId: uuid('org_id')");
+    expect(src).toContain("createdBy: uuid('created_by')");
+  });
+
+  it('schema.ts submissionPackages matches migration (org_id uuid, created_by uuid)', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain("orgId: uuid('org_id')");
+    expect(src).toContain("createdBy: uuid('created_by')");
+  });
+
+  it('schema.ts designInputs/designVerifications/designReviews match migration', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain("dhfId: text('dhf_id')");
+    expect(src).toContain("designInputId: text('design_input_id')");
+  });
+
+  it('schema.ts submissionInteractions matches migration (package_id TEXT)', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain("packageId: text('package_id')");
+  });
+});


### PR DESCRIPTION
## #280 — design_history_files·submission_packages org_id text→uuid FK fix-up

### 원인 (직견)
migrations 0055 + 0056이 6 테이블(design_history_files·design_inputs·design_verifications·design_reviews·submission_packages·submission_interactions)의 org_id/created_by를 TEXT로 선언 → organizations.id/users.id(uuid) FK type mismatch → CREATE rollback → 6 테이블 부재 → **LIVE 11 라우트**(/api/ra/dhf/*, /api/ra/esubmit/*) 500. #281(0090)에서 answer_feedback/samd_assessments만 처리, dhf/esubmit 누락 — 동일 버그 클래스. schema.ts는 이미 uuid().

### 수정
migration 0092_fixup_dhf_esubmit_text_uuid.sql (CREATE TABLE IF NOT EXISTS, 0090 패턴):
- design_history_files: org_id·created_by uuid (id text 유지)
- submission_packages: org_id·created_by uuid (id text 유지)
- design_inputs/verifications/reviews, submission_interactions: 원본 그대로(dhf_id/package_id text)
- 인덱스 6 IF NOT EXISTS, dhf audit_action enum 4종 IF NOT EXISTS
원본 0055/0056 미수정(merged 기록 보존). enterprise-migrations.test.ts: 0092 describe 13 cases 추가.

### 게이트 직견 (오케스트레이터, L-007/008/009/010/012)
- typecheck: exit 0
- lint (biome + lint:hex): **error 0** (warnings 2 pre-existing)
- full test: **4653 passed | 21 skipped · 0 failed** (+15 vs main 4638)
- build: skip (next dev 구동 중, L-012)
- 실DB 적용 (regula-test-db 컨테이너, L-010): 6 테이블 생성 + org_id/created_by uuid 직견 ✅

### 회귀 리스크
낮음 — migration CREATE only(데이터 파괴 0), LIVE route 500→정상 복구.

Fixes #280