### PR TITLE
feat(rlhf): #264 sub-PR 1/3 — quality_tag enum +4 (confidence-breakdown)

### DIFF
--- a/app/api/rlhf/feedback/route.ts
+++ b/app/api/rlhf/feedback/route.ts
@@ -28,8 +28,8 @@ import { emitFeedbackEvent } from '@/lib/rlhf/langfuse-emitter';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
-/** REQ-RLHF-002 / AC-02: EXACTLY 8 quality tag values. */
-const QUALITY_TAGS_8 = [
+/** REQ-RLHF-002 / AC-02: 12 quality tag values (8 original + 4 Issue-264 breakdown). */
+const QUALITY_TAGS_12 = [
   'citation_missing',
   'citation_wrong',
   'answer_incomplete',
@@ -38,10 +38,14 @@ const QUALITY_TAGS_8 = [
   'jurisdiction_mismatch',
   'helpful',
   'excellent',
+  'citation_coverage_low',
+  'source_recency_stale',
+  'source_authority_weak',
+  'source_agreement_conflict',
 ] as const;
 
 /**
- * AC-02 invariant: the zod schema rejects any tag outside the 8-value enum.
+ * AC-02 invariant: the zod schema rejects any tag outside the 12-value enum.
  * The literal tuple (not a string[]) keeps the type narrow so TypeScript also
  * enforces exhaustiveness at compile time.
  *
@@ -52,7 +56,7 @@ const QUALITY_TAGS_8 = [
 const FeedbackRequestSchema = z.object({
   messageId: z.string().uuid(),
   rating: z.enum(['up', 'down']),
-  qualityTags: z.array(z.enum(QUALITY_TAGS_8)).default([]),
+  qualityTags: z.array(z.enum(QUALITY_TAGS_12)).default([]),
   comment: z.string().max(2000).nullable().default(null),
   /** @deprecated client-supplied redactedQuestion — server re-redacts from source. */
   redactedQuestion: z.string().max(500).optional(),

--- a/components/answer-block/__tests__/feedback-control.test.tsx
+++ b/components/answer-block/__tests__/feedback-control.test.tsx
@@ -39,7 +39,7 @@ describe('FeedbackControl (REQ-RLHF-003, AC-01)', () => {
     expect(screen.queryAllByRole('button', { name: /출처 누락/ }).length).toBe(0);
   });
 
-  it('shows 8 quality tags after selecting a rating', () => {
+  it('shows 12 quality tags after selecting a rating', () => {
     render(<FeedbackControl messageId="00000000-0000-0000-0000-000000000001" />);
     fireEvent.click(screen.getByRole('button', { name: '아쉬워요' }));
     expect(screen.getByTestId('feedback-tag-citation_missing')).toBeDefined();
@@ -47,7 +47,7 @@ describe('FeedbackControl (REQ-RLHF-003, AC-01)', () => {
     const tagButtons = screen
       .getAllByRole('button')
       .filter((b) => b.dataset.testid?.startsWith('feedback-tag-'));
-    expect(tagButtons.length).toBe(8);
+    expect(tagButtons.length).toBe(12);
   });
 
   it('submits up-rating feedback with selected tags and forwards the messageId', async () => {

--- a/components/answer-block/feedback-control.tsx
+++ b/components/answer-block/feedback-control.tsx
@@ -5,7 +5,7 @@
 //
 // Architecture: client island rendered below the AnswerBlock prose. The userId
 // is resolved server-side at the API boundary (session.user.id) so this client
-// never handles credentials. qualityTags is limited to the 8-value enum via
+// never handles credentials. qualityTags is limited to the 12-value enum via
 // strict TypeScript + the API re-validates with zod (AC-02). The low-rated
 // acknowledgement surfaces REQ-RLHF-007 (knowledge-gap bridge) without any
 // client-side issue creation.
@@ -13,8 +13,8 @@
 import { ThumbsDown, ThumbsUp } from 'lucide-react';
 import { useState } from 'react';
 
-/** REQ-RLHF-002 / AC-02: EXACTLY 8 quality tag values (frozen enum). */
-export const QUALITY_TAGS_8 = [
+/** REQ-RLHF-002 / AC-02: 12 quality tag values (8 original + 4 Issue-264 breakdown). */
+export const QUALITY_TAGS_12 = [
   'citation_missing',
   'citation_wrong',
   'answer_incomplete',
@@ -23,9 +23,14 @@ export const QUALITY_TAGS_8 = [
   'jurisdiction_mismatch',
   'helpful',
   'excellent',
+  // #264 confidence-breakdown dimensions (sub-PR 1/3):
+  'citation_coverage_low',
+  'source_recency_stale',
+  'source_authority_weak',
+  'source_agreement_conflict',
 ] as const;
 
-export type QualityTag = (typeof QUALITY_TAGS_8)[number];
+export type QualityTag = (typeof QUALITY_TAGS_12)[number];
 
 const TAG_LABELS: Record<QualityTag, string> = {
   citation_missing: '출처 누락',
@@ -36,6 +41,11 @@ const TAG_LABELS: Record<QualityTag, string> = {
   jurisdiction_mismatch: '관할권 불일치',
   helpful: '유용함',
   excellent: '우수함',
+  // #264 confidence-breakdown labels:
+  citation_coverage_low: '인용 커버리지 낮음',
+  source_recency_stale: '출처 최신성 낮음',
+  source_authority_weak: '출처 권위 약함',
+  source_agreement_conflict: '출처 간 충돌',
 };
 
 /**
@@ -48,6 +58,11 @@ const GAP_SIGNAL_TAGS: ReadonlySet<QualityTag> = new Set<QualityTag>([
   'answer_wrong',
   'outdated_info',
   'jurisdiction_mismatch',
+  // #264 confidence-breakdown dimensions — all low-quality gap signals:
+  'citation_coverage_low',
+  'source_recency_stale',
+  'source_authority_weak',
+  'source_agreement_conflict',
 ]);
 
 interface FeedbackControlProps {
@@ -165,7 +180,7 @@ export function FeedbackControl({ messageId, redactedQuestion }: FeedbackControl
           <fieldset className="flex flex-col gap-2" aria-label="품질 태그">
             <legend className="sr-only">품질 태그 (여러 개 선택 가능)</legend>
             <div className="flex flex-wrap gap-1.5">
-              {QUALITY_TAGS_8.map((tag) => {
+              {QUALITY_TAGS_12.map((tag) => {
                 const active = selectedTags.includes(tag);
                 return (
                   <button

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -439,8 +439,9 @@ export const sourceApprovalStatusEnum = pgEnum('source_approval_status', [
 // @MX:REASON Drizzle pgEnum mirrors the SQL types created in 0082_rlhf.sql.
 // Keep in lock-step with the migration or runtime inserts fail.
 // feedback_rating: thumb up/down (REQ-RLHF-001).
-// quality_tag: EXACTLY 8 values — Issue #56 comment extras are deferred to a
-//              follow-up (RLHF-v2). Do NOT expand without a SPEC amendment.
+// quality_tag: 12 values — 8 original (Issue #56) + 4 confidence-breakdown
+//              dimensions (Issue #264 follow-up, sub-PR 1/3). Keep in lock-step
+//              with migration 0082 (CREATE TYPE) + 0093 (ALTER TYPE ADD VALUE).
 export const feedbackRatingEnum = pgEnum('feedback_rating', ['up', 'down']);
 export const qualityTagEnum = pgEnum('quality_tag', [
   'citation_missing',
@@ -451,6 +452,11 @@ export const qualityTagEnum = pgEnum('quality_tag', [
   'jurisdiction_mismatch',
   'helpful',
   'excellent',
+  // #264 confidence-breakdown dimensions (sub-PR 1/3):
+  'citation_coverage_low',
+  'source_recency_stale',
+  'source_authority_weak',
+  'source_agreement_conflict',
 ]);
 
 // @MX:NOTE [AUTO] Knowledge promotion enum — SPEC-REGULA-KNOWLEDGE-PROMO-001 (Issue #50).

--- a/lib/rlhf/gap-promo-bridge.ts
+++ b/lib/rlhf/gap-promo-bridge.ts
@@ -24,6 +24,11 @@ export const LOW_RATED_TAGS = new Set([
   'answer_wrong',
   'outdated_info',
   'jurisdiction_mismatch',
+  // #264 confidence-breakdown dimensions — all low-quality signals (REQ-RLHF-007):
+  'citation_coverage_low',
+  'source_recency_stale',
+  'source_authority_weak',
+  'source_agreement_conflict',
 ]);
 
 /** Quality tags that mark an answer as high-rated (REQ-RLHF-008). */

--- a/migrations/0093_rlhf_quality_tags_plus4.sql
+++ b/migrations/0093_rlhf_quality_tags_plus4.sql
@@ -1,0 +1,29 @@
+-- Migration: RLHF quality_tag enum +4 (confidence-breakdown dimensions)
+-- SPEC: SPEC-REGULA-RLHF-001 (REQ-RLHF-002 extension, Issue #264 sub-PR 1/3)
+-- Scope: ALTER TYPE quality_tag ADD VALUE x4 (idempotent IF NOT EXISTS)
+--   - citation_coverage_low
+--   - source_recency_stale
+--   - source_authority_weak
+--   - source_agreement_conflict
+--
+-- Background:
+--   Issue #264 follow-up — the 8-value enum (migration 0082 §1) is extended
+--   with 4 confidence-breakdown dimensions aligned with the [Confidence Explain]
+--   direction. The original 0082 is NOT edited (merged record); this migration
+--   is additive only. The Drizzle pgEnum (lib/db/schema.ts qualityTagEnum) and
+--   the client/server validators (feedback-control.tsx, /api/rlhf/feedback) are
+--   expanded in lock-step.
+--
+-- Approach:
+--   ALTER TYPE ... ADD VALUE IF NOT EXISTS. Idempotent — safe to re-run. Each
+--   statement runs outside a transaction block (Postgres requirement for
+--   ADD VALUE); psql autocommit handles this when applied via `cat | psql`.
+--
+-- Note: ALTER TYPE ADD VALUE cannot run inside a transaction. Apply via
+--   `cat migrations/0093_rlhf_quality_tags_plus4.sql | psql ... -v ON_ERROR_STOP=1`
+-- (NOT via a multi-statement transaction wrapper).
+
+ALTER TYPE quality_tag ADD VALUE IF NOT EXISTS 'citation_coverage_low';
+ALTER TYPE quality_tag ADD VALUE IF NOT EXISTS 'source_recency_stale';
+ALTER TYPE quality_tag ADD VALUE IF NOT EXISTS 'source_authority_weak';
+ALTER TYPE quality_tag ADD VALUE IF NOT EXISTS 'source_agreement_conflict';

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -2204,3 +2204,30 @@ describe('Migration 0092: DHF + eSubmit text-vs-uuid FK fix (Issue #280)', () =>
     expect(src).toContain("packageId: text('package_id')");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Migration 0093: RLHF quality_tag enum +4 confidence-breakdown (Issue #264 sub-PR 1/3)
+// ---------------------------------------------------------------------------
+describe('Migration 0093: RLHF quality_tag +4 confidence-breakdown (Issue #264)', () => {
+  it('migration file 0093_rlhf_quality_tags_plus4.sql exists', () => {
+    expect(fileExists('migrations/0093_rlhf_quality_tags_plus4.sql')).toBe(true);
+  });
+
+  it('adds 4 quality_tag enum values with ALTER TYPE IF NOT EXISTS', () => {
+    const sql = readText('migrations/0093_rlhf_quality_tags_plus4.sql');
+    expect(sql).toMatch(/ALTER TYPE quality_tag ADD VALUE IF NOT EXISTS 'citation_coverage_low'/);
+    expect(sql).toMatch(/ALTER TYPE quality_tag ADD VALUE IF NOT EXISTS 'source_recency_stale'/);
+    expect(sql).toMatch(/ALTER TYPE quality_tag ADD VALUE IF NOT EXISTS 'source_authority_weak'/);
+    expect(sql).toMatch(
+      /ALTER TYPE quality_tag ADD VALUE IF NOT EXISTS 'source_agreement_conflict'/,
+    );
+  });
+
+  it('schema.ts qualityTagEnum matches migration (12 values, #264 breakdown)', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toContain("'citation_coverage_low'");
+    expect(src).toContain("'source_recency_stale'");
+    expect(src).toContain("'source_authority_weak'");
+    expect(src).toContain("'source_agreement_conflict'");
+  });
+});


### PR DESCRIPTION
## #264 sub-PR 1/3 — quality_tag enum +4 confidence-breakdown

이슈 #264(qualityTags+4 · calibration · alternate-answers) 중 **회귀 낮은 enum 확장**부터.

### 변경
- `quality_tag` enum 8→12: `citation_coverage_low`, `source_recency_stale`, `source_authority_weak`, `source_agreement_conflict` (confidence breakdown 차원)
- schema.ts + migration 0093 (ALTER TYPE ADD VALUE IF NOT EXISTS x4) + feedback route zod 검증 + FeedbackControl UI(라벨+GAP_SIGNAL) + gap-promo-bridge LOW_RATED_TAGS

### 게이트 직견 (오케스트레이터)
- typecheck: exit 0
- lint (biome + lint:hex): **error 0** (warnings 2 pre-existing; `#264` hex 오탐 → `Issue-264` 교정, L-008)
- full test: **4656 passed | 21 skipped · 0 failed** (+3)
- build: skip (next dev, L-012)
- 실DB (regula-test-db, L-010): ALTER TYPE x4 적용 + quality_tag 12값 직견 ✅

### 잔존 (별도 PR)
#264 sub 2/3 confidence calibration 재학습 루프, sub 3/3 alternate answers implicit feedback. 본 PR은 부분 → Refs #264 (이슈 OPEN 유지).

Refs #264