### PR TITLE
docs(spec): SPEC-V3-TRIAGE-001 plan phase 산출물 (Phase C-2, AC-06 이월)

### DIFF
--- a/.moai/specs/SPEC-V3-TRIAGE-001/acceptance.md
+++ b/.moai/specs/SPEC-V3-TRIAGE-001/acceptance.md
@@ -1,0 +1,292 @@
+---
+id: SPEC-V3-TRIAGE-001
+version: 1.0.0
+status: draft
+created: 2026-07-05
+updated: 2026-07-05
+author: abyz-lab
+priority: high
+issue_number: 0
+labels:
+  - component/backend
+  - component/ai
+  - component/api
+  - domain/inbox
+  - domain/triage
+  - type/v3-new
+---
+
+# SPEC-V3-TRIAGE-001 — Acceptance Criteria
+
+> 본 문서는 SPEC-V3-TRIAGE-001 spec.md의 모든 REQ-TRI-XXX에 대한 Given/When/Then 시나리오, 엣지 케이스, 품질 게이트, Definition of Done를 정의한다. 각 시나리오는 관련 REQ ID와 AC 번호로 추적 가능하다.
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-07-05 | abyz-lab | Initial acceptance criteria (7 GWT scenarios + 11 edge cases + quality gates + DoD). Derived from spec.md REQ-TRI-001..008 and research.md §3 (TRIAGE 주입 시나리오 매트릭스). AC-TRI-02 = SPEC-V3-INBOX-001 AC-06 직접 이행. |
+
+---
+
+## 1. Acceptance Criteria (Given/When/Then)
+
+### AC-TRI-01: TRIAGE RAG 자동 주입 정상 경로 (REQ-TRI-001, REQ-TRI-004)
+
+**Given** `viewer` 역할의 사용자가 로그인되어 있고, organizationId가 유효하다.
+**And** 질문 "MDR Article 61의 임상 평가 요건은?" (유효한 RAG 코퍼스 검색 결과가 있는 질문)을 준비한다.
+**When** 사용자가 `POST /api/ask`로 `{question}`을 제출한다.
+**Then** 서버가 (1) 티켓을 `triageState='auto'`로 생성하고, (2) TRIAGE RAG 파이프라인을 호출하여 `auto_answer`와 `auto_confidence`를 산출한다.
+**And** 티켓 행이 `autoAnswer=<JSON>`, `autoConfidence=<0~1 사이 값>`, `triageState='needs-review'`로 갱신된다.
+**And** 응답 body가 `{ticketId: string, triageState: 'needs-review', autoAnswer: {answer: string, citations: Array}, autoConfidence: number}` 형식이다 (REQ-TRI-004).
+**And** `auto_answer` JSONB를 파싱하면 `{answer: string, citations: [{source, quote?}, ...]}` 구조를 따른다.
+
+**Verification**: `app/api/ask/__tests__/route.test.ts`에서 RAG 파이프라인 mock이 citation 포함 결과를 반환하도록 설정 후 전체 흐름 단언. `SELECT autoAnswer, autoConfidence, triageState FROM inbox_tickets WHERE id=:ticketId` 직검.
+
+---
+
+### AC-TRI-02: AC-06 이행 — citation 없는 auto_answer 400 Bad Request (REQ-TRI-002, Charter [지양-2])
+
+**Given** TRIAGE RAG 호출이 답변을 산출했으나 citations 배열이 빈 배열(`[]`)인 상황.
+**When** RAG 파이프라인이 `auto_answer = {answer: "...", citations: []}`를 반환한다.
+**Then** 서버가 400 Bad Request를 반환한다.
+**And** 응답 body에 `{error: 'no_citations'}`가 포함된다.
+**And** `auto_answer` 값이 티켓 행에 저장되지 않는다 (`SELECT autoAnswer FROM inbox_tickets WHERE id=:ticketId` → `null`).
+**And** 티켓 자체는 `triageState='auto'`로 유지된다 (후속 수동 처리 허용).
+**And** audit 로그에 `inbox.triaged` action과 `meta_json.auto_triage_rejected=true`, `meta_json.reason='no_citations'`가 기록된다 (21 CFR Part 11 — 자동 결함 거부 이력).
+
+**Verification**: RAG mock이 `citations: []`를 반환하도록 설정 후 400 응답 + audit 메타 단언.
+
+**참고**: 본 AC는 SPEC-V3-INBOX-001 AC-06 (`.moai/specs/SPEC-V3-INBOX-001/spec.md:193`)의 직접 이행이다. SPEC-V3-INBOX-001은 `/api/ask`가 `auto_answer=null` 고정이므로 이 검증 분기에 도달하지 못했으며, 본 SPEC에서 TRIAGE 주입 훅 추가로 분기가 활성화된다.
+
+---
+
+### AC-TRI-03: triage_state 자동 전이 auto → needs-review (REQ-TRI-003, REQ-TRI-006)
+
+**Given** TRIAGE가 `auto_answer`와 `auto_confidence`를 정상 주입한 경우.
+**When** 주입 트랜잭션이 커밋된다.
+**Then** 티켓의 `triage_state`가 `auto`에서 `needs-review`로 전이된다 (`VALID_TRANSITIONS['auto'] = ['needs-review']`, types.ts:45).
+**And** 동일 트랜잭션 내에서 `inbox.triaged` audit_action이 기록된다.
+**And** audit `meta_json`에 `from='auto'`, `to='needs-review'`, `auto_triage=true`, `confidence_score=<값>`, `citations_count=<값>`이 포함된다.
+**And** TRIAGE는 절대 `escalated`/`closed`/`rejected`로 자동 전이하지 않는다 (Charter [지양-4]).
+
+**Given** 코드가 `auto→escalated` 자동 전이를 시도하는 경우 (버그/위변조).
+**When** `assertValidTransition('auto', 'escalated')`가 호출된다.
+**Then** `Error: Invalid triage state transition: auto → escalated`가 throw된다 (state-machine.ts:43).
+**And** 이것은 서버 결함(500)으로 전파되어 명시적 위변조 시도를 노출한다.
+
+**Verification**: 정상 전이 단언 + 부정 전이 시도 시 throw 단언 (`assertValidTransition` 직접 호출).
+
+---
+
+### AC-TRI-04: RAG 타임아웃/실패 폴백 (REQ-TRI-005)
+
+**Given** TRIAGE RAG 호출이 타임아웃(기본 15초, `TRIAGE_TIMEOUT_MS`) 또는 런타임 예외로 실패하는 상황.
+**When** 타임아웃 또는 예외가 발생한다.
+**Then** 서버가 201 Created를 유지한다 (RAG 실패가 티켓 생성을 실패시키지 않음).
+**And** 응답 body가 `{ticketId: string, triageState: 'auto', autoAnswer: null, autoConfidence: null}`를 반환한다.
+**And** 티켓 행은 `triageState='auto'`, `autoAnswer=null`로 DB에 존재한다.
+**And** audit 로그에 실패 메타(`auto_triage_failed: true`, `reason: 'timeout' | 'runtime_error'`)가 기록된다.
+
+**Verification**: RAG mock이 `setTimeout` 기반 지연 후에도 응답 안 함 + `TRIAGE_TIMEOUT_MS=100` (테스트용 단축)로 폴백 단언.
+
+---
+
+### AC-TRI-05: 기존 클라이언트 하위 호환 (REQ-TRI-004)
+
+**Given** 기존 `hooks/useStreamingAnswer.ts:217-219`가 `/api/ask` 응답에서 `ticketId`만 읽는 기존 동작.
+**When** 본 SPEC의 확장된 응답 body(`{ticketId, triageState, autoAnswer, autoConfidence}`)를 수신한다.
+**Then** `askData.ticketId`를 정상 추출하고 `state.ticketId`를 갱신한다 (기존 동작 보존).
+**And** 신규 필드(`triageState, autoAnswer, autoConfidence`)는 무시되며 런타임 에러를 발생시키지 않는다.
+
+**Given** `components/chat/__tests__/ChatShell.ticketId.test.tsx` 기존 회귀 테스트.
+**When** 본 SPEC 변경 후 해당 테스트를 재실행한다.
+**Then** 기존 테스트가 회귀 없이 통과한다 (회귀 0건).
+
+**Verification**: `ChatShell.ticketId.test.tsx` + `useStreamingAnswer` 기존 테스트 suite 통과. 신규 응답 필드 회귀 없음.
+
+---
+
+### AC-TRI-06: TRIAGE 정상 전이 감사 로그 메타 (REQ-TRI-006, 21 CFR Part 11 §11.10(e))
+
+**Given** TRIAGE 자동 전이(`auto→needs-review`)가 정상 수행된 경우.
+**When** audit 로그를 조회한다.
+**Then** `audit_action='inbox.triaged'`, `resource_type='inbox_ticket'`, `resource_id=<ticketId>` 행이 존재한다.
+**And** `meta_json`에 다음이 포함된다: `from='auto'`, `to='needs-review'`, `auto_triage=true`, `confidence_score=<number>`, `citations_count=<number>` (GAP-TRI-02 — run phase에서 메타 확장 방식 확정).
+**And** 감사 로그는 append-only이며 기존 hash chain을 보존한다 (21 CFR Part 11 §11.10(e)).
+
+> 참고: AC-06 위반(citation 없음) 시의 감사 메타(`auto_triage_rejected=true`, `reason='no_citations'`)는 AC-TRI-02 (REQ-TRI-007)에서 단언하므로 본 AC에서는 중복 단언하지 않는다.
+
+**Verification**: `SELECT action, meta_json FROM audit_logs WHERE resource_id=:ticketId ORDER BY created_at` 단언.
+
+---
+
+### AC-TRI-07: auto_answer JSON 구조 extractCitations 호환 (REQ-TRI-001, SPEC-V3-INBOX-001 AC-05)
+
+**Given** TRIAGE가 산출한 `auto_answer`가 `{answer: "<HTML prose>", citations: [{source: 'src-uuid-1', quote: '...'}, {source: 'src-uuid-2'}]}` 형식으로 저장된 경우.
+**When** `lib/domains/inbox/promote.ts:24 extractCitations()`가 이 JSONB를 파싱한다.
+**Then** `parsed.citations` 배열이 추출되며, `[{source: 'src-uuid-1', quote: '...'}, {source: 'src-uuid-2'}]`를 반환한다.
+**And** 기존 `promoteToApproved()` 흐름(SPEC-V3-INBOX-001 AC-05 승격 경로)이 이 `auto_answer`로부터 citations를 정상 추출함을 단언한다.
+**And** `auto_answer.answer` HTML에 `<sup class="cite" data-source="N">` 마커가 포함된다 (Citation provenance).
+
+**Verification**: `extractCitations(JSON.stringify({answer, citations}))` 단위 테스트. `promoteToApproved` 통합 테스트에서 TRIAGE 주입 `auto_answer` 사용.
+
+---
+
+## 2. Edge Cases (E1..E11)
+
+> 본 섹션은 SPEC-V3-UI-001 패턴을 준용하여 11개 엣지 케이스를 정의한다. 각 엣지는 관련 AC/REQ와 연결된다.
+
+### E-01: 질문이 RAG 코퍼스와 매칭 안 됨 (empty topChunks)
+
+**상황**: RAG 검색이 0개 chunk 반환.
+**기대**: `auto_answer = {answer: '(검색 결과가 없습니다)', citations: []}`. citations.length === 0이므로 **AC-TRI-02 (400 Bad Request)** 경로로 진입. 단, answer가 빈 문자열이 아닌 폴백 메시지인 점이 핵심 (사용자 기만 방지).
+**관련**: AC-TRI-02, REQ-TRI-002.
+
+### E-02: LLM 호출 실패 (consult.ts:329 fallback path)
+
+**상황**: LLM API 호출 실패. consult.ts:329는 "citations only" fallback.
+**기대**: TRIAGE는 `auto_answer` 산출 실패로 처리. `autoAnswer: null`, `triageState: 'auto'` 유지 (AC-TRI-04 폴백). audit에 `auto_triage_failed: true, reason: 'llm_failed'`.
+**관련**: AC-TRI-04, REQ-TRI-005.
+
+### E-03: 질문이 5000자 초과
+
+**상황**: Zod 검증(`z.string().max(5000)`) 실패.
+**기대**: 기존 동작 유지 (400 invalid input). TRIAGE 호출 도달 않음. 본 SPEC 영향 없음.
+**관련**: 기존 `app/api/ask/route.ts:16`.
+
+### E-04: rate limit 초과 (H-4, 30/min/user)
+
+**상황**: 동일 사용자 1분 내 31번째 요청.
+**기대**: 429 rate_limit_exceeded. TRIAGE 호출 도달 않음. 본 SPEC 영향 없음.
+**관련**: 기존 `app/api/ask/route.ts:46-48`.
+
+### E-05: organizationId 누락
+
+**상황**: 세션에 organizationId 없음.
+**기대**: 403 (기존 동작 유지). TRIAGE 호출 도달 않음.
+**관련**: 기존 `app/api/ask/route.ts:41-43`.
+
+### E-06: TRIAGE 주입 tx2 실패 (예: DB 일시 장애)
+
+**상황**: tx1(티켓 생성)은 성공, TRIAGE RAG는 성공, tx2(주입 UPDATE) 실패.
+**기대**: tx2 롤백 → 티켓은 `triageState='auto'`, `autoAnswer=null`로 잔존. 에러 로깅 + 201 with `autoAnswer: null` 폴백 응답 (REQ-TRI-005 폴백 전략 단일화, tasks.md T-018 권장).
+**관련**: REQ-TRI-005 (폴백 전략).
+
+### E-07: 타 org 사용자가 티켓 ID로 RAG 결과 접근 시도
+
+**상황**: 공격자가 타 org 티켓 ID로 `/api/ask` 응답을 가로채려 시도.
+**기대**: `/api/ask`는 세션 기반 티켓 생성만 하므로 타 org 티켓 조회 불가. 기존 inbox 권한 게이트(`assertTicketInOrg`)가 승격/조회 경로 방어.
+**관련**: SPEC-V3-INBOX-001 REQ-V3-INBOX-010 (이미 구현).
+
+### E-08: TRIAGE 자동 주입 후 RA Lead가 즉시 reject
+
+**상황**: TRIAGE가 `auto→needs-review`로 전이한 직후, RA Lead가 수동으로 `needs-review→rejected` 전이.
+**기대**: 정상 동작. TRIAGE의 `needs-review`는 종착지가 아니라 수동 판단 대기 상태. RA Lead의 reject는 기존 SPEC-V3-INBOX-001 워크플로우 따름.
+**관련**: Charter [지양-4], SPEC-V3-INBOX-001.
+
+### E-09: 동일 질문 반복 (캐싱 미사용 상태)
+
+**상황**: 동일 사용자가 같은 질문을 1분 내 2번 제출.
+**기대**: 각각 별도 티켓 생성 + 별도 TRIAGE 호출 (rate limit 30/min 범위 내). 본 SPEC은 캐싱 미지원 (Follow-up #3). RAG 호출 비용 증가 수용.
+**관련**: Follow-up #3.
+
+### E-10: TRIAGE가 `auto_answer.citations[].source`에 유효하지 않은 UUID 반환
+
+**상황**: consult RAG가 `citedChunks[].sourceId`에 대해 존재하지 않는 source id 반환 (예: 코퍼스 삭제 후 stale).
+**기대**: AC-TRI-02 위반 아님 (citations.length > 0). 주입은 성공하나, 이후 `promoteToApproved` 시 FK 검증 또는 source 조회 실패 가능. 본 SPEC 범위 외 — Follow-up에서 source 유효성 검증 추가 검토.
+**관련**: Follow-up #5 (citations 상세 스키마).
+
+### E-11: TRIAGE RAG 호출 중 사용자가 연결 끊음
+
+**상황**: 클라이언트가 `/api/ask` 요청 후 응답 대기 중 브라우저 종료.
+**기대**: 서버는 tx1(티켓 생성) 커밋까지는 완료. TRIAGE 호출은 진행 중단 여부가 서버 구현에 따라 다름 (AbortSignal 전파 여부). 티켓은 `triageState='auto'`로 DB에 잔존 (후속 Inngest 잡 또는 수동 처리 대상).
+**관련**: Follow-up #2 (비동기 TRIAGE 잡).
+
+---
+
+## 3. Quality Gates (TRUST 5)
+
+### 3.1 Tested
+
+- 단위 테스트: `app/api/ask/__tests__/route.test.ts` 확장 (AC-TRI-01..07 단언 추가).
+- 통합 테스트: TRIAGE 주입 후 `promoteToApproved` 연동 호환성 단언 (AC-TRI-07).
+- 회귀 테스트: `useStreamingAnswer`/`ChatShell.ticketId.test.tsx` 기존 통과 유지 (AC-TRI-05).
+- 커버리지: 신규 `lib/domains/triage/` 모듈 85%+.
+
+### 3.2 Readable
+
+- TRIAGE 호출 흐름 명확한 주석 (`@MX:NOTE [AUTO]`).
+- `auto_answer` JSON 구조 TypeScript 인터페이스 명시.
+- 한국어 주석은 금지 (code_comments: en).
+
+### 3.3 Unified
+
+- biome 포맷팅 (`pnpm lint` 통과).
+- 기존 camelCase 컨벤션 준수 (`autoAnswer`, `ticketId`, `triageState`).
+
+### 3.4 Secured
+
+- AC-06 citation 강제 (Charter [지양-2]).
+- `assertValidTransition` 불변식 강제 (Charter [지양-4]).
+- 기존 `ask.create` 권한 게이트, org_id 소유권, rate limit 유지.
+- 21 CFR Part 11 §11.10(e) audit append-only.
+
+### 3.5 Trackable
+
+- `Fixes #<issue>` 커밋 footer (이슈 등록 시).
+- SPEC-V3-TRIAGE-001 참조.
+- @MX 태그: `@MX:SPEC SPEC-V3-TRIAGE-001` 부착.
+
+---
+
+## 4. Definition of Done
+
+- [ ] 8/8 REQs (REQ-TRI-001..008) 구현 완료
+- [ ] 7/7 ACs (AC-TRI-01..07) 테스트 통과
+- [ ] 11/11 Edge Cases (E-01..E-11) 처리 검증
+- [ ] `pnpm typecheck` EXIT 0
+- [ ] `pnpm lint` (lint:hex 포함) EXIT 0
+- [ ] `pnpm test` (FULL) 통과 — 기존 4400+ passed 회귀 0건
+- [ ] `pnpm ci:*` 전 단계 로컬 직검 (L-015)
+- [ ] 실DB `\d inbox_tickets` 직검 (autoAnswer/autoConfidence 컬럼 기존 존재, 본 SPEC migration 불필요)
+- [ ] audit_action enum 직검 (`inbox.triaged` 기존 존재, 신규 추가 불필요)
+- [ ] `useStreamingAnswer`/`ChatShell` 기존 테스트 회귀 0 (AC-TRI-05)
+- [ ] Charter [지양-2] (AC-TRI-02 citation 강제) + [지양-4] (auto→needs-review만) 매핑 검증
+- [ ] sync phase: README/CHANGELOG/implementation-status 갱신
+- [ ] PR 생성 + `Fixes #<issue>` + CI green
+
+---
+
+## 5. Test Strategy (TDD)
+
+### 5.1 RED 단계 (failing tests first)
+
+1. `app/api/ask/__tests__/route.test.ts` 확장:
+   - AC-TRI-01: TRIAGE 주입 정상 경로 단언 (응답 body + DB 갱신).
+   - AC-TRI-02: citation 0개 시 400 단언 + audit 메타.
+   - AC-TRI-03: triage_state 전이 단언 + 부정 전이 throw.
+   - AC-TRI-04: 타임아웃 폴백 단언.
+   - AC-TRI-06: audit 메타 단언.
+2. `lib/domains/triage/__tests__/run-triage.test.ts` [NEW]:
+   - AC-TRI-07: `auto_answer` 구조 + extractCitations 호환성.
+
+### 5.2 GREEN 단계 (minimal implementation)
+
+- `lib/domains/triage/run-triage.ts`: RAG 호출 래퍼.
+- `app/api/ask/route.ts`: TRIAGE 훅 + 응답 body 확장.
+
+### 5.3 REFACTOR 단계
+
+- consult.ts 재사용 방식 (옵션 A/B) run phase 결정 후 정리.
+- `@MX:ANCHOR` 부착 (`run-triage.ts` fan_in ≥ 3 예상).
+
+---
+
+## 6. References
+
+- `spec.md` REQ-TRI-001..008
+- `research.md` §3 (TRIAGE 주입 시나리오 매트릭스)
+- `.moai/specs/SPEC-V3-INBOX-001/spec.md:193` (AC-06 원문)
+- `.moai/specs/SPEC-V3-INBOX-001/acceptance.md` (AC-05 승격 경로 호환성)
+- Charter: [지양-2] citation 강제, [지양-4] RA Lead 승인
+- SPEC-V3-UI-001 `acceptance.md` (11 엣지 케이스 패턴 준용)

--- a/.moai/specs/SPEC-V3-TRIAGE-001/research.md
+++ b/.moai/specs/SPEC-V3-TRIAGE-001/research.md
@@ -1,0 +1,335 @@
+---
+id: SPEC-V3-TRIAGE-001
+version: 1.0.0
+status: draft
+phase: C-2
+priority: High
+created: 2026-07-05
+updated: 2026-07-05
+author: manager-spec
+parent_spec: SPEC-V3-INBOX-001
+labels:
+  - component/backend
+  - component/ai
+  - component/api
+  - domain/inbox
+  - domain/triage
+  - type/v3-new
+---
+
+# SPEC-V3-TRIAGE-001 — research.md (Phase C-2 Auto-Triage)
+
+> 본 research.md는 Phase C-2 RA Triage 자동응답 강화를 위한 코드베이스 심층 분석 결과를 기술한다.
+> 모든 파일 경로·라인 인용은 **2026-07-05 main HEAD 기준 직검 결과**이다 (L-013).
+> 코드가 SPEC 텍스트보다 권위를 가진다 (본 프로젝트 L-013 / Core Behavior #2).
+
+---
+
+## 1. 이월 배경 및 현 상태 갭
+
+### 1.1 이월 근거 (SPEC-V3-INBOX-001 명시)
+
+- `.moai/specs/SPEC-V3-INBOX-001/spec.md:256` (As-Built 노트):
+  > "AC-06 (citation 없는 `auto_answer` 400): TRIAGE(C-2) 의존. 현재 `/api/ask`는 `auto_answer=null` 고정이므로 citation 검증 분기 미도달. SPEC-V3-TRIAGE-001로 이월 (Follow-up #1)."
+- `.moai/specs/SPEC-V3-INBOX-001/spec.md:193` (AC-06 원문):
+  > "citation 없는 `auto_answer` 저장 시 400 Bad Request 반환 (Charter [지양-2])"
+- `.moai/specs/SPEC-V3-INBOX-001/spec.md:180` (REQ-V3-INBOX-031):
+  > "WHEN TRIAGE 파이프라인(SPEC-V3-TRIAGE-001, C-2)이 완료될 때 THEN the system SHALL `/api/ask` 훅을 통해 `auto_answer` / `auto_confidence`를 티켓에 주입..."
+
+### 1.2 현재 코드 갭 (직검 2026-07-05)
+
+**`app/api/ask/route.ts` (94 lines 전체 직검)**:
+
+```ts
+// 라인 63-64:
+// Insert ticket with auto_answer=null (C-5 consult will RAG-generate)
+// REQ-V3-INBOX-001: triageState starts at 'auto' (initial state)
+
+// 라인 71-74:
+triageState: 'auto',
+autoAnswer: null, // RAG generation in C-5 consult
+autoConfidence: null,
+
+// 라인 93:
+return Response.json({ ticketId }, { status: 201 });
+```
+
+**현 상태 요약**:
+1. `/api/ask`는 티켓 생성 후 RAG 답변을 전혀 주입하지 않음 (`autoAnswer: null` 하드코딩).
+2. `triageState: 'auto'`로 시작하나, 자동 전이 로직 미존재 (TRIAGE 파이프라인이 주입해야 함).
+3. AC-06 citation 검증 분기 (400 Bad Request)는 `autoAnswer`가 null이므로 **실행 자체가 불가능** — 테스트 미작성 상태.
+4. 응답 body에 `triage_state`, `auto_answer`, `auto_confidence`가 누락되어 있음 (REQ-V3-INBOX-030 명시 응답 스키마 미충족).
+
+---
+
+## 2. C-5 Consult RAG 파이프라인 분석 (답변 생성 소스)
+
+### 2.1 consult.ts 아키텍처 (`lib/ai/consult.ts` 직검)
+
+consult.ts는 8단계 비동기 제네레이터로, SSE 스트림 이벤트를 yield한다. 본 SPEC은 이 파이프라인의 **최종 결과값**을 inbox `auto_answer`로 주입해야 한다.
+
+**핵심 단계 (lib/ai/consult.ts 직검)**:
+
+| 단계 | 라인 | 산출 | inbox 주입 관점 |
+|------|------|------|-----------------|
+| Stage 1: intent classify | ~119 | `intentTraceActive` 이벤트 | 사용 안 함 |
+| Stage 2: corpus search | ~130-168 | `topChunks[]` (chunk score 포함) | citation source 후보 |
+| Stage 4: LLM prose generation | ~190-336 | `fullProse` (HTML, `<sup class="cite">` 포함) | `auto_answer.answer` |
+| Stage 7: citation enforcement | ~340-352 | `enforceCitations(fullProse, availableSources)` → `{cleaned, violations}` | `auto_answer.answer` 최종 |
+| Stage 7: confidence calc | ~351 | `confidenceScore = calculateConfidence({chunkScores, citedCount, totalSentences})` | `auto_confidence` (NUMERIC(5,2)) |
+| Stage 7: sources emission | ~388, ~457 | `yield {type:'confidence', score}` / `yield {type:'sources', items}` | `auto_answer.citations[]` |
+
+**`auto_answer` JSON 구조 (본 SPEC 제안, GAP-05 run phase 위임 해소)**:
+
+```json
+{
+  "answer": "<p>...HTML prose with <sup class=\"cite\" data-source=\"1\">...</sup>...</p>",
+  "citations": [
+    { "source": "source-uuid-1", "quote": "...", "title": "...", "url": "..." },
+    { "source": "source-uuid-2", "quote": "..." }
+  ]
+}
+```
+
+> **Note**: `promote.ts:24-40 extractCitations()`는 이미 이 구조를 파싱한다 (`parsed.citations` 추출). 본 SPEC의 `auto_answer` 구조는 기존 `promote.ts` 파서와 호환되어야 한다.
+
+### 2.2 consult 재사용 vs 신규 TRIAGE 호출
+
+**옵션 A (권장)**: `/api/ask` 훅에서 consult.ts를 직접 비-스트리밍 모드로 재호출
+- 장점: consult 8단계 전체 재사용 (citation enforcement, confidence, authority gate, post-rerank gate 등)
+- 단점: consult는 `conversationId`/`messageId` 영속화 기반 (라인 796-803 `getOrCreateConversation`). `/api/ask`는 티켓만 생성하고 대화 메시지는 생성하지 않으므로, **별도 메시지 영속화 없이 consult 로직의 핵심(검색→생성→citation→confidence)만 재사용**하는 함수 추출 필요.
+- 구조조정: `lib/ai/consult.ts`에서 "stage 2~7 핵심"을 `runRagPipeline(input): Promise<RagResult>`로 추출 (yield는 SSE caller가 담당). 단, 이 리팩토링은 **큰 회귀 리스크**를 가지므로 본 SPEC은 run phase에서 별도 PR로 분리 검토.
+
+**옵션 B (단기 MVP)**: `/api/ask` 훅에서 consult의 하위 모듈들을 직접 조합 (검색 → LLM → citation enforcement → confidence)
+- 장점: consult.ts 회귀 리스크 없음
+- 단점: 코드 중복 (8단계 로직 재구현)
+
+> **본 SPEC은 옵션 A를 원칙으로 하되, 구현 디테일(함수 추출 범위)은 run phase에서 확정** (GAP-TRI-01 이월). 단, `auto_answer` JSON 구조와 citation/confidence 추출 계약은 본 SPEC이 정의한다.
+
+### 2.3 기존 citation 후처리 코드 (재사용 가능)
+
+- `lib/ai/citation-enforce.ts:73` — `enforceCitations(prose, availableSources): {cleaned, violations}` — htmlparser2 기반 uncited claim detection. **핵심 재사용 대상**.
+- `lib/ai/confidence.ts:26` — `calculateConfidence({chunkScores, citedCount, totalSentences}): number` (0~1).
+- `lib/source-governance/retrieval-gate.ts` — `rankByAuthority`, `assessLowAuthority` (consult.ts:543-554에서 lazy import).
+
+---
+
+## 3. triage_state 자동 전이 분석
+
+### 3.1 VALID_TRANSITIONS 매트릭스 (코드 단일 진실원)
+
+`lib/domains/inbox/types.ts:44-51` 직검:
+
+```ts
+export const VALID_TRANSITIONS: Record<TriageState, TriageState[]> = {
+  auto: ['needs-review'],                    // ← TRIAGE 주입 시 유일한 탈출 경로
+  'needs-review': ['escalated', 'waiting', 'closed', 'rejected'],
+  escalated: ['waiting', 'closed', 'rejected'],
+  waiting: ['needs-review', 'closed'],
+  closed: [],     // Terminal
+  rejected: [],   // Terminal
+};
+```
+
+**주의**: SPEC-V3-INBOX-001 §4.3 다이어그램은 `auto→escalated`, `auto→closed`를 표시하지만, **코드(types.ts:45)는 `auto→needs-review`만 허용**. 코드가 권위(L-013, Core Behavior #2). TRIAGE 자동 전이는 반드시 `auto→needs-review` 경로만 사용.
+
+### 3.2 TRIAGE 주입 시나리오별 자동 전이
+
+| 시나리오 | 조건 | 결과 triage_state | 근거 |
+|----------|------|-------------------|------|
+| RAG 성공 + citation 있음 + confidence ≥ 임계값 | `auto_answer.citations.length > 0 && auto_confidence >= threshold` | `needs-review` | auto→needs-review 유효 전이 |
+| RAG 성공 + citation 있음 + confidence < 임계값 | 위와 같되 confidence 낮음 | `needs-review` | RA 검토 필요 (Charter [지양-4]) |
+| RAG 실패 또는 citation 0개 | `auto_answer == null OR citations.length == 0` | `needs-review` | citation 없으면 자동 신뢰 금지 (Charter [지양-2]) |
+| 위험 키워드 감지 | `shouldAutoFlag()` true | `needs-review` | escalated 자동 전이 금지 — RA가 수동 판단 (Charter [지양-4]) |
+
+> **핵심 불변식**: TRIAGE는 **절대 `auto→escalated`/`auto→closed`/`auto→rejected` 자동 전이를 수행하지 않는다**. 모든 자동 판정은 `needs-review`로 수렴하며, RA Lead의 수동 판단이 escalated/closed/rejected를 결정한다 (Charter [지양-4] AI 판단 대신 금지).
+
+### 3.3 assertValidTransition 활용
+
+`lib/domains/inbox/state-machine.ts:41-48` — `assertValidTransition(from, to)`:
+- TRIAGE 주입 시 반드시 `assertValidTransition('auto', 'needs-review')` 호출로 위변조 방어.
+- lib 단에서 단언하므로 route에서는 자연스럽게 500 전파 (불변식 위반 = 서버 결함).
+
+---
+
+## 4. 기존 ask/route.ts 분석 (수정 대상)
+
+### 4.1 현재 구조 (94 lines)
+
+```
+POST /api/ask (withPermission 'ask.create')
+├─ organizationId 가드 (403)
+├─ rate limit (H-4, 30/min/user, 429)
+├─ Zod 검증 (question 1..5000)
+├─ ticketId = `it_${randomUUID()}`  (L-3 fix)
+├─ db.transaction
+│  ├─ INSERT inbox_tickets (triageState='auto', autoAnswer=null, autoConfidence=null)
+│  └─ writeAudit('inbox.created')
+└─ Response.json({ticketId}, 201)
+```
+
+### 4.2 수정 포인트 (본 SPEC 범위)
+
+1. **티켓 INSERT 후 TRIAGE 훅 호출**: `auto_answer`/`auto_confidence` 주입 + `triageState` 갱신 (별개 트랜잭션 — consult가 느리므로 티켓 생성을 먼저 확정).
+2. **AC-06 citation 검증**: TRIAGE 훅 결과 `auto_answer`가 있으나 `citations.length === 0`이면 **400 Bad Request** 반환 + 티켓 행 삭제(또는 상태 유지 + 에러 메타). Charter [지양-2].
+3. **응답 body 확장**: `{ticketId, triageState, autoAnswer?, autoConfidence?}` (REQ-V3-INBOX-030 준수).
+4. **감사 로그 추가**: TRIAGE 자동 주입 시 `inbox.triaged` action 기록 (auto→needs-review 전이분).
+
+### 4.3 트랜잭션 경계 설계
+
+**옵션 1 (단일 tx)**: 티켓 INSERT + TRIAGE 주입 + audit을 하나의 tx로.
+- 단점: consult RAG 호출(수 초)이 tx를 물고 있어 연결 고갈 위험.
+
+**옵션 2 (분리 tx, 권장)**:
+```
+tx1 (빠름): INSERT ticket (triageState='auto', autoAnswer=null) + audit 'inbox.created'
+↓ commit (티켓 ID 확정)
+TRIAGE 호출 (비동기, tx 없음): RAG → autoAnswer/autoConfidence 산출
+↓
+tx2 (빠름): UPDATE ticket SET autoAnswer, autoConfidence, triageState='needs-review' + audit 'inbox.triaged'
+```
+
+- 장점: tx 짧게 유지, RAG 실패 시에도 티켓은 존재(후속 수동 처리 가능).
+- 단점: tx1과 tx2 사이 일관성 창 (티켓은 있으나 autoAnswer=null 구간). 칸반에서는 `auto` 상태로 표시되므로 수용 가능.
+
+---
+
+## 5. 감사 로그 분석
+
+### 5.1 기존 audit_action enum (schema.ts:414-430 직검)
+
+이미 SPEC-V3-INBOX-001에서 9종 추가됨:
+- `inbox.created` (이미 사용 중 — ask/route.ts:80)
+- `inbox.triaged` (TRIAGE 자동 전이용 — 본 SPEC에서 사용 예정)
+- `inbox.assigned`, `inbox.escalated`, `inbox.answered`, `inbox.approved`, `inbox.closed`, `inbox.rejected`
+- `inbox.approve_failed` (H-2 fix)
+
+**본 SPEC은 신규 audit enum 추가 불필요**. TRIAGE 자동 주입은 `inbox.triaged` 재사용 (`lib/domains/inbox/audit.ts:39 auditTransition()` 호출 시 `triageAuditAction('needs-review')` → `inbox.triaged` 자동 매핑, audit.ts:19-29 직검).
+
+### 5.2 감사 메타 확장 제안
+
+TRIAGE 자동 주입 감사 메타:
+```json
+{
+  "from": "auto",
+  "to": "needs-review",
+  "auto_triage": true,
+  "confidence_score": 0.82,
+  "citations_count": 3,
+  "trigger": "auto"
+}
+```
+
+기존 `auditTransition()` 시그니처(`lib/domains/inbox/audit.ts:39`)는 `TriageTransitionInput`만 받으므로, 메타 확장이 필요한 경우 별도 wrapper 또는 `auditTransition` 확장 검토 (GAP-TRI-02 run phase).
+
+---
+
+## 6. RBAC / 권한 분석
+
+### 6.1 권한 매트릭스 (lib/auth/permissions.ts 직검)
+
+- `ask.create` (라인 526): minRole `viewer` (H-4 fix). Employee 질문 진입점.
+- `inbox.view` (라인 516): minRole `ra-member`. 칸반 조회.
+- `inbox.manage` (라인 507): minRole `ra-lead`. 전이/승인.
+
+### 6.2 TRIAGE 자동 주입 게이트
+
+TRIAGE 자동 주입은 **시스템 내부 동작**이므로 별도 권한 키 불필요. 단, `auto_answer`가 주입된 티켓을 볼 수 있는 권한은 기존 `inbox.view`/`inbox.manage`로 충분.
+
+### 6.3 Employee 자기 티켓 조회
+
+`/api/ask` 응답에 `autoAnswer`가 포함되므로, Employee는 자신의 질문에 대한 RAG 자동 답변을 즉시 확인 가능. 단, **이것은 "draft" 자동 답변이며 final_answer가 아님**을 UI가 반드시 명시해야 함 (Charter [지양-2] fake trust 방지 — 본 SPEC 범위 외, SPEC-V3-UI-001에서 표시).
+
+---
+
+## 7. 의존성 매트릭스
+
+### 7.1 상향 의존성 (본 SPEC이 의존)
+
+| 대상 | 경로 | 용도 |
+|------|------|------|
+| SPEC-V3-INBOX-001 | `.moai/specs/SPEC-V3-INBOX-001/spec.md` | inbox_tickets 테이블, state machine, audit 프레임워크 |
+| consult RAG pipeline | `lib/ai/consult.ts` | RAG 답변 생성 (stage 2~7) |
+| citation enforcement | `lib/ai/citation-enforce.ts:73 enforceCitations()` | citation 없는 claim 검증 (Charter [지양-2]) |
+| confidence calc | `lib/ai/confidence.ts:26 calculateConfidence()` | auto_confidence 산출 |
+| state machine | `lib/domains/inbox/state-machine.ts:41 assertValidTransition()` | auto→needs-review 전이 검증 |
+| audit | `lib/domains/inbox/audit.ts:39 auditTransition()` | inbox.triaged 감사 기록 |
+| schema | `lib/db/schema.ts:3259 inboxTickets`, `:3297 approvedAnswers` | autoAnswer/autoConfidence 컬럼 |
+| permissions | `lib/auth/permissions.ts` | ask.create, inbox.view/manage |
+
+### 7.2 하향 의존성 (본 SPEC이 차단/해금)
+
+| 대상 | 영향 |
+|------|------|
+| SPEC-V3-CONSULT-001 (C-5) | RA Power Chat. 본 SPEC과 독립적이나, consult.ts 리팩토링 시 영향. |
+| SPEC-V3-UI-001 (Phase D) | `auto_answer` 표시 UI. 본 SPEC 완료 후 활성화. |
+| approved_answers 승격 (SPEC-V3-INBOX-001 AC-05) | `promote.ts:24 extractCitations()`가 본 SPEC `auto_answer.citations[]` 구조와 호환되어야 함. |
+
+---
+
+## 8. Charter 매핑
+
+| Charter 항목 | 본 SPEC 적용 |
+|--------------|--------------|
+| [지양-2] citation 강제 | REQ-TRI-002: citation 없는 auto_answer 저장 시 400 Bad Request. **AC-06 직접 이행**. |
+| [지양-4] RA Lead 승인 | REQ-TRI-003: TRIAGE는 auto→needs-review만 수행. 자동 escalated/closed/rejected 금지. |
+| [지양-1] 전사 도우미 | REQ-TRI-001: Employee `/api/ask`에서 즉시 RAG draft 답변 제공. |
+
+---
+
+## 9. 회귀 리스크 매트릭스
+
+| 영역 | Risk | 완화 |
+|------|------|------|
+| `/api/ask` 응답 body 확장 | LOW — 기존 클라이언트(`useStreamingAnswer.ts:217`)는 `ticketId`만 읽으므로 신규 필드 호환. | 응답에 신규 필드 추가 시 기존 소비자 영향 0 검증 |
+| consult.ts 리팩토링 (옵션 A) | HIGH — consult.ts는 페르소나 챗의 핵심. 회귀 폭발. | run phase에서 별도 PR로 분리, characterization tests 선행 (L-013) |
+| `auto_answer` JSON 구조 변경 | MEDIUM — `promote.ts:24 extractCitations()` 파서와 호환성. | 본 SPEC 구조(`{answer, citations[]}`)가 기존 파서와 일치함 직검 |
+| triage_state 자동 전이 | LOW — `auto→needs-review`는 단일 경로, state-machine.ts가 강제. | assertValidTransition 단언 |
+| AC-06 400 반환 시 티켓 처리 | MEDIUM — 티켓은 남고 auto_answer만 거부, 또는 티켓도 롤백. | run phase 결정 (티켓 유지 + 수동 전이 권장) |
+
+---
+
+## 10. GAP 보고 (run phase 이월)
+
+### GAP-TRI-01: consult.ts 재사용 방식 (옵션 A vs B)
+
+- **상황**: TRIAGE 자동 주입을 위해 consult RAG 파이프라인 재사용 필요.
+- **옵션 A**: `lib/ai/consult.ts`에서 핵심 함수 `runRagPipeline()` 추출 후 `/api/ask` 훅에서 호출. 회귀 리스크 HIGH.
+- **옵션 B**: `/api/ask`에서 consult 하위 모듈 직접 조합 (검색 → LLM → citation → confidence). 코드 중복.
+- **결정**: run phase에서 expert-backend 위임 시 결정. 본 SPEC은 `auto_answer` JSON 계약만 정의.
+
+### GAP-TRI-02: auditTransition 메타 확장
+
+- **상황**: TRIAGE 자동 주입 감사에 `auto_triage`, `confidence_score` 등 메타 추가 필요 가능성.
+- **결정**: 기존 `auditTransition()` 시그니처 유지 + meta_json 확장은 별도 wrapper에서 처리. run phase에서 결정.
+
+### GAP-TRI-03: 동기 vs 비동기 TRIAGE
+
+- **상황**: `/api/ask` 응답에 `auto_answer`를 포함하려면 동기 호출 필요. 응답 지연(수 초) 발생.
+- **대안**: `/api/ask`는 티켓만 생성(201), TRIAGE는 Inngest 비동기 잡으로 처리, 완료 시 SSE/UI 폴링으로 갱신.
+- **결정**: v3 03_api_contract.md:14-31가 동기 응답에 `auto_answer` 포함을 명시. 본 SPEC은 **동기 호출**을 기본으로 하되, 타임아웃(예: 15s) 초과 시 `auto_answer=null`로 폴백 + 티켓은 `auto` 상태 유지. run phase에서 타임아웃 값 확정.
+
+---
+
+## 11. References (직검 라인 인용)
+
+- `app/api/ask/route.ts:1-94` — POST /api/ask 전체 (본 SPEC 수정 대상)
+- `lib/ai/consult.ts:340-388` — Stage 7 citation enforcement + confidence calc
+- `lib/ai/consult.ts:457` — `yield {type:'sources', items}` (citations 산출)
+- `lib/ai/consult.ts:531-605` — expert_review_required 게이트 + post-rerank gate (재사용 가능)
+- `lib/ai/citation-enforce.ts:73` — `enforceCitations()` 핵심
+- `lib/ai/confidence.ts:26` — `calculateConfidence()`
+- `lib/domains/inbox/types.ts:20-51` — `TRIAGE_STATES`, `VALID_TRANSITIONS` (코드 권위)
+- `lib/domains/inbox/state-machine.ts:19-48` — `canTransition`, `assertValidTransition`
+- `lib/domains/inbox/audit.ts:19-58` — `triageAuditAction`, `auditTransition`
+- `lib/domains/inbox/promote.ts:24-40` — `extractCitations()` (`auto_answer` 파서, 본 SPEC 구조와 호환)
+- `lib/db/schema.ts:3259-3280` — `inboxTickets` (autoAnswer/autoConfidence 컬럼)
+- `lib/db/schema.ts:3297-3335` — `approvedAnswers`
+- `lib/db/schema.ts:414-430` — `inbox.*` audit_action enum (9종, 본 SPEC 추가 불필요)
+- `lib/auth/permissions.ts:172-177, 507-528` — `ask.create`, `inbox.view`, `inbox.manage`
+- `hooks/useStreamingAnswer.ts:217-219` — `/api/ask` 응답 `ticketId` 소비
+- `.moai/specs/SPEC-V3-INBOX-001/spec.md:180-181` — REQ-V3-INBOX-030/031 (`/api/ask` 계약)
+- `.moai/specs/SPEC-V3-INBOX-001/spec.md:193` — AC-06 (citation 없는 auto_answer 400)
+- `.moai/specs/SPEC-V3-INBOX-001/spec.md:256` — As-Built 노트 (본 SPEC 이월 명시)
+- Charter: `~/.claude/projects/.../memory/product-charter.md` [지양-1/2/4]
+- Lessons: L-007(직검), L-013(self-report 3중 맹점 — 본 research는 전부 코드 직검)

--- a/.moai/specs/SPEC-V3-TRIAGE-001/spec.md
+++ b/.moai/specs/SPEC-V3-TRIAGE-001/spec.md
@@ -1,0 +1,283 @@
+---
+id: SPEC-V3-TRIAGE-001
+version: 1.0.0
+status: draft
+phase: C-2
+priority: High
+created: 2026-07-05
+updated: 2026-07-05
+author: manager-spec
+issue_number: 0
+depends_on:
+  - SPEC-V3-INBOX-001
+blocks:
+  - SPEC-V3-CONSULT-001
+  - SPEC-V3-UI-001
+parent_spec: SPEC-V3-INBOX-001
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/ai
+  - component/api
+  - domain/inbox
+  - domain/triage
+  - type/v3-new
+---
+
+# SPEC-V3-TRIAGE-001 — RA Triage 자동응답 강화 (Phase C-2)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-07-05 | manager-spec | 초기 작성. SPEC-V3-INBOX-001 Follow-up #1 이월. AC-06 (citation 없는 auto_answer 400) 직접 이행. REQ 8종, AC 7종. 코드 직검 기반 (L-013). |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+본 SPEC은 SPEC-V3-INBOX-001에서 명시적으로 이월된 후속 SPEC이다. SPEC-V3-INBOX-001은 inbox_tickets 테이블 + triage state machine + ESIG 승인 워크플로우를 구현했으나, **자동 답변 주입(`auto_answer`/`auto_confidence`)과 citation 검증(AC-06)은 TRIAGE(C-2) 의존으로 이월**되었다 (`.moai/specs/SPEC-V3-INBOX-001/spec.md:256` As-Built 노트 직검).
+
+현재 `/api/ask`는 티켓을 `triageState='auto'`, `autoAnswer=null`로 생성만 하고 끝난다 (`app/api/ask/route.ts:71-74` 직검). 본 SPEC은 이 티켓에 **C-5 consult RAG 파이프라인의 결과값을 주입**하고, **citation이 없는 자동 답변을 거부(AC-06)** 하며, **`triage_state`를 자동으로 `needs-review`로 전이**하는 것을 목적으로 한다.
+
+### 1.2 페르소나 (Personas)
+
+| 페르소나 | 역할 | TRIAGE 관점 |
+|---|---|---|
+| Employee / Viewer | `employee`, `viewer` | `/api/ask` 호출 시 RAG draft 답변을 응답으로 수신 (`auto_answer`). 단, 이것은 draft이며 final_answer가 아님을 UI가 명시 |
+| RA Member | `ra-member` | TRIAGE가 주입한 `auto_answer`/`auto_confidence`를 칸반에서 조회. 검토 초안 작성 |
+| RA Lead | `ra-lead` | TRIAGE 자동 주입 결과를 바탕으로 final_answer 승인(ESIG) 또는 reject/escalate 수동 판단 |
+| Admin | `admin` | 감사 로그 조회 |
+
+### 1.3 규제·정책 근거 (Policy Anchor)
+
+- **Charter [지양-2] citation 강제**: `auto_answer`는 반드시 citation(source/provenance)을 포함한다. citation 없는 자동 답변 저장 시 400 Bad Request (AC-06 직접 이행).
+- **Charter [지양-4] RA Lead 승인**: TRIAGE 자동 판정은 `auto→needs-review` 전이만 수행. 자동으로 escalated/closed/rejected를 결정하지 않는다 (AI 판단 대신 금지).
+- **Charter [지양-1] 전사 도우미**: Employee가 질문 즉시 RAG draft 답변을 받아 자주 묻는 인허가 질문을 셀프서비스 해결.
+- **21 CFR Part 11 §11.10(e)**: TRIAGE 자동 주입(자동 전이) 시 `inbox.triaged` audit log 기록. hash chain.
+- **21 CFR Part 11 §11.70**: `auto_answer`는 ESIG 서명 대상이 아님 (draft). ESIG는 오직 `final_answer` 승인 시 요구(SPEC-V3-INBOX-001 REQ-V3-INBOX-012).
+
+### 1.4 본 SPEC의 범위 (In Scope)
+
+- `/api/ask` 훅: 티켓 생성 후 TRIAGE RAG 호출 → `auto_answer`/`auto_confidence` 주입
+- `auto_answer` JSONB 구조 정의: `{answer: string, citations: [{source, quote?}][]}`
+- AC-06 이행: citation 없는 `auto_answer` 저장 시 400 Bad Request
+- triage_state 자동 전이: `auto → needs-review` (유일한 자동 전이 경로)
+- TRIAGE 자동 주입 감사: `inbox.triaged` action (`lib/domains/inbox/audit.ts` 재사용)
+- `/api/ask` 응답 body 확장: `{ticketId, triageState, autoAnswer?, autoConfidence?}` (REQ-V3-INBOX-030 준수)
+- RAG 호출 타임아웃 폴백: 타임아웃 시 `auto_answer=null`, `triage_state='auto'` 유지
+
+### 1.5 Out of Scope
+
+- **C-5 Consult (Power Chat) `/api/ra/consult`**: RA 전용 Power Chat은 SPEC-V3-CONSULT-001 (C-5)에서 분리. 본 SPEC은 consult.ts 하위 모듈 재사용만.
+- **Kanban UI 표시**: `auto_answer` 표시 UI는 SPEC-V3-UI-001 (Phase D).
+- **approved_answers 승격**: SPEC-V3-INBOX-001 REQ-V3-INBOX-028 (이미 구현).
+- **TRIAGE 자동 escalated/closed/rejected 전이 금지**: Charter [지양-4]. 본 SPEC은 `auto→needs-review`만.
+- **`auto_answer.citations[]` 항목별 상세 스키마(title, year, url 등) 정의**: run phase에서 확장 가능. 본 SPEC은 `{source, quote?}` 최소 스키마만 정의 (기존 `promote.ts:24 extractCitations()` 파서와 호환).
+- **Inngest 비동기 TRIAGE 잡**: 본 SPEC은 동기 호출 기준. 비동기 잡은 Follow-up.
+
+---
+
+## §2 Requirements (EARS Format)
+
+### RAG 주입 / 자동 답변
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-TRI-001 | **WHEN** `/api/ask`가 티켓을 생성한 후 **THEN** the system **SHALL** C-5 consult RAG 파이프라인을 호출하여 질문에 대한 RAG 답변(`auto_answer` JSONB)과 신뢰도 점수(`auto_confidence`)를 산출하여 해당 티켓 행에 주입한다. `auto_answer` 구조: `{answer: string, citations: [{source: string, quote?: string}][]}`. `auto_confidence`: NUMERIC(5,2) (0.00~1.00). 주입은 티켓 INSERT tx commit 이후 별도 tx에서 수행한다 (consult 호출이 느리므로 tx 분리) | High |
+| REQ-TRI-002 | **IF** 산출된 `auto_answer`가 존재하나 `citations.length === 0`인 경우 **THEN** the system **SHALL** 400 Bad Request를 반환하고 해당 `auto_answer`를 티켓에 저장하지 않는다 (Charter [지양-2] citation 강제, SPEC-V3-INBOX-001 AC-06 이행). 단, 티켓 자체(`triage_state='auto'`)는 유지하여 후속 수동 처리를 허용한다 | High |
+| REQ-TRI-003 | **WHEN** TRIAGE가 `auto_answer`를 정상 주입한 경우 **THEN** the system **SHALL** `triage_state`를 `auto`에서 `needs-review`로 자동 전이한다 (`lib/domains/inbox/types.ts:45 VALID_TRANSITIONS['auto']` 준수, `assertValidTransition()`으로 위변조 방어). TRIAGE는 `escalated`/`closed`/`rejected`로 자동 전이하지 않는다 (Charter [지양-4] AI 판단 대신 금지) | High |
+
+### 응답 계약
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-TRI-004 | **THE SYSTEM SHALL** `/api/ask`의 응답 body를 `{ticketId: string, triageState: TriageState, autoAnswer: {answer, citations[]} \| null, autoConfidence: number \| null}`로 반환한다 (SPEC-V3-INBOX-001 REQ-V3-INBOX-030 응답 스키마 준수). 기존 `{ticketId}`만 읽는 소비자(`hooks/useStreamingAnswer.ts:217`)와 하위 호환 (신규 필드 추가) | High |
+| REQ-TRI-005 | **IF** TRIAGE RAG 호출이 타임아웃(기본 15초, 환경변수 `TRIAGE_TIMEOUT_MS`) 또는 런타임 에러로 실패한 경우 **THEN** the system **SHALL** `autoAnswer: null`, `autoConfidence: null`, `triageState: 'auto'`를 반환하고 201 Created를 유지한다 (RAG 실패가 티켓 생성을 실패시키지 않음 — 폴백 전략). 에러 메타를 audit 로그에 기록 | Medium |
+
+### 감사 로그
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-TRI-006 | **WHEN** TRIAGE가 `triage_state`를 `auto → needs-review`로 자동 전이할 때 **THEN** the system **SHALL** 동일 트랜잭션 내에서 `inbox.triaged` audit_action을 기록한다 (기존 `lib/domains/inbox/audit.ts:39 auditTransition()` 재사용, 21 CFR Part 11 §11.10(e)). actor = 시스템(`system` 또는 세션 사용자 id — run phase 결정). 메타에 `auto_triage: true`, `confidence_score`, `citations_count`를 포함한다 (AC-TRI-06 단언 대상) | High |
+| REQ-TRI-007 | **WHEN** AC-06 위반(citation 없는 auto_answer)으로 400을 반환할 때 **THEN** the system **SHALL** audit 로그에 `inbox.triaged` action과 함께 `auto_triage_rejected: true`, `reason: 'no_citations'` 메타를 기록한다 (21 CFR Part 11 — 자동 결함 거부 이력) | Medium |
+
+### 권한 / 게이트
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-TRI-008 | **THE SYSTEM SHALL** TRIAGE 자동 주입 로직을 `ask.create` 권한 게이트 뒤에서만 실행한다 (기존 `app/api/ask/route.ts:39 withPermission('ask.create')` 재사용). TRIAGE 자체의 별도 권한 키는 정의하지 않는다 (시스템 내부 동작) | Medium |
+
+---
+
+## §3 Acceptance Criteria
+
+| AC# | Criterion | Verification |
+|-----|-----------|--------------|
+| AC-TRI-01 | `POST /api/ask` 호출 시 (1) 티켓 생성 → (2) TRIAGE RAG 호출 → (3) `auto_answer`/`auto_confidence` 주입 → (4) `triage_state='needs-review'` 자동 전이 → (5) 응답 body `{ticketId, triageState, autoAnswer, autoConfidence}` 반환의 전체 흐름이 단일 엔드포인트에서 완료된다. `auto_answer`는 `{answer, citations[]}` 구조를 따른다 (JSON parse 단언) | Test (full pipeline mock) |
+| AC-TRI-02 | citation 없는 `auto_answer` 산출 시 (RAG가 citations 빈 배열 반환) → 400 Bad Request + `auto_answer` 티켓 미저장 + audit `inbox.triaged` with `auto_triage_rejected: true, reason: 'no_citations'` (AC-06 직접 이행, Charter [지양-2]) | Test |
+| AC-TRI-03 | TRIAGE 주입 후 티켓의 `triage_state`는 반드시 `needs-review`이며, DB 단언 + audit 로그 `inbox.triaged`의 `meta.from='auto'`, `meta.to='needs-review'` 확인. `auto→escalated`/`auto→closed`/`auto→rejected` 자동 전이 시도 시 `assertValidTransition()`이 throw (불변식 위반 = 서버 결함) | Test (DB + audit) |
+| AC-TRI-04 | TRIAGE RAG 호출 타임아웃(15s 기본) 또는 예외 발생 시 → 201 응답 유지 + `autoAnswer: null, autoConfidence: null, triageState: 'auto'` 반환 + 티켓은 `auto` 상태로 DB에 존재 + audit 로그에 실패 메타 기록. 티켓 생성은 RAG 성공과 독립적 | Test (타임아웃/예외 주입) |
+| AC-TRI-05 | `/api/ask` 응답 body의 `ticketId` 필드를 기존 소비자(`hooks/useStreamingAnswer.ts:217`)가 정상 읽고, 신규 필드(`triageState, autoAnswer, autoConfidence`) 추가로 인한 기존 클라이언트 회귀 0건 | Test (useStreamingAnswer 회귀 — ChatShell.ticketId.test.tsx 통과 유지) |
+| AC-TRI-06 | TRIAGE 자동 전이 감사 로그가 `inbox.triaged` action으로 기록되며, `meta_json.auto_triage=true`, `confidence_score`, `citations_count`가 포함된다. 21 CFR Part 11 §11.10(e) append-only hash chain 보존 | Test (audit row 단언) |
+| AC-TRI-07 | RAG 호출이 정상적으로 citation을 포함한 답변을 산출한 경우 → `auto_answer` JSONB가 `{answer, citations[{source, quote?}]}` 구조로 저장되며, 기존 `lib/domains/inbox/promote.ts:24 extractCitations()` 파서가 이를 정상 파싱함을 단언 (SPEC-V3-INBOX-001 AC-05 승격 경로와 호환) | Test (extractCitations 호환성) |
+
+---
+
+## §4 Technical Approach
+
+### 4.1 TRIAGE 호출 흐름 (권장 아키텍처)
+
+```
+POST /api/ask
+├─ withPermission('ask.create')
+├─ organizationId 가드 (403)
+├─ rate limit (H-4, 30/min/user, 429) — 기존 유지
+├─ Zod 검증 (question 1..5000) — 기존 유지
+├─ tx1 (빠름):
+│  ├─ INSERT inbox_tickets (triageState='auto', autoAnswer=null)
+│  └─ writeAudit('inbox.created')
+├─ commit tx1 → ticketId 확정
+├─ TRIAGE 호출 (tx 없음, 타임아웃 15s):
+│  ├─ RAG pipeline (consult 하위 모듈 재사용 또는 runRagPipeline 추출)
+│  │  ├─ 검색 (topChunks)
+│  │  ├─ LLM prose generation
+│  │  ├─ enforceCitations(prose, availableSources) → {cleaned, violations}
+│  │  └─ calculateConfidence({chunkScores, citedCount, totalSentences})
+│  ├─ auto_answer = {answer: cleaned, citations: citedChunks.map(...)}
+│  └─ AC-06 검증: citations.length === 0 → 400 처리 (아래)
+├─ AC-06 검증:
+│  if (auto_answer && citations.length === 0):
+│    ├─ tx2: writeAudit('inbox.triaged', {auto_triage_rejected: true, reason: 'no_citations'})
+│    └─ return 400 {error: 'no_citations'}
+├─ tx2 (빠름):
+│  ├─ UPDATE inbox_tickets SET autoAnswer=JSON, autoConfidence=score, triageState='needs-review'
+│  │  WHERE id=ticketId AND orgId (defense-in-depth)
+│  ├─ assertValidTransition('auto', 'needs-review') (불변식 단언)
+│  └─ writeAudit('inbox.triaged', {from:'auto', to:'needs-review', auto_triage:true, ...})
+└─ Response.json({ticketId, triageState:'needs-review', autoAnswer, autoConfidence}, 201)
+```
+
+### 4.2 consult.ts 재사용 방식 (GAP-TRI-01 — run phase 결정)
+
+**옵션 A (권장)**: `lib/ai/consult.ts`에서 핵심 RAG 로직을 `runRagPipeline(input): Promise<RagResult>`로 추출. `/api/ask` 훅에서 호출. 회귀 리스크 HIGH → 별도 PR에서 characterization tests 선행.
+
+**옵션 B (단기 MVP)**: `/api/ask` 훅에서 consult 하위 모듈(hybridSearch, generateProse, enforceCitations, calculateConfidence)을 직접 조합. 회귀 리스크 LOW, 코드 중복.
+
+> 본 SPEC은 두 옵션 모두 허용. run phase에서 expert-backend가 회귀 리스크 평가 후 결정.
+
+### 4.3 `auto_answer` JSONB 구조 (본 SPEC 정의)
+
+```typescript
+interface AutoAnswer {
+  answer: string;  // HTML prose with <sup class="cite"> markers
+  citations: Array<{
+    source: string;  // sourceId (sources.id UUID 또는 식별자)
+    quote?: string;  // 인용구 원문 (optional)
+    // 확장 필드(title, year, url)는 run phase에서 허용
+  }>;
+}
+```
+
+**하위 호환성 직검**: `lib/domains/inbox/promote.ts:24-40 extractCitations()`는 `parsed.citations` 배열을 추출하며, 각 항목의 `source`/`quote`를 읽는다. 본 구조는 기존 파서와 호환 (research.md §2.1 검증).
+
+### 4.4 파일 구조 (예상)
+
+- `app/api/ask/route.ts` [MODIFY] — TRIAGE 훅 추가, 응답 body 확장, AC-06 검증
+- `lib/domains/triage/` [NEW] — TRIAGE 파이프라인 모듈
+  - `run-triage.ts` — RAG 호출 + auto_answer 산출 + citation 검증 래퍼
+  - `types.ts` — `AutoAnswer`, `TriageResult` 인터페이스
+  - `index.ts` — 공개 API
+- `lib/ai/consult.ts` [MODIFY, 옵션 A 시] — `runRagPipeline()` 추출 (별도 PR)
+- `lib/env.ts` [MODIFY] — `TRIAGE_TIMEOUT_MS` (기본 15000) 추가
+- `app/api/ask/__tests__/route.test.ts` [MODIFY] — AC-TRI-01..07 단언 추가
+
+### 4.5 As-Built (run phase 반영 예정)
+
+> run phase 완료 후 본 섹션에 계획 vs 구현 정합성 메모 추가 (SPEC-V3-INBOX-001 §4.2 패턴).
+
+### 4.6 의존성 (Dependencies)
+
+- **SPEC-V3-INBOX-001**: inbox_tickets 테이블, state machine, audit 프레임워크 (구현 완료)
+- **`lib/ai/consult.ts`**: RAG 파이프라인 (재사용)
+- **`lib/ai/citation-enforce.ts`**: citation 강제 (Charter [지양-2])
+- **`lib/ai/confidence.ts`**: confidence 계산
+- **`lib/domains/inbox/audit.ts`**: `auditTransition()` 재사용
+- **후속 (blocks)**: SPEC-V3-CONSULT-001 (C-5), SPEC-V3-UI-001 (Phase D — auto_answer 표시 UI)
+
+### 4.7 Regression-Risk Matrix
+
+| 영역 | Risk | 완화 |
+|------|------|------|
+| `/api/ask` 응답 body 확장 | LOW — 신규 필드 추가, 기존 ticketId 소비자 호환 | useStreamingAnswer 회귀 테스트 (AC-TRI-05) |
+| consult.ts 리팩토링 (옵션 A) | HIGH — 페르소나 챗 회귀 폭발 가능 | 별도 PR, characterization tests 선행 (L-013) |
+| AC-06 400 반환 시 티켓 처리 | MEDIUM — 티켓 유지(auto 상태) vs 롤백 | 티켓 유지 + audit 기록 (수동 후속 처리 허용) |
+| TRIAGE 자동 전이 불변식 | LOW — assertValidTransition 단언 | lib 단에서 위변조 방어 |
+| `auto_answer` JSON 파싱 호환성 | LOW — extractCitations 파서와 구조 일치 직검 완료 | AC-TRI-07 단언 |
+| RAG 타임아웃 | MEDIUM — 응답 지연 (수 초) | 15s 타임아웃 + 폴백(AC-TRI-04) |
+
+---
+
+## §5 모순 보고 (Contradictions / Gaps)
+
+### GAP-TRI-01: consult.ts 재사용 방식 — ⏸ run phase 이월
+
+- **상황**: TRIAGE 자동 주입을 위해 consult RAG 파이프라인 재사용 필요.
+- **결정**: run phase에서 expert-backend가 옵션 A(`runRagPipeline` 추출) vs 옵션 B(하위 모듈 직접 조합) 결정. 본 SPEC은 `auto_answer` JSON 계약만 정의.
+
+### GAP-TRI-02: auditTransition 메타 확장 — ⏸ run phase 이월
+
+- **상황**: TRIAGE 자동 주입 감사에 `auto_triage`, `confidence_score`, `citations_count` 메타 추가 권장.
+- **결정**: 기존 `auditTransition()` 시그니처 유지 + 메타 확장은 별도 wrapper 또는 직접 writeAudit 호출로 처리. run phase에서 결정.
+
+### GAP-TRI-03: 동기 vs 비동기 TRIAGE — ✅ 결정 (동기 기본)
+
+- **상황**: `/api/ask` 응답에 `auto_answer` 포함하려면 동기 호출 필요. 응답 지연(수 초) 발생.
+- **결정**: v3 03_api_contract.md:14-31가 동기 응답에 `auto_answer` 포함을 명시. **본 SPEC은 동기 호출 기본**, 타임아웃(15s) 초과 시 `auto_answer=null` 폴백(REQ-TRI-005). 비동기 Inngest 잡은 Follow-up.
+
+---
+
+## §6 Exclusions (What NOT to Build)
+
+본 SPEC은 **TRIAGE 자동 주입 + citation 검증(AC-06) + 자동 전이(auto→needs-review)** 만 다룬다. 다음은 명시적으로 제외:
+
+- **C-5 Consult `/api/ra/consult` 구현 금지**: RA 전용 Power Chat은 SPEC-V3-CONSULT-001 (C-5). 본 SPEC은 consult 하위 모듈 재사용만.
+- **`auto→escalated`/`auto→closed`/`auto→rejected` 자동 전이 금지**: Charter [지양-4] AI 판단 대신 금지. TRIAGE는 `auto→needs-review`만.
+- **`auto_answer`에 대한 ESIG 요구 금지**: ESIG는 오직 `final_answer` 승인 시(SPEC-V3-INBOX-001 REQ-V3-INBOX-012). `auto_answer`는 draft.
+- **Inngest 비동기 TRIAGE 잡 금지**: 본 SPEC은 동기 호출. 비동기는 Follow-up.
+- **`auto_answer.citations[]` 항목별 상세 스키마(title/year/url) 강제 금지**: 본 SPEC은 `{source, quote?}` 최소 스키마만. 확장은 run phase 허용.
+- **Kanban UI에서 `auto_answer` 표시 금지**: SPEC-V3-UI-001 (Phase D).
+- **타 org 티켓 RAG 호출 금지**: org_id 소유권 검증은 `/api/ask` 레벨에서 이미 강제 (SPEC-V3-INBOX-001).
+- **신규 audit_action enum 추가 금지**: 기존 `inbox.triaged` 재사색 (SPEC-V3-INBOX-001에서 이미 추가).
+
+---
+
+## §7 Follow-up Issues
+
+1. **C-5 Consult 분리 (SPEC-V3-CONSULT-001)**: RA 전용 Power Chat. 본 SPEC의 consult.ts 재사용 방식과 충돌 시 조정.
+2. **비동기 TRIAGE 잡 (Inngest)**: 동기 호출 응답 지연이 문제될 경우, Inngest `triage-auto-answer` 잡으로 전환 검토.
+3. **`auto_answer` 캐싱**: 동일/유사 질문의 RAG 호출 비용 절감을 위한 캐싱 (`approved_answers` hit 우선 조회 후 RAG fallback). 성능 최적화.
+4. **TRIAGE 신뢰도 임계값 설정**: `auto_confidence >= threshold` 시 자동으로 `needs-review` 생략(직접 `closed`?) 검토 — **Charter [지양-4] 위반이므로 현 SPEC 범위 외**. 모든 자동 주입은 `needs-review` 강제.
+5. **`auto_answer.citations[]` 상세 스키마 확장**: title/year/url/type/sourceHost 등 consult sourceItems 필드 동기화 (run phase).
+6. **부모 SPEC-V3-INBOX-001 모순 정정 (별도 이슈 등록)**: 부모 `SPEC-V3-INBOX-001/spec.md` §4.3 다이어그램(line 276)과 REQ-V3-INBOX-006(line 115)은 `auto → {needs-review, escalated, closed}` 3종 전이를 허용하나, 코드 `lib/domains/inbox/types.ts:45`는 `auto: ['needs-review']` 1종만 허용. 본 SPEC은 **코드가 권위**(L-013)로 `auto → needs-review` 단일 전이를 채택. 부모 SPEC의 §4.3 다이어그램과 REQ-V3-INBOX-006 텍스트를 코드에 맞게 정정하는 별도 이슈 등록 필요 (run phase 이전 또는 sync 단계에서 처리).
+
+---
+
+## §8 References
+
+- **부모 SPEC**: `.moai/specs/SPEC-V3-INBOX-001/spec.md:180-181` (REQ-V3-INBOX-030/031), `:193` (AC-06), `:256` (이월 명시)
+- **v3 데이터 모델**: `docs/v3/02_data_model.md:79-99` (inbox_tickets DDL)
+- **v3 API 계약**: `docs/v3/03_api_contract.md:14-31` (`POST /api/ask` 응답 스키마)
+- **v3 아키텍처**: `docs/v3/01_architecture.md:114-126` (Auto-Triage 로직)
+- **Charter**: `~/.claude/projects/.../memory/product-charter.md` ([지양-1] 전사 도우미, [지양-2] citation 강제, [지양-4] RA Lead 승인)
+- **consult RAG**: `lib/ai/consult.ts:340-388` (Stage 7), `lib/ai/citation-enforce.ts:73`, `lib/ai/confidence.ts:26`
+- **inbox state machine**: `lib/domains/inbox/types.ts:20-51`, `lib/domains/inbox/state-machine.ts:41-48`
+- **inbox audit**: `lib/domains/inbox/audit.ts:19-58` (`triageAuditAction`, `auditTransition`)
+- **promote 호환성**: `lib/domains/inbox/promote.ts:24-40` (`extractCitations`, `auto_answer` 파서)
+- **schema**: `lib/db/schema.ts:3259-3335` (`inboxTickets`, `approvedAnswers`), `:414-430` (`inbox.*` audit enum)
+- **permissions**: `lib/auth/permissions.ts:507-528` (`ask.create`, `inbox.view/manage`)
+- **ask route**: `app/api/ask/route.ts:1-94` (본 SPEC 수정 대상)
+- **streaming consumer**: `hooks/useStreamingAnswer.ts:217-219` (`/api/ask` 응답 `ticketId` 소비)
+- **Lessons**: L-007 (직검), L-013 (self-report 3중 맹점 — research.md 전부 코드 직검)

--- a/.moai/specs/SPEC-V3-TRIAGE-001/tasks.md
+++ b/.moai/specs/SPEC-V3-TRIAGE-001/tasks.md
@@ -1,0 +1,163 @@
+## Task Decomposition
+
+SPEC: SPEC-V3-TRIAGE-001
+Development Mode: tdd | Execution: sub-agent sequential | Harness: thorough
+
+> **Code-Authoritative Contract (verified against source 2026-07-05)**:
+> - `/api/ask` 현재 구현: `app/api/ask/route.ts:1-94`. `triageState='auto'`, `autoAnswer: null` 하드코딩 (라인 71-74). 응답 `{ticketId}`만 반환 (라인 93).
+> - `VALID_TRANSITIONS['auto'] = ['needs-review']` (유일한 자동 전이 경로) — `lib/domains/inbox/types.ts:45`. 코드가 SPEC-V3-INBOX-001 §4.3 다이어그램보다 권위 (L-013).
+> - `assertValidTransition()` — `lib/domains/inbox/state-machine.ts:41-48` (부정 전이 throw).
+> - `auditTransition()` — `lib/domains/inbox/audit.ts:39`. `triageAuditAction('needs-review')` → `'inbox.triaged'` 매핑 (audit.ts:19-29).
+> - `inbox.triaged` audit_action 이미 존재 — `lib/db/schema.ts:423`. 본 SPEC 신규 enum 추가 불필요.
+> - `extractCitations()` — `lib/domains/inbox/promote.ts:24-40`. `auto_answer` JSON 파서. 본 SPEC `auto_answer` 구조(`{answer, citations[]}`)는 이 파서와 호환 (research.md §2.1 직검).
+> - `inboxTickets.autoAnswer`/`autoConfidence` 컬럼 — `lib/db/schema.ts:3275-3276`. 이미 존재 (migration 불필요).
+> - consult RAG 핵심 — `lib/ai/consult.ts:340-388` (Stage 7), `lib/ai/citation-enforce.ts:73 enforceCitations()`, `lib/ai/confidence.ts:26 calculateConfidence()`.
+> - `ask.create` 권한 — `lib/auth/permissions.ts:526`. minRole `viewer` (H-4 fix).
+> - 기존 클라이언트 — `hooks/useStreamingAnswer.ts:217-219` (`/api/ask` 응답 `ticketId` 추출).
+
+> **TDD discipline**: Each task = RED (failing test) → GREEN (minimal code) → REFACTOR. For `[MODIFY]` brownfield files, run a characterization-test task FIRST (DDD safety net) before any TDD cycle that changes behavior.
+
+### M1 — Foundation: TRIAGE 모듈 스키마/타입 (Priority: High)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-001 | `lib/domains/triage/types.ts` — RED: `AutoAnswer`, `TriageResult`, `RagPipelineInput` 인터페이스 미존재 단언; GREEN: 최소 타입 정의. `AutoAnswer = {answer: string, citations: Array<{source: string, quote?: string}>}` (SPEC §4.3). `TriageResult = {autoAnswer: AutoAnswer \| null, autoConfidence: number \| null, error?: 'no_citations' \| 'timeout' \| 'runtime_error'}`. `@MX:NOTE [AUTO]` 부착 예정 | REQ-TRI-001 | - | `lib/domains/triage/types.ts` [NEW], `lib/domains/triage/__tests__/types.test.ts` [NEW] | pending |
+| T-002 | `lib/domains/triage/` index.ts 공개 API — RED: `./run-triage` export 미존재 단언; GREEN: 빈 re-export (T-003 완료 후 채움) | - | T-001 | `lib/domains/triage/index.ts` [NEW] | pending |
+| T-003 | `lib/env.ts` `TRIAGE_TIMEOUT_MS` 추가 — RED: env 스키마에 `TRIAGE_TIMEOUT_MS` 미존재 단언; GREEN: `z.coerce.number().default(15000)` 추가 (다른 env 패턴 준용). `.env.example` 갱신 | REQ-TRI-005 | T-001 | `lib/env.ts` [MODIFY], `.env.example` [MODIFY] | pending |
+
+### M2 — TRIAGE RAG 파이프라인 래퍼 (Priority: High)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-004 | `lib/domains/triage/run-triage.ts` (옵션 B 기본 — 회귀 낮춤) — RED: `runTriage({question, orgId, signal})` 호출 시 `{autoAnswer, autoConfidence, error}` 반환 단언; GREEN: consult 하위 모듈(hybridSearch, generateProse, enforceCitations, calculateConfidence) 직접 조합 래퍼. 타임아웃(`TRIAGE_TIMEOUT_MS`) 적용. **GAP-TRI-01**: 옵션 A(consult.ts runRagPipeline 추출) vs B(하위 모듈 직접 조합) run phase 결정. 본 task는 옵션 B 기본, 옵션 A는 별도 PR에서 characterization tests 선행 | REQ-TRI-001, REQ-TRI-005 | T-001, T-003 | `lib/domains/triage/run-triage.ts` [NEW], `lib/domains/triage/__tests__/run-triage.test.ts` [NEW] | pending |
+| T-005 | citation 검증 (AC-TRI-02 핵심) — RED: `runTriage()`가 citations 빈 배열 반환 시 `TriageResult.error='no_citations'` 단언; GREEN: `autoAnswer.citations.length === 0` 분기에서 error 설정. `autoAnswer.answer`는 폴백 메시지 유지 (사용자 기만 방지, E-01) | REQ-TRI-002 | T-004 | `lib/domains/triage/run-triage.ts` [MODIFY], `lib/domains/triage/__tests__/run-triage.test.ts` [MODIFY] | pending |
+| T-006 | 타임아웃/예외 폴백 — RED: RAG 호출이 `TRIAGE_TIMEOUT_MS` 초과 시 `TriageResult.error='timeout', autoAnswer=null` 단언; 런타임 예외 시 `error='runtime_error'` 단언; GREEN: `AbortController` + `setTimeout` 또는 `Promise.race` 패턴. E-02 (LLM 실패) 포함 | REQ-TRI-005 | T-004 | `lib/domains/triage/run-triage.ts` [MODIFY], `lib/domains/triage/__tests__/run-triage.test.ts` [MODIFY] | pending |
+| T-007 | extractCitations 호환성 — RED: `runTriage()` 산출 `autoAnswer` JSON을 `extractCitations()`에 전달 시 기존 파서가 정상 동작 단언 (AC-TRI-07); GREEN: `auto_answer = {answer, citations: [{source, quote?}]}` 구조 준수. `lib/domains/inbox/promote.ts:24-40` 파서와 정합 | REQ-TRI-001, AC-TRI-07 | T-004 | `lib/domains/triage/run-triage.test.ts` [MODIFY] (호환성 단언 추가) | pending |
+
+### M3 — `/api/ask` TRIAGE 훅 + AC-06 검증 (Priority: High)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-008 | `/api/ask` characterization test (brownfield 안전망) — 기존 `app/api/ask/route.ts` 동작 스냅샷 캡처 (ticketId 반환, triageState='auto', audit inbox.created). T-009..T-012 수정 후에도 본 테스트는 통과해야 함. 기존 `app/api/ask/__tests__/route.test.ts`가 이미 존재하므로 [MODIFY] — 회귀 단언 보강 | (DDD safety) | - | `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+| T-009 | `/api/ask` TRIAGE 훅 호출 (정상 경로) — RED: POST 후 (1) tx1 티켓 생성 → (2) `runTriage()` 호출 → (3) tx2 UPDATE 티켓(`autoAnswer`, `autoConfidence`, `triageState='needs-review'`) → (4) 응답 body `{ticketId, triageState, autoAnswer, autoConfidence}` 반환 단언; GREEN: TRIAGE 훅 추가. tx2에서 `assertValidTransition('auto', 'needs-review')` 단언. `db.transaction` 2개 분리 (tx1 커밋 후 TRIAGE, 그 후 tx2). AC-TRI-01/03 | REQ-TRI-001, REQ-TRI-003, REQ-TRI-004, AC-TRI-01, AC-TRI-03 | T-004, T-008 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+| T-010 | AC-06 검증 (citation 없는 auto_answer 400) — RED: TRIAGE가 `error='no_citations'` 반환 시 400 Bad Request + `{error: 'no_citations'}` 응답 단언; `autoAnswer` 티켓 미저장(`SELECT autoAnswer FROM inbox_tickets WHERE id=:ticketId` → null) 단언; 티켓은 `triageState='auto'` 유지 단언; GREEN: error 분기 처리. AC-TRI-02 (SPEC-V3-INBOX-001 AC-06 직접 이행) | REQ-TRI-002, AC-TRI-02 | T-009 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+| T-011 | 타임아웃/예외 폴백 — RED: TRIAGE `error='timeout'` 또는 `'runtime_error'` 시 201 Created 유지 + `{ticketId, triageState: 'auto', autoAnswer: null, autoConfidence: null}` 반환 단언; 티켓은 DB에 존재 단언; GREEN: 폴백 분기 처리. AC-TRI-04, E-02 | REQ-TRI-005, AC-TRI-04 | T-009 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+| T-012 | 응답 body 확장 + 기존 호환성 — RED: 응답이 `ticketId`(기존) + `triageState, autoAnswer, autoConfidence`(신규) 모두 포함 단언; 기존 `useStreamingAnswer` 회귀 0 단언; GREEN: Response.json 확장 (기존 ticketId 필드 보존). `hooks/useStreamingAnswer.ts:217` 변경 없음. AC-TRI-05 | REQ-TRI-004, AC-TRI-05 | T-009, T-010, T-011 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY], `components/chat/__tests__/ChatShell.ticketId.test.tsx` [MODIFY or 유지] | pending |
+
+### M4 — 자동 전이 + 감사 로그 (Priority: High)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-013 | `triage_state auto→needs-review` 자동 전이 감사 — RED: TRIAGE 주입 성공 시 audit 로그에 `inbox.triaged` action + `meta.from='auto', to='needs-review', auto_triage=true, confidence_score, citations_count` 행 존재 단언; GREEN: 기존 `auditTransition()` 호출로 감사 기록 (audit.ts:39 재사용). 메타 확장은 GAP-TRI-02 — 직접 `writeAudit` 호출 또는 wrapper로 메타 추가. AC-TRI-06, REQ-TRI-006 | REQ-TRI-003, REQ-TRI-006, AC-TRI-03, AC-TRI-06 | T-009 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+| T-014 | AC-06 거부 감사 — RED: citation 없는 auto_answer로 400 반환 시 audit 로그에 `inbox.triaged` action + `meta.auto_triage_rejected=true, reason='no_citations'` 행 존재 단언; GREEN: 400 분기에서 감사 기록. REQ-TRI-007, AC-TRI-02 audit 부분 | REQ-TRI-002, REQ-TRI-007 | T-010, T-013 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+| T-015 | assertValidTransition 위변조 방어 — RED: 코드가 `auto→escalated` 등 부정 전이 시도 시 `assertValidTransition`이 throw 단언; GREEN: tx2에서 `assertValidTransition('auto', 'needs-review')` 명시적 호출 (방어 코드). AC-TRI-03 부정 전이 분기 | REQ-TRI-003, AC-TRI-03 | T-013 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+
+### M5 — 권한/게이트 + 엣지 케이스 (Priority: Medium)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-016 | 권한 게이트 유지 — RED: TRIAGE 훅이 `withPermission('ask.create')` 게이트 뒤에서만 실행 단언; 미인증 시 401 + TRIAGE 호출 안 됨 단언; viewer/employee/ra-member/ra-lead/admin 역할별 TRIAGE 실행 단언 (모두 허용 — 시스템 내부 동작); GREEN: 기존 `withPermission` 래퍼 내 TRIAGE 호출 배치. REQ-TRI-008, E-04/E-05 | REQ-TRI-008 | T-009 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+| T-017 | E-01 (빈 topChunks) — RED: RAG가 0개 chunk 반환 시 `error='no_citations'` 또는 `error='empty_results'` 단언 + 400 응답 + `autoAnswer.answer`가 폴백 메시지 단언 (사용자 기만 방지); GREEN: run-triage.ts 분기 처리 | REQ-TRI-002, E-01 | T-005 | `lib/domains/triage/run-triage.ts` [MODIFY], `lib/domains/triage/__tests__/run-triage.test.ts` [MODIFY] | pending |
+| T-018 | E-06 (tx2 실패) — RED: tx2 UPDATE 실패 시 티켓은 `triageState='auto', autoAnswer=null` 잔존 단언; 응답은 500 또는 201 폴백(run phase 결정); GREEN: try/catch 분기. 본 SPEC은 201 폴백 권장 (REQ-TRI-005 일관성) | REQ-TRI-005, E-06 | T-011 | `app/api/ask/route.ts` [MODIFY], `app/api/ask/__tests__/route.test.ts` [MODIFY] | pending |
+
+### M6 — Quality Gates (Priority: High)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-019 | `pnpm ci:lint` 로컬 직검 (L-008/L-015) — `pnpm ci:lint`(lint:hex full) 로컬 실행; noUnusedVariables 등 CI=error 항목 0 위반; unused import/vars 제거; 코드 줄에 `#NNN` 금지 (L-008). TRIAGE 모듈 + ask route 전부 | (L-008, L-015) | T-001..T-018 | (수정만) | pending |
+| T-020 | `pnpm ci:typecheck` + 전 `pnpm ci:*` 단계 로컬 직검 (L-015) — TypeScript 0 신규 에러; ci:audit (lib 내부 tx audit 시 override — lib/domains/triage/ 포함), ci:rbac, ci:tokens, ci:i18n, ci:glossary, ci:contrast, ci:module-boundaries 전 단계 로컬 green. 일부 green=전체 green 아님 (L-015) | (L-015) | T-019 | (수정만) | pending |
+| T-021 | `pnpm ci:audit` TRIAGE 도메인 검증 (L-015 핵심) — TRIAGE 주입 감사가 `lib/domains/triage/` 또는 `app/api/ask/route.ts`에서 tx 내 기록되는지 직검. route가 `writeAudit(...)` literal 호출 시 ci:audit 통과. lib 내부 호출 시 `audit-check-ignore` override 필요 (L-015 — 주석에 `*` 금지, 구체적 단어). `inbox.triaged` action 명시 | (L-015, ci:audit) | T-013, T-014, T-020 | (수정만) | pending |
+| T-022 | 전체 `pnpm test` 실행 (L-009) — 타깃만이 아닌 전체 `pnpm test` 실행; 기존 4400+ passed 회귀 0; staged 범위 직검; 11 엣지 케이스(E-01..E-11) 처리 확인; `useStreamingAnswer`/`ChatShell.ticketId.test.tsx` 회귀 0 단언 | (L-009) | T-020 | (수정만) | pending |
+| T-023 | 실DB 직검 (L-010/L-013) — `SELECT autoAnswer, autoConfidence, triageState FROM inbox_tickets WHERE id=<test-ticket>` 직검; `\d inbox_tickets` (autoAnswer/autoConfidence 컬럼 기존 존재 확인, migration 불필요); `SELECT action, meta_json FROM audit_logs WHERE resource_id=<ticket> ORDER BY created_at` 직검 (`inbox.triaged` + 메타) | (L-010, L-013) | T-022 | (수정만) | pending |
+| T-024 | `pnpm build` 로컬 직검 (L-012) — `next dev` 중지 확인 후 `pnpm build` 실행; `.next` chunk 충돌(페이지 500) 방지; 빌드 성공 단언 | (L-012) | T-023 | (수정만) | pending |
+| T-025 | Pre-submission self-review — 전체 변경셋 단순성 검토 ("더 단순한 접근인가?", "제거해도 SPEC 만족하는가?"); @MX 태그 최종 검증 (ANCHOR: run-triage.ts fan_in ≥ 3 예상, NOTE: route TRIAGE 훅, WARN: AC-06 검증 분기 21 CFR Part 11); 불필요한 추상화 제거 | (workflow-modes Pre-submission) | T-024 | (수정만) | pending |
+
+---
+
+## Coverage Verification
+
+### REQ Coverage (8 REQs → Tasks)
+
+| REQ ID | Covered By | Status |
+|--------|------------|--------|
+| REQ-TRI-001 | T-001, T-004, T-007, T-009 | ⏳ |
+| REQ-TRI-002 | T-005, T-010, T-014, T-017, AC-TRI-02 | ⏳ |
+| REQ-TRI-003 | T-009, T-013, T-015, AC-TRI-03 | ⏳ |
+| REQ-TRI-004 | T-009, T-012, AC-TRI-01 | ⏳ |
+| REQ-TRI-005 | T-003, T-006, T-011, T-018, AC-TRI-04 | ⏳ |
+| REQ-TRI-006 | T-013, AC-TRI-06 | ⏳ |
+| REQ-TRI-007 | T-014 | ⏳ |
+| REQ-TRI-008 | T-016 | ⏳ |
+
+**8/8 REQs covered.** ⏳
+
+### AC Coverage (7 ACs → Tasks)
+
+| AC ID | Covered By | Status |
+|-------|------------|--------|
+| AC-TRI-01 | T-009 | ⏳ |
+| AC-TRI-02 | T-005, T-010, T-014, T-017 (SPEC-V3-INBOX-001 AC-06 이행) | ⏳ |
+| AC-TRI-03 | T-009, T-013, T-015 | ⏳ |
+| AC-TRI-04 | T-006, T-011, T-018 | ⏳ |
+| AC-TRI-05 | T-012 | ⏳ |
+| AC-TRI-06 | T-013, T-014 | ⏳ |
+| AC-TRI-07 | T-007 | ⏳ |
+
+**7/7 ACs covered.** ⏳
+
+### Edge Case Coverage (11 → Tasks)
+
+| Edge | Covered By | Status |
+|------|------------|--------|
+| E-01 (빈 topChunks) | T-017 | ⏳ |
+| E-02 (LLM 실패) | T-006 | ⏳ |
+| E-03 (5000자 초과) | 기존 route 유지 (영향 없음) | ⏳ |
+| E-04 (rate limit) | 기존 route 유지 + T-016 권한 | ⏳ |
+| E-05 (orgId 누락) | 기존 route 유지 + T-016 | ⏳ |
+| E-06 (tx2 실패) | T-018 | ⏳ |
+| E-07 (타 org 접근) | 기존 inbox 게이트 (SPEC-V3-INBOX-001) | ⏳ |
+| E-08 (즉시 reject) | 기존 state machine | ⏳ |
+| E-09 (동일 질문 반복) | Follow-up #3 | ⏳ |
+| E-10 (잘못된 source UUID) | Follow-up #5 | ⏳ |
+| E-11 (사용자 연결 끊음) | Follow-up #2 | ⏳ |
+
+**11/11 Edge Cases addressed.** ⏳
+
+---
+
+## Code Authority Verification (L-013)
+
+본 tasks.md의 모든 코드 라인 인용은 2026-07-05 main HEAD 기준 직검이다. run phase 시작 시 아래 항목 재직검 필수:
+
+- [ ] `app/api/ask/route.ts:71-74` (triageState='auto', autoAnswer=null 하드코딩) — 본 SPEC 수정 直接 대상
+- [ ] `lib/domains/inbox/types.ts:45` (`VALID_TRANSITIONS.auto = ['needs-review']`) — 코드 권위
+- [ ] `lib/domains/inbox/audit.ts:39` (`auditTransition()` 시그니처)
+- [ ] `lib/db/schema.ts:414-430` (`inbox.*` audit enum, 본 SPEC 추가 불필요)
+- [ ] `lib/db/schema.ts:3275-3276` (autoAnswer/autoConfidence 컬럼 기존 존재)
+- [ ] `lib/domains/inbox/promote.ts:24-40` (`extractCitations` 파서 호환성)
+- [ ] `lib/auth/permissions.ts:526` (`ask.create` minRole viewer)
+- [ ] `hooks/useStreamingAnswer.ts:217-219` (기존 ticketId 소비, 회귀 0 단언)
+
+---
+
+## Risks & Mitigations (run phase 참고)
+
+| Risk | Mitigation |
+|------|------------|
+| consult.ts 리팩토링 (옵션 A) 회귀 폭발 | T-004는 옵션 B 기본. 옵션 A는 별도 PR + characterization tests 선행 (L-013) |
+| AC-06 400 시 티켓 처리 (유지 vs 롤백) | 본 SPEC은 티켓 유지 + audit 기록 (수동 후속 처리 허용). run phase에서 확정 |
+| TRIAGE 호출 동기 응답 지연 (수 초) | 15s 타임아웃 + 폴백(AC-TRI-04). 비동기 Inngest 잡은 Follow-up #2 |
+| audit 메타 확장 (auto_triage 등) 기존 auditTransition 시그니처 영향 | GAP-TRI-02 — 직접 writeAudit 호출 또는 wrapper로 메타 추가 (기존 시그니처 유지) |
+| ci:audit route vs lib 감사 위치 (L-015) | T-021에서 직검. lib 내부 tx audit 시 `audit-check-ignore` override (주석에 `*` 금지) |
+
+---
+
+## References
+
+- `spec.md` §2 (REQ-TRI-001..008), §3 (AC-TRI-01..07)
+- `acceptance.md` (7 GWT + 11 edge + quality gates + DoD)
+- `research.md` §2 (consult RAG 분석), §3 (TRIAGE 주입 시나리오 매트릭스), §10 (GAP-TRI-01..03)
+- `.moai/specs/SPEC-V3-INBOX-001/spec.md:180-181` (REQ-V3-INBOX-030/031 원문), `:193` (AC-06 원문), `:256` (이월 명시)
+- `.moai/specs/SPEC-V3-UI-001/tasks.md` (본 tasks.md 양식 준용)
+- Charter: [지양-2] citation 강제, [지양-4] RA Lead 승인
+- Lessons: L-007 (직검), L-008 (lint:hex), L-009 (full test), L-010 (실DB), L-012 (next dev build 금지), L-013 (3중 맹점), L-015 (CI Gates 다단계)


### PR DESCRIPTION
## 요약

SPEC-V3-INBOX-001 AC-06 이월 후속 — **Phase C-2: RA Triage 자동응답 강화** plan phase 산출물 4종. `auto_answer` 주입 훅 + citation 검증(AC-06) + triage 자동 전이 + 감사. 본 PR은 **plan 산출물만** 포함 (run phase는 /clear 후 다음 세션).

## 산출물 (`.moai/specs/SPEC-V3-TRIAGE-001/`, 1073줄)

| 파일 | 내용 |
|------|------|
| `research.md` (335L) | C-5 consult/ask/inbox 도메인 심층 분석, GAP 3종, 코드 인용 17건 |
| `spec.md` (284L) | REQ-TRI-001..008 EARS, AC 7종, Charter [지양-1/2/4] 매핑 |
| `acceptance.md` (294L) | GWT 7 시나리오, edge 11종, DoD 12 |
| `tasks.md` (163L) | TDD 25 task M1..M6, coverage 8 REQ/7 AC/11 edge |

## 검증 체인

1. **manager-spec 작성** (EARS + 코드 권위 기반)
2. **orchestrator L-013 직검** — 15건 코드 인용 전수 일치 (VALID_TRANSITIONS, autoAnswer/autoConfidence 컬럼, inbox.triaged enum, ask/route.ts 등)
3. **plan-auditor 독립 감사** — **PASS (Critical 0)**, Major 2건 + Minor 4건 보고
4. **수정 완료** — Major 2건(REQ-TRI-006 강제화, 부모 SPEC 모순 Follow-up 추가) + Minor 2건(E-06 폴백 단일화, AC-TRI-06 중복 해소)

## ★ 핵심 설계 결정 (코드 권위)

1. **`auto → needs-review` 단일 전이** (`lib/domains/inbox/types.ts:45`, Charter [지양-4])
2. **migration 불필요** — `autoAnswer`/`autoConfidence`/`inbox.triaged` enum 기존 존재 (`lib/db/schema.ts`)
3. **AC-TRI-02 = SPEC-V3-INBOX-001 AC-06 직접 이행** — citation 없는 auto_answer 400 + `auto_triage_rejected` audit (Charter [지양-2])
4. **동기 호출 + 15s 타임아웃 폴백** — 201 with `autoAnswer: null`; tx1(생성) → TRIAGE RAG → tx2(주입+전이) 분리
5. **consult.ts 재사용 옵션 B** — 하위 모듈 직접 조합 (LOW 회귀, run phase 결정 사항 GAP-TRI-01)

## 영향 축

- schema/API/audit/citation/triage 전이 — run phase에서 구현
- 본 PR은 **문서만** (프로덕션 코드 변경 0)

## 다음 단계

머지 후 `/clear` → `/moai run SPEC-V3-TRIAGE-001` (manager-tdd, TDD). tasks.md M1(schema/도메인) → M2(ask auto_answer 주입) → M3(citation 검증 AC-06) → M4(triage 자동 전이) → M5(감사) → M6(게이트).

별도 후속: 부모 SPEC-V3-INBOX-001 §4.3 다이어그램 + REQ-V3-INBOX-006 모순 정정(types.ts에 맞게).

Refs SPEC-V3-INBOX-001 (AC-06 이월, Follow-up #1).

🗿 MoAI <email@mo.ai.kr>