### PR TITLE
refactor(ingest): insertSourceSections shared helper 추출 — sync/delta-sync upsert 통합 (#314)

### DIFF
--- a/lib/ingest/source-sections-upsert.ts
+++ b/lib/ingest/source-sections-upsert.ts
@@ -1,0 +1,95 @@
+// @MX:NOTE [AUTO] Shared org-scoped batch insert into source_sections.
+// @MX:SPEC Issue #314 (refactor) — extracts the duplicated org-scoped tx + batch
+//   insert loop that previously lived inline in BOTH:
+//     - lib/radar/delta-sync/orchestrator.ts runDeltaSync step 7c
+//     - lib/knowledge-sources/sync.ts ingestOneFile step h
+//   Both wrote the same shape ({sourceId, anchor, heading, text, embedding,
+//   sectionPath, ingestionRunId, ingestedAt, chunkHash}) inside
+//   withTenantScope(orgId). The helper preserves that exact write semantics.
+//
+// Design note (Enforce Simplicity): the helper does NOT derive anchor/sectionPath
+// because those are caller-specific provenance keys (delta-sync uses
+// `delta-<runId>-<i>`; knowledge-sources uses `<sha8(relPath)>-<i>`). Forcing a
+// shared derivation would create a false abstraction. Callers compute the per-row
+// values; the helper owns the tx + batch + id collection.
+//
+// Org isolation: the insert runs inside withTenantScope(orgId), identical to the
+// original inline blocks. No RLS bypass introduced.
+//
+// 21 CFR Part 11: no audit emission here. Both call sites emit audit at the
+// run/sync level (corpus_sync_runs + corpus.sync_*), and supersession audit fires
+// inside applyOutdateOperations. The insert of NEW sections is not itself a
+// regulated event; preserving the prior tx boundary (no new audit inside this tx)
+// matches the pre-refactor behavior exactly.
+
+import { withTenantScope } from '@/lib/db/client';
+import { sourceSections } from '@/lib/db/schema';
+
+/**
+ * Input row for insertSourceSections — one per chunk to persist.
+ *
+ * Callers populate every field; the helper does not synthesize or override.
+ * This keeps the primitive low-level and free of caller assumptions about
+ * anchor/sectionPath derivation.
+ */
+export interface SourceSectionInsertRow {
+  sourceId: string;
+  anchor: string;
+  heading: string | null;
+  text: string;
+  embedding: number[];
+  sectionPath: string | null;
+  ingestionRunId: string;
+  chunkHash: string;
+}
+
+/**
+ * @MX:ANCHOR [AUTO] insertSourceSections — shared org-scoped batch insert into
+ *   source_sections. Live callers: lib/radar/delta-sync/orchestrator.ts
+ *   runDeltaSync (7c) and lib/knowledge-sources/sync.ts ingestOneFile (h).
+ *   fan_in = 2. Issue #314 extracted this to eliminate the verbatim
+ *   duplication between those two write paths.
+ * @MX:REASON Pre-refactor, the exact same withTenantScope + batch insert loop
+ *   existed inline in both files with identical row shape. A drift bug between
+ *   the two would silently corrupt RAG provenance. Centralizing the write keeps
+ *   the retriever's data contract single-sourced.
+ * @MX:SPEC Issue #314 (priority/low refactor — behavioral equivalence required)
+ *
+ * Executes the batch insert inside `withTenantScope(orgId)` (RLS-enforced) and
+ * returns the ids of the newly-inserted rows in input order. Rows whose insert
+ * returns no row (rare — only on DB-level anomalies) are omitted from the
+ * returned array; callers count via `.length` exactly as before.
+ *
+ * @param orgId   Organization scope for the write (RLS GUC is set inside).
+ * @param rows    Pre-computed per-chunk row values (caller derives anchor/path).
+ * @returns       Array of inserted section ids (length <= rows.length).
+ */
+export async function insertSourceSections(
+  orgId: string,
+  rows: SourceSectionInsertRow[],
+): Promise<string[]> {
+  if (rows.length === 0) return [];
+
+  return withTenantScope(orgId, async (tx) => {
+    const insertedIds: string[] = [];
+    for (const row of rows) {
+      const ins = await tx
+        .insert(sourceSections)
+        .values({
+          sourceId: row.sourceId,
+          anchor: row.anchor,
+          heading: row.heading,
+          text: row.text,
+          embedding: row.embedding,
+          sectionPath: row.sectionPath,
+          ingestionRunId: row.ingestionRunId,
+          ingestedAt: new Date(),
+          chunkHash: row.chunkHash,
+        })
+        .returning({ id: sourceSections.id });
+      const r = ins[0];
+      if (r) insertedIds.push(r.id);
+    }
+    return insertedIds;
+  });
+}

--- a/lib/inngest/docingest/upload-processed.ts
+++ b/lib/inngest/docingest/upload-processed.ts
@@ -159,7 +159,25 @@ async function insertChunks(
   chunks: Array<{ text: string; metadata: Record<string, unknown> }>,
   _embeddings: number[][],
 ): Promise<number> {
-  // In production: batch insert into document_chunks table via withTenantScope
+  // Issue 314: this stub intentionally does NOT use the shared
+  // insertSourceSections helper (lib/ingest/source-sections-upsert.ts) because
+  // the DOCINGEST Phase 3 path lacks the provenance a source_sections row needs:
+  //   - no sources row is created/attached in this pipeline (unlike sync.ts
+  //     which calls resolveOrCreateFileSource); source_sections.source_id is
+  //     NOT NULL with a FK to sources.id.
+  //   - the stub signature drops sourceId/anchor/sectionPath/ingestionRunId/
+  //     chunkHash entirely.
+  // This stub targets a DIFFERENT table than the shared helper. The DOCINGEST
+  // upload path persists to document_chunks (defined in migrations/0015 + 0017,
+  // RLS-enforced via the tenant_isolation_chunks policy), whereas
+  // insertSourceSections writes source_sections (which requires a sources-row
+  // FK + provenance: anchor/sectionPath/ingestionRunId/chunkHash). This stub's
+  // signature (documentId, orgId, chunks, embeddings) drops all source_sections
+  // provenance fields, so it cannot reuse the source_sections helper. Real
+  // implementation requires the R2-backed extract→chunk→embed pipeline writing
+  // document_chunks (DOCINGEST Phase 3). Wiring a fake source_sections insert
+  // here would violate the retriever's data contract. Returning chunks.length
+  // is the honest stub until Phase 3 lands.
   return chunks.length;
 }
 

--- a/lib/knowledge-sources/sync.ts
+++ b/lib/knowledge-sources/sync.ts
@@ -10,14 +10,18 @@ import { mkdir, rm } from 'node:fs/promises';
 import { basename, extname, join, relative } from 'node:path';
 import { promisify } from 'node:util';
 import { writeAudit } from '@/lib/audit';
-import { db, withTenantScope } from '@/lib/db/client';
-import { corpusSyncRuns, knowledgeSources, sourceSections, sources } from '@/lib/db/schema';
+import { db } from '@/lib/db/client';
+import { corpusSyncRuns, knowledgeSources, sources } from '@/lib/db/schema';
 import { chunk } from '@/lib/ingest/chunkers';
 import { DocClass } from '@/lib/ingest/doc-class';
 import { classifyDocument } from '@/lib/ingest/doc-classifier';
 import { embedChunks } from '@/lib/ingest/embed';
 import { extractText } from '@/lib/ingest/extract';
 import { redactPiiForIngest } from '@/lib/ingest/pii/redact';
+import {
+  type SourceSectionInsertRow,
+  insertSourceSections,
+} from '@/lib/ingest/source-sections-upsert';
 import { logger } from '@/lib/observability/logger';
 import { applyOutdateOperations } from '@/lib/radar/delta-sync/ingest';
 import { resolveExistingChunkIds } from '@/lib/radar/delta-sync/orchestrator';
@@ -438,33 +442,28 @@ async function ingestOneFile(
   // g. Resolve existing chunk ids for supersession (org-scoped JOIN — M-1).
   const existingChunkIds = await resolveExistingChunkIds(fileSourceId, ctx.orgId);
 
-  // h. INSERT new source_sections (org-scoped tx) — mirrors orchestrator 7c.
-  const insertedSections = await withTenantScope(ctx.orgId, async (tx) => {
-    const rows: { id: string }[] = [];
-    for (let i = 0; i < chunks.length; i++) {
-      const c = chunks[i];
-      const emb = embeddings[i];
-      if (!c || !emb) continue;
-      const meta = c.metadata as { sectionPath?: string; tokenCount?: number };
-      const ins = await tx
-        .insert(sourceSections)
-        .values({
-          sourceId: fileSourceId,
-          anchor: `${sha8(file.relPath)}-${i}`,
-          heading: meta.sectionPath ?? null,
-          text: c.text,
-          embedding: emb,
-          sectionPath: `${file.relPath}#${meta.sectionPath ?? 'chunk'}`,
-          ingestionRunId: ctx.runId,
-          ingestedAt: new Date(),
-          chunkHash: computeChunkHash(c.text),
-        })
-        .returning({ id: sourceSections.id });
-      const r = ins[0];
-      if (r) rows.push(r);
-    }
-    return rows;
-  });
+  // h. INSERT new source_sections (org-scoped tx). Issue #314: delegates to the
+  // shared insertSourceSections helper used by delta-sync orchestrator 7c. The
+  // anchor/sectionPath provenance keys remain caller-specific (file-path based)
+  // while the tx boundary + batch insert + id collection are centralized.
+  const insertRows: SourceSectionInsertRow[] = [];
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i];
+    const emb = embeddings[i];
+    if (!c || !emb) continue;
+    const meta = c.metadata as { sectionPath?: string; tokenCount?: number };
+    insertRows.push({
+      sourceId: fileSourceId,
+      anchor: `${sha8(file.relPath)}-${i}`,
+      heading: meta.sectionPath ?? null,
+      text: c.text,
+      embedding: emb,
+      sectionPath: `${file.relPath}#${meta.sectionPath ?? 'chunk'}`,
+      ingestionRunId: ctx.runId,
+      chunkHash: computeChunkHash(c.text),
+    });
+  }
+  const insertedSections = await insertSourceSections(ctx.orgId, insertRows);
 
   // i. Supersede prior chunks for this file (re-sync path). Mirrors 7d.
   let outdatedApplied = 0;

