### PR TITLE
feat(knowledge-sources): 데이터 모델 (Issue #307 D-1)

### DIFF
--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -58,6 +58,8 @@ export type PermissionAction =
   | 'knowledgegap.classify'
   | 'knowledgegap.view'
   | 'knowledgegap.replay'
+  | 'knowledgesources.manage'
+  | 'knowledgesources.view'
   // Classification wizard actions (SPEC-REGULA-CLASSIFY-001, Issue #59)
   // generate: ra-lead only — classification drives regulatory pathway decisions.
   // view: ra-member+ — transparent across the RA team.
@@ -305,6 +307,9 @@ export const PERMISSIONS: Record<PermissionAction, PermissionSpec> = {
   // classify + replay: ra-lead only — classification is a judgment call that drives
   // KB augmentation, and replay triggers resolution that closes GitHub issues.
   'knowledgegap.view': { minRole: 'ra-member', scope: 'org', resourceType: 'knowledgeGap' },
+  // Issue #307: 지식베이스 연결(git repo) 관리. ra-lead 관리, ra-member+ 조회.
+  'knowledgesources.manage': { minRole: 'ra-lead', scope: 'org', resourceType: 'knowledgeSource' },
+  'knowledgesources.view': { minRole: 'ra-member', scope: 'org', resourceType: 'knowledgeSource' },
   'knowledgegap.classify': { minRole: 'ra-lead', scope: 'org', resourceType: 'knowledgeGap' },
   'knowledgegap.replay': { minRole: 'ra-lead', scope: 'org', resourceType: 'knowledgeGap' },
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -3471,3 +3471,24 @@ export const productStandardsCompliance = pgTable(
     ),
   }),
 );
+
+// Issue #307: 설정 지식베이스 연결 (git repo 동기화 설정). 코퍼스 청크는 sources/source_sections.
+export const knowledgeSources = pgTable('knowledge_sources', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  organizationId: uuid('organization_id')
+    .notNull()
+    .references(() => organizations.id, { onDelete: 'cascade' }),
+  gitUrl: text('git_url').notNull(),
+  branch: text('branch').notNull().default('main'),
+  sourceHost: text('source_host'),
+  sourceOwner: text('source_owner'),
+  sourceRepo: text('source_repo'),
+  lastSyncedAt: timestamp('last_synced_at', { withTimezone: true, mode: 'date' }),
+  syncStatus: text('sync_status').notNull().default('idle'),
+  authTokenEncrypted: text('auth_token_encrypted'),
+  createdBy: uuid('created_by')
+    .notNull()
+    .references(() => users.id),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});

--- a/migrations/0099_knowledge_sources.sql
+++ b/migrations/0099_knowledge_sources.sql
@@ -1,0 +1,35 @@
+-- 0099_knowledge_sources.sql
+-- Issue #307: 설정 지식베이스 연결 (git repo 동기화)
+-- knowledge_sources: 조직별 git repo 연결 설정 (git URL·lastSyncedAt·syncStatus).
+-- 코퍼스 청크는 기존 sources/source_sections (동기화 결과로 채워짐).
+-- 공개 repo는 auth_token_encrypted=null (인증 없이 clone). private는 토큰(옵션).
+
+CREATE TABLE IF NOT EXISTS knowledge_sources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  git_url text NOT NULL,
+  branch text NOT NULL DEFAULT 'main',
+  source_host text,
+  source_owner text,
+  source_repo text,
+  last_synced_at timestamptz,
+  sync_status text NOT NULL DEFAULT 'idle' CHECK (sync_status IN ('idle', 'syncing', 'synced', 'failed')),
+  auth_token_encrypted text,
+  created_by uuid NOT NULL REFERENCES users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_knowledge_sources_org ON knowledge_sources(organization_id);
+CREATE INDEX idx_knowledge_sources_status ON knowledge_sources(sync_status);
+
+ALTER TABLE knowledge_sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE knowledge_sources FORCE ROW LEVEL SECURITY;
+CREATE POLICY knowledge_sources_org_isolated ON knowledge_sources
+  USING (organization_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (organization_id = current_setting('app.current_org_id', true)::uuid);
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'knowledge_source.created';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'knowledge_source.updated';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'knowledge_source.deleted';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'knowledge_source.synced';


### PR DESCRIPTION
Phase D 안전 로드맵 Step 1. D-2(API/동기화) 결함과 분리, 데이터 모델만 먼저 머지.

- migration 0099: knowledge_sources 테이블 (git_url, branch, last_synced_at, sync_status, auth_token_encrypted) + FORCE RLS(org_isolated) + audit 4종
- schema.ts: knowledgeSources pgTable
- permissions: knowledgesources.manage(ra-lead)/view(ra-member+)

게이트: typecheck 0 · 실DB 직검(테이블+RLS+audit). 공개 repo는 auth_token=null(인증 없이 clone).

이후 D-2(API/동기화/cron) + D-3(UI)는 feat/issue-307에서 Step 2-6 진행.

Refs #307

🗿 MoAI <email@mo.ai.kr>