### PR TITLE
feat(traceability): #238 supersession write path + AC-05 hook wiring + retriever [지양-2] 필터

### DIFF
--- a/lib/ai/retrievers/hybrid-search.ts
+++ b/lib/ai/retrievers/hybrid-search.ts
@@ -115,6 +115,12 @@ export async function hybridSearch(
   // query proceeds without the org filter — callers must ensure orgId is
   // always threaded for any per-org retrieval.
   const orgFilter = orgId ? sql`AND s.organization_id = ${orgId}` : sql``;
+  // REQ-DELTA-005 / [지양-2] — exclude superseded source_sections from retrieval.
+  // When delta-sync refreshes a source, old chunks get superseded_by set while the
+  // source row stays active. The source-level governance gate (filterGovernanceEligible)
+  // does NOT catch section-level supersession within an active source, so this SQL
+  // filter is mandatory — otherwise stale chunks surface in RAG = fake trust.
+  const supersededFilter = sql`AND ss.superseded_by IS NULL`;
   type ExecHandle = Pick<typeof db, 'execute'>;
   const runQueryOnHandle = async (client: ExecHandle): Promise<unknown> => {
     if (embeddingLiteral !== null) {
@@ -129,6 +135,7 @@ export async function hybridSearch(
           WHERE ss.embedding IS NOT NULL
             ${typeFilter}
             ${orgFilter}
+            ${supersededFilter}
           ORDER BY ss.embedding <=> ${embeddingLiteral}::vector
           LIMIT ${k * 4}
         ),
@@ -141,6 +148,7 @@ export async function hybridSearch(
           WHERE to_tsvector('english', ss.text) @@ websearch_to_tsquery('english', ${ftsQuery})
             ${typeFilter}
             ${orgFilter}
+            ${supersededFilter}
           ORDER BY fts_score DESC
           LIMIT ${k * 4}
         )
@@ -167,6 +175,7 @@ export async function hybridSearch(
         LEFT JOIN fts ON fts.section_id = ss.id
         WHERE (vec.vec_score IS NOT NULL OR fts.fts_score IS NOT NULL)
           ${orgFilter}
+          ${supersededFilter}
         LIMIT ${k * 4}
       `);
     }
@@ -194,6 +203,7 @@ export async function hybridSearch(
       WHERE to_tsvector('english', ss.text) @@ websearch_to_tsquery('english', ${ftsQuery})
         ${typeFilter}
         ${orgFilter}
+        ${supersededFilter}
       ORDER BY fts_score DESC
       LIMIT ${k * 4}
     `);

--- a/lib/ai/retrievers/internal-sops.ts
+++ b/lib/ai/retrievers/internal-sops.ts
@@ -79,6 +79,7 @@ export class InternalSopsRetriever implements IRetriever {
             WHERE ss.embedding IS NOT NULL
               AND s.organization_id = ${orgId}
               AND s.type = 'Internal'
+              AND ss.superseded_by IS NULL
             ORDER BY ss.embedding <=> ${embeddingLiteral}::vector
             LIMIT ${limit * 4}
           ),
@@ -91,6 +92,7 @@ export class InternalSopsRetriever implements IRetriever {
             WHERE to_tsvector('english', ss.text) @@ websearch_to_tsquery('english', ${query})
               AND s.organization_id = ${orgId}
               AND s.type = 'Internal'
+              AND ss.superseded_by IS NULL
             ORDER BY fts_score DESC
             LIMIT ${limit * 4}
           )
@@ -115,6 +117,7 @@ export class InternalSopsRetriever implements IRetriever {
           LEFT JOIN vec ON vec.section_id = ss.id
           LEFT JOIN fts ON fts.section_id = ss.id
           WHERE (vec.section_id IS NOT NULL OR fts.section_id IS NOT NULL)
+            AND ss.superseded_by IS NULL
           ORDER BY combined_score DESC
           LIMIT ${limit}
         `);
@@ -142,6 +145,7 @@ export class InternalSopsRetriever implements IRetriever {
         WHERE to_tsvector('english', ss.text) @@ websearch_to_tsquery('english', ${query})
           AND s.organization_id = ${orgId}
           AND s.type = 'Internal'
+          AND ss.superseded_by IS NULL
         ORDER BY combined_score DESC
         LIMIT ${limit}
       `);

--- a/lib/radar/delta-sync/index.ts
+++ b/lib/radar/delta-sync/index.ts
@@ -12,11 +12,13 @@ export {
 } from './detector';
 
 export {
+  applyOutdateOperations,
   assembleEmbeddedChunks,
   buildOutdateOperations,
   chunkForDelta,
   type ChunkDelta,
   type EmbeddedChunk,
+  type SupersessionResult,
 } from './ingest';
 
 export {

--- a/lib/radar/delta-sync/ingest.ts
+++ b/lib/radar/delta-sync/ingest.ts
@@ -12,6 +12,9 @@
 // license is registered out-of-band. The production upload route (C-1) and Inngest
 // worker (C-2) are the primary gated paths. Gating this crawler is a follow-up.
 
+import { withTenantScope } from '@/lib/db/client';
+import { sourceSections } from '@/lib/db/schema';
+import { and, eq, isNull } from 'drizzle-orm';
 import type { Chunk } from '../../ingest/chunkers/base';
 import { chunk } from '../../ingest/chunkers/index';
 import { DocClass } from '../../ingest/doc-class';
@@ -52,6 +55,119 @@ export function buildOutdateOperations(
     supersededBy: newIngestionRunId,
     updatedAt,
   }));
+}
+
+/**
+ * Result of persisting a single section's supersession + firing its hook.
+ */
+export interface SupersessionResult {
+  /** Section id that was processed. */
+  sectionId: string;
+  /** True when this tx actually set superseded_by (false = already superseded, no-op). */
+  applied: boolean;
+  /** Stale-propagation hook outcome for this section. */
+  propagation: { propagated: boolean; affectedCount: number };
+}
+
+/**
+ * @MX:ANCHOR [AUTO] AC-05 supersession write path — persists `source_sections.superseded_by`
+ *   within an org-scoped transaction and fires `onSourceSectionSuperseded` after commit.
+ * @MX:REASON This is the missing production write path for #45 delta-sync: the pure
+ *   `buildOutdateOperations` computed the operations but nothing applied them. This
+ *   function is the single call site that connects delta-sync → DB → traceability
+ *   hook (SPEC-REGULA-TRACEABILITY-001 AC-05). fan_in will reach 3+ once the corpus
+ *   crawler orchestrator (#45 follow-up) and gap-replay (#35) call it.
+ * @MX:WARN [AUTO] Hook fires AFTER the tx commits, not inside it. The hook uses the
+ *   db singleton for `propagateStaleFromNode` (stale_flags + audit), which cannot
+ *   share the supersession tx. A hook failure MUST NOT roll back the supersession —
+ *   the hook is non-blocking by design (wraps its own errors in an audit row + returns).
+ *   This is the correct atomicity boundary: the supersession is the fact; stale
+ *   propagation is a downstream effect.
+ * @MX:SPEC SPEC-REGULA-TRACEABILITY-001 (AC-05, REQ-TRACEABILITY-009)
+ *           SPEC-REGULA-DELTA-SYNC-001 (REQ-DELTA-005, REQ-DELTA-006)
+ *
+ * Idempotent: the WHERE clause guards on `superseded_by IS NULL`, so re-running
+ * the same delta against already-superseded sections is a no-op (returns applied=0).
+ *
+ * Org isolation: the UPDATE runs inside `withTenantScope(orgId)` which sets the
+ * `app.current_org_id` GUC for RLS enforcement, matching every other org-scoped write.
+ *
+ * @returns summary with per-section results + total applied count.
+ */
+export async function applyOutdateOperations(params: {
+  orgId: string;
+  existingChunkIds: string[];
+  newIngestionRunId: string;
+  /** User/system that triggered the sync. Threaded to the hook for audit. null = system. */
+  actorId: string | null;
+}): Promise<{ applied: number; results: SupersessionResult[] }> {
+  if (params.existingChunkIds.length === 0) {
+    return { applied: 0, results: [] };
+  }
+
+  const operations = buildOutdateOperations(params.existingChunkIds, params.newIngestionRunId);
+
+  // Phase 1 — persist the supersession in an org-scoped tx.
+  // We capture which rows were actually touched so the hook only fires for
+  // newly-superseded sections (idempotency: a re-run touches zero rows).
+  const newlySuperseded = await withTenantScope(params.orgId, async (tx) => {
+    const touched: string[] = [];
+    for (const op of operations) {
+      const result = await tx
+        .update(sourceSections)
+        .set({
+          superseded_by: op.supersededBy,
+          updated_at: op.updatedAt,
+        })
+        .where(and(eq(sourceSections.id, op.id), isNull(sourceSections.superseded_by)));
+      // drizzle returns rowCount on execute; if the row was already superseded
+      // the WHERE matches nothing and rowCount is 0 — that's the idempotent path.
+      const affected = (result as unknown as { rowCount?: number }).rowCount ?? 0;
+      if (affected > 0) {
+        touched.push(op.id);
+      }
+    }
+    return touched;
+  });
+
+  // Phase 2 — fire the stale-propagation hook AFTER the tx commits.
+  // Non-blocking: a hook failure is logged as an audit row inside the hook,
+  // never propagated. The supersession is already durable at this point.
+  const results: SupersessionResult[] = [];
+  for (const op of operations) {
+    const applied = newlySuperseded.includes(op.id);
+    let propagation = { propagated: false, affectedCount: 0 };
+    if (applied) {
+      try {
+        propagation = await onSourceSectionSupersededHook({
+          orgId: params.orgId,
+          refId: op.id,
+          actorId: params.actorId,
+        });
+      } catch {
+        // Defense-in-depth: the hook itself never throws, but if the dynamic
+        // import boundary fails we still must not crash the sync.
+        propagation = { propagated: false, affectedCount: 0 };
+      }
+    }
+    results.push({ sectionId: op.id, applied, propagation });
+  }
+
+  return { applied: newlySuperseded.length, results };
+}
+
+/**
+ * Thin indirection so unit tests can mock the hook without importing the full
+ * traceability graph (which pulls env-validated db). The real implementation is
+ * lazily imported at call time to avoid a circular import at module load.
+ */
+async function onSourceSectionSupersededHook(opts: {
+  orgId: string;
+  refId: string;
+  actorId: string | null;
+}): Promise<{ propagated: boolean; affectedCount: number }> {
+  const { onSourceSectionSuperseded } = await import('@/lib/traceability/hooks');
+  return onSourceSectionSuperseded(opts);
 }
 
 /**

--- a/lib/traceability/hooks.ts
+++ b/lib/traceability/hooks.ts
@@ -26,13 +26,12 @@ import type { StaleReason } from './stale-reason';
  *
  * Never throws — supersession must not crash the parent sync job.
  */
-// @MX:TODO [AUTO] AC-05 trigger unwired — call site pending delta-sync supersession write (#45).
-// @MX:REASON This hook is defined but has ZERO call sites. The supersession
-//           write path (source_sections.superseded_by) does not exist yet —
-//           it is #45's job. Once #45 lands, wire this hook at the supersession
-//           write site in lib/radar/delta-sync. Tracked as a follow-up issue.
+// @MX:NOTE [AUTO] AC-05 wired — call site: lib/radar/delta-sync/ingest.ts
+//   `applyOutdateOperations` fires this hook after the supersession tx commits
+//   (#238). The hook is lazy-imported so the delta-sync pure-function tests stay
+//   decoupled from the traceability graph. Hook is non-blocking: failures are
+//   captured as an audit row inside the hook, never crash the parent sync.
 // @MX:SPEC SPEC-REGULA-TRACEABILITY-001 (REQ-TRACEABILITY-009, AC-05)
-// @MX:PRIORITY medium
 export async function onSourceSectionSuperseded(opts: {
   orgId: string;
   refId: string;

--- a/tests/unit/delta-sync-supersession.test.ts
+++ b/tests/unit/delta-sync-supersession.test.ts
@@ -1,0 +1,202 @@
+// @MX:NOTE [AUTO] AC-05 supersession write-path tests — SPEC-REGULA-TRACEABILITY-001.
+// @MX:SPEC SPEC-REGULA-TRACEABILITY-001 (AC-05, REQ-TRACEABILITY-009)
+//           SPEC-REGULA-DELTA-SYNC-001 (REQ-DELTA-005, REQ-DELTA-006)
+//
+// Verifies the #238 deliverables:
+//   1. applyOutdateOperations UPDATEs superseded_by + updated_at in an org-scoped tx.
+//   2. Hook fires once per newly-superseded section (non-blocking).
+//   3. Idempotent — re-running over already-superseded sections is a no-op.
+//   4. Hook failure does NOT roll back the supersession (non-blocking proof).
+//   5. Empty input short-circuits.
+//
+// The db client is mocked at the module boundary so the test never touches a real
+// connection. withTenantScope is stubbed to invoke the callback with a mock tx
+// that records update calls + returns a rowCount the test controls.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---------------------------------------------------------------
+
+// Stub the traceability hook BEFORE importing the function under test, so the
+// dynamic `await import('@/lib/traceability/hooks')` inside applyOutdateOperations
+// resolves to this mock. The hook is non-blocking by contract; we test both the
+// success path and the throw path (which the real hook would swallow internally,
+// but applyOutdateOperations adds its own try/catch around the boundary too).
+const onSourceSectionSupersededMock = vi.fn();
+vi.mock('@/lib/traceability/hooks', () => ({
+  onSourceSectionSuperseded: onSourceSectionSupersededMock,
+}));
+
+// Capture the tx callback so each test can invoke it with a controlled mock tx.
+let capturedTxCallback: ((tx: unknown) => Promise<unknown>) | null = null;
+const updateChain = {
+  set: vi.fn().mockReturnThis(),
+  where: vi.fn().mockImplementation(() => Promise.resolve({ rowCount: 1 })),
+};
+const mockTx = { update: vi.fn().mockReturnValue(updateChain) };
+
+vi.mock('@/lib/db/client', () => ({
+  db: {},
+  // withTenantScope sets the org GUC then calls fn(tx). In the test we skip the
+  // GUC (no real connection) and just invoke the callback with the mock tx.
+  withTenantScope: vi
+    .fn()
+    .mockImplementation(async (_orgId: string, fn: (tx: unknown) => Promise<unknown>) => {
+      capturedTxCallback = fn;
+      return fn(mockTx);
+    }),
+}));
+
+// sourceSections schema symbol — only needs to be a stable object reference for
+// the eq()/isNull() builders; the mock tx.update ignores it.
+vi.mock('@/lib/db/schema', () => ({
+  sourceSections: { id: 'id', superseded_by: 'superseded_by', updated_at: 'updated_at' },
+}));
+
+// drizzle-orm operators — return sentinel objects the test never inspects. The
+// real query is built via the mock chain; we only assert the call shapes.
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((..._args: unknown[]) => ({ op: 'and' })),
+  eq: vi.fn((_a: unknown, _b: unknown) => ({ op: 'eq' })),
+  isNull: vi.fn((_a: unknown) => ({ op: 'isNull' })),
+}));
+
+// Import AFTER mocks are registered.
+import { applyOutdateOperations } from '../../lib/radar/delta-sync/ingest';
+
+describe('delta-sync supersession write path — E. applyOutdateOperations (AC-05)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedTxCallback = null;
+    // Default: each update matches exactly 1 row (the "newly superseded" path).
+    updateChain.where.mockImplementation(() => Promise.resolve({ rowCount: 1 }));
+    onSourceSectionSupersededMock.mockResolvedValue({ propagated: true, affectedCount: 2 });
+  });
+
+  it('empty existingChunkIds short-circuits with zero db calls', async () => {
+    const result = await applyOutdateOperations({
+      orgId: 'org-1',
+      existingChunkIds: [],
+      newIngestionRunId: 'run-1',
+      actorId: null,
+    });
+
+    expect(result.applied).toBe(0);
+    expect(result.results).toEqual([]);
+    expect(mockTx.update).not.toHaveBeenCalled();
+  });
+
+  it('UPDATEs each section + fires the hook once per section', async () => {
+    const result = await applyOutdateOperations({
+      orgId: 'org-1',
+      existingChunkIds: ['sec-a', 'sec-b', 'sec-c'],
+      newIngestionRunId: 'run-42',
+      actorId: 'user-1',
+    });
+
+    // 3 update calls (one per section).
+    expect(mockTx.update).toHaveBeenCalledTimes(3);
+    // Hook fires once per newly-superseded section.
+    expect(onSourceSectionSupersededMock).toHaveBeenCalledTimes(3);
+    expect(onSourceSectionSupersededMock).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      refId: 'sec-a',
+      actorId: 'user-1',
+    });
+
+    expect(result.applied).toBe(3);
+    expect(result.results).toHaveLength(3);
+    expect(result.results[0]).toEqual({
+      sectionId: 'sec-a',
+      applied: true,
+      propagation: { propagated: true, affectedCount: 2 },
+    });
+  });
+
+  it('idempotent — sections already superseded (rowCount=0) skip the hook', async () => {
+    // Simulate the DB finding the row already superseded_by-set.
+    updateChain.where.mockImplementation(() => Promise.resolve({ rowCount: 0 }));
+
+    const result = await applyOutdateOperations({
+      orgId: 'org-1',
+      existingChunkIds: ['sec-already'],
+      newIngestionRunId: 'run-43',
+      actorId: null,
+    });
+
+    expect(result.applied).toBe(0);
+    // Hook MUST NOT fire for a section that was already superseded (no-op).
+    expect(onSourceSectionSupersededMock).not.toHaveBeenCalled();
+    expect(result.results[0]?.applied).toBe(false);
+  });
+
+  it('hook failure does NOT roll back the supersession (non-blocking proof)', async () => {
+    // The real hook swallows internally, but if the dynamic-import boundary
+    // throws, applyOutdateOperations must still return applied=1 for this section.
+    onSourceSectionSupersededMock.mockRejectedValue(new Error('hook explosion'));
+
+    const result = await applyOutdateOperations({
+      orgId: 'org-1',
+      existingChunkIds: ['sec-x'],
+      newIngestionRunId: 'run-44',
+      actorId: 'user-2',
+    });
+
+    // The supersession itself committed — applied=1 despite hook failure.
+    expect(result.applied).toBe(1);
+    expect(result.results[0]?.applied).toBe(true);
+    // propagation reflects the swallowed failure, not a thrown error.
+    expect(result.results[0]?.propagation).toEqual({ propagated: false, affectedCount: 0 });
+  });
+
+  it('runs inside withTenantScope with the provided orgId (RLS scoping)', async () => {
+    const { withTenantScope } = await import('@/lib/db/client');
+    await applyOutdateOperations({
+      orgId: 'org-eu',
+      existingChunkIds: ['sec-eu'],
+      newIngestionRunId: 'run-eu',
+      actorId: 'user-eu',
+    });
+
+    expect(withTenantScope).toHaveBeenCalledWith('org-eu', expect.any(Function));
+    expect(capturedTxCallback).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F. Retriever superseded-section guard ([지양-2] — stale chunks must not surface)
+// ---------------------------------------------------------------------------
+// Source-level governance (filterGovernanceEligible) excludes superseded SOURCES,
+// but section-level supersession happens WITHIN an active source (delta-sync
+// refreshes the same source; old chunks get superseded_by set). This guard verifies
+// the SQL in every source_sections retriever excludes superseded sections.
+describe('retriever superseded-section guard — F. [지양-2] no stale chunks', () => {
+  it('hybrid-search.ts excludes ss.superseded_by IS NULL in every SQL branch', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const src = fs.readFileSync(
+      path.resolve(process.cwd(), 'lib/ai/retrievers/hybrid-search.ts'),
+      'utf8',
+    );
+    // The constant is declared once and interpolated at every WHERE site. Verify
+    // the filter exists (definition) AND is wired at all 4 sites via the
+    // supersededFilter interpolation marker.
+    expect(src).toContain('superseded_by IS NULL');
+    const interpolations = src.match(/\$\{supersededFilter\}/g) ?? [];
+    // 4 WHERE sites: vec CTE, fts CTE, combined, fts-only.
+    expect(interpolations.length).toBe(4);
+  });
+
+  it('internal-sops.ts excludes ss.superseded_by IS NULL in every SQL branch', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const src = fs.readFileSync(
+      path.resolve(process.cwd(), 'lib/ai/retrievers/internal-sops.ts'),
+      'utf8',
+    );
+    // internal-sops uses inline SQL (no constant), so each WHERE site must
+    // contain the literal filter. 4 sites: vec CTE, fts CTE, combined, fts-only.
+    const matches = src.match(/superseded_by IS NULL/g) ?? [];
+    expect(matches.length).toBe(4);
+  });
+});