--- a/lib/radar/delta-sync/orchestrator.ts
+++ b/lib/radar/delta-sync/orchestrator.ts
@@ -24,8 +24,11 @@
 //   when no deliverable cited the section (the supersession itself was unaudited).
 
 import { writeAudit } from '@/lib/audit';
-import { withTenantScope } from '@/lib/db/client';
 import { corpusSyncRuns, sourceSections, sources } from '@/lib/db/schema';
+import {
+  type SourceSectionInsertRow,
+  insertSourceSections,
+} from '@/lib/ingest/source-sections-upsert';
 import { logger } from '@/lib/observability/logger';
 import { and, desc, eq, isNull } from 'drizzle-orm';
 import { embedChunks } from '../../ingest/embed';
@@ -212,37 +215,31 @@ export async function runDeltaSync(input: RunDeltaSyncInput): Promise<RunDeltaSy
       ingestionRunId: runId,
     });
 
-    // 7c. INSERT new source_sections (org-scoped tx). The "added" path mirrors
-    //     scripts/seed-fda-corpus.ts. sectionPath/tokenCount come from chunker
-    //     metadata; anchor is synthesized from the chunk index for uniqueness.
-    const insertedSections = await withTenantScope(orgId, async (tx) => {
-      const rows: { id: string }[] = [];
-      for (let i = 0; i < embedded.length; i++) {
-        const ec = embedded[i];
-        if (!ec) continue;
-        const meta = ec.metadata as {
-          sectionPath?: string;
-          tokenCount?: number;
-        };
-        const ins = await tx
-          .insert(sourceSections)
-          .values({
-            sourceId,
-            anchor: `delta-${runId.slice(0, 8)}-${i}`,
-            heading: (meta.sectionPath as string) ?? null,
-            text: ec.text,
-            embedding: ec.embedding,
-            sectionPath: (meta.sectionPath as string) ?? null,
-            ingestionRunId: runId,
-            ingestedAt: new Date(),
-            chunkHash: computeChunkHash(ec.text),
-          })
-          .returning({ id: sourceSections.id });
-        const r = ins[0];
-        if (r) rows.push(r);
-      }
-      return rows;
-    });
+    // 7c. INSERT new source_sections (org-scoped tx). Issue #314: delegates to
+    //     the shared insertSourceSections helper used by knowledge-sources sync.
+    //     anchor/sectionPath provenance keys remain caller-specific (delta-run
+    //     based) while the tx boundary + batch insert + id collection are
+    //     centralized.
+    const insertRows: SourceSectionInsertRow[] = [];
+    for (let i = 0; i < embedded.length; i++) {
+      const ec = embedded[i];
+      if (!ec) continue;
+      const meta = ec.metadata as {
+        sectionPath?: string;
+        tokenCount?: number;
+      };
+      insertRows.push({
+        sourceId,
+        anchor: `delta-${runId.slice(0, 8)}-${i}`,
+        heading: (meta.sectionPath as string) ?? null,
+        text: ec.text,
+        embedding: ec.embedding,
+        sectionPath: (meta.sectionPath as string) ?? null,
+        ingestionRunId: runId,
+        chunkHash: computeChunkHash(ec.text),
+      });
+    }
+    const insertedSections = await insertSourceSections(orgId, insertRows);
 
     // 7d. applyOutdateOperations — the #238 live call site. Org-scoped tx +
     //     non-blocking hook. M-2 audit (traceability.section_superseded per


