### PR TITLE
feat(rlhf): #264 sub-PR 2/3 — confidence calibration 검출/제안 루프

### DIFF
--- a/app/api/rlhf/calibration/route.ts
+++ b/app/api/rlhf/calibration/route.ts
@@ -1,0 +1,81 @@
+// @MX:NOTE [AUTO] GET /api/rlhf/calibration — confidence-calibration detection view.
+// @MX:SPEC SPEC-REGULA-RLHF-001 (Issue #264 sub-PR 2/3, REQ-RLHF-005/006/014/015)
+// @MX:REASON Surfaces confidence-bucket × observed-feedback aggregates + the
+//           detector's candidate list (overconfident / underconfident buckets)
+//           for RA-Lead review. Reuses rlhf.feedback RBAC (ra-member+) — no
+//           new permission action. RLS is inert project-wide (#239 debt), so
+//           org isolation is enforced at the query layer via the
+//           messages -> conversations -> projects 3-hop join scoped to the
+//           caller's orgId (mirrors heatmap / feedback-aggregate routes).
+//
+// Charter [지양-2]/[지양-4]: this route is DETECTION + VIEW only. It does NOT
+// persist candidates (no write on GET). Candidate persistence happens via a
+// POST follow-up that an RA Lead triggers after reviewing the aggregates.
+
+import { withPermission } from '@/lib/auth/with-permission';
+import { withTenantScope } from '@/lib/db/client';
+import { answerFeedback, conversations, messages, projects } from '@/lib/db/schema';
+import {
+  type ConfidenceFeedbackSample,
+  aggregateConfidenceFeedback,
+  detectCalibrationCandidates,
+} from '@/lib/rlhf/calibration-detector';
+import { eq } from 'drizzle-orm';
+
+/**
+ * REQ-RLHF-005/006: return per-bucket confidence × feedback aggregates and
+ * the detector's candidate list for the caller's org.
+ */
+export const GET = withPermission('rlhf.feedback', async (request, _ctx, session) => {
+  const url = new URL(request.url);
+  const minSampleSize = Number(url.searchParams.get('minSampleSize') ?? '5');
+  const maxTolerance = Number(url.searchParams.get('maxTolerance') ?? '0.15');
+
+  const orgId = session.user.organizationId ?? '';
+  if (!orgId) {
+    return Response.json({ error: 'no_org_context' }, { status: 403 });
+  }
+
+  // C-2 IDOR: scope to the caller's org via the 3-hop join so NO cross-org
+  // feedback rows are returned. #239 Phase 2: withTenantScope sets the
+  // app.current_org_id GUC for RLS enforce; app-level eq(projects.organizationId)
+  // is retained as defense-in-depth (RLS inert until service-role bypass dropped).
+  const rows = await withTenantScope(orgId, async (dbs) =>
+    dbs
+      .select({
+        confidenceScore: messages.confidenceScore,
+        rating: answerFeedback.rating,
+      })
+      .from(answerFeedback)
+      .innerJoin(messages, eq(messages.id, answerFeedback.messageId))
+      .innerJoin(conversations, eq(conversations.id, messages.conversationId))
+      .innerJoin(projects, eq(projects.id, conversations.projectId))
+      .where(eq(projects.organizationId, orgId)),
+  );
+
+  // Project to the detector's sample shape. confidence_score is numeric(4,3)
+  // so Drizzle returns it as a string; parse to number. null/NaN confidence
+  // is passed through — aggregateConfidenceFeedback drops unbucketable samples.
+  const samples: ConfidenceFeedbackSample[] = rows.map((r) => {
+    const raw = r.confidenceScore;
+    const n = raw === null || raw === undefined ? null : Number(raw);
+    return {
+      confidence: n !== null && Number.isFinite(n) ? n : null,
+      rating: r.rating,
+    };
+  });
+
+  const aggregates = aggregateConfidenceFeedback(samples);
+  const candidates = detectCalibrationCandidates(samples, {
+    minSampleSize: Number.isFinite(minSampleSize) ? minSampleSize : undefined,
+    maxTolerance: Number.isFinite(maxTolerance) ? maxTolerance : undefined,
+  });
+
+  return Response.json({
+    orgId,
+    aggregates,
+    candidates,
+    sampledAt: new Date().toISOString(),
+    thresholds: { minSampleSize, maxTolerance },
+  });
+});

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -429,7 +429,12 @@ export type AuditAction =
   //   owning_issue_created          — owning issue opened in target repo (ra-project/MD-process/gitea-wiki/hybrid-ra-saas)
   //   owning_issue_creation_failed  — retry exhausted, degraded to queue, capture not aborted
   | 'owning_issue_created'
-  | 'owning_issue_creation_failed';
+  | 'owning_issue_creation_failed'
+  // SPEC-REGULA-RLHF-001 — Issue #264 sub-PR 2/3, added via 0095_rlhf_calibration_candidates.sql.
+  // rlhf.calibration_proposed: a confidence-calibration candidate was detected
+  // and written as status=pending for RA-Lead governance review. Mirrors
+  // `reranking_proposed` naming — a PENDING proposal, NEVER an applied change.
+  | 'rlhf.calibration_proposed';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -412,6 +412,12 @@ export const auditActionEnum = pgEnum('audit_action', [
   //   owning_issue_creation_failed  — 3x retry exhausted; queue row stays in queued state
   'owning_issue_created',
   'owning_issue_creation_failed',
+  // SPEC-REGULA-RLHF-001 — Issue #264 sub-PR 2/3, added via 0095_rlhf_calibration_candidates.sql.
+  // rlhf.calibration_proposed: a confidence-calibration candidate was detected
+  // and written as status=pending for RA-Lead governance review (REQ-RLHF-005/015,
+  // Charter [지양-2]/[지양-4]). Mirrors `reranking_proposed` naming — PENDING
+  // proposal, NEVER an applied change.
+  'rlhf.calibration_proposed',
 ]);
 
 // @MX:NOTE [AUTO] Source governance enums — SPEC-REGULA-SOURCE-GOVERNANCE-001 (Issue #48).
@@ -457,6 +463,24 @@ export const qualityTagEnum = pgEnum('quality_tag', [
   'source_recency_stale',
   'source_authority_weak',
   'source_agreement_conflict',
+]);
+
+// @MX:NOTE [AUTO] Calibration candidate status enum — SPEC-REGULA-RLHF-001 (Issue #264 sub-PR 2/3).
+// @MX:SPEC SPEC-REGULA-RLHF-001 (REQ-RLHF-005, REQ-RLHF-015)
+// @MX:REASON Drizzle pgEnum mirrors the SQL type created in
+//           0095_rlhf_calibration_candidates.sql. Lifecycle (REQ-RLHF-015):
+//             pending                  — freshly detected, awaiting RA-Lead review
+//             reviewed                  — linked to a governance change_request
+//             dismissed                 — RA-Lead rejected (noise / no action)
+//             applied_via_governance    — #71 change-control approved + rolled out
+//           The detector ONLY inserts 'pending'. The applied_via_governance
+//           transition is set by the governance approve path, never by the
+//           calibration detector (Charter [지양-2]/[지양-4]).
+export const calibrationCandidateStatusEnum = pgEnum('calibration_candidate_status', [
+  'pending',
+  'reviewed',
+  'dismissed',
+  'applied_via_governance',
 ]);
 
 // @MX:NOTE [AUTO] Knowledge promotion enum — SPEC-REGULA-KNOWLEDGE-PROMO-001 (Issue #50).
