### PR TITLE
test(e2e): SPEC-V3-UI-001 inbox a11y + viewer redirect (T-028/T-029)

### DIFF
--- a/tests/e2e/inbox-a11y.spec.ts
+++ b/tests/e2e/inbox-a11y.spec.ts
@@ -1,0 +1,45 @@
+// @MX:NOTE [AUTO] E2E spec: axe-core accessibility scan for /inbox (ra-member view)
+// @MX:SPEC SPEC-V3-UI-001 (REQ-V3-UI-042, AC-UI-010, Issue 328/329)
+
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+import { requiresAuthState, requiresLiveServer } from './fixtures/env-guard';
+
+test.describe('Inbox Accessibility — WCAG 2.1 AA (REQ-V3-UI-042)', () => {
+  test('/inbox has no critical accessibility violations', async ({ page }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    await page.goto('/inbox');
+    await page.waitForLoadState('networkidle');
+
+    const axePage = page as unknown as ConstructorParameters<typeof AxeBuilder>[0]['page'];
+    const results = await new AxeBuilder({ page: axePage })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+      .analyze();
+
+    const critical = results.violations.filter((v) => v.impact === 'critical');
+    expect(
+      critical,
+      `Critical a11y violations on /inbox:\n${critical
+        .map((v) => `  [${v.id}] ${v.description} (${v.nodes.length} node(s))`)
+        .join('\n')}`,
+    ).toHaveLength(0);
+  });
+
+  test('InboxKanban column headers are keyboard-focusable links/buttons', async ({ page }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    await page.goto('/inbox');
+    await page.waitForLoadState('networkidle');
+
+    // Triage action menu / refresh / archive toggle buttons must be keyboard-reachable.
+    const interactiveCount = await page.locator('button[type="button"], a[href]').count();
+    expect(interactiveCount).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/inbox-viewer-redirect.spec.ts
+++ b/tests/e2e/inbox-viewer-redirect.spec.ts
@@ -1,0 +1,26 @@
+// @MX:NOTE [AUTO] E2E spec: viewer role redirect from /inbox → /chat (REQ-V3-UI-030)
+// @MX:SPEC SPEC-V3-UI-001 (REQ-V3-UI-030, Issue 329)
+//
+// 현재 globalSetup이 ra-member 세션만 직렬화하므로, viewer 세션 E2E는
+// viewer 전용 storageState fixture가 선행되어야 활성화.
+// REQ-V3-UI-030 redirect 자체는 단위 테스트(app/(app)/inbox/page.test.tsx)에서
+// 이미 검증됨 — 본 E2E는 viewer 실세션 통합 검증용.
+
+import { expect, test } from '@playwright/test';
+import { requiresLiveServer } from './fixtures/env-guard';
+
+test.describe('Inbox viewer redirect (REQ-V3-UI-030)', () => {
+  test.skip(true, 'viewer storageState fixture 선행 필요 — globalSetup이 ra-member 전용');
+
+  test('viewer visiting /inbox is redirected to /chat', async ({ browser }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+
+    // TODO: viewer storageState fixture(.auth-viewer.json) 적용 후 활성화.
+    const ctx = await browser.newContext({ storageState: undefined });
+    const page = await ctx.newPage();
+    await page.goto('/inbox');
+    await expect(page).toHaveURL('/chat');
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
T-028 axe WCAG 2.1 AA on /inbox, T-029 viewer redirect stub (viewer fixture 선행 시 활성화). Refs: Issue 329. 🗿 MoAI <email@mo.ai.kr>