### PR DESCRIPTION
## Summary

Issue #314 — `sync.ts` ingestOneFile(h)와 `delta-sync` orchestrator runDeltaSync(7c)의 `source_sections` org-scoped batch insert가 동일 shape로 **verbatim 중복**. 공유 helper `insertSourceSections(orgId, rows)`로 tx + batch insert + id collection을 중앙화.

## ⚠️ 이슈 프레이밍 정정 (직검)

이슈 본문은 upload-processed.ts의 `insertChunks` stub도 동일 패턴으로 묶을 것을 제안했으나, **직검 결과 오류**:

- `document_chunks` 테이블은 **실존** (migrations/0015 + 0017, RLS `tenant_isolation_chunks`). 이슈/초기 분석의 "부재" 주장은 틀림.
- 단, upload-processed.ts insertChunks는 `document_chunks` 대상이고 shared helper는 `source_sections` 전용 → **다른 테이블**이라 합류 불가.
- upload-processed stub 시그니처(`documentId, orgId, chunks, embeddings`)가 source_sections provenance(`sourceId`/`anchor`/`sectionPath`/`ingestionRunId`/`chunkHash`) 누락.

따라서 본 PR은 **진짜 중복(sync ↔ delta-sync orchestrator)만** 추출. upload-processed.ts `document_chunks` 실구현은 DOCINGEST Phase 3(R2 인프라 + sources-row resolver) 의존 — 별도 이슈 권장.

