### PR TITLE
fix(inbox): #321 H-1 TOCTOU + H-3 audit action 세분화

### DIFF
--- a/__tests__/lib/domains/inbox/promote.test.ts
+++ b/__tests__/lib/domains/inbox/promote.test.ts
@@ -46,6 +46,16 @@ describe('promoteToApproved', () => {
       }),
       transaction: vi.fn((callback) => {
         const mockTx = {
+          // H-1 (#321): in-tx SELECT ... FOR UPDATE re-verifies org_id.
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                for: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([{ orgId: 'org-1' }]),
+                }),
+              }),
+            }),
+          }),
           insert: vi.fn().mockReturnValue({
             values: vi.fn().mockResolvedValue(undefined),
           }),
@@ -92,6 +102,16 @@ describe('promoteToApproved', () => {
       }),
       transaction: vi.fn((callback) => {
         const mockTx = {
+          // H-1 (#321): in-tx SELECT ... FOR UPDATE re-verifies org_id.
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                for: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([{ orgId: 'org-1' }]),
+                }),
+              }),
+            }),
+          }),
           insert: vi.fn().mockReturnValue({
             values: vi.fn().mockRejectedValue(new Error('DB error')),
           }),

--- a/lib/domains/inbox/audit.ts
+++ b/lib/domains/inbox/audit.ts
@@ -1,18 +1,40 @@
 // @MX:NOTE [AUTO] Audit wrapper for triage state transitions.
-// @MX:SPEC SPEC-V3-INBOX-001 (REQ-V3-INBOX-021, Issue 320)
+// @MX:SPEC SPEC-V3-INBOX-001 (REQ-V3-INBOX-021, Issue 320, #321 H-3)
 
 import type { AuditDbHandle } from '@/lib/audit';
 import { writeAudit } from '@/lib/audit';
