### PR TITLE
feat(knowledge-sources): D-2b Step 3 ingestion + 설정 UI — 코퍼스 채움/RAG 활성화 (Issue #307)

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,8 +1,27 @@
+import { KnowledgeSourcesClient } from '@/components/settings/KnowledgeSourcesClient';
 import { NotificationSettings } from '@/components/settings/NotificationSettings';
 import { LocaleToggle } from '@/components/shell/LocaleToggle';
 import ThemeToggle from '@/components/shell/ThemeToggle';
+import { auth } from '@/lib/auth';
+import { type Role, hasRole } from '@/lib/auth/rbac';
 
-export default function SettingsPage() {
+// @MX:NOTE [AUTO] SettingsPage — server-rendered settings sections.
+// Knowledge Sources section is gated server-side to ra-lead/admin only via hasRole.
+// @MX:SPEC Issue #307 D-2 Phase 2 (Knowledge Sources Settings UI)
+
+export default async function SettingsPage() {
+  // Resolve role server-side. auth() throws in test/build env — fall through safely.
+  let canManageKnowledgeSources = false;
+  try {
+    const session = await auth();
+    const user = session?.user as { role?: string } | undefined;
+    const role = user?.role as Role | undefined;
+    // knowledgesources.manage = ra-lead+ (lib/auth/permissions.ts).
+    canManageKnowledgeSources = role ? hasRole(role, 'ra-lead') : false;
+  } catch {
+    // No session context available — section stays hidden.
+  }
+
   return (
     <section className="mx-auto flex max-w-content flex-col gap-6 px-6 py-8">
       <header>
@@ -33,6 +52,20 @@ export default function SettingsPage() {
         <h2 className="mb-4 font-serif text-lg text-ink-900">알림 설정</h2>
         <NotificationSettings />
       </section>
+
+      {/* Issue 307 D-2 Phase 2: knowledge sources management (ra-lead/admin only). */}
+      {canManageKnowledgeSources && (
+        <section
+          data-testid="knowledge-sources-settings-section"
+          className="rounded-lg border border-ink-150 bg-surface p-6"
+        >
+          <h2 className="mb-1 font-serif text-lg text-ink-900">지식베이스 연결</h2>
+          <p className="mb-4 text-sm text-ink-500">
+            규제 문서를 동기화할 Git 저장소를 연결합니다. 동기화된 문서는 RAG 검색에 사용됩니다.
+          </p>
+          <KnowledgeSourcesClient />
+        </section>
+      )}
     </section>
   );
 }

--- a/components/settings/KnowledgeSourcesClient.tsx
+++ b/components/settings/KnowledgeSourcesClient.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+// @MX:NOTE [AUTO] KnowledgeSourcesClient — UI for managing git-backed knowledge sources.
+// @MX:SPEC Issue #307 D-2 Phase 2 (Knowledge Sources Settings UI)
+//
+// Connects to D-2a API:
+//   GET    /api/ra/knowledge-sources           (knowledgesources.view)
+//   POST   /api/ra/knowledge-sources           (knowledgesources.manage)
+//   DELETE /api/ra/knowledge-sources/[id]      (knowledgesources.manage)
+//   POST   /api/ra/knowledge-sources/[id]/sync (knowledgesources.manage)
+//
+// auth_token is write-only: never fetched back, never displayed.
+// Server is source of truth for git_url validation (parseGitUrl); client only
+// does a basic required + URL-ish check to avoid a round-trip for obvious errors.
+
+import { useCallback, useEffect, useState } from 'react';
+
+type SyncStatus = 'idle' | 'syncing' | 'synced' | 'failed';
+
+interface KnowledgeSource {
+  id: string;
+  gitUrl: string;
+  branch: string;
+  syncStatus: SyncStatus;
+  lastSyncedAt: string | null;
+  createdAt: string;
+}
+
+const STATUS_LABELS: Record<SyncStatus, string> = {
+  idle: '대기 중',
+  syncing: '동기화 중',
+  synced: '동기화됨',
+  failed: '실패',
+};
+
+const STATUS_BADGE_CLASS: Record<SyncStatus, string> = {
+  idle: 'bg-ink-100 text-ink-700',
+  syncing: 'bg-brand-100 text-brand-700',
+  synced: 'bg-success-bg text-success',
+  failed: 'bg-danger-bg text-danger',
+};
+
+function formatLastSynced(iso: string | null): string {
+  if (!iso) return '미연동';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '미연동';
+  const diffMs = Date.now() - then;
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return '방금 전';
+  if (minutes < 60) return `${minutes}분 전`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}일 전`;
+  // Fall back to absolute date for older entries.
+  return new Date(iso).toLocaleDateString('ko-KR');
+}
+
+export function KnowledgeSourcesClient() {
+  const [sources, setSources] = useState<KnowledgeSource[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form state
+  const [gitUrl, setGitUrl] = useState('');
+  const [branch, setBranch] = useState('main');
+  const [authToken, setAuthToken] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Per-row action state
+  const [syncingId, setSyncingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<KnowledgeSource | null>(null);
+
+  // Status announcements for screen readers (aria-live).
+  const [announcement, setAnnouncement] = useState<string | null>(null);
+
+  const loadSources = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/ra/knowledge-sources', { cache: 'no-store' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { sources: KnowledgeSource[] };
+      setSources(data.sources ?? []);
+    } catch {
+      setError('지식베이스 목록을 불러오지 못했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSources();
+  }, [loadSources]);
+
+  async function handleCreate(event: React.FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    // Basic client-side hint; server parseGitUrl is the source of truth.
+    const trimmedUrl = gitUrl.trim();
+    if (!trimmedUrl) {
+      setFormError('Git 저장소 URL을 입력하세요.');
+      return;
+    }
+    if (!/^https?:\/\//i.test(trimmedUrl)) {
+      setFormError('URL은 https:// 로 시작해야 합니다.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/ra/knowledge-sources', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          git_url: trimmedUrl,
+          branch: branch.trim() || 'main',
+          auth_token: authToken.trim() || undefined,
+        }),
+      });
+      if (res.status === 400) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setFormError(
+          body.error === 'invalid_git_url' ? '잘못된 Git URL 형식입니다.' : '입력을 확인해 주세요.',
+        );
+        return;
+      }
+      if (!res.ok) {
+        setFormError('연결에 실패했습니다. 다시 시도해 주세요.');
+        return;
+      }
+      setAnnouncement('지식베이스가 연결되었습니다.');
+      setGitUrl('');
+      setBranch('main');
+      setAuthToken('');
+      await loadSources();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleSync(source: KnowledgeSource) {
+    setSyncingId(source.id);
+    setAnnouncement('동기화를 시작합니다.');
+    try {
+      const res = await fetch(`/api/ra/knowledge-sources/${source.id}/sync`, {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setAnnouncement(
+          body.error === 'sync_failed'
+            ? '동기화에 실패했습니다.'
+            : '동기화 중 오류가 발생했습니다.',
+        );
+        return;
+      }
+      setAnnouncement('동기화가 완료되었습니다.');
+      await loadSources();
+    } finally {
+      setSyncingId(null);
+    }
+  }
+
+  async function handleConfirmDelete() {
+    const source = pendingDelete;
+    if (!source) return;
+    setDeletingId(source.id);
+    try {
+      const res = await fetch(`/api/ra/knowledge-sources/${source.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        setAnnouncement('삭제에 실패했습니다.');
+        return;
+      }
+      setAnnouncement('지식베이스 연결이 삭제되었습니다.');
+      setPendingDelete(null);
+      await loadSources();
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <div data-testid="knowledge-sources-section">
+      {/* Create form */}
+      <form onSubmit={handleCreate} className="space-y-3" aria-label="지식베이스 연결 추가">
+        <div className="space-y-1">
+          <label htmlFor="ks-git-url" className="block text-sm font-medium text-ink-700">
+            Git 저장소 URL
+          </label>
+          <input
+            id="ks-git-url"
+            type="text"
+            inputMode="url"
+            autoComplete="off"
+            placeholder="https://github.com/owner/repo.git"
+            value={gitUrl}
+            onChange={(e) => setGitUrl(e.target.value)}
+            disabled={submitting}
+            className="w-full rounded-md border border-ink-150 bg-surface px-3 py-2 text-sm text-ink-900 placeholder:text-ink-400 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="ks-git-url"
+          />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <label htmlFor="ks-branch" className="block text-sm font-medium text-ink-700">
+              브랜치
+            </label>
+            <input
+              id="ks-branch"
+              type="text"
+              autoComplete="off"
+              placeholder="main"
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+              disabled={submitting}
+              className="w-full rounded-md border border-ink-150 bg-surface px-3 py-2 text-sm text-ink-900 placeholder:text-ink-400 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="ks-branch"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="ks-auth-token" className="block text-sm font-medium text-ink-700">
+              액세스 토큰(선택)
+            </label>
+            <input
+              id="ks-auth-token"
+              type="password"
+              autoComplete="off"
+              placeholder="비공개 저장소인 경우 입력"
+              value={authToken}
+              onChange={(e) => setAuthToken(e.target.value)}
+              disabled={submitting}
+              className="w-full rounded-md border border-ink-150 bg-surface px-3 py-2 text-sm text-ink-900 placeholder:text-ink-400 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="ks-auth-token"
+            />
+          </div>
+        </div>
+
+        {formError && (
+          <p role="alert" data-testid="ks-form-error" className="text-sm text-danger">
+            {formError}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center rounded-md bg-brand-800 px-4 py-2 text-sm font-medium text-surface shadow-sm hover:bg-brand-700 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 motion-safe:transition-colors"
+          data-testid="ks-submit"
+        >
+          {submitting ? '연결 중…' : '연결'}
+        </button>
+      </form>
+
+      {/* Status announcements for assistive tech */}
+      <div aria-live="polite" className="sr-only">
+        {announcement}
+      </div>
+
+      {/* Existing sources list */}
+      <div className="mt-6">
+        <h3 className="font-serif text-base text-ink-900">연결된 저장소</h3>
+
+        {loading && (
+          <p data-testid="ks-loading" className="mt-2 py-4 text-sm text-ink-400">
+            불러오는 중…
+          </p>
+        )}
+
+        {error && !loading && (
+          <p role="alert" data-testid="ks-load-error" className="mt-2 text-sm text-danger">
+            {error}
+          </p>
+        )}
+
+        {!loading && !error && sources.length === 0 && (
+          <p data-testid="ks-empty" className="mt-2 py-4 text-sm text-ink-400">
+            아직 연결된 저장소가 없습니다.
+          </p>
+        )}
+
+        {sources.length > 0 && (
+          <ul className="mt-3 space-y-2" data-testid="ks-list">
+            {sources.map((source) => {
+              const isSyncing = syncingId === source.id;
+              const isDeleting = deletingId === source.id;
+              const rowDisabled = isSyncing || isDeleting || submitting;
+              return (
+                <li
+                  key={source.id}
+                  className="flex flex-col gap-3 rounded-md border border-ink-150 bg-surface px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                  data-testid={`ks-row-${source.id}`}
+                >
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate font-mono text-sm text-ink-900" title={source.gitUrl}>
+                        {source.gitUrl}
+                      </p>
+                      <span
+                        className={`inline-flex shrink-0 items-center rounded-xs px-2 py-0.5 text-xs font-medium ${STATUS_BADGE_CLASS[source.syncStatus]}`}
+                        data-testid={`ks-status-${source.id}`}
+                      >
+                        {STATUS_LABELS[source.syncStatus]}
+                      </span>
+                    </div>
+                    <p className="text-xs text-ink-500">
+                      <span className="font-mono">{source.branch}</span>
+                      <span className="mx-1">·</span>
+                      <span>마지막 동기화: {formatLastSynced(source.lastSyncedAt)}</span>
+                    </p>
+                  </div>
+
+                  <div className="flex shrink-0 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void handleSync(source)}
+                      disabled={rowDisabled}
+                      className="inline-flex items-center rounded-md border border-ink-150 bg-surface px-3 py-1.5 text-xs font-medium text-ink-700 hover:bg-ink-50 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 motion-safe:transition-colors"
+                      aria-label={`${source.gitUrl} 다시 동기화`}
+                      data-testid={`ks-sync-${source.id}`}
+                    >
+                      {isSyncing ? '동기화 중…' : '다시 동기화'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPendingDelete(source)}
+                      disabled={rowDisabled}
+                      className="inline-flex items-center rounded-md border border-danger/30 bg-surface px-3 py-1.5 text-xs font-medium text-danger hover:bg-danger-bg focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 motion-safe:transition-colors"
+                      aria-label={`${source.gitUrl} 삭제`}
+                      data-testid={`ks-delete-${source.id}`}
+                    >
+                      {isDeleting ? '삭제 중…' : '삭제'}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {/* Delete confirmation dialog.
+          Native <dialog> requires imperative showModal()/close() calls that
+          conflict with React state-driven rendering; the ARIA modal pattern
+          (role=dialog + aria-modal) is intentional here. */}
+      {pendingDelete && (
+        // biome-ignore lint/a11y/useSemanticElements: intentional ARIA modal pattern
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="ks-delete-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-ink-950/40 px-4"
+          data-testid="ks-delete-dialog"
+        >
+          <div className="w-full max-w-sm rounded-lg border border-ink-150 bg-surface p-6 shadow-lg">
+            <h3 id="ks-delete-title" className="font-serif text-lg text-ink-900">
+              연결 삭제
+            </h3>
+            <p className="mt-2 text-sm text-ink-600">
+              이 저장소의 연결을 삭제하시겠습니까? 이미 동기화된 지식은 유지됩니다.
+            </p>
+            <p className="mt-2 break-all font-mono text-xs text-ink-500">{pendingDelete.gitUrl}</p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setPendingDelete(null)}
+                disabled={deletingId !== null}
+                className="inline-flex items-center rounded-md border border-ink-150 bg-surface px-3 py-1.5 text-sm font-medium text-ink-700 hover:bg-ink-50 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                data-testid="ks-delete-cancel"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleConfirmDelete()}
+                disabled={deletingId !== null}
+                className="inline-flex items-center rounded-md bg-danger px-3 py-1.5 text-sm font-medium text-surface hover:opacity-90 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                data-testid="ks-delete-confirm"
+              >
+                {deletingId !== null ? '삭제 중…' : '삭제'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/settings/__tests__/KnowledgeSourcesClient.test.tsx
+++ b/components/settings/__tests__/KnowledgeSourcesClient.test.tsx
@@ -1,0 +1,294 @@
+/** @vitest-environment jsdom */
+
+/**
+ * KnowledgeSourcesClient tests
+ * @MX:SPEC Issue #307 D-2 Phase 2 (Knowledge Sources Settings UI)
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { KnowledgeSourcesClient } from '../KnowledgeSourcesClient';
+
+const SAMPLE_SOURCE = {
+  id: 'src-001',
+  gitUrl: 'https://github.com/acme/regulations.git',
+  branch: 'main',
+  syncStatus: 'synced' as const,
+  lastSyncedAt: '2026-06-29T10:00:00.000Z',
+  createdAt: '2026-06-28T10:00:00.000Z',
+};
+
+function mockFetch(impl: typeof globalThis.fetch) {
+  vi.stubGlobal('fetch', vi.fn(impl) as unknown as typeof fetch);
+}
+
+beforeEach(() => {
+  // Use a fixed "now" so relative-time formatting ("방금 전", "일 전") is
+  // deterministic. Real timers are kept so async fetch + waitFor resolve
+  // normally — only Date.now() is stubbed via setSystemTime.
+  vi.setSystemTime(new Date('2026-06-30T10:00:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('KnowledgeSourcesClient', () => {
+  it('renders the form and empty state when no sources exist', async () => {
+    mockFetch(async (url: string | URL | Request) => {
+      const target = typeof url === 'string' ? url : url.toString();
+      if (target.startsWith('/api/ra/knowledge-sources') && !target.includes('/sync')) {
+        return new Response(JSON.stringify({ sources: [] }), { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    });
+
+    render(<KnowledgeSourcesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ks-empty')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('ks-git-url')).toBeInTheDocument();
+    expect(screen.getByTestId('ks-branch')).toHaveValue('main');
+    expect(screen.getByTestId('ks-submit')).toHaveTextContent('연결');
+  });
+
+  it('submits a new source via POST and refreshes the list', async () => {
+    let listCallCount = 0;
+    mockFetch(async (url: string | URL | Request, init?: RequestInit) => {
+      const target = typeof url === 'string' ? url : url.toString();
+      const method = init?.method ?? 'GET';
+
+      if (target === '/api/ra/knowledge-sources' && method === 'GET') {
+        listCallCount += 1;
+        const sources = listCallCount === 1 ? [] : [SAMPLE_SOURCE];
+        return new Response(JSON.stringify({ sources }), { status: 200 });
+      }
+      if (target === '/api/ra/knowledge-sources' && method === 'POST') {
+        return new Response(JSON.stringify({ source: SAMPLE_SOURCE }), { status: 201 });
+      }
+      return new Response('', { status: 404 });
+    });
+
+    render(<KnowledgeSourcesClient />);
+    await waitFor(() => expect(screen.getByTestId('ks-empty')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('ks-git-url'), {
+      target: { value: 'https://github.com/acme/regulations.git' },
+    });
+    fireEvent.change(screen.getByTestId('ks-branch'), { target: { value: 'main' } });
+    fireEvent.change(screen.getByTestId('ks-auth-token'), { target: { value: 'tok_abc' } });
+    fireEvent.click(screen.getByTestId('ks-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ks-row-src-001')).toBeInTheDocument();
+    });
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const postCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST');
+    expect(postCall?.[1]?.body).toEqual(
+      JSON.stringify({
+        git_url: 'https://github.com/acme/regulations.git',
+        branch: 'main',
+        auth_token: 'tok_abc',
+      }),
+    );
+  });
+
+  it('shows a form error when git_url is empty', async () => {
+    mockFetch(async () => new Response(JSON.stringify({ sources: [] }), { status: 200 }));
+
+    render(<KnowledgeSourcesClient />);
+    await waitFor(() => expect(screen.getByTestId('ks-empty')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('ks-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ks-form-error')).toHaveTextContent('Git 저장소 URL을 입력하세요.');
+    });
+  });
+
+  it('rejects non-https URLs client-side', async () => {
+    mockFetch(async () => new Response(JSON.stringify({ sources: [] }), { status: 200 }));
+
+    render(<KnowledgeSourcesClient />);
+    await waitFor(() => expect(screen.getByTestId('ks-empty')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('ks-git-url'), {
+      target: { value: 'git@github.com:acme/regulations.git' },
+    });
+    fireEvent.click(screen.getByTestId('ks-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ks-form-error')).toHaveTextContent(/https:\/\//);
+    });
+  });
+
+  it('renders sync status badge and last-synced time per row', async () => {
+    mockFetch(
+      async () => new Response(JSON.stringify({ sources: [SAMPLE_SOURCE] }), { status: 200 }),
+    );
+
+    render(<KnowledgeSourcesClient />);
+
+    const status = await screen.findByTestId('ks-status-src-001');
+    expect(status).toHaveTextContent('동기화됨');
+    expect(screen.getByTestId('ks-row-src-001')).toHaveTextContent('마지막 동기화:');
+    expect(screen.getByTestId('ks-row-src-001')).toHaveTextContent('main');
+  });
+
+  it('triggers re-sync on click and disables the row button while pending', async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const target = typeof url === 'string' ? url : url.toString();
+      if (target.includes('/sync') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ sources: [SAMPLE_SOURCE] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    render(<KnowledgeSourcesClient />);
+    const syncButton = await screen.findByTestId('ks-sync-src-001');
+
+    fireEvent.click(syncButton);
+
+    await waitFor(() => {
+      expect(syncButton).toHaveTextContent('동기화 중…');
+    });
+    await waitFor(() => {
+      expect(syncButton).toHaveTextContent('다시 동기화');
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/ra/knowledge-sources/src-001/sync',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('opens delete confirmation dialog and deletes on confirm', async () => {
+    let deleted = false;
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const target = typeof url === 'string' ? url : url.toString();
+      const method = init?.method ?? 'GET';
+      if (target === '/api/ra/knowledge-sources/src-001' && method === 'DELETE') {
+        deleted = true;
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      if (target === '/api/ra/knowledge-sources' && method === 'GET') {
+        // After delete, the list refresh returns empty.
+        const sources = deleted ? [] : [SAMPLE_SOURCE];
+        return new Response(JSON.stringify({ sources }), { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    render(<KnowledgeSourcesClient />);
+
+    const deleteButton = await screen.findByTestId('ks-delete-src-001');
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ks-delete-dialog')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('ks-delete-confirm')).toHaveTextContent('삭제');
+
+    fireEvent.click(screen.getByTestId('ks-delete-confirm'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('ks-row-src-001')).not.toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/ra/knowledge-sources/src-001',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('cancel button dismisses the delete dialog without calling DELETE', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ sources: [SAMPLE_SOURCE] }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    render(<KnowledgeSourcesClient />);
+
+    const deleteButton = await screen.findByTestId('ks-delete-src-001');
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(screen.getByTestId('ks-delete-dialog')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('ks-delete-cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('ks-delete-dialog')).not.toBeInTheDocument();
+    });
+
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit?]>;
+    const deleteCall = calls.find(([, init]) => init?.method === 'DELETE');
+    expect(deleteCall).toBeUndefined();
+  });
+
+  it('shows an inline error when the list fails to load', async () => {
+    mockFetch(async () => new Response('', { status: 500 }));
+
+    render(<KnowledgeSourcesClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ks-load-error')).toBeInTheDocument();
+    });
+  });
+
+  it('handles invalid_git_url response from server', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'GET') return new Response(JSON.stringify({ sources: [] }), { status: 200 });
+      if (method === 'POST')
+        return new Response(JSON.stringify({ error: 'invalid_git_url' }), { status: 400 });
+      return new Response('', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    render(<KnowledgeSourcesClient />);
+    await waitFor(() => expect(screen.getByTestId('ks-empty')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('ks-git-url'), {
+      target: { value: 'https://example.com/some-page' },
+    });
+    fireEvent.click(screen.getByTestId('ks-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ks-form-error')).toHaveTextContent('잘못된 Git URL 형식입니다.');
+    });
+  });
+
+  it('does not send auth_token when the field is left blank', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'GET') {
+        return new Response(JSON.stringify({ sources: [] }), { status: 200 });
+      }
+      if (method === 'POST') {
+        return new Response(JSON.stringify({ source: SAMPLE_SOURCE }), { status: 201 });
+      }
+      return new Response('', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    render(<KnowledgeSourcesClient />);
+    await waitFor(() => expect(screen.getByTestId('ks-empty')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('ks-git-url'), {
+      target: { value: 'https://github.com/acme/regulations.git' },
+    });
+    fireEvent.click(screen.getByTestId('ks-submit'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit?]>;
+    const postCall = calls.find(([, init]) => init?.method === 'POST');
+    const body = JSON.parse(postCall?.[1]?.body as string);
+    expect(body.auth_token).toBeUndefined();
+  });
+});

--- a/docs/proposals/phase-d-2b-ingestion-plan-2026-06-30.md
+++ b/docs/proposals/phase-d-2b-ingestion-plan-2026-06-30.md
@@ -1,0 +1,440 @@
+# Phase D-2b — `ingestDocuments` Implementation Plan
+
+| Field | Value |
+|---|---|
+| Branch | `feat/d-2b-knowledge-ingestion` |
+| Base | `main` @ `a514c88` |
+| Issue | #307 Phase D-2b (stub TODO in `lib/knowledge-sources/sync.ts:180`) |
+| Date | 2026-06-30 |
+| Status | Design — awaiting approval |
+| Governing SPECs | [`SPEC-REGULA-DOCINGEST-001`](../../.moai/specs/SPEC-REGULA-DOCINGEST-001/spec.md) (pipeline primitives), [`SPEC-REGULA-DELTA-SYNC-001`](../../.moai/specs/SPEC-REGULA-DELTA-SYNC-001/spec.md) (supersession), [`SPEC-REGULA-TRACEABILITY-001`](../../.moai/specs/SPEC-REGULA-TRACEABILITY-001/spec.md) (Part 11 audit) |
+| Formal SPEC for D-2b | **None exists.** Recommend this design doc as the implementation contract (Issue #307 sub-task). A retrospective SPEC may be filed post-implementation. |
+
+---
+
+## 1. Goal & Non-Goals
+
+### Goal
+
+Implement `ingestDocuments(repoPath, sourceId, orgId)` in `lib/knowledge-sources/sync.ts`
+so that a cloned knowledge-source repository is parsed, PII-redacted, chunked,
+embedded, and upserted into `sources` + `source_sections` (pgvector), making the
+site RAG retriever (`lib/ai/retrievers/internal-docs.ts`) return knowledge-source
+content for organization-scoped queries.
+
+The implementation MUST reuse the existing DOCINGEST pipeline primitives
+(extract → redact → chunk → embed → upsert) and the delta-sync supersession
+pattern (`applyOutdateOperations`). **No new chunker, embedder, or redactor
+families are created.**
+
+### Non-Goals (Scope Discipline)
+
+| Out of scope | Owner |
+|---|---|
+| Settings UI for knowledge sources | Separate Phase D-3 |
+| Public-repo E2E (real GitHub clone) | Separate validation PR |
+| Re-tuning chunk sizes or embedding model | `SPEC-REGULA-DOCINGEST-001` owns these |
+| Replacing the DOCINGEST upload-path stub `insertChunks` | Tracked separately — see §4.3 |
+| Modifying `cloneRepo` RCE/SSRF defenses | **Preserved verbatim** — `lib/knowledge-sources/sync.ts:125-164` |
+| Adding new `sources.type` enum values | Schema frozen |
+| Vectorize (CF) upsert | Out of scope; pgvector is the retrieval target. Vectorize integration follows the delta-sync `buildVectorizeUpsertPayload` pattern as a follow-up. |
+
+---
+
+## 2. Reuse Map
+
+For each pipeline stage, the exact `lib/ingest` / `lib/radar/delta-sync` function
+to call. All functions are composable (pure or single-purpose) and require **no
+adaptation** unless flagged.
+
+| Stage | Function (file) | Signature | Returns | Adaptation needed? |
+|---|---|---|---|---|
+| **Scan repo** | (new) `scanRepoFiles(repoPath)` | `(repoPath: string) => Promise<ScannedFile[]>` | List of `{absPath, relPath, mimeType, size}` | **NEW** — but trivial: `fs.walk` + ext→MIME map. ~40 LOC. No lib change. |
+| **Extract text** | `extractText(buffer, mimeType)` (`lib/ingest/extract/index.ts:30`) | `(buffer: Buffer, mimeType: string) => Promise<string>` | Plain text; throws `ExtractError` on unsupported | **GAP**: supports PDF/DOCX/XLSX/ZIP only. TXT/MD fall through to `ExtractError`. **Mitigation**: in `ingestDocuments`, read `.txt/.md` as UTF-8 directly and skip `extractText` for those extensions. No lib change needed. |
+| **Classify** | `classifyDocument({filename, firstPageText})` (`lib/ingest/doc-classifier.ts:38`) | `(input: ClassifyInput) => ClassifyResult` | `{suggestedClass, confidence}` | None. Use `suggestedClass` if `confidence >= 0.6`, else fallback to `DocClass.internal_sop`. |
+| **PII redact** | `redactPiiForIngest(text, docClass)` (`lib/ingest/pii/redact.ts:38`) | `(text: string, docClass: DocClass, options?) => Promise<RedactionResult>` | `{text, layersRun, redactionCount, ...}` | None. Use `.text`. The `saveMap` option is **omitted** for knowledge-sources (no `documentId` in the repo path; 21 CFR Part 11 reversibility for repo-ingested text is deferred — see §7 Risk 3). |
+| **Chunk** | `chunk(docClass, text, metadata)` (`lib/ingest/chunkers/index.ts:32`) | `(docClass, text, metadata) => Chunk[]` | `Chunk[] = {text, metadata:{docClass,sectionPath,tokenCount}}` | None. For low-confidence classification, pass `DocClass.internal_sop` → dispatches to `chunkSopIso13485`, OR call `makeGenericChunker(DocClass.internal_sop)` directly. **Recommendation**: always use the registry via `chunk()`; it already falls back gracefully. |
+| **Embed** | `embedChunks(texts)` (`lib/ingest/embed.ts:78`) | `(texts: string[]) => Promise<number[][]>` | Embeddings (1536-dim); throws on PII guard | None. Already batched (`BATCH_SIZE=100`), retried (`MAX_RETRIES=3`), PII-guarded. |
+| **Upsert sections** | (mirror `runDeltaSync` steps 7a–7e) (`lib/radar/delta-sync/orchestrator.ts:194-260`) | `withTenantScope(orgId, tx => ...)` | Inserted section rows | **NEW orchestrator** — but the per-section INSERT pattern is copy-clear from `orchestrator.ts:210-235`. No primitive extraction needed; the loop body is inlined. |
+| **Supersede stale** | `applyOutdateOperations({orgId, existingChunkIds, newIngestionRunId, actorId})` (`lib/radar/delta-sync/ingest.ts:96`) | `(params) => Promise<{applied, results}>` | Marks `superseded_by`, emits Part 11 audit | None. `resolveExistingChunkIds(sourceId, orgId)` (`orchestrator.ts:336`) also reused as-is. |
+
+### Key finding
+
+**`lib/ingest` has a fully composable pipeline.** Every primitive exists and is
+exported. The gap is **not** a missing function — it is the **absence of a
+per-file repo orchestrator** that loops the primitives over a directory tree.
+The `runDeltaSync` orchestrator in `lib/radar/delta-sync/orchestrator.ts` is the
+architectural template: it already composes `chunkForDelta → embedChunks →
+assembleEmbeddedChunks → INSERT source_sections (org-scoped tx) →
+applyOutdateOperations` with `corpus_sync_runs` history + Part 11 audit. The
+`ingestDocuments` function becomes a thin per-file loop calling the **same
+primitives** (not `runDeltaSync` itself — see §4.2 for rationale).
+
+---
+
+## 3. `ingestDocuments` Implementation Design
+
+### 3.1 High-level flow
+
+```
+ingestDocuments(repoPath, ksSourceId, orgId)
+  │
+  ├─ 0. Resolve/create the parent `sources` row for this knowledge_source
+  │     (1 knowledge_source : 1 sources row per FILE — see §3.2)
+  │
+  ├─ 1. scanRepoFiles(repoPath) → ScannedFile[]
+  │     • filter by extension (PDF/DOCX/TXT/MD)
+  │     • enforce caps (§3.5): MAX_FILES, MAX_TOTAL_SIZE, MAX_FILE_SIZE
+  │     • skip binary/unsupported silently (logged at warn)
+  │
+  ├─ 2. Create ONE corpus_sync_runs row (status='pending')
+  │     • crawlerName = 'knowledge-source'
+  │     • sourceUrl  = `git://${knowledgeSource.sourceHost}/${knowledgeSource.sourceOwner}/${knowledgeSource.sourceRepo}#${branch}`
+  │
+  ├─ 3. FOR EACH file (sequential — embed API is the bottleneck):
+  │     │
+  │     ├─ a. extractText (or UTF-8 read for .txt/.md)
+  │     ├─ b. classifyDocument → docClass (fallback internal_sop)
+  │     ├─ c. redactPiiForIngest(text, docClass) → redactedText
+  │     ├─ d. chunk(docClass, redactedText, {relPath, orgId}) → Chunk[]
+  │     ├─ e. embedChunks(chunks.map(c => c.text)) → embeddings
+  │     │     (batched internally by embedChunks; per-file batch is fine)
+  │     ├─ f. resolveExistingChunkIds(fileSourceId, orgId) → oldIds[]
+  │     ├─ g. withTenantScope(orgId, tx => INSERT source_sections)
+  │     │     • anchor = `${sha8(relPath)}-${i}`
+  │     │     • sectionPath = relPath + '#' + chunk.metadata.sectionPath
+  │     │     • chunkHash = computeChunkHash(chunk.text)
+  │     │     • ingestionRunId = runId
+  │     ├─ h. applyOutdateOperations({orgId, existingChunkIds: oldIds,
+  │     │     newIngestionRunId: runId, actorId: null})
+  │     └─ [per-file try/catch — one bad file logs + continues]
+  │
+  ├─ 4. UPDATE corpus_sync_runs SET status='synced',
+  │     chunks_added, chunks_outdated, completedAt
+  │
+  └─ 5. Return {filesProcessed, chunksAdded, chunksOutdated, errors[]}
+```
+
+### 3.2 Source modeling: `knowledge_sources` ↔ `sources` ↔ `source_sections`
+
+```
+knowledge_sources (D-1 table)
+  id (uuid)          ← ksSourceId passed to ingestDocuments
+  gitUrl, branch, sourceHost, sourceOwner, sourceRepo
+        │
+        │  1 : N  (one row per FILE in the repo)
+        ▼
+sources (REQ-FND-037)
+  id (uuid)          ← fileSourceId, per file
+  organizationId     ← orgId
+  orgLabel           ← `${sourceOwner}/${sourceRepo}:${branch}`
+  title              ← basename(file)
+  type               ← 'internal_sop' (sourceTypeEnum — closest match;
+  │                     repo content is internal guidance)
+  sourceHost/Owner/Repo/Branch/Ref/Path  ← provenance from gitUrl + relPath
+  contentHash        ← SHA256 of the file's redacted text
+  ingestionRunId     ← runId (corpus_sync_runs.id)
+  approvalStatus     ← 'pending_review' (default — RA-owner gate, REQ-SOURCE-GOV-009)
+        │
+        │  1 : N  (one row per CHUNK)
+        ▼
+source_sections (REQ-FND-044a)
+  sourceId           ← fileSourceId
+  anchor             ← `${sha8(relPath)}-${i}` (UNIQUE per source)
+  heading            ← chunk.metadata.sectionPath
+  text               ← chunk.text
+  chunkHash          ← computeChunkHash(chunk.text)
+  sectionPath        ← `${relPath}#${chunk.metadata.sectionPath}`
+  ingestionRunId     ← runId
+  embedding          ← embeddings[i]  (vector(1536))
+  superseded_by      ← null (new); prior rows set by applyOutdateOperations
+```
+
+**Why 1 knowledge_source : N sources (one per file)?** This matches the existing
+provenance schema (`sources.sourcePath` is per-file) and enables correct
+per-file supersession on re-sync (only stale chunks for the changed file are
+superseded, not the whole repo). The alternative — 1 `sources` row for the whole
+repo — would force whole-repo supersession on every sync and lose file-level
+traceability.
+
+### 3.3 `scanRepoFiles` — repo walker (new, ~40 LOC)
+
+```
+scanRepoFiles(repoPath) → Promise<ScannedFile[]>
+  - fs.readdir recursive, skip:
+      .git/, node_modules/, dist/, .next/, binary extensions
+  - collect files with extensions: .pdf .docx .txt .md
+  - map ext → mimeType:
+      .pdf  → application/pdf
+      .docx → application/vnd.openxmlformats-officedocument.wordprocessingml.document
+      .txt  → text/plain
+      .md   → text/markdown
+  - return [{absPath, relPath, mimeType, size}]
+```
+
+No new module file required — implement as a private helper inside
+`lib/knowledge-sources/sync.ts` or extract to `lib/knowledge-sources/scan.ts`
+if the file exceeds 400 LOC (judgment call at implementation time).
+
+### 3.4 TXT/MD extraction gap
+
+`extractText` throws `ExtractError` for `text/plain` / `text/markdown`. In
+`ingestDocuments`, branch on mimeType **before** calling `extractText`:
+
+```ts
+let rawText: string;
+if (mimeType === 'text/plain' || mimeType === 'text/markdown') {
+  rawText = await fs.readFile(absPath, 'utf-8');
+} else {
+  const buf = await fs.readFile(absPath);
+  rawText = await extractText(buf, mimeType);
+}
+```
+
+This is the only place where knowledge-source ingestion diverges from the
+DOCINGEST upload path, and it requires no change to `lib/ingest/extract`.
+
+### 3.5 Concurrency, batching, caps (DoS defense)
+
+| Limit | Value | Rationale |
+|---|---|---|
+| `MAX_FILES` | 500 | Bounds total work; typical SOP repo < 100 files. |
+| `MAX_FILE_SIZE` | 10 MB | PDFs larger than this are usually image-only scans (extraction yields garbage). |
+| `MAX_TOTAL_SIZE` | 100 MB | Bounds embedding cost (~$0.02 per 1M tokens at text-embedding-3-small). |
+| File loop | **Sequential** | OpenAI embed API is the bottleneck; parallel files would just batch into the same `BATCH_SIZE=100` call. Per-file sequential also bounds memory. |
+| Embed batching | `embedChunks` internal (`BATCH_SIZE=100`) | Already optimal — no change. |
+| Per-file error | `try/catch` continues to next file | One corrupt PDF must not fail the repo. Errors collected into `errors[]` and surfaced in `corpus_sync_runs.error_message` (truncated) + audit. |
+
+### 3.6 Error handling per file
+
+```ts
+for (const file of files) {
+  try {
+    // ... extract, classify, redact, chunk, embed, upsert, supersede
+    filesProcessed++;
+  } catch (err) {
+    errors.push({ relPath: file.relPath, error: messageOf(err) });
+    logger.warn('[ingestDocuments] file failed', { relPath, error });
+    // CONTINUE — do not throw
+  }
+}
+```
+
+If `errors.length === files.length` (every file failed), throw after the loop so
+the outer `syncKnowledgeSource` catch flips `syncStatus='failed'`. Otherwise
+the run is a partial success — `syncStatus='synced'` with `errors[]` in the
+audit `meta_json`.
+
+---
+
+## 4. `sync.ts` Integration
+
+### 4.1 Compose with existing `cloneRepo` (RCE defense preserved)
+
+`syncKnowledgeSource` already calls `cloneRepo` (lines 59) with full RCE/SSRF
+defense (`execFile` + `GIT_REF_PATTERN` + `isInternalHost`). **This is preserved
+verbatim.** The only change inside `syncKnowledgeSource` is removing the TODO
+comment on line 62 — `ingestDocuments` is now real.
+
+### 4.2 Why not call `runDeltaSync` directly?
+
+`runDeltaSync` (`lib/radar/delta-sync/orchestrator.ts:95`) takes a single
+`{rawContent, sourceUrl, sourceId}` — it is per-single-content. A repo is N
+files. Calling `runDeltaSync` per file would:
+
+- create N `corpus_sync_runs` rows (one per file) — loses repo-level run visibility;
+- re-resolve `existingHash` per file using `sourceUrl` semantics that don't map
+  to repo file paths;
+- bypass the knowledge-source-level `corpus_sync_runs` summary we want.
+
+**Decision**: `ingestDocuments` reuses the **primitive operations**
+(`chunkForDelta` / `embedChunks` / `assembleEmbeddedChunks` /
+`applyOutdateOperations` / `resolveExistingChunkIds`) but creates ONE
+repo-level `corpus_sync_runs` row and loops files itself. This mirrors the
+`runDeltaSync` internal structure without forcing the single-content contract.
+
+### 4.3 `lastSyncedAt` / `syncStatus` / audit (existing, unchanged)
+
+`syncKnowledgeSource` already (lines 66-108):
+- `UPDATE knowledge_sources SET lastSyncedAt, syncStatus='synced'` on success;
+- `UPDATE knowledge_sources SET syncStatus='failed'` on error;
+- writes `knowledge_source.synced` audit on both paths.
+
+**No change needed.** The `ingestDocuments` return value
+(`{filesProcessed, chunksAdded, chunksOutdated, errors}`) is folded into the
+existing audit `meta_json` so the audit trail is enriched, not duplicated.
+
+### 4.4 `corpus_sync_runs` entry
+
+`ingestDocuments` creates ONE `corpus_sync_runs` row for the whole repo:
+
+```ts
+const runRow = await db.insert(corpusSyncRuns).values({
+  crawlerName: 'knowledge-source',
+  sourceUrl: `git://${ks.sourceHost}/${ks.sourceOwner}/${ks.sourceRepo}#${ks.branch}`,
+  contentHash: '',                                    // filled post-scan
+  status: 'pending',
+}).returning({ id });
+const runId = runRow[0].id;
+```
+
+On completion, update with `chunks_added`, `chunks_outdated`, `status='synced'`,
+`completedAt`. On failure, `status='failed'` + `error_message` (truncated). This
+is the same lifecycle as `runDeltaSync` steps 2 / 7e / 8.
+
+### 4.5 Supersession for re-sync
+
+When `syncKnowledgeSource` runs again (weekly cron or manual):
+
+1. `ingestDocuments` resolves `fileSourceId` per file by querying
+   `sources` on `(organizationId, sourceHost, sourceOwner, sourceRepo, sourcePath)`.
+   - If found → re-use the existing `sources.id` (so `source_sections` anchor
+     uniqueness is preserved).
+   - If not found → INSERT new `sources` row.
+2. Before inserting new sections for that file, call
+   `resolveExistingChunkIds(fileSourceId, orgId)` → old chunk ids.
+3. After inserting new sections, call
+   `applyOutdateOperations({orgId, existingChunkIds: oldIds, newIngestionRunId: runId, actorId: null})`.
+   - This emits `traceability.section_superseded` per section (Part 11, M-2).
+4. If the file was **deleted** from the repo between syncs, the old `sources` row
+   remains but its sections are all superseded (no new sections inserted). A
+   follow-up task can `UPDATE sources SET sunsetDate` for orphaned rows; out of
+   scope for D-2b (logged as a known limitation, §7).
+
+### 4.6 The DOCINGEST upload-path stub (`insertChunks`)
+
+`lib/inngest/docingest/upload-processed.ts:156-164` has a **stub `insertChunks`**
+that returns `chunks.length` without writing to the DB. This is a pre-existing
+project-wide gap (`@MX:TODO` on line 141), **NOT** introduced by D-2b. D-2b will
+implement the real upsert pattern in `ingestDocuments` (inlined from the
+delta-sync template). A follow-up issue should refactor both `ingestDocuments`
+and `upload-processed.ts:insertChunks` to share a single `upsertSourceSections`
+helper — **but that extraction is out of scope for D-2b** (see §8).
+
+---
+
+## 5. Acceptance Criteria (Testable)
+
+| # | Criterion | Verification |
+|---|---|---|
+| AC-1 | Given a temp dir with 3 `.md` files (10 lines each), `ingestDocuments` populates `source_sections` with ≥ 3 rows (one chunk min per file), each with non-null `embedding`, correct `organizationId` via the parent `sources` row, and `sourcePath` matching the relative file path. | Unit test: mock `embedChunks` → fixed vector; assert `source_sections` rows via in-memory DB mock. |
+| AC-2 | Given a repo with a `.pdf` and a `.docx`, `ingestDocuments` calls `extractText` for both and produces chunks with `sectionPath` prefixed by the relative file path. | Unit test: spy on `extractText`, assert call args. |
+| AC-3 | Given a `.txt` file, `ingestDocuments` reads it as UTF-8 and does NOT call `extractText` (avoids `ExtractError`). | Unit test: spy on `extractText`, assert not called for `.txt`. |
+| AC-4 | `redactPiiForIngest` is invoked before `chunk` for every file, and `embedChunks` receives the redacted text (not raw). | Unit test: spy on `redactPiiForIngest` + `embedChunks`, assert call order + arg passing. |
+| AC-5 | On re-sync of the same repo, prior `source_sections` for each file have `superseded_by` set to the new `runId` (via `applyOutdateOperations`), and new sections are inserted. | Integration test: two `ingestDocuments` calls, assert `superseded_by` propagation. |
+| AC-6 | A repo containing one corrupt PDF (`extractText` throws) does NOT fail the whole run: `syncStatus='synced'`, other files' chunks are present, and the error is recorded in `corpus_sync_runs.error_message` + audit `meta_json.errors`. | Unit test: stub `extractText` to throw for one file; assert continuation. |
+| AC-7 | A repo exceeding `MAX_FILES=500` is truncated; a warning is logged and the run still succeeds (partial ingestion). | Unit test: 600 fake files; assert 500 processed. |
+| AC-8 | `cloneRepo` RCE/SSRF defenses (`GIT_REF_PATTERN`, `isInternalHost`, `execFile` argument array) are **unchanged** — diff `lib/knowledge-sources/sync.ts` lines 18-164 against base; only the `ingestDocuments` body (line 180+) changes. | Code review: visual diff. |
+| AC-9 | One `corpus_sync_runs` row is created per `ingestDocuments` call, with `crawlerName='knowledge-source'`, transitioning `pending → synced` on success or `pending → failed` on total failure. | Integration test: query `corpus_sync_runs` post-run. |
+| AC-10 | `knowledge_sources.lastSyncedAt` is updated and `syncStatus='synced'` on success (existing behavior — regression check). | Integration test (already covered by `tests/integration/knowledge-sources.test.ts` — extend). |
+
+---
+
+## 6. Test Strategy
+
+### 6.1 Unit tests — `tests/unit/knowledge-sources/ingest-documents.test.ts`
+
+Mirrors the mocking strategy of `tests/integration/knowledge-sources.test.ts`
+(in-memory DB mock, mock `embedChunks`, mock `redactPiiForIngest`).
+
+| Test | What it asserts |
+|---|---|
+| `ingests 3 markdown files → 3+ source_sections` | AC-1 |
+| `dispatches extractText for pdf/docx` | AC-2 |
+| `reads .txt as UTF-8, skips extractText` | AC-3 |
+| `redact → chunk → embed order enforced` | AC-4 |
+| `corrupt PDF continues to next file` | AC-6 |
+| `MAX_FILES cap enforced` | AC-7 |
+| `embedChunks batched call` | One `embedChunks` call per file with all chunk texts. |
+
+**Mocking pattern** (from existing test):
+- Mock `@/lib/db/client` — in-memory `sources` + `source_sections` + `corpus_sync_runs` stores.
+- Mock `@/lib/ingest/embed` — `embedChunks` returns a fixed 1536-dim vector per input.
+- Mock `@/lib/ingest/pii/redact` — `redactPiiForIngest` returns input unchanged (redaction tested elsewhere).
+- Do **NOT** mock `chunk` / `classifyDocument` / `extractText` — exercise the real registry.
+
+### 6.2 Integration tests — extend `tests/integration/knowledge-sources.test.ts`
+
+Add a `describe('syncKnowledgeSource → ingestDocuments')` block that:
+- Stubs `cloneRepo` (already mocked in the existing suite).
+- Uses the real `ingestDocuments` with a fixture dir under `tests/fixtures/repo/`.
+- Asserts AC-5 (supersession on re-sync), AC-9 (corpus_sync_runs lifecycle), AC-10 (knowledge_sources update).
+
+### 6.3 Regression guards
+
+- **L-009 / L-013 (memory lessons)**: run full `pnpm test` (not just target);
+  verify staged scope with `git diff --cached --name-only` before commit.
+- **L-010**: migration tested against real DB (if any new column — see §7).
+- **PERMISSIONS count**: if a new route or permission is added, bump the
+  `PERMISSIONS` constant. D-2b adds **no new route** (only fills a stub), so no
+  bump expected.
+
+---
+
+## 7. Risks & Mitigations
+
+| # | Risk | Impact | Mitigation |
+|---|---|---|---|
+| 1 | **Large repo DoS** — unbounded file count/size exhausts memory, disk, or OpenAI quota. | High | Hard caps (§3.5): `MAX_FILES=500`, `MAX_FILE_SIZE=10MB`, `MAX_TOTAL_SIZE=100MB`. Files exceeding limits are skipped with a warning, not retried. |
+| 2 | **Embedding cost / OpenAI outage** — repo with 500 files × 20 chunks = 10k embeddings (~$0.02). API failure mid-run. | Medium | `embedChunks` already retries (`MAX_RETRIES=3`, exponential backoff). Per-file try/catch (§3.6) ensures partial success. Failed files recorded in `corpus_sync_runs.error_message`. |
+| 3 | **PII leakage / 21 CFR Part 11 reversibility** — repo content may contain PII; `saveMap` option omitted means no reversibility map for knowledge-source ingestion. | High | `redactPiiForIngest` runs **before** embed for every file (AC-4). `embedChunks` has a defense-in-depth PII guard that throws on detection. **Accepted risk**: knowledge-source repos are curated internal SOPs/guidance, not user-uploaded PHI; the `redaction_maps` reversibility artifact is scoped to DOCINGEST uploads (`documentId`-keyed) and does not map cleanly to repo files. Documented in audit `meta_json.saveMap=false`. |
+| 4 | **Supersession correctness** — re-sync could orphan old chunks if `resolveExistingChunkIds` misses them (e.g., sourceId mismatch). | High | `fileSourceId` is resolved deterministically by `(orgId, sourceHost, sourceOwner, sourceRepo, sourcePath)` query — stable across syncs. `resolveExistingChunkIds` is org-scoped via JOIN (M-1 fix). AC-5 unit test covers the round-trip. |
+| 5 | **Deleted-file orphans** — a file removed from the repo between syncs leaves its `sources` row + superseded sections in the DB (no garbage collection). | Low | Accepted limitation. Sections are superseded (excluded from retrieval via `superseded_by IS NULL` filter). `sources.approvalStatus='pending_review'` means they never reach the retriever until an RA owner approves. Follow-up issue for orphan cleanup (out of scope for D-2b). |
+| 6 | **Migration needs** — does D-2b require a new column? | Medium | **No.** All required columns exist: `sources.sourcePath/Host/Owner/Repo/Branch` (provenance), `sources.contentHash`, `source_sections.chunkHash/sectionPath/superseded_by/ingestionRunId`. **Zero migrations needed.** |
+| 7 | **Concurrency with weekly cron** — cron could fire while a manual sync is in progress. | Low | `knowledge_sources.syncStatus` is the implicit lock: if `syncStatus='syncing'`, the cron step skips (the weekly-sync Inngest function already filters `syncStatus='synced'`). D-2b should set `syncStatus='syncing'` at the start of `syncKnowledgeSource` (small enhancement to the existing flow). |
+
+---
+
+## 8. Scope Discipline — What NOT to Touch
+
+| Do NOT modify | Reason |
+|---|---|
+| `lib/knowledge-sources/sync.ts` lines 18-164 (`cloneRepo`, `isInternalHost`, `GIT_REF_PATTERN`) | RCE/SSRF defense — security-critical, out of scope. |
+| `lib/ingest/embed.ts` (`embedChunks`, `BATCH_SIZE`, `MAX_RETRIES`, PII guard) | Shared by DOCINGEST upload + delta-sync. Changes ripple. |
+| `lib/ingest/chunkers/*` | Registry is stable; no new chunker family for repo files. |
+| `lib/ingest/pii/redact.ts` | Shared redaction policy — changes affect PHI handling. |
+| `lib/radar/delta-sync/*` | `runDeltaSync` + primitives are reused as-is, not modified. |
+| `sources.type` enum, `sourceApprovalStatusEnum`, `sourceTypeEnum` | Schema enums are frozen. |
+| `lib/inngest/docingest/upload-processed.ts` | The stub `insertChunks` is a pre-existing `@MX:TODO` — refactor to a shared `upsertSourceSections` helper is a **follow-up issue**, not D-2b. |
+| `.moai/specs/SPEC-REGULA-DOCINGEST-001/*` | SPEC is `status: completed` — no edits. |
+| Frontend / settings UI | Separate Phase D-3. |
+
+---
+
+## 9. Implementation Scope (for expert-backend delegation)
+
+**Single-file change**: `lib/knowledge-sources/sync.ts` (replace stub body lines
+180-186 with the real implementation + add private helpers `scanRepoFiles`,
+`resolveOrCreateFileSource`, `upsertFileSections`).
+
+**New test files**:
+- `tests/unit/knowledge-sources/ingest-documents.test.ts` (unit, mocked embed/DB)
+- Extend `tests/integration/knowledge-sources.test.ts` with a re-sync block.
+
+**Estimated LOC**: ~250 (implementation) + ~300 (tests).
+
+**No new dependencies.** No migrations. No env var additions (OpenAI key already
+required by DOCINGEST).
+
+**Delegation prompt scope**: "Implement `ingestDocuments` per
+`docs/proposals/phase-d-2b-ingestion-plan-2026-06-30.md`. Reuse
+`chunk`/`embedChunks`/`redactPiiForIngest`/`extractText`/`applyOutdateOperations`
+as black boxes. Do NOT modify `cloneRepo` or any `lib/ingest/*` file. Add unit
+tests mirroring `tests/integration/knowledge-sources.test.ts` mocking strategy."
+
+---
+
+## 10. Open Questions (for orchestrator approval)
+
+| # | Question | Default if approved silently |
+|---|---|---|
+| Q1 | Is the 1 knowledge_source : N sources (per-file) modeling acceptable, or should we use 1 sources row per repo (whole-repo supersession)? | **Per-file** (recommended — preserves file-level traceability). |
+| Q2 | Should `syncStatus='syncing'` be set at sync start (concurrency lock, Risk 7)? | **Yes** — small enhancement to `syncKnowledgeSource`. |
+| Q3 | Should orphan `sources` rows for deleted files be cleaned up in D-2b or deferred? | **Deferred** — follow-up issue. |
+| Q4 | Is the omission of `saveMap` (Part 11 reversibility) for knowledge-source ingestion acceptable? | **Yes** — documented in audit; repo content is curated internal guidance, not user PHI. |
+
+---
+
+Version: 1.0.0
+Author: manager-strategy (design)
+Approval: pending

--- a/lib/knowledge-sources/sync.ts
+++ b/lib/knowledge-sources/sync.ts
@@ -1,16 +1,27 @@
 // @MX:NOTE [AUTO] Knowledge source sync — clones git repo and ingests via DOCINGEST pipeline.
-// @MX:SPEC Issue #307 D-2 (Knowledge Sources API)
+// @MX:SPEC Issue #307 D-2b (Knowledge Ingestion) — ingestDocuments real impl.
 // @MX:WARN [AUTO] cloneRepo uses execFile (argument array, no shell) + branch/host validation.
 // @MX:REASON RCE 방지 — gitUrl/branch는 사용자 제어 입력. exec 문자열 보간은 shell injection.
 
 import { execFile } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { mkdir, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { basename, extname, join, relative } from 'node:path';
 import { promisify } from 'node:util';
 import { writeAudit } from '@/lib/audit';
-import { db } from '@/lib/db/client';
-import { knowledgeSources } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { db, withTenantScope } from '@/lib/db/client';
+import { corpusSyncRuns, knowledgeSources, sourceSections, sources } from '@/lib/db/schema';
+import { chunk } from '@/lib/ingest/chunkers';
+import { DocClass } from '@/lib/ingest/doc-class';
+import { classifyDocument } from '@/lib/ingest/doc-classifier';
+import { embedChunks } from '@/lib/ingest/embed';
+import { extractText } from '@/lib/ingest/extract';
+import { redactPiiForIngest } from '@/lib/ingest/pii/redact';
+import { logger } from '@/lib/observability/logger';
+import { applyOutdateOperations } from '@/lib/radar/delta-sync/ingest';
+import { resolveExistingChunkIds } from '@/lib/radar/delta-sync/orchestrator';
+import { and, eq } from 'drizzle-orm';
 import { parseGitUrl } from './parse-git-url';
 
 const execFileAsync = promisify(execFile);
@@ -54,14 +65,20 @@ export async function syncKnowledgeSource(source: {
     `knowledge-source-${source.id}-${startTime.getTime()}`,
   );
 
+  // Concurrency lock: flip syncStatus='syncing' BEFORE clone so concurrent cron +
+  // manual re-sync see the lock and skip (weekly Inngest already filters on
+  // syncStatus='synced'; 'syncing' is the active-run signal).
+  await db
+    .update(knowledgeSources)
+    .set({ syncStatus: 'syncing' })
+    .where(eq(knowledgeSources.id, source.id));
+
   try {
     // Step 1: Clone repository (execFile + validation — RCE 방어)
     await cloneRepo(source.gitUrl, source.branch, tmpDir, source.auth_token);
 
-    // Step 2: Ingest documents using DOCINGEST pipeline.
-    // TODO(#307 D-2b): 실제 DOCINGEST 통합(chunking/embedding/pgvector upsert)은 별도.
-    // 현재는 clone 검증 + 메타만. 코퍼스 채움은 ingestDocuments 구현 후.
-    await ingestDocuments(tmpDir, source.id, source.orgId);
+    // Step 2: Ingest documents using DOCINGEST pipeline primitives.
+    const stats = await ingestDocuments(tmpDir, source.id, source.orgId);
 
     // Step 3: Update last_synced_at and sync_status
     await db
@@ -72,7 +89,7 @@ export async function syncKnowledgeSource(source: {
       })
       .where(eq(knowledgeSources.id, source.id));
 
-    // Step 4: Write audit log (성공)
+    // Step 4: Write audit log (성공) — enriched with per-file stats
     await writeAudit({
       actor_id: null, // System-initiated (cron 또는 수동)
       action: 'knowledge_source.synced',
@@ -83,6 +100,10 @@ export async function syncKnowledgeSource(source: {
         branch: source.branch,
         duration: Date.now() - startTime.getTime(),
         status: 'synced',
+        filesProcessed: stats.filesProcessed,
+        chunksAdded: stats.chunksAdded,
+        chunksOutdated: stats.chunksOutdated,
+        errors: stats.errors,
       },
     });
   } catch (error) {
@@ -163,24 +184,363 @@ async function cloneRepo(
   );
 }
 
+// ---------------------------------------------------------------------------
+// Ingestion pipeline (Issue #307 D-2b).
+// Reuses DOCINGEST primitives + delta-sync supersession pattern. See
+// docs/proposals/phase-d-2b-ingestion-plan-2026-06-30.md for the design.
+// ---------------------------------------------------------------------------
+
+// HARD caps (DoS defense — design §3.5).
+const MAX_FILES = 500;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_TOTAL_SIZE = 100 * 1024 * 1024; // 100 MB
+
+const EXT_MIME: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+};
+
+// Skip these directories during repo walk.
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', '.next', 'build', '.cache']);
+
+interface ScannedFile {
+  absPath: string;
+  relPath: string;
+  mimeType: string;
+  size: number;
+}
+
+interface IngestStats {
+  filesProcessed: number;
+  chunksAdded: number;
+  chunksOutdated: number;
+  errors: { relPath: string; error: string }[];
+}
+
 /**
- * Ingest documents from cloned repository.
- * TODO(#307 D-2b): 실제 DOCINGEST 파이프라인 통합 — 현재 stub.
- * 1. 파일 스캔(PDF/DOCX/TXT/MD)
- * 2. 텍스트 추출(lib/ingest/extract)
- * 3. PII redaction(lib/ingest/pii/redact)
- * 4. 청킹(lib/ingest/chunkers)
- * 5. 임베딩(lib/ingest/embed)
- * 6. sources/source_sections upsert
+ * Ingest documents from a cloned repository.
  *
- * @param repoPath - Path to cloned repository
- * @param sourceId - Knowledge source ID
- * @param orgId - Organization ID
+ * Pipeline per file: extract → classify → redact → chunk → embed → upsert.
+ * Reuses extractText/classifyDocument/redactPiiForIngest/chunk/embedChunks
+ * (lib/ingest) and resolveExistingChunkIds/applyOutdateOperations
+ * (lib/radar/delta-sync) verbatim. Mirrors runDeltaSync 7a-7e inline.
+ *
+ * One sources row per file (1 knowledge_source : N sources). One
+ * corpus_sync_runs row per repo. Per-file try/catch — one bad file continues.
+ *
+ * @param repoPath  - Path to cloned repository
+ * @param sourceId  - Knowledge source ID (knowledge_sources.id)
+ * @param orgId     - Organization ID (org scope for all writes)
  */
-async function ingestDocuments(repoPath: string, sourceId: string, orgId: string): Promise<void> {
-  // TODO(#307 D-2b): 실제 ingestion 구현 전까지 no-op. clone은 검증됨.
-  // 사용자가 repo를 연동하면 clone은 성공하지만 코퍼스 채움은 D-2b 구현 후.
-  void repoPath;
-  void sourceId;
-  void orgId;
+// Exported for direct unit testing (test seam). Not part of the public sync API —
+// callers use syncKnowledgeSource; tests exercise the pipeline in isolation.
+export async function ingestDocuments(
+  repoPath: string,
+  sourceId: string,
+  orgId: string,
+): Promise<IngestStats> {
+  const stats: IngestStats = { filesProcessed: 0, chunksAdded: 0, chunksOutdated: 0, errors: [] };
+
+  // Resolve knowledge_source row for provenance fields.
+  const ksRows = await db
+    .select({
+      sourceHost: knowledgeSources.sourceHost,
+      sourceOwner: knowledgeSources.sourceOwner,
+      sourceRepo: knowledgeSources.sourceRepo,
+      branch: knowledgeSources.branch,
+    })
+    .from(knowledgeSources)
+    .where(eq(knowledgeSources.id, sourceId))
+    .limit(1);
+  const ks = ksRows[0];
+  if (!ks) {
+    throw new Error(`knowledge_source_not_found: ${sourceId}`);
+  }
+  const ksHost = ks.sourceHost ?? 'unknown';
+  const ksOwner = ks.sourceOwner ?? 'unknown';
+  const ksRepo = ks.sourceRepo ?? 'unknown';
+  const sourceUrl = `git://${ksHost}/${ksOwner}/${ksRepo}#${ks.branch}`;
+
+  // 1. Scan repo (enforce caps).
+  const files = await scanRepo(repoPath);
+
+  // 2. Create ONE corpus_sync_runs row for the repo (pending → synced/failed).
+  const runRows = await db
+    .insert(corpusSyncRuns)
+    .values({
+      crawlerName: 'knowledge-source',
+      sourceUrl,
+      contentHash: '',
+      status: 'pending',
+      startedAt: new Date(),
+    })
+    .returning({ id: corpusSyncRuns.id });
+  const runId = runRows[0]?.id;
+  if (!runId) throw new Error('failed_to_create_corpus_sync_run');
+
+  try {
+    // 3. Per-file pipeline (sequential — embed API is the bottleneck).
+    for (const file of files) {
+      try {
+        const added = await ingestOneFile(file, {
+          repoPath,
+          orgId,
+          runId,
+          ksHost,
+          ksOwner,
+          ksRepo,
+          ksBranch: ks.branch,
+        });
+        stats.filesProcessed += 1;
+        stats.chunksAdded += added.sectionsInserted;
+        stats.chunksOutdated += added.outdatedApplied;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        stats.errors.push({ relPath: file.relPath, error: msg });
+        logger.warn('[ingestDocuments] file failed — continuing', {
+          relPath: file.relPath,
+          error: msg,
+        });
+        // CONTINUE — one bad file must not fail the repo (design §3.6).
+      }
+    }
+
+    // 4. All-files-failed guard — flip to failed so the outer catch fires.
+    if (files.length > 0 && stats.filesProcessed === 0) {
+      throw new Error(`all_files_failed: ${stats.errors.length} files could not be ingested`);
+    }
+
+    // 5. Update corpus_sync_runs (success).
+    await db
+      .update(corpusSyncRuns)
+      .set({
+        status: 'synced',
+        chunksAdded: stats.chunksAdded,
+        chunksOutdated: stats.chunksOutdated,
+        completedAt: new Date(),
+      })
+      .where(eq(corpusSyncRuns.id, runId));
+
+    return stats;
+  } catch (err) {
+    // 6. Total failure — mark run failed, rethrow for outer syncKnowledgeSource.
+    const msg = err instanceof Error ? err.message : String(err);
+    await db
+      .update(corpusSyncRuns)
+      .set({ status: 'failed', errorMessage: msg.slice(0, 1000), completedAt: new Date() })
+      .where(eq(corpusSyncRuns.id, runId));
+    throw err;
+  }
+}
+
+/**
+ * Walk a repo dir collecting supported files. Enforces HARD caps.
+ * Skip .git/node_modules/dist and unsupported extensions.
+ */
+async function scanRepo(repoPath: string): Promise<ScannedFile[]> {
+  const out: ScannedFile[] = [];
+  let totalSize = 0;
+
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const ent of entries) {
+      if (ent.name.startsWith('.')) continue;
+      const abs = join(dir, ent.name);
+      if (ent.isDirectory()) {
+        if (SKIP_DIRS.has(ent.name)) continue;
+        await walk(abs);
+      } else if (ent.isFile()) {
+        if (out.length >= MAX_FILES) {
+          logger.warn('[scanRepo] MAX_FILES cap reached — skipping remaining files', {
+            cap: MAX_FILES,
+          });
+          return;
+        }
+        const ext = extname(ent.name).toLowerCase();
+        const mimeType = EXT_MIME[ext];
+        if (!mimeType) continue; // unsupported — skip silently
+        const st = await stat(abs);
+        if (st.size > MAX_FILE_SIZE) {
+          logger.warn('[scanRepo] file exceeds MAX_FILE_SIZE — skipping', {
+            path: abs,
+            size: st.size,
+          });
+          continue;
+        }
+        if (totalSize + st.size > MAX_TOTAL_SIZE) {
+          logger.warn('[scanRepo] MAX_TOTAL_SIZE cap reached — stopping scan', {
+            cap: MAX_TOTAL_SIZE,
+          });
+          return;
+        }
+        totalSize += st.size;
+        out.push({ absPath: abs, relPath: relative(repoPath, abs), mimeType, size: st.size });
+      }
+    }
+  }
+
+  await walk(repoPath);
+  return out;
+}
+
+/**
+ * Run the full pipeline for ONE file and upsert its sources/source_sections.
+ * Mirrors runDeltaSync 7a-7e: resolve existing chunk ids → insert new sections
+ * (org-scoped tx) → applyOutdateOperations for supersession.
+ */
+async function ingestOneFile(
+  file: ScannedFile,
+  ctx: {
+    repoPath: string;
+    orgId: string;
+    runId: string;
+    ksHost: string;
+    ksOwner: string;
+    ksRepo: string;
+    ksBranch: string;
+  },
+): Promise<{ sectionsInserted: number; outdatedApplied: number }> {
+  // a. Extract text. TXT/MD are not in extractText's SUPPORTED_MIME_TYPES;
+  //    read UTF-8 directly to avoid ExtractError (design §3.4).
+  let rawText: string;
+  if (file.mimeType === 'text/plain' || file.mimeType === 'text/markdown') {
+    rawText = await readFile(file.absPath, 'utf-8');
+  } else {
+    const buf = await readFile(file.absPath);
+    rawText = await extractText(buf, file.mimeType);
+  }
+
+  // b. Classify — fallback to internal_sop on low confidence (design §2).
+  const cls = classifyDocument({
+    filename: basename(file.absPath),
+    firstPageText: rawText.slice(0, 2000),
+  });
+  const docClass = cls.confidence >= 0.6 ? cls.suggestedClass : DocClass.internal_sop;
+
+  // c. PII redaction (saveMap OMITTED for knowledge-sources — design §2/Q4).
+  const redacted = await redactPiiForIngest(rawText, docClass);
+
+  // d. Chunk (registry dispatches by docClass; internal_sop → chunkSopIso13485).
+  const chunks = chunk(docClass, redacted.text, {
+    relPath: file.relPath,
+    organizationId: ctx.orgId,
+  });
+
+  // e. Embed (batched internally BATCH_SIZE=100, MAX_RETRIES=3, PII-guarded).
+  const embeddings = await embedChunks(chunks.map((c) => c.text));
+
+  // f. Resolve or create the parent sources row for this file (stable key:
+  //    orgId + host/owner/repo/path so re-sync reuses the row).
+  const fileSourceId = await resolveOrCreateFileSource(file, ctx);
+
+  // g. Resolve existing chunk ids for supersession (org-scoped JOIN — M-1).
+  const existingChunkIds = await resolveExistingChunkIds(fileSourceId, ctx.orgId);
+
+  // h. INSERT new source_sections (org-scoped tx) — mirrors orchestrator 7c.
+  const insertedSections = await withTenantScope(ctx.orgId, async (tx) => {
+    const rows: { id: string }[] = [];
+    for (let i = 0; i < chunks.length; i++) {
+      const c = chunks[i];
+      const emb = embeddings[i];
+      if (!c || !emb) continue;
+      const meta = c.metadata as { sectionPath?: string; tokenCount?: number };
+      const ins = await tx
+        .insert(sourceSections)
+        .values({
+          sourceId: fileSourceId,
+          anchor: `${sha8(file.relPath)}-${i}`,
+          heading: meta.sectionPath ?? null,
+          text: c.text,
+          embedding: emb,
+          sectionPath: `${file.relPath}#${meta.sectionPath ?? 'chunk'}`,
+          ingestionRunId: ctx.runId,
+          ingestedAt: new Date(),
+          chunkHash: computeChunkHash(c.text),
+        })
+        .returning({ id: sourceSections.id });
+      const r = ins[0];
+      if (r) rows.push(r);
+    }
+    return rows;
+  });
+
+  // i. Supersede prior chunks for this file (re-sync path). Mirrors 7d.
+  let outdatedApplied = 0;
+  if (existingChunkIds.length > 0) {
+    const outdateResult = await applyOutdateOperations({
+      orgId: ctx.orgId,
+      existingChunkIds,
+      newIngestionRunId: ctx.runId,
+      actorId: null,
+    });
+    outdatedApplied = outdateResult.applied;
+  }
+
+  return { sectionsInserted: insertedSections.length, outdatedApplied };
+}
+
+/**
+ * Resolve an existing sources row for this file by stable provenance key, or
+ * create a new one. Enables per-file supersession on re-sync (design §3.2/4.5).
+ */
+async function resolveOrCreateFileSource(
+  file: ScannedFile,
+  ctx: {
+    orgId: string;
+    runId: string;
+    ksHost: string;
+    ksOwner: string;
+    ksRepo: string;
+    ksBranch: string;
+  },
+): Promise<string> {
+  const existing = await db
+    .select({ id: sources.id })
+    .from(sources)
+    .where(
+      and(
+        eq(sources.organizationId, ctx.orgId),
+        eq(sources.sourceHost, ctx.ksHost),
+        eq(sources.sourceOwner, ctx.ksOwner),
+        eq(sources.sourceRepo, ctx.ksRepo),
+        eq(sources.sourcePath, file.relPath),
+      ),
+    )
+    .limit(1);
+  if (existing[0]?.id) return existing[0].id;
+
+  const rows = await db
+    .insert(sources)
+    .values({
+      id: randomUUID(),
+      organizationId: ctx.orgId,
+      orgLabel: `${ctx.ksOwner}/${ctx.ksRepo}:${ctx.ksBranch}`,
+      title: basename(file.relPath),
+      type: 'Internal',
+      sourceHost: ctx.ksHost,
+      sourceOwner: ctx.ksOwner,
+      sourceRepo: ctx.ksRepo,
+      sourceBranch: ctx.ksBranch,
+      sourcePath: file.relPath,
+      contentHash: computeChunkHash(file.relPath),
+      ingestionRunId: ctx.runId,
+      ingestedAt: new Date(),
+      approvalStatus: 'pending_review', // RA-owner gate — never reaches retriever until approved
+    })
+    .returning({ id: sources.id });
+  const id = rows[0]?.id;
+  if (!id) throw new Error(`failed_to_create_source_row: ${file.relPath}`);
+  return id;
+}
+
+/** 8-char hex digest for compact anchor keys (collision-bounded for anchors). */
+function sha8(input: string): string {
+  return createHash('sha256').update(input).digest('hex').slice(0, 8);
+}
+
+/** SHA256 hex digest for chunk content / file provenance hashing. */
+function computeChunkHash(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
 }

--- a/tests/unit/knowledge-sources/ingest-documents.test.ts
+++ b/tests/unit/knowledge-sources/ingest-documents.test.ts
@@ -1,0 +1,577 @@
+// @MX:NOTE [AUTO] Unit tests for ingestDocuments — per-file pipeline, caps, supersession.
+// @MX:SPEC Issue #307 D-2b (Knowledge Ingestion) AC-1..AC-7
+//
+// Strategy (mirrors tests/integration/knowledge-sources.test.ts):
+//   1. Mock @/lib/db/client — in-memory store for knowledge_sources + sources +
+//      source_sections + corpus_sync_runs, recording inserts/selects/updates so
+//      pipeline behavior is verifiable without a real database.
+//   2. Mock @/lib/ingest/embed — embedChunks returns a fixed 1536-dim vector per
+//      input (avoids hitting the OpenAI API).
+//   3. Mock @/lib/radar/delta-sync/orchestrator (resolveExistingChunkIds) and
+//      @/lib/radar/delta-sync/ingest (applyOutdateOperations) — record calls.
+//   4. Do NOT mock chunk/classifyDocument/redactPiiForIngest/extractText —
+//      exercise the real registry with .md/.txt/.pdf fixtures.
+//
+// Asserts (design §5 AC-1..AC-7):
+//   - AC-1: 3 markdown files → ≥1 source_section each with embedding.
+//   - AC-2: pdf/docx dispatch extractText; sectionPath prefixed by relPath.
+//   - AC-3: txt reads as UTF-8, does NOT call extractText.
+//   - AC-4: redact → chunk → embed call order enforced.
+//   - AC-5: re-sync supersedes prior chunks (applyOutdateOperations called).
+//   - AC-6: one corrupt file does not abort the repo.
+//   - AC-7: MAX_FILES cap (500) enforced.
+
+import { randomUUID } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// In-memory stores
+// ---------------------------------------------------------------------------
+
+// Index signature allows the in-memory rows to flow through the generic
+// Record<string, unknown> predicates used by the db.update mock.
+interface KnowledgeSourceRow {
+  [key: string]: unknown;
+  id: string;
+  organizationId: string;
+  branch: string;
+  sourceHost: string | null;
+  sourceOwner: string | null;
+  sourceRepo: string | null;
+  syncStatus: string;
+}
+
+interface SourceRow {
+  [key: string]: unknown;
+  id: string;
+  organizationId: string;
+  sourceHost: string | null;
+  sourceOwner: string | null;
+  sourceRepo: string | null;
+  sourcePath: string | null;
+  type: string;
+  approvalStatus: string;
+  ingestionRunId: string | null;
+}
+
+interface SourceSectionRow {
+  [key: string]: unknown;
+  id: string;
+  sourceId: string;
+  anchor: string | null;
+  heading: string | null;
+  text: string;
+  embedding: unknown;
+  sectionPath: string | null;
+  ingestionRunId: string | null;
+  chunkHash: string | null;
+}
+
+interface CorpusSyncRunRow {
+  [key: string]: unknown;
+  id: string;
+  crawlerName: string;
+  sourceUrl: string;
+  status: string;
+  chunksAdded: number | null;
+  chunksOutdated: number | null;
+}
+
+const knowledgeSourcesStore: KnowledgeSourceRow[] = [];
+const sourcesStore: SourceRow[] = [];
+const sectionsStore: SourceSectionRow[] = [];
+const runsStore: CorpusSyncRunRow[] = [];
+
+// Spies on the mocked primitives.
+let extractTextCalls: { mimeType: string }[] = [];
+let embedCalls: string[][] = [];
+let resolveExistingCalls: { sourceId: string; orgId: string }[] = [];
+let applyOutdateCalls: { existingChunkIds: string[]; newIngestionRunId: string }[] = [];
+
+// Control knobs.
+let extractTextThrowFor: string[] = []; // mime types that should throw
+
+// ---------------------------------------------------------------------------
+// DB mock (in-memory).
+// ---------------------------------------------------------------------------
+
+const DRIZZLE_NAME = Symbol.for('drizzle:Name');
+function tableName(table: unknown): string {
+  if (table && typeof table === 'object') {
+    const t = table as Record<symbol | string, unknown>;
+    if (t[DRIZZLE_NAME] && typeof t[DRIZZLE_NAME] === 'string') return t[DRIZZLE_NAME] as string;
+    for (const sym of Object.getOwnPropertySymbols(table)) {
+      const v = t[sym as symbol];
+      if (typeof v === 'string' && /name/i.test(String(sym))) return v;
+    }
+  }
+  return 'unknown';
+}
+
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase());
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Drizzle select chain returns a thenable; rows typed loosely.
+function buildSelectChain(boundTableRef: { t: string }, selected?: Record<string, unknown>): any {
+  let pendingWhere: ((r: Record<string, unknown>) => boolean) | null = null;
+
+  const compute = (): unknown[] => {
+    let store: Record<string, unknown>[];
+    if (boundTableRef.t === 'knowledge_sources')
+      store = knowledgeSourcesStore as unknown as Record<string, unknown>[];
+    else if (boundTableRef.t === 'sources')
+      store = sourcesStore as unknown as Record<string, unknown>[];
+    else if (boundTableRef.t === 'source_sections')
+      store = sectionsStore as unknown as Record<string, unknown>[];
+    else if (boundTableRef.t === 'corpus_sync_runs')
+      store = runsStore as unknown as Record<string, unknown>[];
+    else store = [];
+    let rows = store.slice();
+    if (pendingWhere) rows = rows.filter(pendingWhere as (r: unknown) => boolean);
+    return selected ? rows.map((row) => projectSelected(row, selected)) : rows;
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: recursive chain needs any self-type
+  const lazyChain: any = {
+    from: vi.fn((table: unknown) => {
+      boundTableRef.t = tableName(table);
+      return lazyChain;
+    }),
+    where: vi.fn((pred?: (r: Record<string, unknown>) => boolean) => {
+      if (pred) pendingWhere = pred;
+      return lazyChain;
+    }),
+    orderBy: vi.fn(() => lazyChain),
+    limit: vi.fn(() => Promise.resolve(compute())),
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable for await semantics
+    then: <U>(onfulfilled?: (v: unknown[]) => U | PromiseLike<U>) =>
+      Promise.resolve(compute()).then(onfulfilled),
+  };
+  return lazyChain;
+}
+
+function projectSelected(
+  row: Record<string, unknown>,
+  cols: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(cols)) out[key] = row[key];
+  return out;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: query builder chain is deeply nested; loosely typed for test fidelity.
+const dbMock: any = {
+  select: vi.fn((cols?: Record<string, unknown>) => {
+    const ref = { t: 'knowledge_sources' };
+    return buildSelectChain(ref, cols);
+  }),
+  insert: vi.fn((table: unknown) => {
+    const tn = tableName(table);
+    let pendingValues: Record<string, unknown> | Record<string, unknown>[] = {};
+    // biome-ignore lint/suspicious/noExplicitAny: recursive chain needs any self-type
+    const chain: any = {
+      values: vi.fn((values: Record<string, unknown> | Record<string, unknown>[]) => {
+        pendingValues = values;
+        return chain;
+      }),
+      returning: vi.fn(async (cols?: Record<string, unknown>) => {
+        const arr = Array.isArray(pendingValues) ? pendingValues : [pendingValues];
+        const created: Record<string, unknown>[] = [];
+        for (const v of arr) {
+          const id = (v.id as string) ?? randomUUID();
+          if (tn === 'knowledge_sources') {
+            const row: KnowledgeSourceRow = {
+              id,
+              organizationId: v.organizationId as string,
+              branch: v.branch as string,
+              sourceHost: (v.sourceHost as string | null) ?? null,
+              sourceOwner: (v.sourceOwner as string | null) ?? null,
+              sourceRepo: (v.sourceRepo as string | null) ?? null,
+              syncStatus: (v.syncStatus as string) ?? 'idle',
+            };
+            knowledgeSourcesStore.push(row);
+            created.push(row);
+          } else if (tn === 'sources') {
+            const row: SourceRow = {
+              id,
+              organizationId: v.organizationId as string,
+              sourceHost: (v.sourceHost as string | null) ?? null,
+              sourceOwner: (v.sourceOwner as string | null) ?? null,
+              sourceRepo: (v.sourceRepo as string | null) ?? null,
+              sourcePath: (v.sourcePath as string | null) ?? null,
+              type: (v.type as string) ?? 'Internal',
+              approvalStatus: (v.approvalStatus as string) ?? 'pending_review',
+              ingestionRunId: (v.ingestionRunId as string | null) ?? null,
+            };
+            sourcesStore.push(row);
+            created.push(row);
+          } else if (tn === 'source_sections') {
+            const row: SourceSectionRow = {
+              id,
+              sourceId: v.sourceId as string,
+              anchor: (v.anchor as string | null) ?? null,
+              heading: (v.heading as string | null) ?? null,
+              text: v.text as string,
+              embedding: v.embedding,
+              sectionPath: (v.sectionPath as string | null) ?? null,
+              ingestionRunId: (v.ingestionRunId as string | null) ?? null,
+              chunkHash: (v.chunkHash as string | null) ?? null,
+            };
+            sectionsStore.push(row);
+            created.push(row);
+          } else if (tn === 'corpus_sync_runs') {
+            const row: CorpusSyncRunRow = {
+              id,
+              crawlerName: v.crawlerName as string,
+              sourceUrl: v.sourceUrl as string,
+              status: (v.status as string) ?? 'pending',
+              chunksAdded: null,
+              chunksOutdated: null,
+            };
+            runsStore.push(row);
+            created.push(row);
+          }
+        }
+        // Returning: respect selected cols if provided (sources.id, corpusSyncRuns.id).
+        if (cols && Object.keys(cols).length > 0) {
+          return created.map((row) => projectSelected(row, cols as Record<string, unknown>));
+        }
+        return created;
+      }),
+    };
+    return chain;
+  }),
+  update: vi.fn((table: unknown) => {
+    const tn = tableName(table);
+    let pendingSet: Record<string, unknown> = {};
+    let pendingWhere: ((r: Record<string, unknown>) => boolean) | null = null;
+    return {
+      set: vi.fn((s: Record<string, unknown>) => {
+        pendingSet = s;
+        return {
+          where: vi.fn((pred?: (r: Record<string, unknown>) => boolean) => {
+            if (pred) pendingWhere = pred;
+            // Apply the update against the in-memory store.
+            const apply = (store: Record<string, unknown>[]) => {
+              for (const row of store) {
+                if (!pendingWhere || pendingWhere(row)) {
+                  for (const [k, v] of Object.entries(pendingSet)) row[k] = v;
+                }
+              }
+            };
+            if (tn === 'knowledge_sources')
+              apply(knowledgeSourcesStore as unknown as Record<string, unknown>[]);
+            else if (tn === 'sources') apply(sourcesStore as unknown as Record<string, unknown>[]);
+            else if (tn === 'source_sections')
+              apply(sectionsStore as unknown as Record<string, unknown>[]);
+            else if (tn === 'corpus_sync_runs')
+              apply(runsStore as unknown as Record<string, unknown>[]);
+            return Promise.resolve();
+          }),
+        };
+      }),
+    };
+  }),
+  transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(dbMock)),
+};
+
+// eq override — predicate reads column .name (snake_case), maps to row camelCase.
+async function getDrizzleMock() {
+  const actual = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
+  const eq = vi.fn(
+    (column: unknown, value: unknown): ((row: Record<string, unknown>) => boolean) => {
+      const colName =
+        column && typeof column === 'object' && 'name' in column
+          ? String((column as { name: unknown }).name)
+          : 'unknown';
+      const field = snakeToCamel(colName);
+      return (row: Record<string, unknown>) => row[field] === value;
+    },
+  );
+  // and(): combine multiple predicates.
+  const and = vi.fn(
+    (...preds: ((r: Record<string, unknown>) => boolean)[]) =>
+      (row: Record<string, unknown>) =>
+        preds.every((p) => (p ? p(row) : true)),
+  );
+  return { ...actual, eq, and };
+}
+
+vi.mock('drizzle-orm', () => getDrizzleMock());
+vi.mock('@/lib/db/client', () => ({
+  db: dbMock,
+  withTenantScope: vi.fn(
+    async <T>(orgId: string, fn: (tx: typeof dbMock) => Promise<T>): Promise<T> => {
+      void orgId;
+      return fn(dbMock);
+    },
+  ),
+}));
+
+// Mock embed — fixed 1536-dim vector per input text (avoids OpenAI call).
+vi.mock('@/lib/ingest/embed', () => ({
+  embedChunks: vi.fn(async (texts: string[]): Promise<number[][]> => {
+    embedCalls.push(texts);
+    return texts.map(() => Array.from({ length: 1536 }, () => 0.1));
+  }),
+}));
+
+// Mock extractText — only pdf/docx supported; txt/md never reach it.
+vi.mock('@/lib/ingest/extract', () => ({
+  extractText: vi.fn(async (buffer: Buffer, mimeType: string): Promise<string> => {
+    extractTextCalls.push({ mimeType });
+    if (extractTextThrowFor.includes(mimeType)) {
+      throw new Error(`extract_failed: ${mimeType}`);
+    }
+    return buffer.toString('utf-8');
+  }),
+}));
+
+// Mock resolveExistingChunkIds + applyOutdateOperations (delta-sync reuse).
+vi.mock('@/lib/radar/delta-sync/orchestrator', () => ({
+  resolveExistingChunkIds: vi.fn(async (sourceId: string, orgId: string): Promise<string[]> => {
+    resolveExistingCalls.push({ sourceId, orgId });
+    // Return sections previously inserted for this source (simulating a re-sync).
+    return sectionsStore.filter((s) => s.sourceId === sourceId).map((s) => s.id);
+  }),
+}));
+vi.mock('@/lib/radar/delta-sync/ingest', () => ({
+  applyOutdateOperations: vi.fn(
+    async (params: { orgId: string; existingChunkIds: string[]; newIngestionRunId: string }) => {
+      applyOutdateCalls.push({
+        existingChunkIds: params.existingChunkIds,
+        newIngestionRunId: params.newIngestionRunId,
+      });
+      return { applied: params.existingChunkIds.length, results: [] };
+    },
+  ),
+}));
+
+// Mock audit (not asserted here, but the real writeAudit would need a DB).
+vi.mock('@/lib/audit', () => ({ writeAudit: vi.fn(async () => undefined) }));
+
+// Import AFTER mocks are registered.
+const { ingestDocuments } = await import('@/lib/knowledge-sources/sync');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedKnowledgeSource(orgId = 'org-A', id = 'ks-1'): KnowledgeSourceRow {
+  const row: KnowledgeSourceRow = {
+    id,
+    organizationId: orgId,
+    branch: 'main',
+    sourceHost: 'github.com',
+    sourceOwner: 'acme',
+    sourceRepo: 'sop-repo',
+    syncStatus: 'synced',
+  };
+  knowledgeSourcesStore.push(row);
+  return row;
+}
+
+async function makeRepo(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), `ks-ingest-${randomUUID().slice(0, 8)}-`));
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    const parent = abs.slice(0, abs.lastIndexOf('/'));
+    await mkdir(parent, { recursive: true });
+    await writeFile(abs, content, 'utf-8');
+  }
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  knowledgeSourcesStore.length = 0;
+  sourcesStore.length = 0;
+  sectionsStore.length = 0;
+  runsStore.length = 0;
+  extractTextCalls = [];
+  embedCalls = [];
+  resolveExistingCalls = [];
+  applyOutdateCalls = [];
+  extractTextThrowFor = [];
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  // Vitest caches tmpdirs only in-process; OS reaps them. No-op here.
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ingestDocuments — per-file pipeline', () => {
+  it('AC-1: ingests 3 markdown files → ≥3 source_sections with embeddings', async () => {
+    const repo = await makeRepo({
+      'a.md': '# SOP A\nRevision History\n1.0 init\n\n1. Body content A\n',
+      'b.md': '# SOP B\nRevision History\n1.0 init\n\n1. Body content B\n',
+      'c.md': '# SOP C\nRevision History\n1.0 init\n\n1. Body content C\n',
+    });
+    seedKnowledgeSource();
+
+    const stats = await ingestDocuments(repo, 'ks-1', 'org-A');
+
+    expect(stats.filesProcessed).toBe(3);
+    expect(stats.chunksAdded).toBeGreaterThanOrEqual(3);
+    expect(sectionsStore.length).toBeGreaterThanOrEqual(3);
+    // Every section has a non-null embedding + links back to a sources row.
+    for (const sec of sectionsStore) {
+      expect(sec.embedding).toBeDefined();
+      expect(sec.sourceId).toBeTruthy();
+      const parent = sourcesStore.find((s) => s.id === sec.sourceId);
+      expect(parent).toBeDefined();
+      expect(parent?.organizationId).toBe('org-A');
+    }
+    // 3 distinct sources rows (one per file).
+    expect(sourcesStore.length).toBe(3);
+    // corpus_sync_runs row created + synced.
+    expect(runsStore.length).toBe(1);
+    expect(runsStore[0]?.status).toBe('synced');
+    expect(runsStore[0]?.crawlerName).toBe('knowledge-source');
+  });
+
+  it('AC-2: pdf/docx dispatch extractText; sectionPath prefixed by relPath', async () => {
+    // extractText mock reads the buffer as UTF-8 — so write text content as bytes.
+    const pdfContent = 'fake-pdf-body-text content here';
+    const docxContent = 'fake-docx-body-text content here';
+    const repo = await makeRepo({
+      'guide.pdf': pdfContent,
+      'manual.docx': docxContent,
+    });
+    seedKnowledgeSource();
+
+    await ingestDocuments(repo, 'ks-1', 'org-A');
+
+    // extractText was called for BOTH pdf and docx (not skipped).
+    const calledMimes = extractTextCalls.map((c) => c.mimeType);
+    expect(calledMimes).toContain('application/pdf');
+    expect(calledMimes).toContain(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    );
+    // sectionPath on every inserted section is prefixed by the relPath.
+    for (const sec of sectionsStore) {
+      expect(sec.sectionPath).toMatch(/^(guide\.pdf|manual\.docx)#/);
+    }
+  });
+
+  it('AC-3: txt reads as UTF-8, does NOT call extractText', async () => {
+    const repo = await makeRepo({
+      'notes.txt': 'plain text notes line one\n1. body item\n',
+    });
+    seedKnowledgeSource();
+
+    await ingestDocuments(repo, 'ks-1', 'org-A');
+
+    // extractText must NOT be called for text/plain.
+    expect(extractTextCalls.map((c) => c.mimeType)).not.toContain('text/plain');
+    // Still produced at least one section.
+    expect(sectionsStore.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('AC-4: redact → chunk → embed order enforced (embed receives redacted text)', async () => {
+    const repo = await makeRepo({
+      'sop.md': '# SOP\nRevision History\n1.0 init\n\n1. Body line one\n2. Body line two\n',
+    });
+    seedKnowledgeSource();
+
+    await ingestDocuments(repo, 'ks-1', 'org-A');
+
+    // embedChunks was called exactly once per file, with an array of chunk texts.
+    expect(embedCalls.length).toBe(1);
+    expect(embedCalls[0]?.length).toBeGreaterThanOrEqual(1);
+    // Every embedded text corresponds to an inserted section text (pipeline integrity).
+    const embeddedTexts = embedCalls[0] ?? [];
+    for (const t of embeddedTexts) {
+      expect(sectionsStore.some((s) => s.text === t)).toBe(true);
+    }
+  });
+
+  it('AC-5: re-sync supersedes prior chunks (applyOutdateOperations called)', async () => {
+    const repo = await makeRepo({
+      'sop.md': '# SOP\nRevision History\n1.0 init\n\n1. Body content\n',
+    });
+    seedKnowledgeSource();
+
+    // First sync — inserts sections.
+    await ingestDocuments(repo, 'ks-1', 'org-A');
+    const firstRunSections = sectionsStore.length;
+    expect(firstRunSections).toBeGreaterThan(0);
+    // On the first run, resolveExistingChunkIds returned [] (no prior sections),
+    // so applyOutdateOperations should NOT have been called.
+    expect(applyOutdateCalls.length).toBe(0);
+
+    // Second sync — re-ingest the same repo. Now resolveExistingChunkIds returns
+    // the previously-inserted section ids, and applyOutdateOperations must fire.
+    await ingestDocuments(repo, 'ks-1', 'org-A');
+
+    expect(applyOutdateCalls.length).toBe(1);
+    expect(applyOutdateCalls[0]?.existingChunkIds.length).toBe(firstRunSections);
+    // Two corpus_sync_runs rows (one per run).
+    expect(runsStore.length).toBe(2);
+  });
+
+  it('AC-6: one corrupt file does NOT abort the repo (per-file isolation)', async () => {
+    // Make extractText throw for PDF only — DOCX/TXT/MD must still succeed.
+    extractTextThrowFor = ['application/pdf'];
+    const repo = await makeRepo({
+      'broken.pdf': 'not-a-real-pdf',
+      'good.md': '# Good SOP\nRevision History\n1.0 init\n\n1. Body\n',
+      'good.txt': 'plain notes\n1. body\n',
+    });
+    seedKnowledgeSource();
+
+    const stats = await ingestDocuments(repo, 'ks-1', 'org-A');
+
+    // 2 files processed (md + txt); 1 error recorded (pdf).
+    expect(stats.filesProcessed).toBe(2);
+    expect(stats.errors.length).toBe(1);
+    expect(stats.errors[0]?.relPath).toBe('broken.pdf');
+    // Run still succeeded (partial) — corpus_sync_runs status='synced'.
+    expect(runsStore[0]?.status).toBe('synced');
+    // Good files' sections are present.
+    expect(sectionsStore.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('AC-7: MAX_FILES cap (500) enforced — excess files skipped', async () => {
+    // Build a repo with 600 tiny files. scanRepo must cap at 500.
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 600; i++) {
+      files[`f${i}.md`] = `# File ${i}\nRevision History\n1.0 init\n\n1. Body ${i}\n`;
+    }
+    const repo = await makeRepo(files);
+    seedKnowledgeSource();
+
+    const stats = await ingestDocuments(repo, 'ks-1', 'org-A');
+
+    // Cap is 500 — no more than 500 files processed.
+    expect(stats.filesProcessed).toBeLessThanOrEqual(500);
+    expect(stats.filesProcessed).toBe(500);
+  });
+
+  it('skips .git internals and unsupported binary extensions', async () => {
+    const repo = await makeRepo({
+      'sop.md': '# SOP\nRevision History\n1.0 init\n\n1. Body\n',
+      '.git/config': 'should-be-skipped', // hidden + inside .git (double-guarded)
+      'image.png': 'binary-content', // unsupported ext
+      'binary.exe': 'MZ', // unsupported ext
+    });
+    seedKnowledgeSource();
+
+    await ingestDocuments(repo, 'ks-1', 'org-A');
+
+    // Only the .md was processed → 1 source row, ≥1 section.
+    expect(sourcesStore.length).toBe(1);
+    expect(sourcesStore[0]?.sourcePath).toBe('sop.md');
+  });
+});


### PR DESCRIPTION
## D-2b Step 3 실제 ingestion — 코퍼스 채움/RAG 활성화 (Issue #307)

Phase D-2b: `ingestDocuments` stub → 실구현. 주간 cron이 clone한 repo를 코퍼스로 채워 사이트 RAG 작동 활성화.

### 구현 (sync.ts +387/-27)
- **ingestDocuments**: scanRepo(HARD caps: 500 files / 10MB/file / 100MB total, .git·binary skip) → per-file pipeline(extract → classify → PII redact → chunk → embed) → sources(파일별 1행) + source_sections(org-scoped tx, vector 1536) upsert
- **supersession**: re-sync 시 기존 chunk `superseded_by` 처리(delta-sync 패턴)
- **per-file 격리**: 1개 bad file이 repo 전체 fail시키지 않음
- **corpus_sync_runs** lifecycle + **syncing 잠금**(동시 cron/수동 방지)

### 재사용 (lib/ingest·delta-sync 미변경)
extractText·classifyDocument·redactPiiForIngest·chunk·embedChunks + runDeltaSync 7a-7e 패턴. **migration 불필요**(컬럼 사전 존재). cloneRepo RCE 방어 원형 보존.

### 전략 결정 (사용자 확정)
1 ks : N sources(파일별) · syncing 잠금 · orphan 정리 follow-up · saveMap 생략(repo = curated SOP, 비 PHI)

### 직검 (L-007)
- typecheck exit 0 / lint exit 0(2 pre-existing) / full test **4803 passed | 0 failed**(+8)
- scope: sync.ts + test + 설계문서 only. lib/ingest·delta-sync·upload-processed·migration **미변경**
- cloneRepo RCE 방어(GIT_REF_PATTERN·isInternalHost·execFile) 보존 직검

### 테스트 (8, AC-1~7)
chunk/embed 무결성 · TXT 직접 read · PDF/DOCX extractText · supersession · per-file 격리 · 500 cap · .git/binary skip

### Follow-up (별도 이슈)
- orphan cleanup cron(sources.approvalStatus pending_review가 최종 gate)
- insertChunks shared-helper 추출(upload-processed.ts @MX:TODO 통합)
- **공개 repo 연동 E2E**(실제 clone→ingestion→RAG 인용 검증)

### ⚠️ 핵심
- seed 제거 상태 유지. 본 PR로 ingestion 코드는 완성, **실제 repo 연동 + 코퍼스 채움은 설정 UI + 공개 repo E2E 후 사이트 작동**.
- 설계 문서: docs/proposals/phase-d-2b-ingestion-plan-2026-06-30.md

Refs #307

🗿 MoAI <email@mo.ai.kr>