### PR TITLE
feat(labeling): #249 eSubmit 브리지 활성화 (AC-07/REQ-009)

### DIFF
--- a/.moai/specs/SPEC-REGULA-LABELING-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-LABELING-001/spec.md
@@ -100,7 +100,7 @@ Regula가 분류, CER, PCCP, DHF, 전자 제출까지 지원해도 실제 제품
 | AC-04 | comparative/superiority claim 자동 경고 표시 | unit test |
 | AC-05 | 한/영 라벨 의미 차이 검출 및 승인 로그 기록 | integration test |
 | AC-06 | 라벨링 변경 → Change Control 자동 생성 또는 연결 | E2E test |
-| AC-07 | 승인본이 전자 제출 패키지에 포함됨 | integration test |
+| AC-07 | 승인본이 전자 제출 패키지에 포함됨 | integration test ✅ (#249 — bridge activated) |
 | AC-08 | 권한 없는 승인 시도 거부됨 | RBAC negative test |
 
 ---
@@ -142,5 +142,5 @@ lib/db/schema/labeling.ts
 - #42 Crossmarket (관할권별 라벨링 갭 분석)
 - #47 Traceability (claim ↔ evidence 연결)
 - #54 Change Control (라벨링 변경 영향 평가)
-- #65 eSubmit (제출 패키지 포함)
+- #65 eSubmit (제출 패키지 포함) — 활성화 via #249 (라벨링 승인 → package_manifest append)
 - #64 DHF (설계 산출물 및 변경 이력 연결)

--- a/app/(app)/labeling/[documentId]/_components/LabelingWorkbench.tsx
+++ b/app/(app)/labeling/[documentId]/_components/LabelingWorkbench.tsx
@@ -205,9 +205,6 @@ export function LabelingWorkbench({
                 <CheckCircle2 aria-hidden="true" size={14} />
               )}
               승인 (RA Lead)
-              <span className="ml-1 rounded-xs bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800">
-                eSubmit Beta
-              </span>
             </button>
           )}
           <button

--- a/app/api/labeling/documents/[id]/approve/route.ts
+++ b/app/api/labeling/documents/[id]/approve/route.ts
@@ -157,11 +157,14 @@ export const POST = withPermission('label.approve', async (_req, ctx, session) =
       );
     });
 
-    // REQ-009: forward to eSubmit (stub — #65 not yet implemented).
+    // REQ-009 / AC-07: forward the approved labeling into the project's eSubmit
+    // submission package (non-fatal hook). Runs OUTSIDE the approval tx so the
+    // 21 CFR Part 11 audit integrity of the approval is never compromised.
     const esubmitResult = await forwardLabelingToESubmit({
       documentId,
       projectId: doc.projectId,
       orgId: organizationId,
+      actorId: session.user.id,
     });
 
     // REQ-008 / AC-06: link the labeling change to #54 Change Control. Runs

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -261,12 +261,14 @@ export type AuditAction =
   //   label.translation_diff_detected   — semantic diff detected in translation (REQ-007)
   //   label.approved                    — RA-lead approved labeling document (REQ-012)
   //   label.export_blocked              — export denied: unsupported claims exist (REQ-006)
+  //   label.esubmit_forwarded           — approved labeling forwarded into eSubmit package (REQ-009, AC-07)
   | 'label.document_created'
   | 'label.claim_validated'
   | 'label.claim_citation_rejected'
   | 'label.translation_diff_detected'
   | 'label.approved'
   | 'label.export_blocked'
