### PR TITLE
feat(chat): T-024 viewer 질문 → inbox ticket (옵션 B)

### DIFF
--- a/components/chat/ChatShell.tsx
+++ b/components/chat/ChatShell.tsx
@@ -44,6 +44,7 @@ export function ChatShell() {
     structured,
     error,
     duration_ms: durationMs,
+    ticketId,
     ragRoute,
     start,
     abort,
@@ -183,6 +184,23 @@ export function ChatShell() {
             ragRoute={ragRoute}
             onRegenerate={handleRegenerate}
           />
+        </div>
+      )}
+
+      {/* T-024 (Option B): viewer question → inbox ticket surfacing (REQ-V3-UI-033) */}
+      {showAnswer && ticketId && (
+        <div
+          className="mb-4 rounded-lg border border-brand-200 bg-brand-50 px-4 py-2 text-sm"
+          data-testid="chat-ticket-status"
+        >
+          <span className="text-ink-600">내 질문이 RA 인박스에 등록되었습니다.</span>{' '}
+          <a
+            href={`/inbox/${ticketId}`}
+            data-testid="chat-ticket-link"
+            className="font-medium text-brand-700 underline"
+          >
+            triage 상태 보기 →
+          </a>
         </div>
       )}
 

--- a/hooks/useStreamingAnswer.ts
+++ b/hooks/useStreamingAnswer.ts
@@ -42,6 +42,7 @@ export interface StreamingState {
   };
   error: string | null;
   duration_ms: number | null;
+  ticketId: string | null;
 }
 
 const INITIAL_STATE: StreamingState = {
@@ -51,6 +52,7 @@ const INITIAL_STATE: StreamingState = {
   structured: {},
   error: null,
   duration_ms: null,
+  ticketId: null,
 };
 
 /**
@@ -157,6 +159,7 @@ export interface UseStreamingAnswerReturn {
   meta: MetaEvent | undefined;
   error: StreamingState['error'];
   duration_ms: StreamingState['duration_ms'];
+  ticketId: StreamingState['ticketId'];
   ragRoute: RagRouteEvent | undefined;
   start: (input: ConsultRequest) => void;
   abort: () => void;
@@ -197,6 +200,29 @@ export function useStreamingAnswer(): UseStreamingAnswerReturn {
       });
 
       void (async () => {
+        // T-024 (Option B): create inbox ticket first so the viewer question
+        // enters the RA Kanban triage pipeline. Best-effort — failure does not
+        // block the answer stream.
+        try {
+          const askRes = await fetch('/api/ask', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              question: input.question,
+              projectId: input.projectId ?? projectId ?? undefined,
+            }),
+            signal: ac.signal,
+          });
+          if (askRes.ok) {
+            const askData = (await askRes.json()) as { ticketId?: string };
+            if (askData.ticketId) {
+              setState((s) => ({ ...s, ticketId: askData.ticketId ?? null }));
+            }
+          }
+        } catch {
+          // Best-effort: ticket creation failure does not block the answer stream.
+        }
+
         try {
           // REQ-CHAT-052 — check response.ok.
           const response = await fetch('/api/ra/consult', {
@@ -260,6 +286,7 @@ export function useStreamingAnswer(): UseStreamingAnswerReturn {
     meta: state.structured.meta,
     error: state.error,
     duration_ms: state.duration_ms,
+    ticketId: state.ticketId,
     ragRoute: state.structured.ragRoute,
     start,
     abort,


### PR DESCRIPTION
## T-024 (옵션 B) — viewer 질문 → RA inbox ticket 파이프라인 복원

**문제**: chat이 \`/api/ra/consult\`만 호출 → viewer 질문이 inbox ticket으로 생성되지 않아 RA Kanban triage 대상에서 누락.

**해결 (옵션 B)**: \`useStreamingAnswer\`가 consult 전 \`/api/ask\`로 ticket 먼저 생성.
- \`/api/ask\` 기존 기능(ticket 생성) 재사용 → 백엔드 변경 불필요
- best-effort: ask 실패해도 답변 스트림 진행
- ChatShell에 ticketId 패널 + \`/inbox/[id]\` 링크 (REQ-V3-UI-033)

## 검증
- tsc EXIT 0, biome 0, vitest 55/55 (회귀 없음)

## 별도 서브태스크
viewer가 \`/inbox/[id]\` 클릭 시 자기 ticket 상세(ViewerTicketSummary)를 보려면, page의 viewer redirect(REQ-V3-UI-030)를 자기 소유 ticket은 예외 처리 필요 — 별도 PR.

Refs: SPEC-V3-UI-001, Issue 328

🗿 MoAI <email@mo.ai.kr>