### PR DESCRIPTION
## 범위 — SPEC-REGULA-TRACEABILITY-001 AC-05 (delta-sync supersession → 자동 stale 전파)

### 산출
- **write path** \`applyOutdateOperations\` (lib/radar/delta-sync/ingest.ts, 신규 export) — buildOutdateOperations 결과를 org-scoped tx 내에서 source_sections UPDATE(superseded_by, updated_at) + 커밋 후 \`onSourceSectionSuperseded\` hook 발화(non-blocking, 기존 hook 설계 준수). idempotent(isNull 가드).
- **retriever [지양-2] 필터** — \`hybrid-search.ts\`(4 WHERE) + \`internal-sops.ts\`(4 WHERE)에 \`AND ss.superseded_by IS NULL\` 추가. **즉시 가치** (superseded chunk RAG 노출 차단).
- \`hooks.ts\` \`@MX:TODO AC-05 unwired\` → \`@MX:NOTE wired\` 교체.

### ★ dead-code 한계 (투명 — 사용자 "머지 + 별도 이슈 추적" 확정)
\`applyOutdateOperations\`는 **프로덕션 호출부 0** — #45의 delta-sync 동기화 실행 진입점(orchestrator)이 inactive(index.ts barrel만, corpus_sync_runs INSERT 0, inngest/cron/route 0). 즉 write path는 동기화 활성화 시 작동(테스트됨). AC-05는 동기화 실행 시 자동 작동. → **별도 이슈 #300** 추적.

### 보안 리뷰 — expert-security PASS-WITH-CONDITIONS
- **Check 1 retriever coverage ([지양-2] CRITICAL): PASS** — filter가 모든 source_sections read site 커버. hybrid-search(4)+internal-sops(4). fda/eu-mdr/mfds/nmpa/pmda는 hybridSearch 위임→상속. internal-docs(document_chunks)/promoted-answers(promoted_answers)는 별개 테이블. **bypass 0, fake-trust 차단 확정**.
- **M-1**(org-isolation caller 의존, source_sections에 org_id 없음) · **M-2**(Part 11 audit gap, supersession 자체 audit 0) — **latent dead path**, #45 활성화 전제조건(#300 추적).
- non-blocking hook · idempotent · Drizzle parameterized(SQL injection 0) · audit enum pre-exists(#47).

### 게이트 직견 (orchestrator)
- typecheck 0 / lint(biome+lint:hex) 0 / test FULL **4749 passed | 21 skipped | 0 failed**
- migration 불필요 (0065에 superseded_by/updated_at/인덱스 있음).

Fixes #238 (별도 이슈 #300로 동기화 진입점 + M-1/M-2 추적)

🗿 MoAI <email@mo.ai.kr>