### PR TITLE
feat(inbox): viewer 자기 ticket 상세 (ViewerTicketSummary)

### DIFF
--- a/app/(app)/inbox/[id]/__tests__/page.test.tsx
+++ b/app/(app)/inbox/[id]/__tests__/page.test.tsx
@@ -29,19 +29,20 @@ describe('Inbox Detail Page (T-020/T-021)', () => {
     vi.clearAllMocks();
   });
 
-  it('redirects to /chat for viewer role (REQ-V3-UI-030)', async () => {
+  it('renders InboxDetailClient for viewer role (own-ticket, REQ-V3-UI-034)', async () => {
     const { auth } = await import('@/lib/auth');
     const { redirect: mockRedirect } = await import('next/navigation');
-    const { hasRole } = await import('@/lib/auth/rbac');
 
     vi.mocked(auth).mockResolvedValue({ user: { role: 'viewer' } } as unknown as never);
-    vi.mocked(hasRole).mockReturnValue(false);
 
     const Page = (await import('../page')).default;
-    // page.tsx wraps redirect in try/catch (test/build env fallback), so the
-    // Page promise resolves; the redirect spy call is the assertion that matters.
-    await Page({ params: Promise.resolve({ id: 't-1' }) });
-    expect(mockRedirect).toHaveBeenCalledWith('/chat');
+    // viewer no longer redirected from /inbox/[id] — sees own ticket summary.
+    // Backend IDOR gates tickets the viewer doesn't own.
+    const ui = await Page({ params: Promise.resolve({ id: 't-1' }) });
+    const { container } = render(ui as React.ReactElement);
+
+    expect(container.querySelector('[data-testid="inbox-detail-client"]')).toBeInTheDocument();
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 
   it('renders InboxDetailClient for ra-member role', async () => {

--- a/app/(app)/inbox/[id]/page.tsx
+++ b/app/(app)/inbox/[id]/page.tsx
@@ -1,10 +1,12 @@
 // @MX:NOTE [AUTO] Inbox detail page — server component, RBAC + param resolution.
-// @MX:SPEC SPEC-V3-UI-001 (REQ-V3-UI-010/030/032, AC-UI-003, Issue 320)
-// RBAC: ra-member+ only. Viewer redirects to /chat (data fetching is client-side).
+// @MX:SPEC SPEC-V3-UI-001 (REQ-V3-UI-010/032/034, AC-UI-003/009, Issue 320)
+// RBAC: ra-member+ sees full detail. Viewer sees their OWN ticket only
+// (ViewerTicketSummary, REQ-V3-UI-034) — backend IDOR (access.ts) returns 404
+// for tickets the viewer doesn't own. REQ-V3-UI-030 redirect applies to /inbox
+// (list), not to /inbox/[id] own-ticket detail.
 
 import { InboxDetailClient } from '@/components/inbox/InboxDetailClient';
 import type { Role } from '@/lib/auth/rbac';
-import { redirect } from 'next/navigation';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -16,13 +18,8 @@ export default async function InboxDetailPage({ params }: PageProps) {
   let userRole: Role | undefined;
   try {
     const { auth } = await import('@/lib/auth');
-    const { hasRole } = await import('@/lib/auth/rbac');
     const session = await auth();
     userRole = (session?.user as { role?: Role })?.role;
-    // REQ-V3-UI-030: viewer-only → /chat redirect. ra-member+ only.
-    if (!userRole || !hasRole(userRole, 'ra-member')) {
-      redirect('/chat');
-    }
   } catch {
     // test/build env where auth is unavailable — fall through with undefined role.
   }

--- a/components/inbox/InboxDetailClient.tsx
+++ b/components/inbox/InboxDetailClient.tsx
@@ -7,6 +7,7 @@ import { useInboxTicket } from '@/lib/queries/useInbox';
 import { ActivityTimeline } from './ActivityTimeline';
 import { ApproveDialog } from './ApproveDialog';
 import { TicketCard } from './TicketCard';
+import { ViewerTicketSummary } from './ViewerTicketSummary';
 
 interface InboxDetailClientProps {
   ticketId: string;
@@ -24,6 +25,15 @@ export function InboxDetailClient({ ticketId, userRole }: InboxDetailClientProps
     return (
       <div data-testid="inbox-detail-notfound" className="p-4">
         Ticket not found.
+      </div>
+    );
+  }
+
+  // Viewer: minimal own-ticket summary (REQ-V3-UI-034). Backend IDOR gates others.
+  if (userRole === 'viewer') {
+    return (
+      <div className="p-4">
+        <ViewerTicketSummary ticket={ticket} />
       </div>
     );
   }


### PR DESCRIPTION
PR #331 서브태스크 — viewer가 chat 링크로 자기 ticket triage 상태 확인 가능. /inbox/[id] viewer redirect 제거 + ViewerTicketSummary 렌더. 백엔드 IDOR이 타인 ticket 게이트. Refs: Issue 328. 🗿 MoAI <email@mo.ai.kr>