-import type { TriageTransitionInput } from './types';
+import type { TriageState, TriageTransitionInput } from './types';
+
+/**
+ * Map a triage `to` state to a granular audit_action (#321 H-3).
+ *
+ * Migration 0104 defines inbox.triaged / escalated / closed / rejected / approved.
+ * Terminal and escalation transitions get a dedicated action for 21 CFR Part 11
+ * audit precision (the action column alone identifies what happened, without
+ * requiring meta_json inspection). The remaining states (needs-review, waiting,
+ * auto) reuse the generic inbox.triaged action — no dedicated enum exists.
+ */
+function triageAuditAction(
+  to: TriageState,
+): 'inbox.triaged' | 'inbox.escalated' | 'inbox.closed' | 'inbox.rejected' {
+  switch (to) {
+    case 'escalated':
+      return 'inbox.escalated';
+    case 'closed':
+      return 'inbox.closed';
+    case 'rejected':
+      return 'inbox.rejected';
+    default:
+      return 'inbox.triaged';
+  }
+}
 
 /**
  * Write an audit row for a triage state transition.
  *
  * All inbox triage transitions MUST be audited for 21 CFR Part 11 compliance.
- * The action value 'inbox.triaged' covers all valid transitions (needs-review,
- * escalated, waiting, closed, rejected).
- *
- * This wrapper ensures audit consistency across all triage operations.
+ * The action reflects the destination state (inbox.triaged for generic moves,
+ * inbox.escalated / closed / rejected for escalation and terminal transitions).
  */
 export async function auditTransition(
   tx: AuditDbHandle,
@@ -21,7 +43,7 @@ export async function auditTransition(
   await writeAudit(
     {
       actor_id: input.actorId,
-      action: 'inbox.triaged',
+      action: triageAuditAction(input.to),
       resource_type: 'inbox_ticket',
       resource_id: input.ticketId,
       meta_json: {

--- a/lib/domains/inbox/promote.ts
+++ b/lib/domains/inbox/promote.ts
@@ -7,7 +7,7 @@
 import { writeAudit } from '@/lib/audit';
 import type { Database } from '@/lib/db/client';
 import { approvedAnswers, inboxTickets } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { assertValidTransition } from './state-machine';
 import type { PromotionInput } from './types';
 
@@ -103,7 +103,22 @@ export async function promoteToApproved(db: Database, input: PromotionInput): Pr
 
   // Step 4: Execute atomic transaction
   await db.transaction(async (tx) => {
-    // 4a. Update ticket to closed state
+    // H-1 TOCTOU (#321): re-verify org_id inside the transaction with a row
+    // lock (SELECT ... FOR UPDATE) so the ticket cannot change ownership
+    // between the outer read (line ~66) and this UPDATE. The outer
+    // assertTicketInOrg check in the route plus this in-tx re-check close the
+    // time-of-check / time-of-use window.
+    const locked = await tx
+      .select({ orgId: inboxTickets.orgId })
+      .from(inboxTickets)
+      .where(and(eq(inboxTickets.id, input.ticketId), eq(inboxTickets.orgId, current.orgId)))
+      .for('update')
+      .limit(1);
+    if (!locked[0]) {
+      throw new Error('Ticket not found in organization (TOCTOU check failed)');
+    }
+
+    // 4a. Update ticket to closed state (org_id re-checked in WHERE)
     await tx
       .update(inboxTickets)
       .set({
@@ -112,7 +127,7 @@ export async function promoteToApproved(db: Database, input: PromotionInput): Pr
         approvedAt: new Date(),
         closedAt: new Date(),
       })
-      .where(eq(inboxTickets.id, input.ticketId));
+      .where(and(eq(inboxTickets.id, input.ticketId), eq(inboxTickets.orgId, current.orgId)));
 
     // 4b. Create approved_answers row
     const approvedAnswerId = `aa_${current.id}`; // Derive ID from ticket ID


### PR DESCRIPTION
## SPEC-V3-INBOX-001 백엔드 보안 follow-up — High 2종 (#321 부분)

expert-security 감사(PR #322)에서 이월된 결함 중 **High 2종** 수정. 나머지(M-1/C-1/H-4/migration/L-1~L-4)는 별도 PR.

## 변경 내용

### H-1 TOCTOU (`lib/domains/inbox/promote.ts`)
`promoteToApproved` tx 외부 조회(line ~66)와 tx 내 UPDATE 사이 TOCTOU 창 존재. route의 `assertTicketInOrg` 통과 후 tx 실행 전 ticket org 변경 경쟁 방어:
- tx 내 `SELECT ... FOR UPDATE`로 row 잠금 + org_id 재확보
- `UPDATE WHERE id AND org_id` (org_id 이중 검증)
- 잠금 조회 실패 시 `throw` (rollback)

### H-3 audit action 단일화 (`lib/domains/inbox/audit.ts`)
`auditTransition`이 항상 `inbox.triaged` 사용 → migration 0104의 `escalated/closed/rejected` enum이 미사용이었음. `to` 상태별 action 매핑으로 21 CFR Part 11 감사 정밀성 향상:
- `escalated` → `inbox.escalated`
- `closed` → `inbox.closed`
- `rejected` → `inbox.rejected`
- `needs-review`/`waiting`/`auto` → `inbox.triaged` (전용 enum 없음)

### 테스트
- `promote.test.ts` mockTx에 `SELECT ... FOR UPDATE` 체인 추가 (H-1 회귀). 기존 AC-05/AC-11 단언 유지.

## 게이트 직검 (L-008/L-009)
- typecheck EXIT 0
- lint EXIT 0 (pre-existing warning 1: model-gov-eval-gate noConsole, 본 작업 무관)
- full test **4411 passed** (+2 vs baseline)

## 본 PR 범위 외 (별도)
- **M-1** from_user 소유권 (`access.ts`) — SPEC team-transparency 정책 확인 선행
- **C-1** HMAC §11.70 바인딩 — `lib/signature/*` 재사용 검토 (큰 작업)
- **H-4** `/api/ask` rate-limit (큰 작업)
- **migration 자동화** — pgEnum ADD VALUE CI 감지 (운영 인프라)
- **L-1~L-4** — triage z.enum 공유 / tx FOR UPDATE / crypto.randomUUID / offset 상한

Refs #321 (부분 해결 — High만)

🗿 MoAI <email@mo.ai.kr>