### PR TITLE
test(e2e): 이슈 #329 — T-028/T-029 inbox WCAG axe + viewer redirect E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,7 +216,7 @@ dist-ssr/
 # ===========================================
 # Playwright E2E auth state (contains session secrets — never commit)
 # ===========================================
-tests/e2e/fixtures/.auth.json
+tests/e2e/fixtures/.auth*.json
 
 # ===========================================
 # Playwright E2E test artifacts

--- a/.moai/specs/SPEC-V3-UI-001/progress.md
+++ b/.moai/specs/SPEC-V3-UI-001/progress.md
@@ -20,7 +20,7 @@
 - **M2 Kanban Board COMPLETE (T-010~014)**: SlaBadge/TicketCard/KanbanColumn/InboxKanban + /inbox 통합. manager-tdd 위임(2회) + Hook 위반/biome/Unhandled Rejection 직접 수정 (KanbanColumnContainer 패턴).
 - **M3 Triage Action COMPLETE (T-015~017)**: TriageActionMenu (VALID_TRANSITIONS, ra-lead 전용, reason prompt) + TicketCard 조건부 렌더. manager-tdd 위임 + 13 tests 회귀 직접 해결 (테스트 2개 삭제, TicketCard 구조 수정).
 - **M4 Detail + ESIG COMPLETE (T-018~022)**: ActivityTimeline (minimal), ApproveDialog (ESIG 401/400 인라인), /inbox/[id] (서버 RBAC + InboxDetailClient). **orchestrator 직접 구현** (사용자 결정).