## Changes

- **lib/ingest/source-sections-upsert.ts** (신규): `insertSourceSections(orgId, rows)` + `SourceSectionInsertRow`. `withTenantScope(orgId)` tx 보존 (RLS). `@MX:ANCHOR` fan_in=2. Part 11: audit은 run/sync 수준에서 (helper 내부 audit 없음, pre-refactor 동일).
- **sync.ts**: step h inline 26줄 → helper 호출. anchor/sectionPath caller-specific provenance 유지.
- **orchestrator.ts**: step 7c inline 28줄 → helper 호출.
- **upload-processed.ts**: stub 주석 정정 (document_chunks 실존 인정 + 왜 helper 합류 불가인지 정확한 근거).

## Design (Enforce Simplicity)

helper는 `anchor`/`sectionPath` provenance key를 강제하지 않음 — delta-sync는 `delta-<runId>-<i>`, knowledge-sources는 `<sha8(relPath)>-<i>`로 caller-specific. 진짜 중복(tx + batch + id collection)만 공유하고, 존재하지 않는 공통점을 억지로 만들지 않음.

## Behavioral Equivalence (직검)

- row 값: `sourceId`/`anchor`/`heading`/`text`/`embedding`/`sectionPath`/`ingestionRunId`/`ingestedAt`/`chunkHash` 전부 동일
- tx boundary: `withTenantScope(orgId)` 보존 (RLS GUC 동일)
- return shape: `insertedSections.length` 카운트 동일
- supersession: `applyOutdateOperations` 호출 순서 불변

## 직검 (L-007/013)

- `pnpm typecheck` exit 0
- `pnpm lint` (biome + lint:hex full) exit 0
- `pnpm test` full: **4815 passed | 21 skipped | 0 failed** (baseline 일치, 회귀 0)
- helper live 2 caller grep 확증 (sync.ts:466, orchestrator.ts:242)
- sync.ts diff behavioral equivalence 직검
- `pnpm build` skip (`next dev` 구동 중, L-012)

## AC

- [x] 단일 helper로 sync/delta-sync 양쪽 재사용 (진짜 중복 해결)
- [x] 기존 테스트 회귀 0 (upload-processed + ingest-documents)
- ℹ️ upload-processed.ts `document_chunks` 실구현은 별도 테이블이므로 본 PR scope 외 (Phase 3 의존)

## Scope

순수 refactor — migration/enum/permission/count assertion 변경 0. RCE/SSRF guards 미접촉.

Refs #307. Fixes #314 (진짜 중복 해결; upload-processed document_chunks 실구현은 Phase 3 후 별도 추적 권장).

🗿 MoAI <email@mo.ai.kr>