+  | 'label.esubmit_forwarded'
   // SPEC-REGULA-CAPA-001 (Issue #68, REQ-CAPA-010). 7 complaint/CAPA lifecycle
   // audit actions for 21 CFR Part 11 traceability. Mirror the schema enum.
   //   complaint.intake_created             — new structured complaint inserted (REQ-001)

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -293,6 +293,9 @@ export const auditActionEnum = pgEnum('audit_action', [
   'label.translation_diff_detected',
   'label.approved',
   'label.export_blocked',
+  // SPEC-REGULA-LABELING-001 — added via 0097_label_esubmit_forwarded.sql (REQ-009, AC-07):
+  //   label.esubmit_forwarded — approved labeling folded into submission package manifest
+  'label.esubmit_forwarded',
   // SPEC-REGULA-CAPA-001 — added via 0073_capa.sql (REQ-CAPA-010):
   // 7 complaint/capa lifecycle audit actions for 21 CFR Part 11 traceability.
   //   complaint.intake_created             — new structured complaint inserted (REQ-001)

--- a/lib/labeling/esubmit-bridge.ts
+++ b/lib/labeling/esubmit-bridge.ts
@@ -1,46 +1,230 @@
-// @MX:TODO [AUTO] REQ-009 — #65 eSubmit forward hook (STUB).
-// @MX:REASON #65 eSubmit package generation is not yet implemented. Per L-004,
-//           only the interface + a no-op stub are provided here. When #65
-//           lands, replace the stub body with a real call to
-//           lib/esubmit/validators.ts validateSubmissionPackage, adding the
-//           labeling sections to the submission bundle.
+// @MX:NOTE [AUTO] REQ-009 — eSubmit forward hook (ACTIVE).
 // @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-009, AC-07)
-// @MX:PRIORITY P2 — activate after #65 merges.
+// @MX:REASON [AUTO] Activated in #249. The approve route calls this AFTER the
+//           approval tx commits; failure here is non-fatal (forward hook, not a gate).
+//
+// Package-linkage decision (Charter [지양-2] provenance, [ simplicity ]):
+//   submission_packages has NO project_id column (only org_id). Rather than
+//   adding a linkage table or a new column, the linkage is carried inside
+//   package_manifest jsonb:
+//     - manifest._projectId   → the labeling project this package belongs to
+//     - manifest._origin      → 'labeling_approval' (distinguishes from manually
+//                                created packages that have no _origin)
+//     - manifest.labeling_documents[] → provenance entries (documentId, version,
+//                                jurisdiction, approvedBy, approvedAt, sectionType)
+//   Lookup: by (orgId, manifest->>_projectId = projectId, manifest->>\_origin).
+//   If none exists, a new package is created for that project. This preserves
+//   the existing submission_packages schema (no migration needed for linkage)
+//   while keeping full traceability of which approved labeling docs were folded in.
+//
+// Idempotency: re-forwarding the same approved document updates its provenance
+// entry in-place (matched by documentId) instead of appending a duplicate.
+//
+// Manifest append shape (validateSubmissionPackage-compatible):
+//   Each labeling section becomes a top-level manifest key named after its
+//   section_type (e.g. "device_description", "intended_use"). validateSubmission
+//   Package checks these top-level keys for min-20-char presence, so the
+//   forwarded labeling content satisfies that contract directly.
 
-/**
- * REQ-009: forward an approved labeling document to the eSubmit pipeline.
- *
- * STUB BEHAVIOR (current): no-op + structured log. The function signature is
- * stable so the approve route can wire it now; the real integration is a
- * follow-up tracked in #65.
- *
- * Future contract (when #65 is implemented):
- *   - Validate the labeling sections via validateSubmissionPackage.
- *   - Append the labeling document to the eSubmission bundle.
- *   - Return the updated package ID / validation result.
- */
+import { writeAudit } from '@/lib/audit';
+import { db } from '@/lib/db/client';
+import { labelingDocuments, labelingSections, submissionPackages } from '@/lib/db/schema';
+import { and, eq, sql } from 'drizzle-orm';
+
 export interface ESubmitBridgeResult {
-  /** True when the eSubmit package was updated; false for the stub. */
+  /** True when the eSubmit package was created or updated with the labeling. */
   forwarded: boolean;
-  /** Stub reason or future package ID. */
+  /** Package id on success, or a stable reason code on failure. */
   detail: string;
 }
 
+/**
+ * Minimum content length for a manifest section to be considered "complete"
+ * by validateSubmissionPackage. We skip forwarding sections below this threshold
+ * rather than emitting incomplete entries.
+ */
+const MIN_SECTION_CHARS = 20;
+
+/**
+ * REQ-009: forward an approved labeling document into the project's eSubmit
+ * submission package. Appends each approved section into package_manifest as a
+ * top-level key (so validateSubmissionPackage sees them), records provenance
+ * under manifest.labeling_documents, and writes a 21 CFR Part 11 audit row.
+ *
+ * Non-fatal: returns {forwarded:false, detail:<reason>} on any failure rather
+ * than throwing — the approve route's success must not depend on the forward.
+ */
 export async function forwardLabelingToESubmit(params: {
   documentId: string;
   projectId: string;
   orgId: string;
+  /** Caller's user id (for the audit row). */
+  actorId?: string;
 }): Promise<ESubmitBridgeResult> {
-  // STUB: structured log only. The real implementation will live in #65.
-  // We intentionally do NOT throw — the approve route must still succeed when
-  // eSubmit is not yet wired (REQ-009 is a forward hook, not a gate).
-  console.warn('[esubmit-bridge] REQ-009 stub invoked — #65 eSubmit not yet implemented', {
-    documentId: params.documentId,
-    projectId: params.projectId,
-  });
+  const { documentId, projectId, orgId } = params;
+  const actorId = params.actorId ?? null;
 
-  return {
-    forwarded: false,
-    detail: 'esubmit_not_implemented_stub_invoked',
-  };
+  try {
+    const result = await db.transaction(async (tx) => {
+      // 1. Load the approved labeling document (org-scoped — IDOR defense).
+      const [doc] = await tx
+        .select({
+          id: labelingDocuments.id,
+          productName: labelingDocuments.productName,
+          jurisdiction: labelingDocuments.jurisdiction,
+          status: labelingDocuments.status,
+          approvedBy: labelingDocuments.approvedBy,
+          approvedAt: labelingDocuments.approvedAt,
+          createdBy: labelingDocuments.createdBy,
+        })
+        .from(labelingDocuments)
+        .where(and(eq(labelingDocuments.id, documentId), eq(labelingDocuments.orgId, orgId)))
+        .limit(1);
+      if (!doc) {
+        return { forwarded: false as const, detail: 'labeling_document_not_found' };
+      }
+      if (doc.status !== 'approved') {
+        return { forwarded: false as const, detail: 'labeling_not_approved' };
+      }
+
+      // 2. Load the document's sections. Bounded to a generous ceiling so an
+      // accidentally huge section set does not scan unboundedly.
+      const sections = await tx
+        .select({
+          sectionType: labelingSections.sectionType,
+          content: labelingSections.content,
+        })
+        .from(labelingSections)
+        .where(and(eq(labelingSections.documentId, documentId), eq(labelingSections.orgId, orgId)))
+        .limit(500);
+
+      // 3. Find or create the project's submission package (manifest-scoped linkage).
+      const [existing] = await tx
+        .select({ id: submissionPackages.id, packageManifest: submissionPackages.packageManifest })
+        .from(submissionPackages)
+        .where(
+          and(
+            eq(submissionPackages.orgId, orgId),
+            sql`${submissionPackages.packageManifest}->>'_projectId' = ${projectId}`,
+            sql`${submissionPackages.packageManifest}->>'_origin' = 'labeling_approval'`,
+          ),
+        )
+        .limit(1);
+
+      const sectionEntries = sections.filter(
+        (s) => typeof s.content === 'string' && s.content.trim().length >= MIN_SECTION_CHARS,
+      );
+
+      let packageId: string;
+      let manifest: Record<string, unknown>;
+
+      if (existing) {
+        packageId = existing.id;
+        manifest = (existing.packageManifest as Record<string, unknown>) ?? {};
+      } else {
+        // Create a new package for this project, seeded with linkage metadata.
+        const [created] = await tx
+          .insert(submissionPackages)
+          .values({
+            orgId,
+            submissionType: deriveSubmissionType(doc.jurisdiction),
+            jurisdiction: doc.jurisdiction,
+            deviceName: doc.productName,
+            version: '1.0',
+            // createdBy is NOT NULL. Prefer the approved-by user (the RA-lead
+            // who approved the labeling); fall back to the caller actor, then
+            // the document's creator (guaranteed non-null by schema).
+            createdBy: doc.approvedBy ?? actorId ?? doc.createdBy,
+            packageManifest: {
+              _origin: 'labeling_approval',
+              _projectId: projectId,
+              labeling_documents: [],
+            } as unknown,
+          })
+          .returning({ id: submissionPackages.id });
+        if (!created) {
+          return { forwarded: false as const, detail: 'package_create_failed' };
+        }
+        packageId = created.id;
+        manifest = {
+          _origin: 'labeling_approval',
+          _projectId: projectId,
+          labeling_documents: [],
+        };
+      }
+
+      // 4. Append labeling sections as top-level manifest keys.
+      for (const s of sectionEntries) {
+        manifest[s.sectionType] = s.content;
+      }
+
+      // 5. Update provenance array (idempotent: replace entry with same documentId).
+      const labelingDocs = Array.isArray(manifest.labeling_documents)
+        ? (manifest.labeling_documents as Array<Record<string, unknown>>)
+        : [];
+      const provenanceEntry: Record<string, unknown> = {
+        documentId,
+        jurisdiction: doc.jurisdiction,
+        approvedBy: doc.approvedBy,
+        approvedAt: doc.approvedAt?.toISOString() ?? null,
+        sectionTypes: sectionEntries.map((s) => s.sectionType),
+      };
+      const idx = labelingDocs.findIndex((e) => e.documentId === documentId);
+      if (idx >= 0) {
+        labelingDocs[idx] = provenanceEntry;
+      } else {
+        labelingDocs.push(provenanceEntry);
+      }
+      manifest.labeling_documents = labelingDocs;
+
+      await tx
+        .update(submissionPackages)
+        .set({ packageManifest: manifest as unknown, updatedAt: new Date() })
+        .where(eq(submissionPackages.id, packageId));
+
+      // 6. Audit the forward (21 CFR Part 11 traceability).
+      await writeAudit(
+        {
+          actor_id: actorId,
+          action: 'label.esubmit_forwarded',
+          resource_type: 'submission_package',
+          resource_id: packageId,
+          meta_json: {
+            documentId,
+            projectId,
+            sectionsForwarded: sectionEntries.map((s) => s.sectionType),
+          },
+        },
+        tx,
+      );
+
+      return { forwarded: true as const, detail: packageId };
+    });
+
+    return result;
+  } catch (err) {
+    // Non-fatal: do NOT propagate. The approve route must still succeed.
+    const reason = err instanceof Error ? err.message : 'forward_exception';
+    return { forwarded: false, detail: `esubmit_forward_failed:${reason}` };
+  }
+}
+
+/**
+ * Map a labeling jurisdiction to a submission_type accepted by the
+ * submission_packages CHECK constraint. Falls back to '510k' for FDA and for
+ * any unrecognized jurisdiction (manual review will catch mismatches).
+ */
+function deriveSubmissionType(jurisdiction: string): string {
+  switch (jurisdiction) {
+    case 'EU':
+      return 'cer';
+    case 'FDA':
+      return '510k';
+    case 'MFDS':
+      return 'mfds_import';
+    case 'NMPA':
+      return 'nmpa_ecdt';
+    default:
+      return '510k';
+  }
 }

--- a/lib/labeling/esubmit-bridge.ts
+++ b/lib/labeling/esubmit-bridge.ts
@@ -46,6 +46,24 @@ export interface ESubmitBridgeResult {
 const MIN_SECTION_CHARS = 20;
 
 /**
+ * @MX:NOTE [AUTO] Reserved manifest keys — forwarding must NEVER clobber these.
+ * @MX:REASON [AUTO] Defense-in-depth (M-1): today the labeling_sections.section_type
+ *           CHECK constraint (5-value allowlist) blocks `__proto__`/`constructor`
+ *           and these reserved names from ever reaching the append loop. But a
+ *           FUTURE migration widening the allowlist could let a section type
+ *           collide with submission metadata keys (`_origin`, `_projectId`,
+ *           `labeling_documents`) or validator-consumed keys (`predicate_device`
+ *           — see lib/esubmit/validators.ts). The bridge would then silently
+ *           overwrite submission package metadata. Skip reserved keys explicitly.
+ */
+const RESERVED_MANIFEST_KEYS = new Set([
+  '_origin',
+  '_projectId',
+  'labeling_documents',
+  'predicate_device',
+]);
+
+/**
  * REQ-009: forward an approved labeling document into the project's eSubmit
  * submission package. Appends each approved section into package_manifest as a
  * top-level key (so validateSubmissionPackage sees them), records provenance
@@ -132,9 +150,12 @@ export async function forwardLabelingToESubmit(params: {
             deviceName: doc.productName,
             version: '1.0',
             // createdBy is NOT NULL. Prefer the approved-by user (the RA-lead
-            // who approved the labeling); fall back to the caller actor, then
-            // the document's creator (guaranteed non-null by schema).
-            createdBy: doc.approvedBy ?? actorId ?? doc.createdBy,
+            // who approved the labeling); fall back to the document's creator
+            // (guaranteed non-null and same-org as the document). The actorId
+            // fallback was dropped (M-2): actorId could reference a cross-org
+            // user if a future caller passed a mismatched (orgId, actorId)
+            // pair. actorId is still used for the AUDIT row actor_id below.
+            createdBy: doc.approvedBy ?? doc.createdBy,
             packageManifest: {
               _origin: 'labeling_approval',
               _projectId: projectId,
@@ -154,7 +175,12 @@ export async function forwardLabelingToESubmit(params: {
       }
 
       // 4. Append labeling sections as top-level manifest keys.
+      // @MX:WARN [AUTO] Skip reserved keys (M-1): a section_type collision with
+      //       _origin / _projectId / labeling_documents / predicate_device MUST
+      //       NOT clobber submission metadata. The DB CHECK blocks these today,
+      //       but this guard survives a future allowlist widening.
       for (const s of sectionEntries) {
+        if (RESERVED_MANIFEST_KEYS.has(s.sectionType)) continue;
         manifest[s.sectionType] = s.content;
       }
 

--- a/migrations/0097_label_esubmit_forwarded.sql
+++ b/migrations/0097_label_esubmit_forwarded.sql
@@ -1,0 +1,24 @@
+-- Migration: label.esubmit_forwarded audit action — Issue #249
+-- SPEC: SPEC-REGULA-LABELING-001 (REQ-009, AC-07)
+--
+-- Scope:
+--   1. audit_action enum +1 (label.esubmit_forwarded)
+--
+-- Background:
+--   The eSubmit labeling bridge (#249) activates the previously-stubbed
+--   forwardLabelingToESubmit hook. When an RA-lead approves a labeling
+--   document, the approved sections are appended into the project's
+--   submission_packages.package_manifest jsonb, and a 21 CFR Part 11 audit
+--   row is written so the forward is traceable to an actor + timestamp.
+--
+-- Charter anchors:
+--   [지양-2] Provenance preserved — manifest.labeling_documents[] records
+--            documentId, jurisdiction, approvedBy, approvedAt, sectionTypes.
+--   [지양-4] Only approved labeling is forwarded (the approve route gates this).
+--
+-- Compatibility:
+--   Additive enum extension. Idempotent (IF NOT EXISTS). No schema change to
+--   submission_packages — the linkage lives in package_manifest jsonb
+--   (_projectId, _origin, labeling_documents[]).
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'label.esubmit_forwarded';

--- a/tests/integration/capa.test.ts
+++ b/tests/integration/capa.test.ts
@@ -525,20 +525,20 @@ describe('Count regression (L-007 baseline)', () => {
     expect(vals).toContain("'clinical_investigation'");
   });
 
-  it('audit_action enum has 191 values (183 + 8 source.* SOURCE-GOVERNANCE Issue #48)', () => {
+  it('audit_action enum has 192 values (183 + 8 source.* SOURCE-GOVERNANCE Issue #48 + 1 label.esubmit_forwarded #249)', () => {
     const src = readText('lib/db/schema.ts');
     const match = src.match(
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(207); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3)
+    expect(vals.length).toBe(208); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249)
   });
 
-  it('AuditAction type has 199 values (sync with schema enum)', () => {
+  it('AuditAction type has 200 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(207); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3)
+    expect(vals.length).toBe(208); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249)
   });
 
   it('PERMISSIONS matrix has 70 entries (68 + 2 sourcegov.* SOURCE-GOVERNANCE Issue #48)', () => {

--- a/tests/integration/cyberdevice.test.ts
+++ b/tests/integration/cyberdevice.test.ts
@@ -595,21 +595,21 @@ describe('AC-07: entitlement denial → 403 + audit (REQ-013)', () => {
 // ---------------------------------------------------------------------------
 // Count-sync (L-009): audit_action + PermissionAction deltas.
 // ---------------------------------------------------------------------------
-describe('count-sync: audit_action (174→191) + PermissionAction (66→70)', () => {
-  it('audit_action enum has 191 values', () => {
+describe('count-sync: audit_action (174→192) + PermissionAction (66→70)', () => {
+  it('audit_action enum has 192 values', () => {
     const src = readText('lib/db/schema.ts');
     const match = src.match(
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(207); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3)
+    expect(vals.length).toBe(208); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249)
   });
 
-  it('AuditAction type has 199 values (sync with schema enum)', () => {
+  it('AuditAction type has 200 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(207); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3)
+    expect(vals.length).toBe(208); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249)
   });
 
   it('PERMISSIONS matrix has 71 entries', () => {

--- a/tests/integration/labeling-esubmit-bridge.test.ts
+++ b/tests/integration/labeling-esubmit-bridge.test.ts
@@ -524,3 +524,128 @@ describe('AC-07: manifest shape passes validateSubmissionPackage', () => {
     expect(forwardedSectionIssues).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// M-1: reserved manifest-key collision guard
+// ---------------------------------------------------------------------------
+// The append loop `manifest[s.sectionType] = s.content` runs after the package
+// is seeded with linkage metadata (_origin, _projectId, labeling_documents) and
+// a validator-consumed key (predicate_device). The DB CHECK on section_type
+// blocks these names today, but a future migration widening the allowlist could
+// let a section_type collide. This test simulates that future state by seeding
+// a section whose section_type IS a reserved key, and asserts the metadata the
+// bridge wrote in step 3 survives the append loop in step 4.
+//
+// Approach: integration-level (forwardLabelingToESubmit is not decomposed into
+// an exportable append-only helper; the loop lives inside the transaction). We
+// drive the guard through the real forward path by pushing a reserved-named
+// section into labelingSectionsStore before the call. The mock layer passes
+// the section through to the bridge verbatim (no section_type filtering at the
+// DB layer in this harness), which is exactly the future-DB-CHECK-widened
+// scenario we want to defend against.
+describe('M-1: reserved manifest-key collision guard (AC-07 defense-in-depth)', () => {
+  it('does NOT clobber _origin/_projectId/_labeling_documents/predicate_device when a section type collides', async () => {
+    seedApprovedLabelingDoc();
+    // Simulate a future DB allowlist that permits reserved-named section types.
+    labelingSectionsStore.push(
+      {
+        id: 'sec-reserved-origin',
+        org_id: ORG_A,
+        document_id: DOC_A,
+        section_type: '_origin',
+        content: 'attacker-controlled origin value that must NOT overwrite the linkage meta',
+      },
+      {
+        id: 'sec-reserved-pid',
+        org_id: ORG_A,
+        document_id: DOC_A,
+        section_type: '_projectId',
+        content: 'attacker-controlled projectId that must NOT overwrite the linkage meta',
+      },
+      {
+        id: 'sec-reserved-labeling-docs',
+        org_id: ORG_A,
+        document_id: DOC_A,
+        section_type: 'labeling_documents',
+        content: 'must NOT clobber the provenance array',
+      },
+      {
+        id: 'sec-reserved-predicate',
+        org_id: ORG_A,
+        document_id: DOC_A,
+        section_type: 'predicate_device',
+        content: 'a predicate-device section that must NOT silently overwrite validator key',
+      },
+    );
+
+    const { forwardLabelingToESubmit } = await import('@/lib/labeling/esubmit-bridge');
+    const result = await forwardLabelingToESubmit({
+      documentId: DOC_A,
+      projectId: PROJECT_ID,
+      orgId: ORG_A,
+      actorId: USER_A,
+    });
+    expect(result.forwarded).toBe(true);
+
+    const pkg = requirePackage(0);
+    const manifest = pkg.package_manifest;
+
+    // Reserved linkage metadata survived the append loop intact.
+    expect(manifest._origin).toBe('labeling_approval');
+    expect(manifest._projectId).toBe(PROJECT_ID);
+
+    // Provenance array is a real array with one entry — NOT clobbered by the
+    // reserved section_type='labeling_documents' content string.
+    const labelingDocs = manifest.labeling_documents as unknown;
+    expect(Array.isArray(labelingDocs)).toBe(true);
+    expect(labelingDocs as Array<Record<string, unknown>>).toHaveLength(1);
+    expect((labelingDocs as Array<Record<string, unknown>>)[0]?.documentId).toBe(DOC_A);
+
+    // Non-reserved sections still appended (the guard skips only reserved keys).
+    expect(manifest.device_description).toMatch(/CardioSense Pro/);
+    expect(manifest.intended_use).toMatch(/arrhythmias/);
+
+    // predicate_device reserved key was NOT set to the section content (the
+    // validator in lib/esubmit/validators.ts would otherwise see a non-PMA
+    // string in place of its expected predicate_device shape). The bridge
+    // never sets predicate_device at all here (no explicit seed), so it must
+    // remain undefined.
+    expect(manifest.predicate_device).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M-2: createdBy cross-org fallback narrowing
+// ---------------------------------------------------------------------------
+// The package's submission_packages.created_by column was previously
+// `doc.approvedBy ?? actorId ?? doc.createdBy`. The actorId fallback was a
+// cross-org risk if a future caller passed a mismatched (orgId, actorId)
+// pair. Now it is `doc.approvedBy ?? doc.createdBy`, both guaranteed same-org
+// as the document. actorId must still flow to the AUDIT row actor_id.
+describe('M-2: createdBy is sourced from document, actorId still threads to audit', () => {
+  it('package.created_by = doc.approvedBy (no actorId fallback), audit actor_id = actorId', async () => {
+    seedApprovedLabelingDoc(); // approved_by = USER_A, created_by = USER_A
+    const { forwardLabelingToESubmit } = await import('@/lib/labeling/esubmit-bridge');
+
+    // A hypothetical cross-org caller passes actorId pointing to a user in
+    // another org. The package.created_by must NOT pick this up.
+    const CROSS_ORG_ACTOR = '99999999-9999-9999-9999-999999999999';
+    const result = await forwardLabelingToESubmit({
+      documentId: DOC_A,
+      projectId: PROJECT_ID,
+      orgId: ORG_A,
+      actorId: CROSS_ORG_ACTOR,
+    });
+    expect(result.forwarded).toBe(true);
+
+    const pkg = requirePackage(0);
+    // created_by sourced from doc.approvedBy (USER_A) — NOT the cross-org actor.
+    expect(pkg.created_by).toBe(USER_A);
+
+    // But the audit row's actor_id MUST still be the caller (the human who
+    // triggered the forward), even if they are not the package creator.
+    expect(auditRecords).toHaveLength(1);
+    expect(auditRecords[0]?.actor_id).toBe(CROSS_ORG_ACTOR);
+    expect(auditRecords[0]?.action).toBe('label.esubmit_forwarded');
+  });
+});

--- a/tests/integration/labeling-esubmit-bridge.test.ts
+++ b/tests/integration/labeling-esubmit-bridge.test.ts
@@ -1,0 +1,526 @@
+// @MX:NOTE [AUTO] AC-07 / REQ-009 — eSubmit labeling bridge end-to-end roundtrip test.
+// @MX:SPEC SPEC-REGULA-LABELING-001 (REQ-009, AC-07)
+// @MX:REASON [AUTO] Load-bearing test: exercises the REAL forwardLabelingToESubmit
+//           against an in-memory submission_packages store. Proves the full path:
+//           approved labeling → package_manifest append (top-level section keys +
+//           labeling_documents provenance) → label.esubmit_forwarded audit row.
+//           NOT a false-pass: the in-memory store actually receives the update.
+//
+// Strategy (mirrors cer-persist-roundtrip.test.ts):
+//   1. Mock @/lib/db/client — in-memory stores for submission_packages,
+//      labeling_documents, labeling_sections, audit_logs.
+//   2. Mock @/lib/audit — record writeAudit calls so we can assert the action.
+//   3. Call REAL forwardLabelingToESubmit.
+//
+// Coverage:
+//   - Forward creates a new package when none exists, appends sections.
+//   - Forward reuses the existing package on second approval (idempotent).
+//   - Cross-org IDOR: org-B document lookup returns forwarded:false.
+//   - validateSubmissionPackage sees the appended top-level keys.
+//   - Audit row label.esubmit_forwarded is written.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ORG_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const USER_A = '11111111-1111-1111-1111-111111111111';
+const DOC_A = '22222222-2222-2222-2222-222222222222';
+
+// ---------------------------------------------------------------------------
+// In-memory stores
+// ---------------------------------------------------------------------------
+interface SubmissionPackageRow {
+  id: string;
+  org_id: string;
+  submission_type: string;
+  jurisdiction: string;
+  device_name: string;
+  status: string;
+  version: string;
+  package_manifest: Record<string, unknown>;
+  created_by: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface LabelingDocumentRow {
+  id: string;
+  org_id: string;
+  project_id: string;
+  product_name: string;
+  jurisdiction: string;
+  status: string;
+  approved_by: string | null;
+  approved_at: Date | null;
+  created_by: string;
+}
+
+interface LabelingSectionRow {
+  id: string;
+  org_id: string;
+  document_id: string;
+  section_type: string;
+  content: string;
+}
+
+interface AuditRow {
+  actor_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  meta_json: Record<string, unknown> | null;
+}
+
+const submissionPackagesStore: SubmissionPackageRow[] = [];
+const labelingDocumentsStore: LabelingDocumentRow[] = [];
+const labelingSectionsStore: LabelingSectionRow[] = [];
+const auditRecords: AuditRow[] = [];
+
+// Active orgId for the current forward call — the Drizzle where-condition is
+// opaque to the mock, so we drive org-scoping via this variable (set by each
+// test just before invoking forwardLabelingToESubmit).
+let activeOrgId = ORG_A;
+
+let packageIdCounter = 0;
+function nextPackageId(): string {
+  packageIdCounter += 1;
+  return `pkg-${packageIdCounter.toString().padStart(3, '0')}`;
+}
+
+/** Safe accessor — biome rejects non-null assertions; tests always assert length first. */
+function requirePackage(index: number): SubmissionPackageRow {
+  const pkg = submissionPackagesStore[index];
+  if (!pkg) throw new Error(`submission_packages[${index}] missing`);
+  return pkg;
+}
+
+// ---------------------------------------------------------------------------
+// Drizzle table-name extraction (pgTable stores name at Symbol(drizzle:Name))
+// ---------------------------------------------------------------------------
+function getDrizzleTableName(table: unknown): string | undefined {
+  if (!table || typeof table !== 'object') return undefined;
+  for (const symbol of Object.getOwnPropertySymbols(table)) {
+    if (String(symbol) === 'Symbol(drizzle:Name)') {
+      return (table as Record<symbol, unknown>)[symbol] as string | undefined;
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Where-clause interpretation
+// ---------------------------------------------------------------------------
+// Drizzle encodes eq()/and() conditions opaquely. Our bridge always filters by
+// (id, orgId) or (orgId, manifest->>_projectId, manifest->>\_origin). We decode
+// by inspecting the SQL string embedded in the condition when possible, falling
+// back to returning all rows for the matching table (then filter in JS).
+interface WhereFilter {
+  table: string;
+  docId?: string;
+  orgId?: string;
+  manifestProjectId?: string;
+  manifestOrigin?: string;
+}
+
+function interpretWhere(table: string, condition: unknown): WhereFilter {
+  const filter: WhereFilter = { table };
+  // Drizzle's and()/eq() build a SQL fragment; we sniff the rendered SQL via
+  // the condition's toSQL() if available, else stringify.
+  let sqlText = '';
+  try {
+    if (condition && typeof condition === 'object') {
+      const c = condition as { toSQL?: () => { sql: string } };
+      if (typeof c.toSQL === 'function') {
+        sqlText = c.toSQL().sql;
+      } else {
+        sqlText = String(JSON.stringify(condition));
+      }
+    } else {
+      sqlText = String(condition);
+    }
+  } catch {
+    sqlText = String(condition);
+  }
+
+  // Match "id" = $N or "labeling_documents"."id" = $N — we can't see bound
+  // params through the opaque SQL fragment, so we rely on test-known constants
+  // when the fragment references the expected columns.
+  void sqlText;
+  return filter;
+}
+
+// ---------------------------------------------------------------------------
+// DB mock
+// ---------------------------------------------------------------------------
+interface UpdateReturningChain {
+  returning: (fields?: unknown) => Promise<Row[]>;
+}
+interface UpdateWhereChain {
+  where: (condition: unknown) => UpdateReturningChain;
+}
+interface UpdateSetChain {
+  set: (values: Record<string, unknown>) => UpdateWhereChain;
+}
+
+interface InsertChain {
+  values: (v: Record<string, unknown>) => InsertChain;
+  returning: (fields?: unknown) => Promise<Row[]>;
+}
+
+interface SelectChain {
+  from: (table: unknown) => SelectChain;
+  where: (condition: unknown) => SelectChain;
+  limit: (n: number) => Promise<Row[]>;
+}
+
+type Row = Record<string, unknown>;
+
+interface DbMock {
+  insert: (table: unknown) => InsertChain;
+  select: (fields?: unknown) => SelectChain;
+  update: (table: unknown) => UpdateSetChain;
+  transaction: (fn: (tx: unknown) => Promise<unknown>) => Promise<unknown>;
+}
+
+function makeSelectChain(table: string, capturedWhere: WhereFilter): SelectChain {
+  const chain: SelectChain = {
+    from: vi.fn((_t: unknown) => {
+      capturedWhere.table = getDrizzleTableName(_t) ?? table;
+      return chain;
+    }),
+    where: vi.fn((condition: unknown) => {
+      Object.assign(capturedWhere, interpretWhere(capturedWhere.table, condition));
+      return chain;
+    }),
+    limit: vi.fn(async (n: number) => {
+      void n;
+      const f = capturedWhere;
+      if (f.table === 'labeling_documents') {
+        return labelingDocumentsStore
+          .filter((r) => r.id === DOC_A && r.org_id === activeOrgId)
+          .slice(0, 1)
+          .map((r) => ({
+            id: r.id,
+            productName: r.product_name,
+            jurisdiction: r.jurisdiction,
+            status: r.status,
+            approvedBy: r.approved_by,
+            approvedAt: r.approved_at,
+          }));
+      }
+      if (f.table === 'labeling_sections') {
+        return labelingSectionsStore
+          .filter((r) => r.document_id === DOC_A && r.org_id === activeOrgId)
+          .map((r) => ({ sectionType: r.section_type, content: r.content }));
+      }
+      if (f.table === 'submission_packages') {
+        // The bridge filters by orgId + manifest->>_projectId + manifest->>\_origin.
+        // Our manifest-based linkage filter can't be decoded from the opaque
+        // Drizzle SQL fragment, so we filter the store directly by org + projectId.
+        return submissionPackagesStore
+          .filter(
+            (r) =>
+              r.org_id === activeOrgId &&
+              (r.package_manifest as Record<string, unknown>)._projectId ===
+                (f.manifestProjectId ?? PROJECT_ID) &&
+              (r.package_manifest as Record<string, unknown>)._origin === 'labeling_approval',
+          )
+          .slice(0, 1)
+          .map((r) => ({
+            id: r.id,
+            packageManifest: r.package_manifest,
+          }));
+      }
+      return [];
+    }),
+  };
+  return chain;
+}
+
+const dbMock: DbMock = {
+  insert: vi.fn((table: unknown) => {
+    const tableName = getDrizzleTableName(table) ?? '';
+    const chain: InsertChain = {
+      values: vi.fn((v: Record<string, unknown>) => {
+        if (tableName === 'submission_packages') {
+          const id = (v.id as string) ?? nextPackageId();
+          const row: SubmissionPackageRow = {
+            id,
+            org_id: (v.orgId as string) ?? ORG_A,
+            submission_type: (v.submissionType as string) ?? '510k',
+            jurisdiction: (v.jurisdiction as string) ?? 'FDA',
+            device_name: (v.deviceName as string) ?? 'device',
+            status: (v.status as string) ?? 'draft',
+            version: (v.version as string) ?? '1.0',
+            package_manifest: (v.packageManifest as Record<string, unknown>) ?? {},
+            created_by: (v.createdBy as string) ?? USER_A,
+            created_at: new Date(),
+            updated_at: new Date(),
+          };
+          submissionPackagesStore.push(row);
+        }
+        return chain;
+      }),
+      returning: vi.fn(async () => {
+        const last = submissionPackagesStore[submissionPackagesStore.length - 1];
+        return [{ id: last?.id ?? nextPackageId() }];
+      }),
+    };
+    return chain;
+  }),
+  select: vi.fn((_fields?: unknown) => {
+    // The bridge uses .select({...}).from(table).where(cond).limit(1).
+    // We don't know the table until .from() is called, so we defer.
+    const captured: WhereFilter = { table: '' };
+    return makeSelectChain('', captured);
+  }),
+  update: vi.fn((table: unknown) => {
+    const tableName = getDrizzleTableName(table) ?? '';
+    let pendingValues: Record<string, unknown> | null = null;
+    const returningChain: UpdateReturningChain = {
+      returning: vi.fn(async () => []),
+    };
+    const whereChain: UpdateWhereChain = {
+      where: vi.fn((_condition: unknown) => {
+        // Can't decode the target id from the opaque Drizzle condition, so we
+        // apply to the last package (always the one just created/found here).
+        if (tableName === 'submission_packages' && pendingValues) {
+          const last = submissionPackagesStore[submissionPackagesStore.length - 1];
+          if (last) {
+            if (pendingValues.packageManifest !== undefined) {
+              last.package_manifest = pendingValues.packageManifest as Record<string, unknown>;
+            }
+            if (pendingValues.updatedAt !== undefined) {
+              last.updated_at = pendingValues.updatedAt as Date;
+            }
+          }
+        }
+        return returningChain;
+      }),
+    };
+    const chain: UpdateSetChain = {
+      set: vi.fn((values: Record<string, unknown>) => {
+        pendingValues = values;
+        return whereChain;
+      }),
+    };
+    return chain;
+  }),
+  transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+    return fn(dbMock as unknown);
+  }),
+};
+
+vi.mock('@/lib/db/client', () => ({ db: dbMock }));
+
+// Capture audit writes directly (the real writeAudit inserts into auditLogs —
+// we route via auditRecords so assertions are simple).
+vi.mock('@/lib/audit', () => ({
+  writeAudit: vi.fn(
+    async (params: {
+      actor_id: string | null;
+      action: string;
+      resource_type: string;
+      resource_id: string;
+      meta_json?: Record<string, unknown>;
+    }) => {
+      auditRecords.push({
+        actor_id: params.actor_id,
+        action: params.action,
+        resource_type: params.resource_type,
+        resource_id: params.resource_id,
+        meta_json: params.meta_json ?? null,
+      });
+    },
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+function seedApprovedLabelingDoc(orgId: string = ORG_A, docId: string = DOC_A): void {
+  labelingDocumentsStore.length = 0;
+  labelingSectionsStore.length = 0;
+  labelingDocumentsStore.push({
+    id: docId,
+    org_id: orgId,
+    project_id: PROJECT_ID,
+    product_name: 'CardioSense Pro',
+    jurisdiction: 'FDA',
+    status: 'approved',
+    approved_by: USER_A,
+    approved_at: new Date('2026-06-15T00:00:00Z'),
+    created_by: USER_A,
+  });
+  labelingSectionsStore.push(
+    {
+      id: 'sec-1',
+      org_id: orgId,
+      document_id: docId,
+      section_type: 'device_description',
+      content:
+        'The CardioSense Pro is a Class II electrocardiograph device intended for non-invasive monitoring of cardiac activity in adult patients.',
+    },
+    {
+      id: 'sec-2',
+      org_id: orgId,
+      document_id: docId,
+      section_type: 'intended_use',
+      content:
+        'Intended for use by trained clinicians in hospital and clinical environments for the detection of arrhythmias.',
+    },
+    {
+      id: 'sec-3',
+      org_id: orgId,
+      document_id: docId,
+      section_type: 'stub_short',
+      content: 'too short', // below MIN_SECTION_CHARS — should be skipped
+    },
+  );
+}
+
+beforeEach(() => {
+  submissionPackagesStore.length = 0;
+  labelingDocumentsStore.length = 0;
+  labelingSectionsStore.length = 0;
+  auditRecords.length = 0;
+  packageIdCounter = 0;
+  activeOrgId = ORG_A;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('AC-07: eSubmit labeling bridge roundtrip (REQ-009)', () => {
+  it('forwards approved labeling into a new submission package + writes audit', async () => {
+    seedApprovedLabelingDoc();
+    const { forwardLabelingToESubmit } = await import('@/lib/labeling/esubmit-bridge');
+
+    const result = await forwardLabelingToESubmit({
+      documentId: DOC_A,
+      projectId: PROJECT_ID,
+      orgId: ORG_A,
+      actorId: USER_A,
+    });
+
+    expect(result.forwarded).toBe(true);
+    expect(result.detail).toMatch(/^pkg-/);
+
+    // Package created with manifest linkage + provenance.
+    expect(submissionPackagesStore).toHaveLength(1);
+    const pkg = requirePackage(0);
+    expect(pkg.package_manifest._origin).toBe('labeling_approval');
+    expect(pkg.package_manifest._projectId).toBe(PROJECT_ID);
+
+    // Sections appended as top-level manifest keys (validateSubmissionPackage-compatible).
+    expect(pkg.package_manifest.device_description).toMatch(/CardioSense Pro/);
+    expect(pkg.package_manifest.intended_use).toMatch(/arrhythmias/);
+    expect(pkg.package_manifest.stub_short).toBeUndefined(); // below threshold
+
+    // Provenance array.
+    const labelingDocs = pkg.package_manifest.labeling_documents as Array<Record<string, unknown>>;
+    expect(labelingDocs).toHaveLength(1);
+    expect(labelingDocs[0]?.documentId).toBe(DOC_A);
+    expect(labelingDocs[0]?.approvedBy).toBe(USER_A);
+    expect(labelingDocs[0]?.sectionTypes).toEqual(
+      expect.arrayContaining(['device_description', 'intended_use']),
+    );
+
+    // Audit row (21 CFR Part 11 traceability).
+    expect(auditRecords).toHaveLength(1);
+    expect(auditRecords[0]?.action).toBe('label.esubmit_forwarded');
+    expect(auditRecords[0]?.resource_type).toBe('submission_package');
+    expect(auditRecords[0]?.actor_id).toBe(USER_A);
+  });
+
+  it('is idempotent — re-forwarding the same document does not duplicate', async () => {
+    seedApprovedLabelingDoc();
+    const { forwardLabelingToESubmit } = await import('@/lib/labeling/esubmit-bridge');
+
+    await forwardLabelingToESubmit({
+      documentId: DOC_A,
+      projectId: PROJECT_ID,
+      orgId: ORG_A,
+      actorId: USER_A,
+    });
+    await forwardLabelingToESubmit({
+      documentId: DOC_A,
+      projectId: PROJECT_ID,
+      orgId: ORG_A,
+      actorId: USER_A,
+    });
+
+    // Still one package, one provenance entry (replaced, not duplicated).
+    expect(submissionPackagesStore).toHaveLength(1);
+    const pkg = requirePackage(0);
+    const labelingDocs = pkg.package_manifest.labeling_documents as Array<Record<string, unknown>>;
+    expect(labelingDocs).toHaveLength(1);
+    expect(labelingDocs[0]?.documentId).toBe(DOC_A);
+  });
+
+  it('forward-failure does not throw (non-fatal hook)', async () => {
+    // No document seeded → bridge returns forwarded:false, does NOT throw.
+    const { forwardLabelingToESubmit } = await import('@/lib/labeling/esubmit-bridge');
+    const result = await forwardLabelingToESubmit({
+      documentId: '00000000-0000-0000-0000-000000000999',
+      projectId: PROJECT_ID,
+      orgId: ORG_A,
+    });
+    expect(result.forwarded).toBe(false);
+    expect(typeof result.detail).toBe('string');
+  });
+
+  it('cross-org IDOR — org-B cannot forward into org-A document', async () => {
+    seedApprovedLabelingDoc(ORG_A); // doc belongs to ORG_A
+    const { forwardLabelingToESubmit } = await import('@/lib/labeling/esubmit-bridge');
+
+    // Attacker (org-B) attempts to forward org-A's document.
+    activeOrgId = ORG_B;
+    const result = await forwardLabelingToESubmit({
+      documentId: DOC_A,
+      projectId: PROJECT_ID,
+      orgId: ORG_B, // attacker org
+    });
+
+    expect(result.forwarded).toBe(false);
+    expect(result.detail).toBe('labeling_document_not_found');
+    expect(submissionPackagesStore).toHaveLength(0);
+  });
+});
+
+describe('AC-07: manifest shape passes validateSubmissionPackage', () => {
+  it('FDA package manifest has no error-severity issues for forwarded 510k sections', async () => {
+    seedApprovedLabelingDoc();
+    const { forwardLabelingToESubmit } = await import('@/lib/labeling/esubmit-bridge');
+    await forwardLabelingToESubmit({
+      documentId: DOC_A,
+      projectId: PROJECT_ID,
+      orgId: ORG_A,
+      actorId: USER_A,
+    });
+
+    const { validateSubmissionPackage } = await import('@/lib/esubmit/validators');
+    const pkg = requirePackage(0);
+    const manifest = pkg.package_manifest;
+    // Bridge created an FDA/510k package; validate it.
+    const issues = validateSubmissionPackage(pkg.submission_type, manifest);
+    // device_description + intended_use were forwarded (present), but
+    // substantial_equivalence, performance_testing, biocompatibility are still
+    // missing (they would be added from other labeling docs). We assert that
+    // the forwarded sections do NOT themselves surface as errors.
+    const forwardedSectionIssues = issues.filter(
+      (i) =>
+        (i.section === 'device_description' || i.section === 'intended_use') &&
+        i.severity === 'error',
+    );
+    expect(forwardedSectionIssues).toHaveLength(0);
+  });
+});

--- a/tests/integration/labeling.test.ts
+++ b/tests/integration/labeling.test.ts
@@ -15,7 +15,7 @@
 //   AC-04 — comparative/superiority detection (detectComparativeClaim)
 //   AC-05 — KO↔EN translation diff (detectSemanticDiff)
 //   AC-06 — change-control linkage (linkLabelingChangeToChangeControl → assessChange)
-//   AC-07 — eSubmit forward hook stub (forwardLabelingToESubmit)
+//   AC-07 — eSubmit forward hook (forwardLabelingToESubmit, activated #249)
 //   AC-08 — RBAC: label.approve restricted to ra-lead (PERMISSIONS matrix)
 
 import fs from 'node:fs';
@@ -25,7 +25,6 @@ import { assessChange } from '@/lib/change-control/engine';
 import { linkLabelingChangeToChangeControl } from '@/lib/labeling/change-control-link';
 import { isUnsupportedClaim, validateClaimCitations } from '@/lib/labeling/claim-validator';
 import { detectComparativeClaim } from '@/lib/labeling/comparable-detector';
-import { forwardLabelingToESubmit } from '@/lib/labeling/esubmit-bridge';
 import {
   ALL_LABELING_JURISDICTIONS,
   REQUIRED_LABEL_ELEMENTS,
@@ -239,17 +238,44 @@ describe('AC-06: change-control linkage (REQ-008)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC-07: eSubmit forward hook stub (REQ-009)
+// AC-07: eSubmit forward hook (REQ-009, activated #249)
+// Source-level guards — the full DB-backed roundtrip lives in
+// tests/integration/labeling-esubmit-bridge.test.ts.
 // ---------------------------------------------------------------------------
-describe('AC-07: eSubmit forward hook stub (REQ-009)', () => {
-  it('returns forwarded=false with stub detail (no throw)', async () => {
-    const result = await forwardLabelingToESubmit({
-      documentId: 'doc-1',
-      projectId: 'proj-1',
-      orgId: 'org-1',
-    });
-    expect(result.forwarded).toBe(false);
-    expect(result.detail).toBe('esubmit_not_implemented_stub_invoked');
+describe('AC-07: eSubmit forward hook (REQ-009)', () => {
+  it('forwardLabelingToESubmit signature accepts documentId/projectId/orgId/actorId', () => {
+    // Source-level guard against signature drift — the approve route passes
+    // actorId so the 21 CFR Part 11 audit row is attributable.
+    const src = readText('lib/labeling/esubmit-bridge.ts');
+    expect(src).toMatch(/forwardLabelingToESubmit\(params:\s*\{/);
+    expect(src).toMatch(/documentId:\s*string/);
+    expect(src).toMatch(/projectId:\s*string/);
+    expect(src).toMatch(/orgId:\s*string/);
+    expect(src).toMatch(/actorId\?:\s*string/);
+  });
+
+  it('approve route passes actorId into forwardLabelingToESubmit', () => {
+    const src = readText('app/api/labeling/documents/[id]/approve/route.ts');
+    expect(src).toMatch(/forwardLabelingToESubmit\([\s\S]*actorId:\s*session\.user\.id/);
+  });
+
+  it('bridge writes label.esubmit_forwarded audit action', () => {
+    const src = readText('lib/labeling/esubmit-bridge.ts');
+    expect(src).toMatch(/action:\s*'label\.esubmit_forwarded'/);
+  });
+
+  it('approve route threads esubmitForwarded + esubmitDetail into the response', () => {
+    const src = readText('app/api/labeling/documents/[id]/approve/route.ts');
+    expect(src).toMatch(/esubmitForwarded:\s*esubmitResult\.forwarded/);
+    expect(src).toMatch(/esubmitDetail:\s*esubmitResult\.detail/);
+  });
+
+  it('bridge failure is non-fatal — wrapped in try/catch, returns forwarded:false', () => {
+    // Source-level guard: the bridge body must not let exceptions escape.
+    const src = readText('lib/labeling/esubmit-bridge.ts');
+    expect(src).toMatch(/try\s*\{/);
+    expect(src).toMatch(/catch\s*\(err\)/);
+    expect(src).toMatch(/forwarded:\s*false,\s*detail:\s*`esubmit_forward_failed/);
   });
 });
 

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(207); // +3 memory_* (#51) +4 standards.* (#62) +2 owning_issue_* (#157) +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3)
+    expect(values).toHaveLength(208); // +3 memory_* (#51) +4 standards.* (#62) +2 owning_issue_* (#157) +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249)
   });
 
   it.each([

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -326,7 +326,7 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     const values = extractAuditActionEnumValues(src);
     const typeValues = extractAuditActionTypeValues(auditSrc);
     expect(values).toEqual(typeValues);
-    expect(values).toHaveLength(207); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3)
+    expect(values).toHaveLength(208); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249)
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -382,7 +382,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(207); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3)
+    expect(values).toHaveLength(208); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249)
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(


### PR DESCRIPTION
## 범위 — SPEC-REGULA-LABELING-001 AC-07/REQ-009 (승인본 → 전자 제출 패키지 포함)

### ★ 직견 정정 — 본 이슈 전제 시대착오
이슈 본문은 "#65 eSubmit 미구현, L-004 의존 블로커"라 명시했으나, 직견 결과 **#65 eSubmit 패키지 생성은 이미 구현됨** (POST /api/ra/esubmit create + submission_packages INSERT + packageManifest jsonb + validators). → stub bridge만 실제 연동하면 AC-07 활성화.

### 산출
- **\`forwardLabelingToESubmit\` 실제 구현** (lib/labeling/esubmit-bridge.ts, stub→real): approved labeling → submission_package manifest append. projectId 컬럼 없음 → manifest jsonb 메타데이터 연결(\`_projectId\`, \`_origin='labeling_approval'\`, \`labeling_documents[]\` provenance).
- approve 라우트 actorId thread + \`esubmitForwarded: true\` 응답.
- audit \`label.esubmit_forwarded\` + migration 0097 (ALTER TYPE).
- 프론트 "eSubmit Beta" 배지 제거 (LabelingWorkbench.tsx).
- SPEC AC-07 DEFERRED → ✅ completed.

### 보안 리뷰 — expert-security PASS-WITH-CONDITIONS
Charter [지양-2/4]·IDOR(org isolation 3테이블 WHERE 바인딩)·Part 11 audit tx(append+writeAudit 동일 tx)·non-fatal forward(approve 실패 미전파)·provenance 완전성(documentId/jurisdiction/approvedBy/approvedAt/sectionTypes)·approval gating(브리지 자체 status 재검증)·RBAC(label.approve 상속, 신규 엔드포인트 0) 전부 PASS.
- **M-1**(reserved manifest-key collision, latent-DB CHECK 방어) → **본 PR fix**: RESERVED_MANIFEST_KEYS 가드(4키).
- **M-2**(createdBy actorId cross-org fallback, latent) → **본 PR fix**: actorId fallback 제거(audit엔 여전 thread).
- L-1(PMDA→510k data-quality) → follow-up (SPEC 인지).

### 게이트 직견 (orchestrator)
- typecheck 0 / lint(biome+lint:hex) 0 / test FULL **4760 passed | 21 skipped | 0 failed**
- migration 0097 regula-test-db 적용 완료 (L-010).

Fixes #249

🗿 MoAI <email@mo.ai.kr>