-- **M5 Viewer + WCAG 부분 완료 (T-023/025/027)**: chat characterization, ViewerTicketSummary, state-tokens (디자인 토큰 단일 진실원). **보류**: T-024 (ChatShell brownfield 연동, @MX:TODO), T-026 (기존 게이팅으로 커버), T-028/T-029 (Playwright E2E, 환경 의존).
+- **M5 Viewer + WCAG 완료 (T-023/025/027/028/029)**: chat characterization, ViewerTicketSummary, state-tokens (디자인 토큰 단일 진실원). **T-028/T-029 COMPLETE (PR #334, Issue #329)**: WCAG axe(`/inbox` + `/inbox/[id]` ApproveDialog) + 키보드 Tab + 아이콘 버튼 `aria-label` + viewer redirect E2E — snap Chromium 로컬 실행 5/5 PASSED. **잔여 보류**: T-024 (ChatShell brownfield 연동, @MX:TODO), T-026 (기존 게이팅으로 커버).
 - **M6 Quality Gates 본 범위 통과 (T-030~034)**: orchestrator 직접 실행.
   - ci:typecheck/rbac/audit/tokens/i18n/glossary/contrast/module-boundaries/migrations — **전부 EXIT 0**
   - ci:build — **EXIT 0** (next dev 중지 후, L-012 회피)
@@ -36,12 +36,12 @@
 ## 본 SPEC 범위 밖 잔여 이슈 (별도 처리 권장)
 1. **ci:lint 3 errors**: `scripts/qa/model-gov-eval-gate.ts:42` noConsole — 본 SPEC-V3-UI-001 범위 밖 (scripts/qa/, 기존 에러). 별도 이슈화 권장.
 2. **frontend-shell.test.ts timeout (15s)**: `tests/unit/frontend-shell.test.ts > REQ-FND-012 root metadata` — root `app/layout.tsx` 회귀, 본 변경(app/(app)/layout.tsx)과 무관. 환경 timeout 가능성. 별도 조사.
-3. **M5 보류**: T-024 (ChatShell ticket_id surfacing), T-028/T-029 (Playwright E2E — WCAG axe, viewer redirect). 후속 PR 또는 환경 정비 후.
+3. **M5 잔여 보류**: T-024 (ChatShell ticket_id surfacing)만. T-028/T-029는 PR #334로 완료 (이슈 #329) — snap Chromium 로컬 5/5 PASSED.
 
 ## Resume Instructions (next session)
 - Branch: feat/spec-v3-ui-001 (M1-M4 커밋 완료, M5 변경셋 uncommitted)
 - **M1-M4 커밋됨, M5/M6 산출물 커밋 대기** (state-tokens, ViewerTicketSummary, chat/page.test, TriageActionMenu 등 M3 이후 변경)
 - 본 SPEC-V3-UI-001 핵심 기능 (4-column Kanban + Triage + ESIG Approve + Detail) 완료.
-- Next: 보류 항목 (T-024 ChatShell 연동, T-028/T-029 E2E) + 잔여 이슈 (ci:lint scripts/qa, frontend-shell timeout) — 별도 세션.
+- Next: 잔여 보류 (T-024 ChatShell 연동만) + 잔여 이슈 (ci:lint scripts/qa, frontend-shell timeout) — 별도 세션. **T-028/T-029는 PR #334로 완료** (이슈 #329).
 - Execution: orchestrator 직접 구현 검증됨 (M4-M6). manager-tdd 위임 시 L-013 직검 필수 (Hook 규칙 grep, vitest Errors 카운트, biome "허용" 판단 금지).
 - Contract reminders: VALID_TRANSITIONS types.ts:33-40, approve body {password, esigSignature}

--- a/.moai/specs/SPEC-V3-UI-001/spec.md
+++ b/.moai/specs/SPEC-V3-UI-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-V3-UI-001
 version: 1.0.0
-status: draft
+status: implemented
 created: 2026-07-03
-updated: 2026-07-03
+updated: 2026-07-04
 author: abyz-lab
 priority: high
 issue_number: 326

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
   - UI(4-column Kanban)는 Phase D / SPEC-V3-UI-001로 이월(SPEC §1.5/§6).
   - 검증: typecheck 0 · lint 0 · test **4346 passed** | 23 skipped · 실DB `\d` AC-01/12 + `inbox.approve_failed` enum 확인.
 
+### v3 Phase D — RA Inbox Kanban UI (SPEC-V3-UI-001, Issue 326, PR #327/#330/#331/#332)
+
+- **RA Inbox 4-column Kanban + Triage + ESIG Approve + Detail UI** (Phase D).
+  - **M1-M4**: messages inbox namespace · Zustand store · useInbox hooks(4) · Sidebar showInbox 게이팅(ra-member+) · SlaBadge/TicketCard/KanbanColumn/InboxKanban(`KanbanColumnContainer`로 React Hook 규칙 준수) · TriageActionMenu(VALID_TRANSITIONS 게이팅, ra-lead 전용, reason prompt) · ApproveDialog(ESIG `{password, esigSignature}`, 401/400 인라인) · ActivityTimeline · `/inbox`+`/inbox/[id]`(서버 RBAC + viewer → /chat redirect).
+  - **M5**: state-tokens(triageState별 디자인 토큰 단일 진실원) · ViewerTicketSummary · chat characterization.
+  - **T-024 옵션 B(PR #331/#332)**: viewer chat 질문 → `/api/ask` ticket 생성 → RA inbox triage **파이프라인 복원**(기존 chat이 ticket 안 만들던 갭 해소). ChatShell ticketId 링크 + `/inbox/[id]` ViewerTicketSummary. **백엔드 변경 불필요**(기존 `/api/ask` 재사용).
+  - **E2E stub(PR #330)**: inbox a11y axe + viewer redirect(viewer storageState fixture 선행 시 활성화, 이슈 #329).
+  - 검증: tsc 0 · lint 0(lint:hex `#NNN` 주석 회피) · 본 변경 vitest 47/49/55 green · ci:* 전 EXIT 0 · build EXIT 0.
+  - 진행 방식: M1-M3 manager-tdd 위임 + orchestrator L-013 직검/수정 루프(에이전트 self-report 빈틈: Hook 규칙 위반 · prop 누락 · 테스트-구현 불일치 · biome 자의적 "허용"), M4-M6 orchestrator 직접 구현(사용자 결정).
+
 ---
 
 ## [1.0.0] — 2026-06-28

--- a/playwright/globalSetup.ts
+++ b/playwright/globalSetup.ts
@@ -132,6 +132,14 @@ export default async function globalSetup(): Promise<void> {
     process.env.PLAYWRIGHT_ADMIN_AUTH_STATE ?? 'tests/e2e/fixtures/.admin-auth.json';
   const adminEmail = process.env.E2E_ADMIN_USER_EMAIL ?? 'admin@example.test';
   const adminPassword = process.env.E2E_ADMIN_USER_PASSWORD ?? password;
+  // @MX:NOTE [AUTO] Viewer storageState for REQ-V3-UI-030 redirect E2E (Issue #329).
+  // globalSetup previously serialized only ra-member + admin sessions; viewer redirect
+  // E2E needs a viewer-role session so /inbox → /chat can be asserted against a real
+  // authenticated viewer (not a logged-out context).
+  const viewerAuthStatePath =
+    process.env.PLAYWRIGHT_VIEWER_AUTH_STATE ?? 'tests/e2e/fixtures/.auth-viewer.json';
+  const viewerEmail = process.env.E2E_VIEWER_USER_EMAIL ?? 'viewer@example.test';
+  const viewerPassword = process.env.E2E_VIEWER_USER_PASSWORD ?? password;
   const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
 
   const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
@@ -154,6 +162,14 @@ export default async function globalSetup(): Promise<void> {
       email: adminEmail,
       password: adminPassword,
       authStatePath: adminAuthStatePath,
+      baseUrl,
+    });
+
+    await signInAndStoreState({
+      browser,
+      email: viewerEmail,
+      password: viewerPassword,
+      authStatePath: viewerAuthStatePath,
       baseUrl,
     });
   } finally {

--- a/tests/e2e/inbox-a11y.spec.ts
+++ b/tests/e2e/inbox-a11y.spec.ts
@@ -1,9 +1,31 @@
-// @MX:NOTE [AUTO] E2E spec: axe-core accessibility scan for /inbox (ra-member view)
-// @MX:SPEC SPEC-V3-UI-001 (REQ-V3-UI-042, AC-UI-010, Issue 328/329)
+// @MX:NOTE [AUTO] E2E spec: axe-core accessibility scan for /inbox + /inbox/[id] (ra-member view)
+// @MX:SPEC SPEC-V3-UI-001 (REQ-V3-UI-042, AC-UI-010, Issue 329)
 
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 import { requiresAuthState, requiresLiveServer } from './fixtures/env-guard';
+
+// @MX:NOTE [AUTO] AxeBuilder v4 expects a Playwright Page typed against its own forked types;
+// the runtime object is the standard Playwright Page. This cast bridges the version skew.
+function axePage(page: import('@playwright/test').Page) {
+  return page as unknown as ConstructorParameters<typeof AxeBuilder>[0]['page'];
+}
+
+async function runAxe(page: import('@playwright/test').Page) {
+  return new AxeBuilder({ page: axePage(page) })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+    .analyze();
+}
+
+function expectNoCritical(results: Awaited<ReturnType<typeof runAxe>>, where: string) {
+  const critical = results.violations.filter((v) => v.impact === 'critical');
+  expect(
+    critical,
+    `Critical a11y violations on ${where}:\n${critical
+      .map((v) => `  [${v.id}] ${v.description} (${v.nodes.length} node(s))`)
+      .join('\n')}`,
+  ).toHaveLength(0);
+}
 
 test.describe('Inbox Accessibility — WCAG 2.1 AA (REQ-V3-UI-042)', () => {
   test('/inbox has no critical accessibility violations', async ({ page }) => {
@@ -15,21 +37,10 @@ test.describe('Inbox Accessibility — WCAG 2.1 AA (REQ-V3-UI-042)', () => {
     await page.goto('/inbox');
     await page.waitForLoadState('networkidle');
 
-    const axePage = page as unknown as ConstructorParameters<typeof AxeBuilder>[0]['page'];
-    const results = await new AxeBuilder({ page: axePage })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
-      .analyze();
-
-    const critical = results.violations.filter((v) => v.impact === 'critical');
-    expect(
-      critical,
-      `Critical a11y violations on /inbox:\n${critical
-        .map((v) => `  [${v.id}] ${v.description} (${v.nodes.length} node(s))`)
-        .join('\n')}`,
-    ).toHaveLength(0);
+    expectNoCritical(await runAxe(page), '/inbox');
   });
 
-  test('InboxKanban column headers are keyboard-focusable links/buttons', async ({ page }) => {
+  test('/inbox interactive elements are reachable via keyboard (Tab)', async ({ page }) => {
     const s = requiresLiveServer();
     test.skip(s.skip, s.reason);
     const a = requiresAuthState();
@@ -38,8 +49,73 @@ test.describe('Inbox Accessibility — WCAG 2.1 AA (REQ-V3-UI-042)', () => {
     await page.goto('/inbox');
     await page.waitForLoadState('networkidle');
 
-    // Triage action menu / refresh / archive toggle buttons must be keyboard-reachable.
-    const interactiveCount = await page.locator('button[type="button"], a[href]').count();
-    expect(interactiveCount).toBeGreaterThan(0);
+    // REQ-V3-UI-042: all action buttons keyboard-reachable. Tab must land focus on a
+    // genuinely interactive element (not a stale <body>). axe's tabindex rule is the
+    // authoritative check; this is the explicit behavioral assertion.
+    await page.keyboard.press('Tab');
+    const focused = await page.evaluate(() => document.activeElement?.tagName ?? '');
+    expect(['BUTTON', 'A', 'INPUT', 'SELECT', 'TEXTAREA']).toContain(focused);
+  });
+
+  test('/inbox icon-only buttons expose an accessible name (aria-label)', async ({ page }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    await page.goto('/inbox');
+    await page.waitForLoadState('networkidle');
+
+    // REQ-V3-UI-042: icon-only buttons must carry an accessible name. axe's button-name
+    // rule already enforces this in the critical scan above; we assert it explicitly so
+    // a future regression surfaces with the offending element rather than a generic axe dump.
+    const buttons = page.locator('button');
+    const total = await buttons.count();
+    expect(total).toBeGreaterThan(0);
+
+    for (let i = 0; i < total; i++) {
+      const btn = buttons.nth(i);
+      const { text, ariaLabel, title } = await btn.evaluate((el) => {
+        const b = el as HTMLButtonElement;
+        return {
+          text: (b.textContent ?? '').trim(),
+          ariaLabel: b.getAttribute('aria-label'),
+          title: b.getAttribute('title'),
+        };
+      });
+      // Buttons with visible text are fine. Icon-only buttons need aria-label/title.
+      if (text.length === 0) {
+        expect(
+          (ariaLabel?.length ?? 0) > 0 || (title?.length ?? 0) > 0,
+          `Icon-only button #${i} missing aria-label/title`,
+        ).toBeTruthy();
+      }
+    }
+  });
+
+  test('/inbox/[id] detail (incl. ApproveDialog form) has no critical axe violations', async ({
+    page,
+  }) => {
+    const s = requiresLiveServer();
+    test.skip(s.skip, s.reason);
+    const a = requiresAuthState();
+    test.skip(a.skip, a.reason);
+
+    await page.goto('/inbox');
+    await page.waitForLoadState('networkidle');
+
+    // TicketCard renders <Link href="/inbox/{id}">. Resolve the first ticket href
+    // straight from the rendered Kanban — same path a ra-lead takes clicking a card,
+    // and avoids coupling the a11y scan to the /api/inbox response shape.
+    const ticketLink = page.locator('a[href*="/inbox/"]').first();
+    const href = await ticketLink.getAttribute('href').catch(() => null);
+    test.skip(!href, 'no ticket links rendered on /inbox — /inbox/[id] axe skipped');
+
+    await page.goto(href as string);
+    await page.waitForLoadState('networkidle');
+
+    // ApproveDialog is an inline form (data-testid="approve-dialog") on this route,
+    // so a full-page axe scan covers REQ-V3-UI-042 for the dialog as well.
+    expectNoCritical(await runAxe(page), href as string);
   });
 });

--- a/tests/e2e/inbox-viewer-redirect.spec.ts
+++ b/tests/e2e/inbox-viewer-redirect.spec.ts
@@ -1,26 +1,37 @@
 // @MX:NOTE [AUTO] E2E spec: viewer role redirect from /inbox → /chat (REQ-V3-UI-030)
 // @MX:SPEC SPEC-V3-UI-001 (REQ-V3-UI-030, Issue 329)
 //
-// 현재 globalSetup이 ra-member 세션만 직렬화하므로, viewer 세션 E2E는
-// viewer 전용 storageState fixture가 선행되어야 활성화.
-// REQ-V3-UI-030 redirect 자체는 단위 테스트(app/(app)/inbox/page.test.tsx)에서
-// 이미 검증됨 — 본 E2E는 viewer 실세션 통합 검증용.
+// globalSetup serializes a viewer session to .auth-viewer.json (E2E_VIEWER_USER_EMAIL).
+// We open /inbox inside a viewer-authenticated context and assert the server-side
+// gate (app/(app)/inbox/page.tsx) redirects to /chat. Unit test page.test.tsx
+// already covers the redirect branch in isolation; this is the live integration check.
 
+import * as fs from 'node:fs';
 import { expect, test } from '@playwright/test';
 import { requiresLiveServer } from './fixtures/env-guard';
 
-test.describe('Inbox viewer redirect (REQ-V3-UI-030)', () => {
-  test.skip(true, 'viewer storageState fixture 선행 필요 — globalSetup이 ra-member 전용');
+const viewerAuthPath =
+  process.env.PLAYWRIGHT_VIEWER_AUTH_STATE ?? 'tests/e2e/fixtures/.auth-viewer.json';
 
+test.describe('Inbox viewer redirect (REQ-V3-UI-030)', () => {
   test('viewer visiting /inbox is redirected to /chat', async ({ browser }) => {
     const s = requiresLiveServer();
     test.skip(s.skip, s.reason);
 
-    // TODO: viewer storageState fixture(.auth-viewer.json) 적용 후 활성화.
-    const ctx = await browser.newContext({ storageState: undefined });
+    // Skip cleanly when the viewer fixture has not been generated (e.g. creds unset).
+    test.skip(
+      !fs.existsSync(viewerAuthPath),
+      `${viewerAuthPath} 없음 — globalSetup viewer 로그인(E2E_VIEWER_USER_EMAIL) 확인 필요`,
+    );
+
+    const ctx = await browser.newContext({ storageState: viewerAuthPath });
     const page = await ctx.newPage();
-    await page.goto('/inbox');
-    await expect(page).toHaveURL('/chat');
-    await ctx.close();
+    try {
+      await page.goto('/inbox');
+      // REQ-V3-UI-030: viewer/employee is server-redirected to /chat.
+      await expect(page).toHaveURL(/\/chat(?:\b|$)/);
+    } finally {
+      await ctx.close();
+    }
   });
 });


### PR DESCRIPTION
## 이슈 #329 — SPEC-V3-UI-001 후속 T-028/T-029 Playwright E2E

PR #330 stub을 실동작 테스트로 완성.

## 변경 내용

### T-028 (REQ-V3-UI-042 WCAG 2.1 AA) — `tests/e2e/inbox-a11y.spec.ts`
- `/inbox` axe critical 위반 0 (기존 유지)
- `/inbox` 키보드 Tab 포커스 단언
- `/inbox` 아이콘 전용 버튼 `aria-label` 단언
- `/inbox/[id]` axe (ApproveDialog form 포함) — TicketCard `<Link>` 기반 ID 획득

### T-029 (REQ-V3-UI-030 viewer redirect) — `tests/e2e/inbox-viewer-redirect.spec.ts`
- `playwright/globalSetup.ts`: viewer 세션 로그인 추가 (`.auth-viewer.json`, `E2E_VIEWER_USER_EMAIL`)
- `test.skip(true)` 제거 → viewer `/inbox` → `/chat` 실세션 redirect 단언
- env-guard로 LIVE_SERVER / fixture 미비 시 자동 skip

### 보호
- `.gitignore`: `.auth.json` → `.auth*.json` broaden (viewer 세션 secret 보호)

## 게이트 직검 (L-013)
snap Chromium + dev 서버 + Docker test DB 로컬 실제 실행:
- typecheck EXIT 0
- lint EXIT 0 (pre-existing warning 1: model-gov-eval-gate noConsole, 본 작업 무관)
- lint:hex EXIT 0
- **T-028/T-029 E2E 5/5 PASSED** (1.0m)

## 이슈 본문-코드 모순 처리
이슈 본문 "T-028: `/inbox/[id]`" — `/inbox/[id]`는 viewer 접근 불가 (백엔드 IDOR). ra-lead 세션으로 axe 검사. `/inbox/[id]` viewer 자기 티켓 허용은 REQ-V3-UI-034 (PR #332)로 별개.

CI에서 `/inbox/[id]` 테스트는 티켓 seed 의존 — 티켓 없으면 자동 skip, 나머지 4개 통과.

Fixes #329

🗿 MoAI <email@mo.ai.kr>