@@ -849,6 +873,60 @@ export const answerFeedback = pgTable(
     messageIdx: index('idx_answer_feedback_message').on(t.messageId),
     createdIdx: index('idx_answer_feedback_created').on(t.createdAt),
     user_idx: index('idx_answer_feedback_user').on(t.userId),
+  }),
+);
+
+// @MX:NOTE [AUTO] calibration_candidates — SPEC-REGULA-RLHF-001 (Issue #264 sub-PR 2/3).
+// @MX:SPEC SPEC-REGULA-RLHF-001 (REQ-RLHF-005, REQ-RLHF-006, REQ-RLHF-014, REQ-RLHF-015)
+// @MX:REASON Confidence-calibration detection surface. Each row captures ONE
+//           observation: "in confidence bucket B, across N samples, the
+//           observed up-vote ratio was R". Overconfident / underconfident
+//           buckets become pending candidates for RA-Lead review.
+//           Charter [지양-2]: correction values are NEVER auto-applied —
+//           status starts at 'pending' and only transitions via governance.
+//           Charter [지양-4]: any applied change flows through #71
+//           MODEL-GOVERNANCE via the nullable governance_change_request_id FK.
+//           RLS is inert project-wide (#239 debt); query-layer eq(orgId) is
+//           the authoritative tenant boundary (mirrors answer_feedback).
+export const calibrationCandidates = pgTable(
+  'calibration_candidates',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    // @MX:WARN [AUTO] confidence_bucket is text (half-open interval label),
+    //   NOT numeric — keeps candidate rows stable + human-readable in audit.
+    //   @MX:REASON the detector buckets confidence into named bands; storing
+    //     the label (not the raw score) matches detection granularity.
+    confidenceBucket: text('confidence_bucket').notNull(),
+    // Optional secondary dimension (default 'all' for the whole-bucket view).
+    sourceType: text('source_type').notNull().default('all'),
+    observedUpRatio: numeric('observed_up_ratio', { precision: 4, scale: 3 }),
+    sampleSize: integer('sample_size').notNull().default(0),
+    verdict: text('verdict').notNull(),
+    status: calibrationCandidateStatusEnum('status').notNull().default('pending'),
+    proposedBy: uuid('proposed_by').references(() => users.id, { onDelete: 'set null' }),
+    proposedAt: timestamp('proposed_at', { withTimezone: true, mode: 'date' })
+      .notNull()
+      .defaultNow(),
+    reviewedBy: uuid('reviewed_by').references(() => users.id, { onDelete: 'set null' }),
+    reviewedAt: timestamp('reviewed_at', { withTimezone: true, mode: 'date' }),
+    // Nullable link to #71 MODEL-GOVERNANCE change_request. Forward reference
+    // — changeRequest is defined later in this module (Drizzle resolves it).
+    governanceChangeRequestId: uuid('governance_change_request_id'),
+    reviewNotes: text('review_notes'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    orgStatusIdx: index('idx_calibration_candidates_org_status').on(t.orgId, t.status),
+    orgBucketIdx: index('idx_calibration_candidates_org_bucket').on(
+      t.orgId,
+      t.confidenceBucket,
+      t.sourceType,
+    ),
+    proposedAtIdx: index('idx_calibration_candidates_proposed_at').on(t.proposedAt),
   }),
 );
 

