### PR TITLE
feat(knowledge-sources): orphan sources 정리 cron — superseded-only source sunset (#313)

### DIFF
--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -399,6 +399,13 @@ export type AuditAction =
   | 'source.low_authority_flagged'
   | 'source.governance_updated'
   | 'source.delta_sync_updated'
+  // Issue 313 — orphan sources cleanup cron. Added via 0101_source_orphan_sunset.sql.
+  // source.orphan_sunsetted — daily cron set approval_status to sunset on a source
+  //   because all its source_sections are superseded (orphan detection). DISTINCT
+  //   from source.superseded (replaced by a newer source version) and
+  //   source.rejected (human RA-owner rejection) so regulators can distinguish
+  //   the three lifecycle events in the audit trail (21 CFR Part 11).
+  | 'source.orphan_sunsetted'
   // SPEC-REGULA-RLHF-001 — added via 0082_rlhf.sql (Issue #56, REQ-RLHF-013).
   // feedback_submitted: every feedback write (21 CFR Part 11 audit-material).
   //   The revision-vs-new distinction is carried in meta_json.revised (L-2),

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -385,6 +385,13 @@ export const auditActionEnum = pgEnum('audit_action', [
   'source.low_authority_flagged',
   'source.governance_updated',
   'source.delta_sync_updated',
+  // Issue 313 — orphan sources cleanup cron. Added via 0101_source_orphan_sunset.sql.
+  // Fired by the daily orphan-cleanup cron (lib/inngest/knowledge-sources/orphan-cleanup.ts)
+  // when a source's approval_status is set to 'sunset' because all its
+  // source_sections are superseded. DISTINCT from 'source.superseded' (replaced
+  // by a newer source version) and 'source.rejected' (human RA-owner rejection)
+  // so regulators can distinguish the three lifecycle events (21 CFR Part 11).
+  'source.orphan_sunsetted',
   // SPEC-REGULA-RLHF-001 — added via 0082_rlhf.sql (Issue #56, REQ-RLHF-013).
   // feedback_submitted: every feedback write (21 CFR Part 11 audit-material).
   //   The revision-vs-new distinction is carried in meta_json.revised (L-2),
@@ -459,6 +466,13 @@ export const sourceApprovalStatusEnum = pgEnum('source_approval_status', [
   'pending_review',
   'approved',
   'rejected',
+  // Issue 313 — orphan sources cleanup cron. Added via 0101_source_orphan_sunset.sql.
+  // 'sunset' is set by the daily cleanup cron when ALL source_sections are superseded.
+  // Semantically distinct from 'rejected' (human RA-owner rejection of a pending_review
+  // source): 'sunset' is a system-driven lifecycle event. The retrieval gate
+  // (retrieval-gate.ts: approvalStatus !== 'approved') permanently excludes sunset
+  // sources from RAG search without requiring a retriever logic change.
+  'sunset',
 ]);
 
 // @MX:NOTE [AUTO] RLHF enums — SPEC-REGULA-RLHF-001 (Issue #56).

--- a/lib/inngest/__tests__/functions.test.ts
+++ b/lib/inngest/__tests__/functions.test.ts
@@ -31,7 +31,8 @@ describe('function registry', () => {
     expect(ids).toContain('capa-effectiveness-due-reminder');
     expect(ids).toContain('standards-revision-daily');
     expect(ids).toContain('messages-embedding-backfill');
-    expect(functions).toHaveLength(6); // +standards-revision-daily Issue 62 +messages-embedding-backfill Issue 275
+    expect(ids).toContain('knowledge-sources-orphan-cleanup');
+    expect(functions).toHaveLength(7); // +standards-revision-daily Issue 62 +messages-embedding-backfill Issue 275 +orphan-cleanup Issue 313
   });
 
   it('weekly digest function is the same instance exported from its module', () => {

--- a/lib/inngest/functions.ts
+++ b/lib/inngest/functions.ts
@@ -7,6 +7,7 @@ import { knowledgeGapDailyDigestFn } from './digest/knowledge-gap-daily-digest';
 import { weeklyDigestFn } from './digest/weekly-digest';
 import { uploadProcessedFn } from './docingest/upload-processed';
 import { messagesEmbeddingBackfillJob } from './knowledge-promo/messages-embedding-backfill';
+import { knowledgeSourcesOrphanCleanupFn } from './knowledge-sources/orphan-cleanup';
 import { standardsRevisionDailyFn } from './standards/standards-revision-daily';
 
 /**
@@ -19,5 +20,6 @@ export const functions = [
   uploadProcessedFn,
   capaEffectivenessDueReminderFn,
   standardsRevisionDailyFn,
-  messagesEmbeddingBackfillJob, // Issue NNN — messages embedding backfill
+  messagesEmbeddingBackfillJob, // Issue 275 — messages embedding backfill
+  knowledgeSourcesOrphanCleanupFn, // Issue 313 — daily orphan sources cleanup
 ];

--- a/lib/inngest/knowledge-sources/orphan-cleanup.ts
+++ b/lib/inngest/knowledge-sources/orphan-cleanup.ts
@@ -1,0 +1,146 @@
+// @MX:NOTE [AUTO] Daily orphan sources cleanup cron (Issue 313).
+// @MX:SPEC Issue 313 — orphan sources sunset (21 CFR Part 11 audit-material)
+// @MX:REASON Phase D-2b (#307) re-sync supersession handles source_sections
+//   (superseded_by set, excluded from retrieval), but the parent sources row
+//   lingers as an orphan when all its sections are superseded. This cron
+//   detects such orphans and sets approval_status='sunset' + sunset_date=today
+//   so the source catalog stays clean and the retrieval gate permanently
+//   excludes them (retrieval-gate.ts: approvalStatus !== 'approved').
+//
+// Design choice (dedicated cron vs inline cleanup in sync.ts):
+//   A dedicated Inngest cron is chosen over inline cleanup at re-sync end.
+//   Reasons: (1) matches the codebase pattern (weekly-sync, knowledge-gap-daily,
+//   standards-revision-daily are all separate crons); (2) keeps sync.ts focused
+//   on the ingestion path — scope discipline, since Issue 314 also touches
+//   sync-adjacent code and isolating 313 reduces merge risk; (3) orphan
+//   detection is a batch query better suited to a background cron than blocking
+//   the re-sync response; (4) daily cadence is appropriate — orphan
+//   accumulation is gradual, no urgency.
+//
+// Orphan definition:
+//   A source is "orphan eligible for sunset" when ALL its source_sections are
+//   superseded (no active section remains). Detected via NOT EXISTS active
+//   section (superseded_by IS NULL). Sources already at approval_status='sunset'
+//   or 'rejected' are skipped (idempotent — no re-sunset).
+//
+// Audit trail (21 CFR Part 11):
+//   One 'source.orphan_sunsetted' audit row per sunset batch per org, with
+//   meta_json listing the sunset sourceIds. System actor (cron has no session).
+//   triggeredBy='cron' distinguishes from any future manual path.
+
+import { inngest } from '../client';
+
+/** Cron schedule: every day at 03:00 UTC (off-peak, daily cadence). */
+export const ORPHAN_CLEANUP_CRON_SCHEDULE = '0 3 * * *';
+
+/**
+ * Daily orphan sources cleanup function. Registered with Inngest so the
+ * dev/prod server triggers it on schedule.
+ *
+ * The cron iterates all orgs that have sources, detects orphans per-org
+ * (withTenantScope enforces RLS org isolation), and sunsets them in a tx with
+ * the audit write (21 CFR Part 11 atomicity — H2 pattern).
+ */
+export const knowledgeSourcesOrphanCleanupFn = inngest.createFunction(
+  {
+    id: 'knowledge-sources-orphan-cleanup',
+    name: 'Daily Orphan Sources Cleanup',
+    triggers: [{ cron: ORPHAN_CLEANUP_CRON_SCHEDULE }],
+  },
+  async ({ step, logger }) => {
+    // Lazy imports — keeps the cron module import-light (L-003 pattern) and
+    // avoids eagerly loading lib/db/client → lib/env at module registration
+    // time (env validation requires DATABASE_URL etc. which are absent in the
+    // Inngest function-registration test environment).
+    const { db } = await import('@/lib/db/client');
+    const { withTenantScope } = await import('@/lib/db/client');
+    const { sources, sourceSections } = await import('@/lib/db/schema');
+    const { writeAudit } = await import('@/lib/audit');
+    const { and, eq, inArray, notExists, sql } = await import('drizzle-orm');
+
+    // Step 1: enumerate distinct org_ids that have sources (system-actor query,
+    // no RLS scope — db singleton bypasses RLS via the service role).
+    const orgs = await step.run('enumerate-orgs', async () => {
+      const rows = await db
+        .select({ orgId: sources.organizationId })
+        .from(sources)
+        .groupBy(sources.organizationId);
+      return rows.map((r) => r.orgId).filter((id): id is string => Boolean(id));
+    });
+
+    let totalSunset = 0;
+    const perOrg: Record<string, number> = {};
+
+    // Step 2: per-org orphan detection + sunset + audit.
+    for (const orgId of orgs) {
+      try {
+        const sunsetCount = await step.run(`cleanup-org-${orgId}`, async () => {
+          return await withTenantScope(orgId, async (tx) => {
+            // Detect orphan sources: all sections superseded (NOT EXISTS active section).
+            // Skip sources already sunset/rejected (idempotent).
+            const orphans = await tx
+              .select({ id: sources.id, title: sources.title })
+              .from(sources)
+              .where(
+                and(
+                  eq(sources.organizationId, orgId),
+                  // Only sunset sources currently in active-or-pending state.
+                  // Already-sunset or rejected sources are left alone.
+                  inArray(sources.approvalStatus, ['pending_review', 'approved']),
+                  // Orphan condition: no active (non-superseded) section exists.
+                  notExists(
+                    sql`SELECT 1 FROM ${sourceSections} ss WHERE ss.source_id = ${sources.id} AND ss.superseded_by IS NULL`,
+                  ),
+                ),
+              );
+
+            if (orphans.length === 0) return 0;
+
+            const orphanIds = orphans.map((o) => o.id);
+            const today = new Date().toISOString().slice(0, 10);
+
+            // Sunset the orphans: approval_status='sunset' + sunset_date=today.
+            await tx
+              .update(sources)
+              .set({
+                approvalStatus: 'sunset',
+                sunsetDate: today,
+              })
+              .where(inArray(sources.id, orphanIds));
+
+            // 21 CFR Part 11 audit — single row per org batch. Non-PII meta only.
+            // tx-scoped so the sunset + audit ride the same transaction boundary
+            // (H2 atomicity pattern — a failure between them rolls back both).
+            await writeAudit(
+              {
+                actor_id: null, // system actor — cron has no session
+                action: 'source.orphan_sunsetted',
+                resource_type: 'source',
+                resource_id: `org:${orgId}`,
+                meta_json: {
+                  orgId,
+                  sunsetCount: orphanIds.length,
+                  sourceIds: orphanIds,
+                  triggeredBy: 'cron',
+                  reason: 'all source_sections superseded (orphan cleanup Issue 313)',
+                },
+              },
+              tx,
+            );
+
+            return orphanIds.length;
+          });
+        });
+        perOrg[orgId] = sunsetCount;
+        totalSunset += sunsetCount;
+      } catch (error) {
+        // Per-org failure does NOT abort the whole run — other orgs still get cleaned.
+        logger.error(`[orphan-cleanup] Failed for org ${orgId}:`, error);
+        perOrg[orgId] = 0;
+      }
+    }
+
+    logger.info('[orphan-cleanup] batch complete', { totalSunset, orgCount: orgs.length });
+    return { totalSunset, orgCount: orgs.length, perOrg };
+  },
+);

--- a/lib/source-governance/retrieval-gate.ts
+++ b/lib/source-governance/retrieval-gate.ts
@@ -67,7 +67,10 @@ export async function filterGovernanceEligible(
     const eligible = new Set<string>();
 
     for (const row of rows as GovernanceRow[]) {
-      // REQ-009: pending_review / rejected always excluded from search.
+      // REQ-009: pending_review / rejected / sunset always excluded from search.
+      // The `!== 'approved'` check covers all non-approved statuses uniformly.
+      // Issue 313: 'sunset' is set by the daily orphan-cleanup cron when all
+      // source_sections are superseded — it is permanently excluded here.
       if (row.approvalStatus !== 'approved') continue;
       // REQ-005: superseded excluded unless historical=true (REQ-006).
       if (!historical && row.supersededBy !== null) continue;

--- a/migrations/0101_source_orphan_sunset.sql
+++ b/migrations/0101_source_orphan_sunset.sql
@@ -1,0 +1,39 @@
+-- 0101_source_orphan_sunset.sql
+-- Issue 313: orphan sources cleanup cron.
+--
+-- Background:
+--   Phase D-2b (#307, PR #311) implemented re-sync supersession for
+--   source_sections via applyOutdateOperations (sync.ts:472). When a file is
+--   deleted from the repo, its source_sections rows are superseded (excluded
+--   from retrieval via superseded_by IS NULL filter). But the parent sources
+--   row remains as an ORPHAN — no active section, yet sources.approvalStatus
+--   stays at its prior value and the row lingers indefinitely.
+--
+--   sources.approvalStatus='pending_review' is the final retrieval gate
+--   (retrieval-gate.ts: approvalStatus !== 'approved' excludes from search),
+--   so orphan accumulation does not cause incorrect RAG results today. But
+--   long-term accumulation pollutes the source catalog and makes audit
+--   trails ambiguous ("was this source ever active?").
+--
+-- Scope:
+--   1. source_approval_status ADD VALUE 'sunset' — a dedicated value for
+--      cron-driven orphan cleanup. Semantically DISTINCT from 'rejected'
+--      (which means a human RA owner rejected a pending_review source during
+--      the approval workflow). 'sunset' means the system cron detected all
+--      sections are superseded and the source is no longer authoritative.
+--      The retrieval gate (retrieval-gate.ts:119) already excludes any
+--      status !== 'approved', so 'sunset' is permanently excluded from RAG
+--      search without requiring a retriever logic change.
+--   2. audit_action ADD VALUE 'source.orphan_sunsetted' — 21 CFR Part 11
+--      audit-material record for the cron-driven sunset batch. DISTINCT from
+--      'source.superseded' (which means replaced by a newer source version)
+--      and 'source.rejected' (human RA-owner rejection) so regulators can
+--      distinguish the three lifecycle events in the audit trail.
+--
+-- Compatibility:
+--   Backwards compatible — both are ADD VALUE (enum extension). Existing rows
+--   keep their current approval_status / the new value only applies to rows
+--   the cron touches. Idempotent via IF NOT EXISTS.
+
+ALTER TYPE source_approval_status ADD VALUE IF NOT EXISTS 'sunset';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'source.orphan_sunsetted';

--- a/tests/integration/capa.test.ts
+++ b/tests/integration/capa.test.ts
@@ -525,20 +525,20 @@ describe('Count regression (L-007 baseline)', () => {
     expect(vals).toContain("'clinical_investigation'");
   });
 
-  it('audit_action enum has 214 values (183 + 8 source.* SOURCE-GOVERNANCE Issue #48 + 1 label.esubmit_forwarded #249)', () => {
+  it('audit_action enum has 218 values (183 + 8 source.* SOURCE-GOVERNANCE Issue #48 + 1 label.esubmit_forwarded #249 + 1 source.orphan_sunsetted Issue 313)', () => {
     const src = readText('lib/db/schema.ts');
     const match = src.match(
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(214); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2)
+    expect(vals.length).toBe(218); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2) +1 source.orphan_sunsetted (Issue 313)
   });
 
-  it('AuditAction type has 214 values (sync with schema enum)', () => {
+  it('AuditAction type has 215 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(214); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2)
+    expect(vals.length).toBe(215); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2) +1 source.orphan_sunsetted (Issue 313)
   });
 
   it('PERMISSIONS matrix has 70 entries (68 + 2 sourcegov.* SOURCE-GOVERNANCE Issue #48)', () => {

--- a/tests/integration/cyberdevice.test.ts
+++ b/tests/integration/cyberdevice.test.ts
@@ -596,20 +596,20 @@ describe('AC-07: entitlement denial → 403 + audit (REQ-013)', () => {
 // Count-sync (L-009): audit_action + PermissionAction deltas.
 // ---------------------------------------------------------------------------
 describe('count-sync: audit_action (174→192) + PermissionAction (66→70)', () => {
-  it('audit_action enum has 214 values', () => {
+  it('audit_action enum has 218 values', () => {
     const src = readText('lib/db/schema.ts');
     const match = src.match(
       /export const auditActionEnum = pgEnum\('audit_action', \[([\s\S]*?)\]\);/,
     );
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(214); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2)
+    expect(vals.length).toBe(218); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2) +1 source.orphan_sunsetted (Issue 313)
   });
 
-  it('AuditAction type has 214 values (sync with schema enum)', () => {
+  it('AuditAction type has 215 values (sync with schema enum)', () => {
     const src = readText('lib/audit.ts');
     const match = src.match(/export type AuditAction =\s*([\s\S]*?);/);
     const vals = match?.[1]?.match(/'[a-z_.]+'/g) ?? [];
-    expect(vals.length).toBe(214); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2)
+    expect(vals.length).toBe(215); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2) +1 source.orphan_sunsetted (Issue 313)
   });
 
   it('PERMISSIONS matrix has 71 entries', () => {

--- a/tests/integration/source-governance.test.ts
+++ b/tests/integration/source-governance.test.ts
@@ -179,6 +179,24 @@ describe('AC-02: superseded filtering (REQ-SOURCE-GOV-005/006)', () => {
     expect(eligible.has('src-pending')).toBe(false);
   });
 
+  it('domain: sunset sources always excluded (Issue 313 orphan cleanup)', async () => {
+    // Orphan cleanup cron sets approvalStatus='sunset' when all sections are
+    // superseded. The retrieval gate must permanently exclude such sources.
+    mockRows.select = [
+      {
+        id: 'src-sunset',
+        authorityGrade: 'regulator_official',
+        approvalStatus: 'sunset',
+        supersededBy: null,
+        sunsetDate: '2026-07-01',
+        effectiveDate: null,
+      },
+    ];
+    const { filterGovernanceEligible } = await import('@/lib/source-governance/retrieval-gate');
+    const eligible = await filterGovernanceEligible(['src-sunset'], { orgId: 'org-1' });
+    expect(eligible.has('src-sunset')).toBe(false);
+  });
+
   it('source-level: composeRetrievalGates wired at all 3 retriever call sites', () => {
     const hybrid = readText('lib/ai/retrievers/hybrid-search.ts');
     const sops = readText('lib/ai/retrievers/internal-sops.ts');

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(214); // +3 memory_* (#51) +4 standards.* (#62) +2 owning_issue_* (#157) +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2)
+    expect(values).toHaveLength(215); // +3 memory_* (#51) +4 standards.* (#62) +2 owning_issue_* (#157) +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2) +1 source.orphan_sunsetted (Issue 313)
   });
 
   it.each([

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -429,8 +429,8 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     // order is NOT required to match (enum and type legitimately group migrations
     // differently with interspersed comments). Set-equality is the correct check.
     expect(new Set(values)).toEqual(new Set(typeValues));
-    expect(values).toHaveLength(214); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2)
-    expect(typeValues).toHaveLength(214);
+    expect(values).toHaveLength(215); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2) +1 source.orphan_sunsetted (Issue 313)
+    expect(typeValues).toHaveLength(215);
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -486,7 +486,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(214); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2)
+    expect(values).toHaveLength(215); // +1 rlhf.calibration_proposed (#264 2/3) +1 rlhf.implicit_feedback_recorded (#264 3/3) +1 label.esubmit_forwarded (#249) +1 traceability.section_superseded (#300 M-2) +1 source.orphan_sunsetted (Issue 313)
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(


### PR DESCRIPTION
## Summary

Issue #313 — re-sync 시 `source_sections`는 superseded 처리되나 `sources` 행이 잔존(orphan). 일일 Inngest cron이 all-sections-superseded source를 감지해 `approvalStatus='sunset'` + `sunsetDate` 오늘로 전환.

## Changes

- **migration 0101**: `source_approval_status` ADD `'sunset'` + `audit_action` ADD `'source.orphan_sunsetted'` (`ADD VALUE IF NOT EXISTS`, idempotent/backward-compatible). `'sunset'`는 `'rejected'`(human RA-owner 거부)와 의미 구분 — system cron lifecycle event.
- **lib/inngest/knowledge-sources/orphan-cleanup.ts** (신규): 일일 03:00 UTC cron. `withTenantScope(orgId)` org-isolation + `notExists(active section)` orphan 감지 + tx-scoped `writeAudit` (21 CFR Part 11 atomicity) + per-org try/catch (한 org 실패해도 계속).
- **functions.ts**: registry 6→7 + `functions.test.ts` `toHaveLength(7)`.
- **retrieval-gate.ts**: comment만 (logic 변경 없음). `approvalStatus !== 'approved'`가 이미 sunset 포함 모든 비-approved 값을 source-level에서 제외.
- **source-governance.test.ts**: sunset status retrieval 제외 회귀 테스트.
- count assertions 산재 4 파일 갱신.

## Retriever 영구 제외 (dead-code 방지 #50 lesson)

`composeRetrievalGates` → `filterGovernanceEligible` (`retrieval-gate.ts:74` `approvalStatus !== 'approved'`)가 3개 live retriever에서 호출:
- `lib/ai/retrievers/internal-docs.ts:161,166`
- `lib/ai/retrievers/hybrid-search.ts:266,268`
- `lib/ai/retrievers/internal-sops.ts:187,189`

sunset source는 이 gate에서 자동 제외 → RAG 영구 제외. logic 변경 없이 enum 값 추가로 달성.

## 직견 (L-007/009/010/013 — 오케스트레이터 직접)

- `pnpm typecheck` exit 0
- `pnpm lint` (biome + lint:hex full) exit 0 (2 pre-existing warnings)
- `pnpm test` full: **4815 passed | 21 skipped | 0 failed** (baseline 4814 → +1)
- migration 0101 격리 DB(`regula_e2e_test`) 실DB 적용: `ALTER TYPE`×2 성공 + `pg_enum`에서 `sunset`/`source.orphan_sunsetted` 값 직검
- `pnpm build` skip (`next dev` 구동 중, L-012)

## AC

- [x] re-sync 후 삭제 파일 sources가 sunset 처리 (orphan = all-sections-superseded 감지)
- [x] retriever에서 영구 제외 (live gate grep 확증 + 회귀 테스트)
- [x] cron 일일 실행 + audit (functions.ts registry + tx-scoped writeAudit)

## Scope

`sync.ts` / `upload-processed.ts` 미수정 (RCE guards 보존, #314 영역 침범 없음).

Refs #307. Fixes #313.

🗿 MoAI <email@mo.ai.kr>