### PR TITLE
fix(ci): ci:audit Part 11 debt — 16 route audit-check-ignore override (#324)

### DIFF
--- a/app/api/corpus-license/entitlement/route.ts
+++ b/app/api/corpus-license/entitlement/route.ts
@@ -5,6 +5,8 @@ import { assertSourceLicenseInOrg } from '@/lib/corpus-license/access';
 import { grantEntitlement, revokeEntitlement } from '@/lib/corpus-license/entitlement';
 import { entitlementInputSchema } from '@/lib/corpus-license/types';
 
+/* audit-check-ignore: audit is written inside grantEntitlement()/revokeEntitlement()
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('corpuslicense.manage', async (req, _ctx, session) => {
   const organizationId = session.user.organizationId;
   if (!organizationId) {

--- a/app/api/corpus-license/ingestion-gate/route.ts
+++ b/app/api/corpus-license/ingestion-gate/route.ts
@@ -12,6 +12,8 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { assertIngestionLicensed } from '@/lib/corpus-license/license-gate';
 import { ingestionGateInputSchema } from '@/lib/corpus-license/types';
 
+/* audit-check-ignore: ingestion gate delegates to assertIngestionLicensed(); audit
+   (access denied/granted) is written inside the gate within the same tx (Part 11) */
 export const POST = withPermission('corpuslicense.view', async (req, _ctx, session) => {
   const organizationId = session.user.organizationId;
   if (!organizationId) {

--- a/app/api/corpus-license/source-license/route.ts
+++ b/app/api/corpus-license/source-license/route.ts
@@ -19,6 +19,8 @@ export const GET = withPermission('corpuslicense.view', async (_req, _ctx, sessi
 });
 
 // POST — create license metadata. REQ-CORPUSLIC-001/010.
+/* audit-check-ignore: this route calls auditLicenseSet()/auditCorpusAccessDenied() (lib
+   audit wrappers) within the same tx (Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('corpuslicense.manage', async (req, _ctx, session) => {
   const organizationId = session.user.organizationId;
   if (!organizationId) {

--- a/app/api/knowledge-gap/replay/[queueId]/route.ts
+++ b/app/api/knowledge-gap/replay/[queueId]/route.ts
@@ -32,6 +32,8 @@ async function resolveQueueId(ctx: QueueCtx): Promise<string> {
   return params.queueId ?? '';
 }
 
+/* audit-check-ignore: audit is written inside replayGapTest() (knowledge-gap/replay)
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('knowledgegap.replay', async (_req, ctx, session) => {
   const queueId = await resolveQueueId(ctx as QueueCtx);
   if (!queueId) {

--- a/app/api/knowledge-promo/promote/[id]/route.ts
+++ b/app/api/knowledge-promo/promote/[id]/route.ts
@@ -9,6 +9,8 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { assertPromotedAnswerInOrg } from '@/lib/knowledge-promo/access';
 import { unpromoteAnswer } from '@/lib/knowledge-promo/promote';
 
+/* audit-check-ignore: audit is written inside unpromoteAnswer() (knowledge-promo)
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const DELETE = withPermission('knowledgepromo.promote', async (_req, ctx, session) => {
   const params =
     typeof ctx?.params === 'object' && ctx.params !== null

--- a/app/api/knowledge-promo/promote/route.ts
+++ b/app/api/knowledge-promo/promote/route.ts
@@ -16,6 +16,8 @@ const PromoteRequestSchema = z.object({
   tags: z.array(z.string().min(1).max(50)).max(20).default([]),
 });
 
+/* audit-check-ignore: audit is written inside promoteAnswer() (knowledge-promo)
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('knowledgepromo.promote', async (req, _ctx, session) => {
   let body: unknown;
   try {

--- a/app/api/model-governance/approve/route.ts
+++ b/app/api/model-governance/approve/route.ts
@@ -16,6 +16,8 @@ import {
 } from '@/lib/model-governance/change-workflow';
 import { approveChangeRequestInputSchema } from '@/lib/model-governance/types';
 
+/* audit-check-ignore: audit is written inside approveChangeRequest() (change-workflow)
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('modelgov.approve', async (req, _ctx, session) => {
   const organizationId = session.user.organizationId;
   if (!organizationId) {

--- a/app/api/model-governance/change-request/[id]/eval/route.ts
+++ b/app/api/model-governance/change-request/[id]/eval/route.ts
@@ -21,6 +21,8 @@ const evalInputSchema = z.object({
   evalResultRef: z.string().max(1024).optional(),
 });
 
+/* audit-check-ignore: audit is written inside recordEvalResult() (change-workflow)
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('modelgov.manage', async (req, ctx, session) => {
   const organizationId = session.user.organizationId;
   if (!organizationId) {

--- a/app/api/model-governance/change-request/route.ts
+++ b/app/api/model-governance/change-request/route.ts
@@ -9,6 +9,8 @@ import { createChangeRequest } from '@/lib/model-governance/change-workflow';
 import { createChangeRequestInputSchema } from '@/lib/model-governance/types';
 import { eq } from 'drizzle-orm';
 
+/* audit-check-ignore: audit is written inside createChangeRequest() (change-workflow)
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('modelgov.manage', async (req, _ctx, session) => {
   const organizationId = session.user.organizationId;
   if (!organizationId) {

--- a/app/api/model-governance/model-pinning/route.ts
+++ b/app/api/model-governance/model-pinning/route.ts
@@ -5,6 +5,8 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { listModelPins, registerModelPin } from '@/lib/model-governance/model-pinning';
 import { registerModelPinInputSchema } from '@/lib/model-governance/types';
 
+/* audit-check-ignore: audit is written inside registerModelPin() (model-pinning)
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('modelgov.manage', async (req, _ctx, session) => {
   const organizationId = session.user.organizationId;
   if (!organizationId) {

--- a/app/api/model-governance/rollback/route.ts
+++ b/app/api/model-governance/rollback/route.ts
@@ -5,6 +5,8 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { RollbackError, rollbackCombination } from '@/lib/model-governance/rollback';
 import { rollbackInputSchema } from '@/lib/model-governance/types';
 
+/* audit-check-ignore: audit is written inside rollbackCombination() (rollback)
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('modelgov.manage', async (req, _ctx, session) => {
   const organizationId = session.user.organizationId;
   if (!organizationId) {

--- a/app/api/project-memory/[id]/route.ts
+++ b/app/api/project-memory/[id]/route.ts
@@ -29,6 +29,9 @@ const PatchMemorySchema = z.object({
 });
 
 // PATCH /api/project-memory/[id] — same-key supersession (ra-lead only).
+/* audit-check-ignore: audit (memory action) is written inside updateMemory() /
+   invalidateMemory() within the same tx (21 CFR Part 11 atomicity) — route-level
+   writeAudit would duplicate */
 export const PATCH = withPermission('projectmemory.manage', async (req, ctx, session) => {
   const params = ctx.params && 'then' in ctx.params ? await ctx.params : (ctx.params ?? {});
   const memoryId = params?.id;

--- a/app/api/project-memory/route.ts
+++ b/app/api/project-memory/route.ts
@@ -59,6 +59,8 @@ export const GET = withPermission('projectmemory.view', async (req, _ctx, sessio
 });
 
 // POST /api/project-memory — create a memory (ra-lead only).
+/* audit-check-ignore: audit (memory action) is written inside createMemory()
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('projectmemory.manage', async (req, _ctx, session) => {
   let body: unknown;
   try {

--- a/app/api/project-memory/suggest/approve/route.ts
+++ b/app/api/project-memory/suggest/approve/route.ts
@@ -15,6 +15,8 @@ const ApproveSchema = z.object({
   memoryId: z.string().uuid(),
 });
 
+/* audit-check-ignore: audit (memory action) is written inside approveSuggestedMemory()
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('projectmemory.manage', async (req, _ctx, session) => {
   let body: unknown;
   try {

--- a/app/api/ra/hybrid/audit-export/route.ts
+++ b/app/api/ra/hybrid/audit-export/route.ts
@@ -13,6 +13,8 @@ const ExportSchema = z.object({
   format: z.enum(['csv', 'json']).optional(),
 });
 
+/* audit-check-ignore: audit (integration gap) is written inside recordIntegrationGap()
+   within the same tx (21 CFR Part 11 atomicity) — route-level writeAudit would duplicate */
 export const POST = withPermission('audit.package.generate', async (request, _ctx, session) => {
   let body: unknown;
   try {

--- a/app/api/ra/knowledge-sources/[id]/sync/route.ts
+++ b/app/api/ra/knowledge-sources/[id]/sync/route.ts
@@ -8,6 +8,9 @@ import { assertKnowledgeSourceInOrg } from '@/lib/knowledge-sources/access';
 import { syncKnowledgeSource } from '@/lib/knowledge-sources/sync';
 import { eq } from 'drizzle-orm';
 
+/* audit-check-ignore: audit (knowledge_source.synced) is written inside
+   syncKnowledgeSource() within the same tx (21 CFR Part 11 atomicity) —
+   route-level writeAudit would duplicate */
 export const POST = withPermission('knowledgesources.manage', async (_req, ctx, session) => {
   const orgId = session.user.organizationId;
 


### PR DESCRIPTION
Refs #324. main CI 빨간 상태 회복 — ci:audit 전 도메인 Part 11 audit 결함 해결.

## 원인
ci:audit(audit-completeness.ts)가 route 파일 body의 `writeAudit(` literal만 인식. 각 도메인 route는 lib 함수 내부에서 tx와 함께 audit 작성(21 CFR Part 11 atomicity)하지만, route에 literal이 없어 ci:audit가 "missing writeAudit"로 잡음. route에 추가하면 **중복 audit**(Part 11 위반).

## 해결 — 16 route `audit-check-ignore` override
ci:audit 공식 override 메커니즘(`/* audit-check-ignore: ... */`)으로 각 route 파일에 정당 사유(lib 내부 tx audit, route-level은 중복) 명시:

| 도메인 | route | lib audit 함수 |
|---|---|---|
| project-memory | suggest/approve, route, [id] | approveSuggestedMemory/createMemory/updateMemory/invalidateMemory |
| model-governance | approve, change-request, eval, model-pinning, rollback | change-workflow/model-pinning/rollback |
| corpus-license | entitlement, ingestion-gate, source-license(POST+PUT) | grantEntitlement/assertIngestionLicensed/auditLicenseSet |
| knowledge-gap | replay/[queueId] | replayGapTest |
| knowledge-promo | promote(POST), promote/[id](DELETE) | promoteAnswer/unpromoteAnswer |
| ra | hybrid/audit-export, knowledge-sources/[id]/sync | recordIntegrationGap/syncKnowledgeSource |

(PR #323의 source-governance 4건에 이어, 본 PR에서 나머지 16건.)

## ★ 핵심 교훈 (L-008/L-013 확장)
1. **ci:audit 정규식 `/audit-check-ignore[^*]*\*\//`** — `[^*]*`라 주석 내 `*` 문자 불가. `memory_*`(wildcard) → `memory action`으로 수정해야 override 인식.
2. **ci:audit는 lib 내부 tx audit 인식 못 함** — route literal만. 도메인이 lib에 audit 위임하는 패턴(권장)은 override 필요.
3. **main 머지 전 CI Gates 전 단계 로컬 직검 필수** — typecheck/lint/test만으로 CI green 단정 금지.

## 게이트 (로컬 직검)
- ci:audit: **PASS** ✅
- ci:lint / ci:format / typecheck / ci:rbac / ci:tokens / ci:i18n / ci:glossary / ci:contrast / ci:module-boundaries / ci:migrations: 전부 **EXIT 0** ✅
- ci:test: 주석만 추가(로직 변경 0) → 회귀 0, CI에서 확인
- ci:build: 로컬 next dev 구동 중(L-012) → CI에서 확인

## 리뷰 포인트
각 route의 lib 함수가 실제로 tx 내부에서 audit하는지 검증 권장(override 정당성). 모든 도메인 lib는 writeAudit wrapper/직접 호출 확인됨.

---
🤖 Generated with MoAI