### PR TITLE
fix(migrations): #296 — 0077 ON DELETE 따옴표 구문 에러 (model-gov 테이블 4개 부재 → #71 500)

### DIFF
--- a/migrations/0077_model_governance.sql
+++ b/migrations/0077_model_governance.sql
@@ -65,7 +65,7 @@ CREATE TABLE prompt_registry (
   content text NOT NULL,
   version integer NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
-  created_by uuid REFERENCES users(id) ON DELETE 'set null'
+  created_by uuid REFERENCES users(id) ON DELETE SET NULL
 );
 
 CREATE INDEX idx_prompt_registry_org_kind_hash ON prompt_registry(org_id, kind, content_hash);
@@ -80,7 +80,7 @@ CREATE TABLE model_pin (
   model_version text NOT NULL,
   retrieval_config jsonb NOT NULL DEFAULT '{}'::jsonb,
   created_at timestamptz NOT NULL DEFAULT now(),
-  created_by uuid REFERENCES users(id) ON DELETE 'set null'
+  created_by uuid REFERENCES users(id) ON DELETE SET NULL
 );
 
 CREATE INDEX idx_model_pin_org ON model_pin(org_id);
@@ -89,16 +89,16 @@ CREATE INDEX idx_model_pin_org ON model_pin(org_id);
 CREATE TABLE change_request (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
-  prompt_id uuid REFERENCES prompt_registry(id) ON DELETE 'restrict',
-  model_pin_id uuid REFERENCES model_pin(id) ON DELETE 'restrict',
+  prompt_id uuid REFERENCES prompt_registry(id) ON DELETE RESTRICT,
+  model_pin_id uuid REFERENCES model_pin(id) ON DELETE RESTRICT,
   eval_run_id text,
   eval_status eval_status NOT NULL DEFAULT 'pending',
   eval_result_ref text,
   approval_status modelgov_approval_status NOT NULL DEFAULT 'pending_review',
-  approver_id uuid REFERENCES users(id) ON DELETE 'set null',
+  approver_id uuid REFERENCES users(id) ON DELETE SET NULL,
   approved_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT now(),
-  created_by uuid REFERENCES users(id) ON DELETE 'set null'
+  created_by uuid REFERENCES users(id) ON DELETE SET NULL
 );
 
 CREATE INDEX idx_change_request_org ON change_request(org_id);
@@ -109,12 +109,12 @@ CREATE INDEX idx_change_request_org_status ON change_request(org_id, approval_st
 CREATE TABLE approved_combination (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
-  prompt_id uuid NOT NULL REFERENCES prompt_registry(id) ON DELETE 'restrict',
-  model_pin_id uuid NOT NULL REFERENCES model_pin(id) ON DELETE 'restrict',
+  prompt_id uuid NOT NULL REFERENCES prompt_registry(id) ON DELETE RESTRICT,
+  model_pin_id uuid NOT NULL REFERENCES model_pin(id) ON DELETE RESTRICT,
   active boolean NOT NULL DEFAULT false,
   approved_at timestamptz NOT NULL DEFAULT now(),
-  superseded_by uuid REFERENCES approved_combination(id) ON DELETE 'set null',
-  change_request_id uuid REFERENCES change_request(id) ON DELETE 'set null'
+  superseded_by uuid REFERENCES approved_combination(id) ON DELETE SET NULL,
+  change_request_id uuid REFERENCES change_request(id) ON DELETE SET NULL
 );
 
 CREATE INDEX idx_approved_combination_org_active ON approved_combination(org_id, active);


### PR DESCRIPTION
## 원인 (직견)
\`migrations/0077_model_governance.sql\` 에 \`ON DELETE 'set null'\` / \`'restrict'\` **따옴표 구문 에러 10곳**. Postgres는 키워드 \`SET NULL\`/\`RESTRICT\` (따옴표 없음) 요구 → CREATE TABLE 4개 전부 구문 에러로 롤백, enum/TYPE만 적용.

## 프로덕션 영향
- regula_test (앱 실사용 DB = .env.local DATABASE_URL)에 change_request/prompt_registry/model_pin/approved_combination **부재** → **#71 model-gov 라우트 6종 런타임 500**.
- CI는 mock/in-memory DB (마이그레이션 SQL 실DB 적용 X) → 게이트 green으로 포착 못 함 (L-010).

## Fix (사용자 확정: 0077 직접 수정)
- \`'set null'\`→\`SET NULL\` (6곳), \`'restrict'\`→\`RESTRICT\` (4곳) 따옴표 제거.
- merged record 수정이나 명백 구문 에러 버그 fix (사용자 승인). 향후 fresh DB 정상 적용.

## 직견
- regula-test-db 재적용(ON_ERROR_STOP=0): CREATE TYPE은 already-exists skip, **CREATE TABLE ×4 + INDEX + RLS POLICY 전부 성공**.
- 4 테이블 존재 확인 + **0095 FK(calibration_candidates.governance_change_request_id → change_request) ALTER 성공** (#295 H-1 fix의 사전 존재 블로커 해소).
- enterprise-migrations.test.ts: 0077 검증은 따옴표 패턴 매칭 없음 → 수정 영향 0, 게이트 통과.

## 게이트 직견
- typecheck 0 / lint(biome+lint:hex) 0 / test FULL **4760 passed | 21 skipped | 0 failed**

Fixes #296

🗿 MoAI <email@mo.ai.kr>