--- a/lib/inngest/__tests__/functions.test.ts
+++ b/lib/inngest/__tests__/functions.test.ts
@@ -31,7 +31,7 @@ describe('function registry', () => {
     expect(ids).toContain('capa-effectiveness-due-reminder');
     expect(ids).toContain('standards-revision-daily');
     expect(ids).toContain('messages-embedding-backfill');
-    expect(functions).toHaveLength(6); // +standards-revision-daily (#62) +messages-embedding-backfill (#275)
+    expect(functions).toHaveLength(6); // +standards-revision-daily Issue 62 +messages-embedding-backfill Issue 275
   });
 
   it('weekly digest function is the same instance exported from its module', () => {

--- a/lib/rlhf/calibration-detector.ts
+++ b/lib/rlhf/calibration-detector.ts
@@ -1,0 +1,206 @@
+// @MX:NOTE [AUTO] calibration-detector.ts — pure functions for confidence
+// calibration detection (REQ-RLHF-005 aggregate, REQ-RLHF-006 trend).
+// @MX:SPEC SPEC-REGULA-RLHF-001 (Issue #264 sub-PR 2/3, REQ-RLHF-005/006/014/015)
+// @MX:REASON Pure, deterministic functions with no I/O deps so they are
+//           trivially testable and reusable from the API route and (future)
+//           daily-digest cron. Mirrors feedback-aggregator.ts discipline.
+//
+// Calibration semantics:
+//   The system emits a confidenceScore per answer (messages.confidence_score).
+//   Users submit answer_feedback (rating up/down). A confidence bucket that is
+//   consistently downvoted is "overconfident"; consistently upvoted is
+//   "underconfident". This module measures that gap and surfaces candidates.
+//
+// Charter [지양-2] / [지양-4]: detection ONLY. No Platt scaling, no isotonic
+// regression, no learned mapping applied to scores — that math is pointless
+// here because auto-application is forbidden. The output is a candidate row
+// for human review, nothing more.
+
+/**
+ * Minimal shape of a (confidence, rating) sample needed for aggregation.
+ * Callers project from messages + answer_feedback rows to this shape.
+ */
+export interface ConfidenceFeedbackSample {
+  /** Emitted confidence for the answer, in [0, 1]. May be null if unrecorded. */
+  confidence: number | null;
+  rating: 'up' | 'down';
+}
+
+/**
+ * Canonical confidence buckets (half-open intervals). The label is stored
+ * verbatim in calibration_candidates.confidence_bucket so candidate rows are
+ * human-readable in audit + dashboards. Buckets are aligned with
+ * DEFAULT_CONFIDENCE_FLOOR (0.7) from post-rerank-gate.ts — the floor sits at
+ * the boundary between the '0.6-0.7' and '0.7-0.8' buckets, so calibration
+ * drift across the safety threshold is directly visible.
+ */
+export const CONFIDENCE_BUCKETS = [
+  { label: '0.0-0.2', lo: 0.0, hi: 0.2 },
+  { label: '0.2-0.4', lo: 0.2, hi: 0.4 },
+  { label: '0.4-0.6', lo: 0.4, hi: 0.6 },
+  { label: '0.6-0.8', lo: 0.6, hi: 0.8 },
+  { label: '0.8-1.0', lo: 0.8, hi: 1.0001 }, // closed on top to include 1.0
+] as const;
+
+/**
+ * Resolve a confidence score to its bucket label. Returns null for scores
+ * outside [0, 1] (treated as missing — unbucketed).
+ */
+export function bucketForConfidence(confidence: number): string | null {
+  if (confidence < 0 || confidence > 1) return null;
+  for (const b of CONFIDENCE_BUCKETS) {
+    if (confidence >= b.lo && confidence < b.hi) return b.label;
+  }
+  return null;
+}
+
+/**
+ * Per-bucket aggregate result. One per bucket that has at least one sample.
+ */
+export interface ConfidenceBucketAggregate {
+  confidenceBucket: string;
+  /** Midpoint of the bucket interval — the "expected" up-ratio if calibrated. */
+  bucketMidpoint: number;
+  /** Observed up-vote ratio in [0, 1]. */
+  observedUpRatio: number;
+  sampleSize: number;
+  upCount: number;
+  downCount: number;
+}
+
+/**
+ * REQ-RLHF-005: aggregate (confidence, rating) samples into per-bucket
+ * up-ratio statistics. Samples with null confidence are dropped (no bucket).
+ *
+ * @MX:NOTE [AUTO] aggregateConfidenceFeedback — pure aggregation, no DB.
+ */
+export function aggregateConfidenceFeedback(
+  samples: readonly ConfidenceFeedbackSample[],
+): ConfidenceBucketAggregate[] {
+  // Bucket the samples.
+  const buckets = new Map<string, { up: number; down: number; midpoint: number }>();
+  for (const b of CONFIDENCE_BUCKETS) {
+    buckets.set(b.label, { up: 0, down: 0, midpoint: (b.lo + Math.min(b.hi, 1)) / 2 });
+  }
+
+  for (const s of samples) {
+    if (s.confidence === null) continue;
+    const label = bucketForConfidence(s.confidence);
+    if (label === null) continue;
+    const entry = buckets.get(label);
+    if (!entry) continue;
+    if (s.rating === 'up') entry.up += 1;
+    else entry.down += 1;
+  }
+
+  const out: ConfidenceBucketAggregate[] = [];
+  for (const [label, entry] of buckets) {
+    const total = entry.up + entry.down;
+    if (total === 0) continue; // omit empty buckets
+    out.push({
+      confidenceBucket: label,
+      bucketMidpoint: round3(entry.midpoint),
+      observedUpRatio: round3(entry.up / total),
+      sampleSize: total,
+      upCount: entry.up,
+      downCount: entry.down,
+    });
+  }
+  return out;
+}
+
+/**
+ * Detection verdict for a single bucket.
+ *   overconfident    — emitted confidence exceeds observed accuracy
+ *                      (observed up-ratio materially below bucket midpoint)
+ *   underconfident   — emitted confidence is materially below observed accuracy
+ *                      (observed up-ratio above bucket midpoint)
+ *   well_calibrated  — within the tolerance band
+ */
+export type CalibrationVerdict = 'overconfident' | 'underconfident' | 'well_calibrated';
+
+/**
+ * A candidate proposed by the detector. Overconfident / underconfident
+ * buckets with enough samples become candidates; well-calibrated buckets do
+ * not (the caller may still surface them in an aggregate view).
+ */
+export interface CalibrationCandidateInput {
+  confidenceBucket: string;
+  bucketMidpoint: number;
+  observedUpRatio: number;
+  sampleSize: number;
+  verdict: CalibrationVerdict;
+}
+
+/** Detection thresholds (defaults; overridable by the caller for tuning). */
+export interface DetectionThresholds {
+  /** Minimum samples in a bucket before a candidate is proposed (avoids noise). */
+  minSampleSize: number;
+  /**
+   * Maximum tolerated |observedUpRatio - bucketMidpoint| before the bucket is
+   * flagged. 0.15 means a bucket whose observed up-ratio deviates by more than
+   * 15 percentage points from its midpoint is a candidate.
+   */
+  maxTolerance: number;
+}
+
+export const DEFAULT_DETECTION_THRESHOLDS: DetectionThresholds = {
+  minSampleSize: 5,
+  maxTolerance: 0.15,
+};
+
+/**
+ * Classify a single bucket aggregate into a verdict.
+ *
+ * @MX:NOTE [AUTO] classifyBucket — pure verdict function.
+ */
+export function classifyBucket(
+  agg: ConfidenceBucketAggregate,
+  thresholds: DetectionThresholds = DEFAULT_DETECTION_THRESHOLDS,
+): CalibrationVerdict {
+  const delta = agg.observedUpRatio - agg.bucketMidpoint;
+  if (delta < -thresholds.maxTolerance) return 'overconfident';
+  if (delta > thresholds.maxTolerance) return 'underconfident';
+  return 'well_calibrated';
+}
+
+/**
+ * REQ-RLHF-006: detect calibration candidates from aggregated samples. Returns
+ * the buckets whose verdict is overconfident or underconfident AND whose
+ * sample size meets the minimum. Well-calibrated buckets are omitted from the
+ * candidate list (but the caller can call aggregateConfidenceFeedback +
+ * classifyBucket separately to surface them in a dashboard view).
+ *
+ * Pure: no DB. The caller persists candidates via calibration-proposal.ts.
+ *
+ * @MX:ANCHOR [AUTO] detectCalibrationCandidates — detector entry point.
+ * @MX:REASON Consumed by the calibration API route and (future) digest cron.
+ *           fan_in expected to reach 3+.
+ */
+export function detectCalibrationCandidates(
+  samples: readonly ConfidenceFeedbackSample[],
+  opts: Partial<DetectionThresholds> = {},
+): CalibrationCandidateInput[] {
+  const thresholds = { ...DEFAULT_DETECTION_THRESHOLDS, ...opts };
+  const aggregates = aggregateConfidenceFeedback(samples);
+
+  const candidates: CalibrationCandidateInput[] = [];
+  for (const agg of aggregates) {
+    if (agg.sampleSize < thresholds.minSampleSize) continue;
+    const verdict = classifyBucket(agg, thresholds);
+    if (verdict === 'well_calibrated') continue;
+    candidates.push({
+      confidenceBucket: agg.confidenceBucket,
+      bucketMidpoint: agg.bucketMidpoint,
+      observedUpRatio: agg.observedUpRatio,
+      sampleSize: agg.sampleSize,
+      verdict,
+    });
+  }
+  return candidates;
+}
+
+/** Round to 3 decimal places (matches numeric(4,3) column precision). */
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/lib/rlhf/calibration-proposal.ts
+++ b/lib/rlhf/calibration-proposal.ts
@@ -1,0 +1,146 @@
+// @MX:NOTE [AUTO] calibration-proposal.ts — persist calibration candidates.
+// @MX:SPEC SPEC-REGULA-RLHF-001 (Issue #264 sub-PR 2/3, REQ-RLHF-005/006/015)
+// @MX:REASON Writes a calibration_candidates row (status=pending) AND emits
+//           the rlhf.calibration_proposed audit IN THE SAME TRANSACTION.
+//           withTenantScope wraps a single db.transaction, so the candidate
+//           insert + audit insert ride one tx boundary — a failure between
+//           them rolls back both (21 CFR Part 11 §11.10(e) atomicity).
+//
+// Charter [지양-2] / [지양-4]: the ONLY status this function sets is 'pending'.
+// Transitions to reviewed / applied_via_governance happen through RA-Lead
+// governance review + the #71 MODEL-GOVERNANCE change-control approve path,
+// never here. The detector output is a proposal, not an applied change.
+
+import { type AuditDbHandle, writeAudit } from '@/lib/audit';
+import { withTenantScope } from '@/lib/db/client';
+import { calibrationCandidates } from '@/lib/db/schema';
+import type { CalibrationCandidateInput } from './calibration-detector';
+
+/**
+ * Input for persisting a single candidate. Produced by
+ * detectCalibrationCandidates (pure) and passed here by the API route or cron.
+ */
+export interface PersistCandidateInput extends CalibrationCandidateInput {
+  orgId: string;
+  /** User who triggered the detection run (null for system / cron). */
+  proposedBy: string | null;
+  /** Optional secondary dimension (default 'all' via the column default). */
+  sourceType?: string;
+}
+
+/** The persisted candidate row shape returned to the caller. */
+export interface PersistedCandidate {
+  id: string;
+  orgId: string;
+  confidenceBucket: string;
+  sourceType: string;
+  observedUpRatio: string | null;
+  sampleSize: number;
+  verdict: string;
+  status: string;
+}
+
+/**
+ * REQ-RLHF-015 / Charter [지양-2]/[지양-4]: persist ONE calibration candidate
+ * as status=pending + emit rlhf.calibration_proposed audit in the same tx.
+ *
+ * The function is intentionally single-candidate so the caller controls the
+ * batch boundary (the API route loops over detectCalibrationCandidates output).
+ * Each candidate gets its own transaction so a failure on row N does not roll
+ * back rows 1..N-1.
+ *
+ * @MX:WARN [AUTO] audit MUST share the tx — do NOT move writeAudit outside
+ *   withTenantScope. 21 CFR Part 11 §11.10(e): candidate + audit are atomic.
+ *   @MX:REASON previous RLHF defect class in this repo had audit-outside-tx;
+ *     the integration test in tests/integration/rlhf-calibration.test.ts
+ *     asserts the tx-failure path writes NO candidate AND NO audit.
+ *
+ * @MX:ANCHOR [AUTO] proposeCalibrationCandidate — proposal write entry point.
+ * @MX:REASON fan_in expected to reach 3 (API route, future digest cron,
+ *           governance review fixture).
+ */
+export async function proposeCalibrationCandidate(
+  input: PersistCandidateInput,
+): Promise<PersistedCandidate> {
+  return withTenantScope(input.orgId, async (tx) => {
+    const [row] = await tx
+      .insert(calibrationCandidates)
+      .values({
+        orgId: input.orgId,
+        confidenceBucket: input.confidenceBucket,
+        sourceType: input.sourceType ?? 'all',
+        observedUpRatio: input.observedUpRatio.toString(),
+        sampleSize: input.sampleSize,
+        verdict: input.verdict,
+        // status defaults to 'pending' via the column default — explicit here
+        // for clarity + defense against a future default change.
+        status: 'pending',
+        proposedBy: input.proposedBy,
+      })
+      .returning({
+        id: calibrationCandidates.id,
+        orgId: calibrationCandidates.orgId,
+        confidenceBucket: calibrationCandidates.confidenceBucket,
+        sourceType: calibrationCandidates.sourceType,
+        observedUpRatio: calibrationCandidates.observedUpRatio,
+        sampleSize: calibrationCandidates.sampleSize,
+        verdict: calibrationCandidates.verdict,
+        status: calibrationCandidates.status,
+      });
+
+    if (!row) throw new Error('calibration_candidates insert returned no rows');
+
+    // 21 CFR Part 11: audit rides the SAME tx. PII-free meta — only the
+    // detection verdict + bucket + ratio + sample size. No question/answer text.
+    await writeAudit(
+      {
+        actor_id: input.proposedBy,
+        action: 'rlhf.calibration_proposed',
+        resource_type: 'calibration_candidate',
+        resource_id: row.id,
+        meta_json: {
+          org_id: input.orgId,
+          confidence_bucket: input.confidenceBucket,
+          source_type: input.sourceType ?? 'all',
+          observed_up_ratio: input.observedUpRatio,
+          sample_size: input.sampleSize,
+          verdict: input.verdict,
+          bucket_midpoint: input.bucketMidpoint,
+        },
+      },
+      tx as unknown as AuditDbHandle,
+    );
+
+    return row;
+  });
+}
+
+/**
+ * Bulk helper: persist all candidates from a detector run. Each candidate is
+ * persisted in its own transaction (see proposeCalibrationCandidate) so a
+ * failure on one does not block the others. Returns the successful persists.
+ */
+export async function proposeCalibrationCandidates(
+  orgId: string,
+  proposedBy: string | null,
+  candidates: readonly CalibrationCandidateInput[],
+  sourceType?: string,
+): Promise<PersistedCandidate[]> {
+  const out: PersistedCandidate[] = [];
+  for (const c of candidates) {
+    try {
+      const row = await proposeCalibrationCandidate({
+        ...c,
+        orgId,
+        proposedBy,
+        sourceType,
+      });
+      out.push(row);
+    } catch {
+      // Per-candidate isolation: a failure on one candidate does not abort the
+      // batch. The audit for failed candidates is absent by design (the tx
+      // rolled back). Caller can observe the gap via the returned row count.
+    }
+  }
+  return out;
+}

--- a/migrations/0095_rlhf_calibration_candidates.sql
+++ b/migrations/0095_rlhf_calibration_candidates.sql
@@ -1,0 +1,125 @@
+-- Migration: RLHF confidence-calibration candidates (Issue #264 sub-PR 2/3)
+-- SPEC: SPEC-REGULA-RLHF-001 (REQ-RLHF-005 aggregate, REQ-RLHF-006 trend,
+--        REQ-RLHF-014 post-rerank invariant, REQ-RLHF-015 no auto-promotion)
+--
+-- Scope:
+--   1. New enum: calibration_candidate_status (4 values)
+--   2. New table: calibration_candidates — proposed confidence-calibration
+--      adjustments detected from observed feedback vs emitted confidence.
+--   3. audit_action +1 (rlhf.calibration_proposed)
+--
+-- Product charter anchors (NON-NEGOTIABLE):
+--   [지양-2] No fake trust  — calibration correction values are NEVER
+--            auto-applied to retrieval. status starts at 'pending' and only
+--            transitions via RA-Lead governance review.
+--   [지양-4] No AI regulatory judgment — any calibration change flows through
+--            #71 MODEL-GOVERNANCE change-control. The nullable
+--            governance_change_request_id column links an approved candidate
+--            to its change_request row once the RA Lead creates one.
+--
+-- Calibration semantics:
+--   A row captures ONE observation: "in confidence bucket B (e.g. [0.7,0.8)),
+--   across N feedback samples, the observed up-vote ratio was R". When R is
+--   materially below the bucket midpoint (overconfident) or above
+--   (underconfident), a candidate is proposed for human review. The
+--   detection thresholds + min sample size live in
+--   lib/rlhf/calibration-detector.ts (pure functions, no DB).
+--
+-- Reuse: organizations (FK), users (FK), change_request (nullable FK link to
+-- #71 governance domain so an approved candidate can be tied to the
+-- change-control record that authorized its application).
+
+-- -------------------------------------
+-- §1 New enum: calibration_candidate_status
+-- -------------------------------------
+
+-- REQ-RLHF-015: lifecycle of a calibration candidate.
+--   pending                   — freshly detected, awaiting RA-Lead review
+--   reviewed                  — RA-Lead reviewed; linked to a governance
+--                               change_request (governance_change_request_id)
+--   dismissed                 — RA-Lead reviewed and rejected (noise / no action)
+--   applied_via_governance    — the linked change_request was approved AND
+--                               rolled out through #71 change-control. This
+--                               status is set ONLY by the governance approve
+--                               path, never by the calibration detector.
+CREATE TYPE calibration_candidate_status AS ENUM (
+  'pending',
+  'reviewed',
+  'dismissed',
+  'applied_via_governance'
+);
+
+-- -------------------------------------
+-- §2 New table: calibration_candidates
+-- -------------------------------------
+
+-- @MX:WARN [AUTO] confidence_bucket is text, NOT numeric — it encodes a
+--   half-open interval label (e.g. '0.7-0.8') so the candidate row is
+--   human-readable in audit + dashboards without a join.
+-- @MX:REASON the detector buckets confidence into named bands; storing the
+--   band label (not the raw score) matches the detection granularity and
+--   keeps the candidate row stable across minor score drift.
+CREATE TABLE calibration_candidates (
+  id                                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id                            uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  -- Human-readable half-open confidence band, e.g. '0.7-0.8'. See
+  -- lib/rlhf/calibration-detector.ts CONFIDENCE_BUCKETS for the canonical list.
+  confidence_bucket                 text NOT NULL,
+  -- Optional secondary dimension: 'all' | 'regulation' | 'guidance' | etc.
+  -- Lets the detector surface calibration drift per source-type subset.
+  source_type                       text NOT NULL DEFAULT 'all',
+  -- Observed ratio of up-votes in this bucket (NULL until first sample).
+  observed_up_ratio                 numeric(4,3),
+  -- Number of feedback samples aggregated into this candidate.
+  sample_size                       integer NOT NULL DEFAULT 0,
+  -- Detection verdict: 'overconfident' | 'underconfident' | 'well_calibrated'.
+  -- Only overconfident/underconfident produce a pending candidate row.
+  verdict                           text NOT NULL,
+  -- Lifecycle (REQ-RLHF-015). Defaults to 'pending' — the detector MUST NOT
+  -- set any other value. Transitions to reviewed/applied_via_governance happen
+  -- only through RA-Lead governance review.
+  status                            calibration_candidate_status NOT NULL DEFAULT 'pending',
+  proposed_by                       uuid REFERENCES users(id) ON DELETE SET NULL,
+  proposed_at                       timestamptz NOT NULL DEFAULT now(),
+  reviewed_by                       uuid REFERENCES users(id) ON DELETE SET NULL,
+  reviewed_at                       timestamptz,
+  -- Nullable link to #71 MODEL-GOVERNANCE change_request. Set when the RA Lead
+  -- creates a change_request to act on this candidate. NULL until then.
+  governance_change_request_id      uuid REFERENCES change_request(id) ON DELETE 'set null',
+  -- Free-form RA-Lead notes (review decision rationale). PII-free.
+  review_notes                      text,
+  created_at                        timestamptz NOT NULL DEFAULT now(),
+  updated_at                        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_calibration_candidates_org_status
+  ON calibration_candidates(org_id, status);
+CREATE INDEX idx_calibration_candidates_org_bucket
+  ON calibration_candidates(org_id, confidence_bucket, source_type);
+CREATE INDEX idx_calibration_candidates_proposed_at
+  ON calibration_candidates(proposed_at);
+
+-- RLS: org isolation. RLS is inert project-wide (#239 debt — service-role db
+-- client bypasses row security). The query-layer eq(org_id, session.orgId)
+-- guard in lib/rlhf/calibration-proposal.ts + the API route is the ACTUAL
+-- tenant boundary. The policy below is defense-in-depth for when #239 enables
+-- per-request SET LOCAL role.
+ALTER TABLE calibration_candidates ENABLE ROW LEVEL SECURITY;
+CREATE POLICY calibration_candidates_org_isolation ON calibration_candidates
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM org_members om
+      WHERE om.org_id = calibration_candidates.org_id
+    )
+  );
+
+-- -------------------------------------
+-- §3 Extend audit_action enum (+1)
+-- -------------------------------------
+
+-- REQ-RLHF-005/015 / 21 CFR Part 11: every calibration proposal is an
+-- audit-material record. The action name `rlhf.calibration_proposed` mirrors
+-- the `reranking_proposed` naming convention — the candidate is a PENDING
+-- proposal, NEVER an applied change.
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'rlhf.calibration_proposed';

--- a/tests/integration/capa.test.ts
+++ b/tests/integration/capa.test.ts
@@ -531,14 +531,14 @@ describe('Count regression (L-007 baseline)', () => {
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(205);
+    expect(vals.length).toBe(206); // +1 rlhf.calibration_proposed (Issue #264 sub-PR 2/3)
   });
 
   it('AuditAction type has 199 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(205);
+    expect(vals.length).toBe(206); // +1 rlhf.calibration_proposed (Issue #264 sub-PR 2/3)
   });
 
   it('PERMISSIONS matrix has 70 entries (68 + 2 sourcegov.* SOURCE-GOVERNANCE Issue #48)', () => {

--- a/tests/integration/cyberdevice.test.ts
+++ b/tests/integration/cyberdevice.test.ts
@@ -602,14 +602,14 @@ describe('count-sync: audit_action (174→191) + PermissionAction (66→70)', ()
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(205);
+    expect(vals.length).toBe(206); // +1 rlhf.calibration_proposed (Issue #264 sub-PR 2/3)
   });
 
   it('AuditAction type has 199 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(205);
+    expect(vals.length).toBe(206); // +1 rlhf.calibration_proposed (Issue #264 sub-PR 2/3)
   });
 
   it('PERMISSIONS matrix has 71 entries', () => {

--- a/tests/integration/rlhf-calibration.test.ts
+++ b/tests/integration/rlhf-calibration.test.ts
@@ -1,0 +1,415 @@
+// @MX:NOTE [AUTO] Integration tests for calibration proposal + API route.
+// @MX:SPEC SPEC-REGULA-RLHF-001 (Issue #264 sub-PR 2/3, REQ-RLHF-005/006/015)
+// @MX:REASON Runtime counterpart to the pure detector tests. Exercises:
+//   1. REQ-RLHF-015 / Charter [지양-2]: proposeCalibrationCandidate writes
+//      status=pending ONLY (never applied_via_governance).
+//   2. 21 CFR Part 11 §11.10(e): candidate + audit ride the SAME tx — a
+//      mid-flight tx failure writes NEITHER.
+//   3. C-2 IDOR: the route returns only caller-org aggregates (cross-org
+//      feedback is invisible).
+//
+// Strategy (mirrors tests/integration/rlhf-idor-runtime.test.ts):
+//   - Mock @/lib/db/client (db + withTenantScope) with an in-memory store.
+//   - Mock @/lib/auth/with-permission — bypass auth, inject a session per org.
+//   - The REAL calibration-detector (pure) and the REAL route handler run.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// vi.hoisted lifts the mock state + factories ABOVE the vi.mock calls so the
+// hoisted mock factories can reference them without a TDZ error. Mirrors the
+// pattern in tests/integration/rlhf-idor-runtime.test.ts.
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+interface SessionShape {
+  user: { id: string; organizationId: string };
+}
+
+const {
+  calibrationStore,
+  feedbackStore,
+  messagesStore,
+  conversationsStore,
+  projectsStore,
+  auditRecords,
+  flags,
+  session,
+  dbMock,
+  withTenantScopeMock,
+  withPermissionMock,
+} = vi.hoisted(() => {
+  const calibrationStore: Row[] = [];
+  const feedbackStore: Row[] = [];
+  const messagesStore: Row[] = [];
+  const conversationsStore: Row[] = [];
+  const projectsStore: Row[] = [];
+  const auditRecords: { action: string; resource_id?: string; meta?: Row }[] = [];
+  const flags = { auditShouldFail: false, transactionShouldFail: false };
+  const session: { current: SessionShape | null } = { current: null };
+
+  function tableName(table: unknown): string {
+    if (typeof table !== 'object' || table === null) return 'unknown';
+    // biome-ignore lint/suspicious/noExplicitAny: symbol index access for Drizzle
+    const t = table as any;
+    return t?.[Symbol.for('drizzle:Name')] ?? t?.name ?? 'unknown';
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle query builder chain
+  const dbMock: any = {
+    insert: vi.fn((table: unknown) => {
+      const tn = tableName(table);
+      let pendingValues: Row | Row[] = {};
+      // commitInsert is called from BOTH the .returning() chain method AND the
+      // inherited-Promise .then path (writeAudit awaits .values() with no
+      // .returning()). The `committed` guard makes it idempotent so a single
+      // insert never double-writes when both paths fire.
+      let committed = false;
+      let committedResult: Row[] = [];
+      function commitInsert(): Row[] {
+        if (committed) return committedResult;
+        committed = true;
+        if (tn === 'audit_logs' && flags.auditShouldFail) {
+          throw new Error('simulated audit failure');
+        }
+        const arr = Array.isArray(pendingValues) ? pendingValues : [pendingValues];
+        const first = (arr[0] as Row) ?? {};
+        // Generate the id ONCE so the stored row and the returned row agree
+        // (Drizzle's defaultRandom produces a single id used for both).
+        const generatedId = first.id ?? crypto.randomUUID();
+        if (tn === 'calibration_candidates') {
+          for (let i = 0; i < arr.length; i++) {
+            const v = arr[i] as Row;
+            const row = { ...v, id: i === 0 ? generatedId : (v.id ?? crypto.randomUUID()) };
+            calibrationStore.push(row);
+          }
+        }
+        if (tn === 'audit_logs') {
+          auditRecords.push({
+            action: String(first.action),
+            resource_id: first.resourceId as string | undefined,
+            meta: first.metaJson as Row | undefined,
+          });
+        }
+        const firstRow = arr[0] as Row;
+        committedResult = [{ ...firstRow, id: generatedId }];
+        return committedResult;
+      }
+      // The insert chain extends Promise so `await client.insert(t).values(v)`
+      // (the writeAudit call shape — no .returning()) resolves via the inherited
+      // .then, AND .returning() is available for the calibration-proposal path.
+      // Extending Promise avoids lint/suspicious/noThenProperty (then is
+      // inherited, not a freshly-defined property). The commit is deferred via
+      // queueMicrotask so it reads pendingValues AFTER .values() has set them.
+      class InsertChain extends Promise<Row[]> {
+        values = (values: Row | Row[]) => {
+          pendingValues = values;
+          return this;
+        };
+        returning = vi.fn(async () => commitInsert());
+      }
+      return new InsertChain((resolve) => {
+        queueMicrotask(() => resolve(commitInsert()));
+      });
+    }),
+    select: vi.fn(() => makeSelectChain()),
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle query builder chain
+  function makeSelectChain(): any {
+    class SelectChain extends Promise<Row[]> {
+      from = vi.fn(() => this);
+      innerJoin = vi.fn(() => this);
+      where = vi.fn(() => this);
+      orderBy = vi.fn(() => this);
+      limit = vi.fn(() => this);
+    }
+    const orgId = session.current?.user.organizationId ?? '';
+    const orgMessageIds = new Set(
+      messagesStore
+        .filter((m) => {
+          const conv = conversationsStore.find((c) => c.id === m.conversationId);
+          const proj = projectsStore.find((p) => p.id === conv?.projectId);
+          return proj?.organizationId === orgId;
+        })
+        .map((m) => m.id),
+    );
+    const rows: Row[] = feedbackStore
+      .filter((f) => orgMessageIds.has(f.messageId as string))
+      .map((f) => {
+        const msg = messagesStore.find((m) => m.id === f.messageId);
+        return { confidenceScore: msg?.confidenceScore ?? null, rating: f.rating };
+      });
+    return SelectChain.resolve(rows);
+  }
+
+  const withTenantScopeMock = vi.fn(
+    async <T>(_orgId: string, fn: (db: typeof dbMock) => Promise<T>): Promise<T> => {
+      if (flags.transactionShouldFail) {
+        throw new Error('simulated transaction failure');
+      }
+      return fn(dbMock);
+    },
+  );
+
+  const withPermissionMock = vi.fn(
+    (_action: string, handler: (req: Request, ctx: unknown, session: SessionShape) => unknown) =>
+      async (req: Request, _ctx: unknown) => {
+        const s = session.current;
+        if (!s) throw new Error('no currentSession set');
+        return handler(req, _ctx, s);
+      },
+  );
+
+  return {
+    calibrationStore,
+    feedbackStore,
+    messagesStore,
+    conversationsStore,
+    projectsStore,
+    auditRecords,
+    flags,
+    session,
+    dbMock,
+    withTenantScopeMock,
+    withPermissionMock,
+  };
+});
+
+vi.mock('@/lib/db/client', () => ({
+  db: dbMock,
+  withTenantScope: withTenantScopeMock,
+}));
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: withPermissionMock,
+}));
+
+import { GET } from '@/app/api/rlhf/calibration/route';
+import {
+  proposeCalibrationCandidate,
+  proposeCalibrationCandidates,
+} from '@/lib/rlhf/calibration-proposal';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedOrgAFeedback() {
+  // 6 high-confidence (0.9) answers, all downvoted -> overconfident bucket.
+  const projId = 'proj-org-a';
+  const convId = 'conv-org-a';
+  projectsStore.push({ id: projId, organizationId: 'org-a' });
+  conversationsStore.push({ id: convId, projectId: projId });
+  for (let i = 0; i < 6; i++) {
+    const msgId = `msg-org-a-${i}`;
+    messagesStore.push({ id: msgId, conversationId: convId, confidenceScore: '0.90' });
+    feedbackStore.push({ messageId: msgId, rating: 'down' });
+  }
+}
+
+function seedOrgBFeedback() {
+  // Org-B owns one upvoted low-confidence answer (should be invisible to org-A).
+  const projId = 'proj-org-b';
+  const convId = 'conv-org-b';
+  projectsStore.push({ id: projId, organizationId: 'org-b' });
+  conversationsStore.push({ id: convId, projectId: projId });
+  const msgId = 'msg-org-b-0';
+  messagesStore.push({ id: msgId, conversationId: convId, confidenceScore: '0.10' });
+  feedbackStore.push({ messageId: msgId, rating: 'up' });
+}
+
+function makeRequest(params: Record<string, string> = {}): Request {
+  const url = new URL('http://localhost/api/rlhf/calibration');
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new Request(url.toString());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  calibrationStore.length = 0;
+  feedbackStore.length = 0;
+  messagesStore.length = 0;
+  conversationsStore.length = 0;
+  projectsStore.length = 0;
+  auditRecords.length = 0;
+  flags.auditShouldFail = false;
+  flags.transactionShouldFail = false;
+  session.current = { user: { id: 'user-a', organizationId: 'org-a' } };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('proposeCalibrationCandidate — REQ-RLHF-015 / Charter [지양-2]/[지양-4]', () => {
+  it('writes status=pending ONLY (never applied_via_governance)', async () => {
+    await proposeCalibrationCandidate({
+      orgId: 'org-a',
+      proposedBy: 'user-a',
+      confidenceBucket: '0.8-1.0',
+      bucketMidpoint: 0.9,
+      observedUpRatio: 0.1,
+      sampleSize: 6,
+      verdict: 'overconfident',
+    });
+
+    expect(calibrationStore).toHaveLength(1);
+    const candidate = (calibrationStore[0] as Row) ?? {};
+    expect(candidate.status).toBe('pending');
+    expect(candidate.verdict).toBe('overconfident');
+    expect(candidate.governanceChangeRequestId).toBeUndefined();
+  });
+
+  it('emits rlhf.calibration_proposed audit in the SAME transaction', async () => {
+    await proposeCalibrationCandidate({
+      orgId: 'org-a',
+      proposedBy: 'user-a',
+      confidenceBucket: '0.8-1.0',
+      bucketMidpoint: 0.9,
+      observedUpRatio: 0.1,
+      sampleSize: 6,
+      verdict: 'overconfident',
+    });
+
+    expect(auditRecords).toHaveLength(1);
+    const audit = (auditRecords[0] as { action: string; resource_id?: string; meta?: Row }) ?? {
+      action: '',
+      resource_id: undefined,
+      meta: undefined,
+    };
+    expect(audit.action).toBe('rlhf.calibration_proposed');
+    expect(audit.resource_id).toBe(calibrationStore[0]?.id);
+    expect(audit.meta?.confidence_bucket).toBe('0.8-1.0');
+    expect(audit.meta?.verdict).toBe('overconfident');
+    // PII guard: no question/answer text in meta.
+    expect(audit.meta?.question).toBeUndefined();
+    expect(audit.meta?.answer).toBeUndefined();
+  });
+
+  it('writes NEITHER candidate NOR audit when the transaction fails mid-flight (21 CFR Part 11 atomicity)', async () => {
+    flags.transactionShouldFail = true;
+    await expect(
+      proposeCalibrationCandidate({
+        orgId: 'org-a',
+        proposedBy: 'user-a',
+        confidenceBucket: '0.8-1.0',
+        bucketMidpoint: 0.9,
+        observedUpRatio: 0.1,
+        sampleSize: 6,
+        verdict: 'overconfident',
+      }),
+    ).rejects.toThrow('simulated transaction failure');
+
+    expect(calibrationStore).toHaveLength(0);
+    expect(auditRecords).toHaveLength(0);
+  });
+});
+
+describe('proposeCalibrationCandidates — per-candidate isolation', () => {
+  it('continues the batch when one candidate fails (others still persist)', async () => {
+    // Two candidates: the first succeeds; the second is forced to fail by
+    // flipping the audit flag AFTER the first proposal completes. Each
+    // proposal does 2 inserts (candidate + audit), so we count proposals via
+    // the withTenantScope wrapper, not raw inserts.
+    const candidates = [
+      {
+        confidenceBucket: '0.8-1.0',
+        bucketMidpoint: 0.9,
+        observedUpRatio: 0.1,
+        sampleSize: 6,
+        verdict: 'overconfident' as const,
+      },
+      {
+        confidenceBucket: '0.0-0.2',
+        bucketMidpoint: 0.1,
+        observedUpRatio: 0.9,
+        sampleSize: 6,
+        verdict: 'underconfident' as const,
+      },
+    ];
+
+    // Make the SECOND proposal fail mid-flight: the first proposal runs the
+    // original impl; a wrapper counts calls and throws on the 2nd, so that
+    // tx (candidate + audit) is skipped — proving per-candidate isolation.
+    let proposalCount = 0;
+    const origImpl = withTenantScopeMock.getMockImplementation();
+    withTenantScopeMock.mockImplementation(
+      async <T>(orgId: string, fn: (db: typeof dbMock) => Promise<T>): Promise<T> => {
+        proposalCount += 1;
+        if (proposalCount === 2) {
+          throw new Error('simulated second-candidate tx failure');
+        }
+        // origImpl is erased to unknown at runtime (generic <T>); cast back.
+        return (origImpl ? origImpl(orgId, fn) : fn(dbMock)) as Promise<T>;
+      },
+    );
+
+    const out = await proposeCalibrationCandidates('org-a', 'user-a', candidates);
+    expect(out).toHaveLength(1); // only the first succeeded
+    expect(calibrationStore).toHaveLength(1);
+    expect(calibrationStore[0]?.confidenceBucket).toBe('0.8-1.0');
+
+    // Restore the original withTenantScope impl so the override does not leak.
+    if (origImpl) withTenantScopeMock.mockImplementation(origImpl);
+  });
+});
+
+describe('GET /api/rlhf/calibration — C-2 IDOR + detection view', () => {
+  it('returns only caller-org feedback aggregates (cross-org invisible)', async () => {
+    seedOrgAFeedback(); // org-a: 6 downvoted @0.9
+    seedOrgBFeedback(); // org-b: 1 upvoted @0.1 — MUST be invisible to org-a
+
+    session.current = { user: { id: 'user-a', organizationId: 'org-a' } };
+    const res = await GET(makeRequest(), {});
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // Org-A's 6 downvoted @0.9 land in the 0.8-1.0 bucket -> overconfident.
+    const bucket = body.aggregates.find(
+      (b: { confidenceBucket: string }) => b.confidenceBucket === '0.8-1.0',
+    );
+    expect(bucket).toBeDefined();
+    expect(bucket?.sampleSize).toBe(6);
+    expect(bucket?.observedUpRatio).toBe(0);
+    // Org-B's lone upvote @0.1 is NOT visible: no 0.0-0.2 bucket in org-A's view.
+    const orgBBucket = body.aggregates.find(
+      (b: { confidenceBucket: string }) => b.confidenceBucket === '0.0-0.2',
+    );
+    expect(orgBBucket).toBeUndefined();
+    // Candidate list reflects the overconfident bucket.
+    expect(body.candidates).toHaveLength(1);
+    expect(body.candidates[0]?.verdict).toBe('overconfident');
+  });
+
+  it('returns 403 when the session has no org context', async () => {
+    session.current = { user: { id: 'user-x', organizationId: '' } };
+    const res = await GET(makeRequest(), {});
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('no_org_context');
+  });
+
+  it('returns an empty candidate list when no feedback exists', async () => {
+    // No seeding — org-a has zero feedback.
+    const res = await GET(makeRequest(), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.aggregates).toEqual([]);
+    expect(body.candidates).toEqual([]);
+  });
+
+  it('accepts overridden thresholds via query params', async () => {
+    seedOrgAFeedback();
+    // With minSampleSize=10, the 6-sample bucket no longer qualifies.
+    const res = await GET(makeRequest({ minSampleSize: '10' }), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.candidates).toEqual([]);
+    expect(body.thresholds.minSampleSize).toBe(10);
+  });
+});

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(205); // +3 memory_* (#51) +4 standards.* (#62) +2 owning_issue_* (#157)
+    expect(values).toHaveLength(206); // +3 memory_* (#51) +4 standards.* (#62) +2 owning_issue_* (#157) +1 rlhf.calibration_proposed (#264 sub-PR 2/3)
   });
 
   it.each([

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -326,7 +326,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     const values = extractAuditActionEnumValues(src);
     const typeValues = extractAuditActionTypeValues(auditSrc);
     expect(values).toEqual(typeValues);
-    expect(values).toHaveLength(205); // +3 memory_* (#51) +4 standards.* (#62)
+    expect(values).toHaveLength(206); // +3 memory_* (#51) +4 standards.* (#62) +1 rlhf.calibration_proposed (#264 sub-PR 2/3)
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -382,7 +382,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(205); // +3 memory_* (#51) +4 standards.* (#62)
+    expect(values).toHaveLength(206); // +3 memory_* (#51) +4 standards.* (#62) +1 rlhf.calibration_proposed (#264 sub-PR 2/3)
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(
@@ -2259,5 +2259,71 @@ describe('Migration 0094: messages embedding (Issue #275)', () => {
   it('schema.ts messages table has embedding column', () => {
     const src = readText('lib/db/schema.ts');
     expect(src).toContain('embedding: vector');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration 0095: RLHF confidence-calibration candidates (Issue #264 sub-PR 2/3)
+// ---------------------------------------------------------------------------
+describe('Migration 0095: RLHF calibration candidates (Issue #264 sub-PR 2/3)', () => {
+  it('migration file 0095_rlhf_calibration_candidates.sql exists', () => {
+    expect(fileExists('migrations/0095_rlhf_calibration_candidates.sql')).toBe(true);
+  });
+
+  it('creates calibration_candidate_status enum with 4 values', () => {
+    const sql = readText('migrations/0095_rlhf_calibration_candidates.sql');
+    expect(sql).toMatch(/CREATE TYPE calibration_candidate_status AS ENUM/);
+    expect(sql).toMatch(/'pending'/);
+    expect(sql).toMatch(/'reviewed'/);
+    expect(sql).toMatch(/'dismissed'/);
+    expect(sql).toMatch(/'applied_via_governance'/);
+  });
+
+  it('creates calibration_candidates table with org isolation + governance link', () => {
+    const sql = readText('migrations/0095_rlhf_calibration_candidates.sql');
+    expect(sql).toMatch(/CREATE TABLE calibration_candidates/);
+    expect(sql).toMatch(/org_id\s+uuid NOT NULL REFERENCES organizations/);
+    expect(sql).toMatch(/confidence_bucket\s+text NOT NULL/);
+    expect(sql).toMatch(/observed_up_ratio\s+numeric\(4,3\)/);
+    expect(sql).toMatch(/sample_size\s+integer NOT NULL DEFAULT 0/);
+    // Charter [지양-2]: status defaults to pending (never auto-applied).
+    expect(sql).toMatch(/status\s+calibration_candidate_status NOT NULL DEFAULT 'pending'/);
+    // Charter [지양-4]: nullable governance link to #71.
+    expect(sql).toMatch(/governance_change_request_id\s+uuid/);
+    // RLS enabled (defense-in-depth; #239 debt acknowledged).
+    expect(sql).toMatch(/ALTER TABLE calibration_candidates ENABLE ROW LEVEL SECURITY/);
+    expect(sql).toMatch(/CREATE POLICY calibration_candidates_org_isolation/);
+  });
+
+  it('adds rlhf.calibration_proposed audit action (ALTER TYPE IF NOT EXISTS)', () => {
+    const sql = readText('migrations/0095_rlhf_calibration_candidates.sql');
+    expect(sql).toMatch(
+      /ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'rlhf\.calibration_proposed'/,
+    );
+  });
+
+  it('schema.ts calibrationCandidateStatusEnum matches migration (4 values)', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toMatch(/export const calibrationCandidateStatusEnum\s*=\s*pgEnum/);
+    expect(src).toMatch(/calibration_candidate_status/);
+    expect(src).toContain("'pending'");
+    expect(src).toContain("'reviewed'");
+    expect(src).toContain("'dismissed'");
+    expect(src).toContain("'applied_via_governance'");
+  });
+
+  it('schema.ts calibrationCandidates table mirrors migration columns', () => {
+    const src = readText('lib/db/schema.ts');
+    expect(src).toMatch(/export const calibrationCandidates\s*=\s*pgTable/);
+    expect(src).toMatch(/'calibration_candidates'/);
+    expect(src).toMatch(/confidenceBucket:\s*text\('confidence_bucket'\)/);
+    expect(src).toMatch(/observedUpRatio:\s*numeric\('observed_up_ratio'/);
+    expect(src).toMatch(/calibrationCandidateStatusEnum\('status'\)/);
+    expect(src).toMatch(/governanceChangeRequestId:\s*uuid\('governance_change_request_id'\)/);
+  });
+
+  it('lib/audit.ts AuditAction union includes rlhf.calibration_proposed', () => {
+    const src = readText('lib/audit.ts');
+    expect(src).toMatch(/'rlhf\.calibration_proposed'/);
   });
 });

--- a/tests/unit/rlhf-calibration-detector.test.ts
+++ b/tests/unit/rlhf-calibration-detector.test.ts
@@ -1,0 +1,226 @@
+// @MX:NOTE [AUTO] Pure-function tests for calibration-detector.ts.
+// @MX:SPEC SPEC-REGULA-RLHF-001 (Issue #264 sub-PR 2/3, REQ-RLHF-005/006)
+// @MX:REASON The detector is pure (no DB) — these tests cover the four key
+//           cases: overconfident, underconfident, well-calibrated, and
+//           insufficient-sample. Mirrors the discipline of feedback-aggregator
+//           tests (pure deterministic inputs/outputs).
+
+import {
+  CONFIDENCE_BUCKETS,
+  type ConfidenceFeedbackSample,
+  DEFAULT_DETECTION_THRESHOLDS,
+  aggregateConfidenceFeedback,
+  bucketForConfidence,
+  classifyBucket,
+  detectCalibrationCandidates,
+} from '@/lib/rlhf/calibration-detector';
+import { describe, expect, it } from 'vitest';
+
+describe('bucketForConfidence', () => {
+  it('maps scores to the correct half-open bucket label', () => {
+    expect(bucketForConfidence(0.0)).toBe('0.0-0.2');
+    expect(bucketForConfidence(0.19)).toBe('0.0-0.2');
+    expect(bucketForConfidence(0.2)).toBe('0.2-0.4');
+    expect(bucketForConfidence(0.65)).toBe('0.6-0.8');
+    expect(bucketForConfidence(0.79)).toBe('0.6-0.8');
+    expect(bucketForConfidence(0.8)).toBe('0.8-1.0');
+    expect(bucketForConfidence(1.0)).toBe('0.8-1.0'); // top bucket closed
+  });
+
+  it('returns null for scores outside [0, 1]', () => {
+    expect(bucketForConfidence(-0.1)).toBeNull();
+    expect(bucketForConfidence(1.5)).toBeNull();
+  });
+
+  it('exposes a canonical CONFIDENCE_BUCKETS list aligned with the 0.7 floor', () => {
+    // The 0.7 floor (DEFAULT_CONFIDENCE_FLOOR) sits at the boundary between
+    // 0.6-0.8 bucket midpoint region — drift across it is directly visible.
+    expect(CONFIDENCE_BUCKETS).toHaveLength(5);
+    const labels = CONFIDENCE_BUCKETS.map((b) => b.label);
+    expect(labels).toContain('0.6-0.8');
+    expect(labels).toContain('0.8-1.0');
+  });
+});
+
+describe('aggregateConfidenceFeedback (REQ-RLHF-005)', () => {
+  it('returns an empty array when there are no samples', () => {
+    expect(aggregateConfidenceFeedback([])).toEqual([]);
+  });
+
+  it('drops samples with null confidence (no bucket)', () => {
+    const samples: ConfidenceFeedbackSample[] = [
+      { confidence: null, rating: 'up' },
+      { confidence: 0.75, rating: 'up' },
+    ];
+    const out = aggregateConfidenceFeedback(samples);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.confidenceBucket).toBe('0.6-0.8');
+    expect(out[0]?.sampleSize).toBe(1);
+    expect(out[0]?.observedUpRatio).toBe(1);
+  });
+
+  it('computes observed up-ratio, sample size, and midpoint per bucket', () => {
+    // 0.6-0.8 bucket: 3 up, 1 down -> ratio 0.75, midpoint 0.7
+    const samples: ConfidenceFeedbackSample[] = [
+      { confidence: 0.7, rating: 'up' },
+      { confidence: 0.72, rating: 'up' },
+      { confidence: 0.78, rating: 'up' },
+      { confidence: 0.75, rating: 'down' },
+    ];
+    const out = aggregateConfidenceFeedback(samples);
+    const bucket = out.find((b) => b.confidenceBucket === '0.6-0.8');
+    expect(bucket).toBeDefined();
+    expect(bucket?.sampleSize).toBe(4);
+    expect(bucket?.upCount).toBe(3);
+    expect(bucket?.downCount).toBe(1);
+    expect(bucket?.observedUpRatio).toBe(0.75);
+    expect(bucket?.bucketMidpoint).toBe(0.7);
+  });
+
+  it('omits buckets with zero samples', () => {
+    const samples: ConfidenceFeedbackSample[] = [{ confidence: 0.95, rating: 'up' }];
+    const out = aggregateConfidenceFeedback(samples);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.confidenceBucket).toBe('0.8-1.0');
+  });
+});
+
+describe('classifyBucket (verdict logic)', () => {
+  const thresholds = DEFAULT_DETECTION_THRESHOLDS;
+
+  it('returns overconfident when observed up-ratio is materially below midpoint', () => {
+    const agg = {
+      confidenceBucket: '0.8-1.0',
+      bucketMidpoint: 0.9,
+      observedUpRatio: 0.5, // 0.4 below midpoint -> overconfident
+      sampleSize: 10,
+      upCount: 5,
+      downCount: 5,
+    };
+    expect(classifyBucket(agg, thresholds)).toBe('overconfident');
+  });
+
+  it('returns underconfident when observed up-ratio is materially above midpoint', () => {
+    const agg = {
+      confidenceBucket: '0.0-0.2',
+      bucketMidpoint: 0.1,
+      observedUpRatio: 0.5, // 0.4 above midpoint -> underconfident
+      sampleSize: 10,
+      upCount: 5,
+      downCount: 5,
+    };
+    expect(classifyBucket(agg, thresholds)).toBe('underconfident');
+  });
+
+  it('returns well_calibrated when within the tolerance band', () => {
+    const agg = {
+      confidenceBucket: '0.6-0.8',
+      bucketMidpoint: 0.7,
+      observedUpRatio: 0.65, // 0.05 deviation, within 0.15 tolerance
+      sampleSize: 20,
+      upCount: 13,
+      downCount: 7,
+    };
+    expect(classifyBucket(agg, thresholds)).toBe('well_calibrated');
+  });
+});
+
+describe('detectCalibrationCandidates (REQ-RLHF-006)', () => {
+  it('returns an overconfident candidate when a high-confidence bucket is downvoted', () => {
+    // 0.8-1.0 bucket, midpoint 0.9. All 6 down -> observed ratio 0.0,
+    // delta = -0.9 (overconfident), sampleSize 6 >= min 5.
+    const samples: ConfidenceFeedbackSample[] = [
+      { confidence: 0.9, rating: 'down' },
+      { confidence: 0.85, rating: 'down' },
+      { confidence: 0.95, rating: 'down' },
+      { confidence: 0.88, rating: 'down' },
+      { confidence: 0.92, rating: 'down' },
+      { confidence: 0.97, rating: 'down' },
+    ];
+    const candidates = detectCalibrationCandidates(samples);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.confidenceBucket).toBe('0.8-1.0');
+    expect(candidates[0]?.verdict).toBe('overconfident');
+    expect(candidates[0]?.sampleSize).toBe(6);
+    expect(candidates[0]?.observedUpRatio).toBe(0);
+  });
+
+  it('returns an underconfident candidate when a low-confidence bucket is upvoted', () => {
+    // 0.0-0.2 bucket, midpoint 0.1. All 5 up -> observed ratio 1.0,
+    // delta = +0.9 (underconfident), sampleSize 5 >= min 5.
+    const samples: ConfidenceFeedbackSample[] = [
+      { confidence: 0.05, rating: 'up' },
+      { confidence: 0.1, rating: 'up' },
+      { confidence: 0.15, rating: 'up' },
+      { confidence: 0.02, rating: 'up' },
+      { confidence: 0.18, rating: 'up' },
+    ];
+    const candidates = detectCalibrationCandidates(samples);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.confidenceBucket).toBe('0.0-0.2');
+    expect(candidates[0]?.verdict).toBe('underconfident');
+  });
+
+  it('returns NO candidate for a well-calibrated bucket', () => {
+    // 0.6-0.8 bucket, midpoint 0.7. 7 up / 3 down -> ratio 0.7, delta 0.
+    const samples: ConfidenceFeedbackSample[] = [
+      { confidence: 0.7, rating: 'up' },
+      { confidence: 0.72, rating: 'up' },
+      { confidence: 0.75, rating: 'up' },
+      { confidence: 0.78, rating: 'up' },
+      { confidence: 0.71, rating: 'up' },
+      { confidence: 0.73, rating: 'up' },
+      { confidence: 0.77, rating: 'up' },
+      { confidence: 0.74, rating: 'down' },
+      { confidence: 0.76, rating: 'down' },
+      { confidence: 0.79, rating: 'down' },
+    ];
+    const candidates = detectCalibrationCandidates(samples);
+    expect(candidates).toEqual([]);
+  });
+
+  it('returns NO candidate when sample size is below the minimum', () => {
+    // 0.8-1.0 bucket, 2 down (overconfident pattern) but sampleSize 2 < 5.
+    const samples: ConfidenceFeedbackSample[] = [
+      { confidence: 0.9, rating: 'down' },
+      { confidence: 0.85, rating: 'down' },
+    ];
+    const candidates = detectCalibrationCandidates(samples);
+    expect(candidates).toEqual([]);
+  });
+
+  it('respects overridden thresholds', () => {
+    // With minSampleSize=2 + maxTolerance=0.05, the 2-sample overconfident
+    // case above now qualifies (delta -0.9 > 0.05).
+    const samples: ConfidenceFeedbackSample[] = [
+      { confidence: 0.9, rating: 'down' },
+      { confidence: 0.85, rating: 'down' },
+    ];
+    const candidates = detectCalibrationCandidates(samples, {
+      minSampleSize: 2,
+      maxTolerance: 0.05,
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.verdict).toBe('overconfident');
+  });
+
+  it('returns multiple candidates when several buckets are miscalibrated', () => {
+    // 0.8-1.0 overconfident (5 down) AND 0.0-0.2 underconfident (5 up).
+    const samples: ConfidenceFeedbackSample[] = [
+      { confidence: 0.9, rating: 'down' },
+      { confidence: 0.85, rating: 'down' },
+      { confidence: 0.95, rating: 'down' },
+      { confidence: 0.88, rating: 'down' },
+      { confidence: 0.92, rating: 'down' },
+      { confidence: 0.05, rating: 'up' },
+      { confidence: 0.1, rating: 'up' },
+      { confidence: 0.15, rating: 'up' },
+      { confidence: 0.02, rating: 'up' },
+      { confidence: 0.18, rating: 'up' },
+    ];
+    const candidates = detectCalibrationCandidates(samples);
+    expect(candidates).toHaveLength(2);
+    const verdicts = candidates.map((c) => c.verdict).sort();
+    expect(verdicts).toEqual(['overconfident', 'underconfident']);
+  });
+});


### PR DESCRIPTION
## 범위 — SPEC-REGULA-RLHF-001 (REQ-RLHF-005/006/014/015) confidence calibration

confidence score × 사용자 feedback 교차 집계 → overconfident/underconfident 버킷 **감지** → **calibration 후보**로 `calibration_candidates` 행(pending) + audit 기록. #71 MODEL-GOVERNANCE change-control 경유 RA Lead 승인 후 적용.

### Charter 준수 (NON-NEGOTIABLE)
- **[지양-2] 가짜 신뢰 생성기 금지**: confidence 보정값 **자동 반영 경로 0** (grep 검증). proposal-only (`status='pending'`).
- **[지양-4] AI 규제 판단 금지**: `applied_via_governance` enum 값은 존재하나 자동 설정 코드 0 — #71 human approve 경유 전용.

### 산출
- migration `0095_rlhf_calibration_candidates.sql`: `calibration_candidate_status` enum(4) + `calibration_candidates` 테이블(org_id uuid FK, confidence_bucket, observed_up_ratio, sample_size, verdict, status, governance_change_request_id FK→change_request, RLS org-isolation) + audit_action +1 `rlhf.calibration_proposed`.
- `lib/rlhf/calibration-detector.ts` (pure, no DB): `aggregateConfidenceFeedback` + `detectCalibrationCandidates` (minSampleSize=5, maxTolerance=0.15).
- `lib/rlhf/calibration-proposal.ts`: `proposeCalibrationCandidate` — candidate INSERT + `writeAudit` 동일 tx (21 CFR Part 11 §11.10(e) 원자성).
- `app/api/rlhf/calibration/route.ts`: GET 집계 뷰 (RBAC `rlhf.feedback`, 3-hop join org-isolation, IDOR 방어).
- schema.ts + audit.ts lock-step.

### 게이트 직견 (orchestrator)
- `pnpm typecheck` exit 0
- `pnpm lint` (biome + lint:hex) exit 0
- `pnpm test` FULL **4702 passed | 21 skipped | 0 failed**
- 실DB(regula-test-db pg16) 적용 검증: 테이블/enum 4값/RLS/uuid FK 전부 확인.

### 보안 리뷰 — expert-security PASS-WITH-CONDITIONS
Charter gates([지양-2/4], Part 11 tx 원자성, IDOR 3-hop, RBAC, FK type match) **전부 PASS**.
- H-1 FK 누락(governance_change_request_id) → **본 PR fix** (REFERENCES change_request(id) ON DELETE SET NULL 추가).
- M-1 RLS user_id/GUC binding → #239 RLS enforce 일괄 처리로 이관 (inert 현재, query-layer가 실제 gate).
- M-2/L-1 (LOW) → 후속 polish.

Refs #264 (sub-PR 2/3 — 3/3 alternate answers 진행 예정)

🗿 MoAI <email@mo.ai.kr>