### PR TITLE
docs(spec): SPEC-V3-CONSULT-001 plan phase 산출물 4종 (Phase C-5)

### DIFF
--- a/.moai/specs/SPEC-V3-CONSULT-001/acceptance.md
+++ b/.moai/specs/SPEC-V3-CONSULT-001/acceptance.md
@@ -1,0 +1,313 @@
+# Acceptance Criteria — SPEC-V3-CONSULT-001
+
+**작성일**: 2026-07-05
+**SPEC**: SPEC-V3-CONSULT-001 (RA Power Chat, v3 Phase C-5)
+**총 AC**: 7종
+**총 Edge Cases**: 11종
+
+---
+
+## Given-When-Then Scenarios
+
+### AC-CONS-01: Power Chat 세션 생성 성공
+
+**Given** RA Member가 로그인되어 있고
+**When** POST /api/consult/sessions를 `{title: "EU MDR 분석", projectId: "uuid-proj", locale: "ko"}`로 호출하면
+**Then** 시스템은 201 Created와 함께 다음을 반환한다:
+```json
+{
+  "sessionId": "uuid-v4",
+  "title": "EU MDR 분석",
+  "projectId": "uuid-proj",
+  "locale": "ko",
+  "createdAt": "2026-07-05T00:00:00Z"
+}
+```
+**And** consult_sessions 테이블에 해당 row가 존재하고 deletedAt은 null이다.
+
+### AC-CONS-02: Power Chat 세션 목록 조회 성공
+
+**Given** RA Member가 3개의 세션을 생성하고 (turnCount 각각 5, 2, 0)
+**When** GET /api/consult/sessions를 호출하면
+**Then** 시스템은 200 OK와 함께 다음을 반환한다:
+```json
+{
+  "sessions": [
+    {
+      "sessionId": "uuid-1",
+      "title": "세션 1",
+      "projectId": "uuid-proj",
+      "createdAt": "2026-07-05T01:00:00Z",
+      "turnCount": 5
+    },
+    {
+      "sessionId": "uuid-2",
+      "title": "세션 2",
+      "projectId": null,
+      "createdAt": "2026-07-04T12:00:00Z",
+      "turnCount": 2
+    },
+    {
+      "sessionId": "uuid-3",
+      "title": "세션 3",
+      "projectId": "uuid-proj",
+      "createdAt": "2026-07-03T10:00:00Z",
+      "turnCount": 0
+    }
+  ]
+}
+```
+**And** 세션 목록은 createdAt 내림차순 정렬된다 (최신 first).
+
+### AC-CONS-03: Power Chat 턴 생성 성공 (citation 포함)
+
+**Given** RA Member가 세션을 생성하고
+**When** POST /api/consult/sessions/:sessionId/turns를 `{question: "EU MDR 2017/745 Article 10 요구사항은?"}`로 호출하고
+**And** RAG 파이프라인이 citation을 포함한 답변을 성공적으로 생성하면
+**Then** 시스템은 201 Created와 함께 다음을 반환한다:
+```json
+{
+  "turnId": "uuid-turn",
+  "sessionId": "uuid-session",
+  "turnNumber": 1,
+  "answer": "<p>EU MDR Article 10은 <sup class=\"cite\" data-source=\"1\">제조사는 품질경영시스템을 수립해야 한다</sup>를 요구한다...</p>",
+  "confidence": 0.85,
+  "sources": [
+    {
+      "id": "src-eu-mdr",
+      "citeIndex": 1,
+      "orgLabel": "EU MDR",
+      "title": "Regulation (EU) 2017/745",
+      "year": 2017,
+      "type": "Regulation",
+      "anchor": "Article 10"
+    }
+  ],
+  "createdAt": "2026-07-05T02:00:00Z"
+}
+```
+**And** consult_turns 테이블에 해당 row가 존재하고 role은 'assistant'이다.
+**And** audit_logs 테이블에 `consult.turn.create` row가 존재한다.
+
+### AC-CONS-04: Power Chat 턴 생성 실패 (citation 없음)
+
+**Given** RA Member가 세션을 생성하고
+**When** POST /api/consult/sessions/:sessionId/turns를 호출하고
+**And** RAG 파이프라인이 citation을 포함하지 않은 답변을 생성하면
+**Then** 시스템은 400 Bad Request와 함께 다음을 반환한다:
+```json
+{
+  "error": "Citations required",
+  "message": "Answer must include at least one cited source"
+}
+```
+**And** consult_turns 테이블에 새 row가 추가되지 않는다.
+**And** 세션은 turnCount=0 상태로 유지된다 (후속 재시도 가능).
+
+### AC-CONS-05: Power Chat 턴 생성 실패 (타임아웃)
+
+**Given** RA Member가 세션을 생성하고
+**When** POST /api/consult/sessions/:sessionId/turns를 호출하고
+**And** RAG 파이프라인이 15s 타임아웃으로 실패하면
+**Then** 시스템은 400 Bad Request와 함께 다음을 반환한다:
+```json
+{
+  "error": "RAG timeout",
+  "message": "RAG pipeline timed out after 15s"
+}
+```
+**And** audit_logs 테이블에 `consult.turn.failed` row가 존재하고 meta_json에는 error: 'timeout'을 포함한다.
+
+### AC-CONS-06: Power Chat 세션 삭제 성공 (RA Lead)
+
+**Given** RA Lead가 세션을 생성하고
+**When** DELETE /api/consult/sessions/:sessionId를 호출하면
+**Then** 시스템은 200 OK와 함께 다음을 반환한다:
+```json
+{
+  "sessionId": "uuid-session",
+  "deletedAt": "2026-07-05T03:00:00Z"
+}
+```
+**And** consult_sessions 테이블의 해당 row에서 deletedAt이 현재 timestamp로 설정되고 실제 row는 삭제되지 않는다 (soft-delete).
+**And** audit_logs 테이블에 `consult.session.delete` row가 존재한다.
+
+### AC-CONS-07: RBAC 권한 검증
+
+**Given** RA Member가 다른 RA Member의 세션을 생성하고
+**When** DELETE /api/consult/sessions/:sessionId를 호출하면
+**Then** 시스템은 403 Forbidden를 반환한다.
+**And** audit_logs 테이블에 `consult.session.delete` row가 존재하지 않는다.
+
+---
+
+## Edge Cases
+
+### Edge-01: 빈 세션 목록 조회
+
+**Given** RA Member가 세션을 하나도 생성하지 않고
+**When** GET /api/consult/sessions를 호출하면
+**Then** 시스템은 200 OK와 함께 빈 배열을 반환한다:
+```json
+{
+  "sessions": []
+}
+```
+
+### Edge-02: 존재하지 않는 세션 조회
+
+**Given** RA Member가 세션을 생성하지 않고
+**When** GET /api/consult/sessions/non-existent-session-id를 호출하면
+**Then** 시스템은 404 Not Found를 반환한다.
+
+### Edge-03: 존재하지 않는 세션에 턴 생성 시도
+
+**Given** RA Member가 세션을 생성하지 않고
+**When** POST /api/consult/sessions/non-existent-session-id/turns를 호출하면
+**Then** 시스템은 404 Not Found를 반환한다.
+
+### Edge-04: 삭제된 세션에 턴 생성 시도
+
+**Given** RA Member가 세션을 생성하고
+**When** RA Lead가 DELETE /api/consult/sessions/:sessionId를 호출하여 삭제하고
+**And** RA Member가 POST /api/consult/sessions/:sessionId/turns를 호출하면
+**Then** 시스템은 404 Not Found를 반환한다 (soft-delete된 세션은 조회되지 않음).
+
+### Edge-05: title 없는 세션 생성
+
+**Given** RA Member가 로그인되어 있고
+**When** POST /api/consult/sessions를 `{projectId: "uuid-proj"}` (title 누락)로 호출하면
+**Then** 시스템은 400 Bad Request를 반환한다:
+```json
+{
+  "error": "Validation failed",
+  "issues": [
+    {
+      "code": "invalid_type",
+      "path": ["title"],
+      "message": "Required"
+    }
+  ]
+}
+```
+
+### Edge-06: 제목이 너무 긴 세션 생성 (>500자)
+
+**Given** RA Member가 로그인되어 있고
+**When** POST /api/consult/sessions를 `{title: "A"*500}` (500자 초과)로 호출하면
+**Then** 시스템은 400 Bad Request를 반환하고 Zod validation error를 표시한다.
+
+### Edge-07: 잘못된 sessionId UUID 형식
+
+**Given** RA Member가 로그인되어 있고
+**When** GET /api/consult/sessions/invalid-uuid-format를 호출하면
+**Then** 시스템은 400 Bad Request를 반환하고 Zod validation error를 표시한다.
+
+### Edge-08: RBAC 없는 유저의 세션 조회 시도
+
+**Given** Employee (viewer role)가 로그인되어 있고
+**When** GET /api/consult/sessions를 호출하면
+**Then** 시스템은 403 Forbidden를 반환한다 (Power Chat은 ra-member+ 전용).
+
+### Edge-09: Admin의 세션 삭제 시도
+
+**Given** Admin이 로그인되어 있고
+**When** DELETE /api/consult/sessions/:sessionId를 호출하면
+**Then** 시스템은 200 OK를 반환하고 deletedAt을 설정한다 (admin도 삭제 권한 보유).
+
+### Edge-10: RAG 파이프라인 런타임 에러 (LLM failure)
+
+**Given** RA Member가 세션을 생성하고
+**When** POST /api/consult/sessions/:sessionId/turns를 호출하고
+**And** RAG 파이프라인이 LLM API 실패로 에러를 던지면
+**Then** 시스템은 400 Bad Request와 함께 다음을 반환한다:
+```json
+{
+  "error": "RAG runtime error",
+  "message": "LLM generation failed"
+}
+```
+**And** audit_logs 테이블에 `consult.turn.failed` row가 존재하고 meta_json에는 error: 'runtime_error'을 포함한다.
+
+### Edge-11: 연속 턴 생성 (턴 번호 누적)
+
+**Given** RA Member가 세션을 생성하고
+**When** POST /api/consult/sessions/:sessionId/turns를 3회 연속 호출하면
+**Then** 시스템은 각 호출에 대해 turnNumber=1, 2, 3을 할당하고 정상적으로 저장한다.
+**And** GET /api/consult/sessions/:sessionId를 호출하면 turns 배열에 3개의 턴이 turnNumber 오름차순으로 정렬되어 반환된다.
+
+---
+
+## Quality Gates
+
+### Functional Correctness
+
+- [ ] 모든 AC (AC-CONS-01 ~ AC-CONS-07)가 Given-When-Then 형식으로 검증됨
+- [ ] RAG 파이프라인이 consult.ts 하위 모듈을 재사용하여 회귀 리스크 완화됨
+- [ ] Citation 강제가 Charter [지양-2]를 준수하여 enforceCitations로 검증됨
+- [ ] RBAC이 v3 01_architecture.md:95를 준수하여 ra-member/ra-lead/admin 분리됨
+
+### Data Integrity
+
+- [ ] consult_sessions/turns 테이블 FK 제약조건 준수 (REQ-CONS-012)
+- [ ] Soft-delete가 정확히 동작 (deletedAt 설정, 실제 row 유지)
+- [ ] Turn 번호 누적이 정확함 (MAX(turnNumber) + 1 할당)
+- [ ] Audit log가 21 CFR Part 11 §11.10(e)를 준수하여 기록됨
+
+### Performance
+
+- [ ] 세션 목록 조회가 turnCount 서브쿼리로 최적화됨 (N+1 query 방지)
+- [ ] RAG 파이프라인 15s 타임아웃이 정확히 동작함 (TRIAGE 패턴 재사용)
+- [ ] GET /api/consult/sessions/:sessionId가 turns JOIN을 효율적으로 수행함
+
+### Security
+
+- [ ] RBAC 권한 검증이 모든 엔드포인트에 적용됨
+- [ ] RA Member가 자신의 세션만 삭제/조회할 수 있음
+- [ ] RA Lead/Admin가 모든 세션에 접근할 수 있음
+- [ ] Employee/Viewer가 Power Chat에 접근할 수 없음 (403)
+
+### Observability
+
+- [ ] 모든 CRUD 작업이 audit_logs에 기록됨 (REQ-CONS-008, REQ-CONS-009, REQ-CONS-010)
+- [ ] RAG 실패가 consult.turn.failed audit로 기록됨
+- [ ] Audit meta_json에 sessionId, turnId, confidenceScore, sourceCount 포함됨
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] 모든 REQ-CONS-001 ~ REQ-CONS-012가 구현됨
+- [ ] 모든 AC-CONS-01 ~ AC-CONS-07가 Given-When-Then로 검증됨
+- [ ] consult_sessions/turns 테이블이 migration으로 생성됨
+- [ ] run-consult.ts 래퍼가 consult.ts 하위 모듈을 재사용함
+- [ ] RBAC 권한 3종이 permissions.ts에 추가됨
+
+### Test Complete
+
+- [ ] Unit test: run-consult.ts RAG 파이프라인 (citation 검증, 타임아웃)
+- [ ] Unit test: consult_sessions/turns CRUD (FK 제약조건)
+- [ ] Integration test: 4종 API endpoint (/sessions, /sessions/:id, /sessions/:id/turns, DELETE)
+- [ ] E2E test: RA Member가 세션 생성 → 턴 생성 → 세션 삭제 흐름
+- [ ] Regression test: 기존 /api/ra/consult가 깨지지 않음 (v2 호환성)
+
+### Documentation Complete
+
+- [ ] API 문서화: 4종 endpoint에 대한 Swagger/OpenAPI spec
+- [ ] DB 스키마 문서화: consult_sessions/turns 테이블 컬럼 설명
+- [ ] Migration guide: v2 conversations → v3 consult_sessions 마이그레이션 (선택)
+- [ ] RBAC matrix 업데이트: consult.session.create/view/delete 권한
+
+### Quality Gates Passed
+
+- [ ] Type check: `pnpm tsc --noEmit` — 0 errors
+- [ ] Lint: `pnpm lint` (biome) — 0 errors, 0 warnings
+- [ ] Unit test: `pnpm test` — 85%+ coverage (new code만)
+- [ ] Integration test: `pnpm test:integration` — 모든 테스트 패스
+- [ ] E2E test: `pnpm test:e2e` — Power Chat 흐름 패스
+
+---
+
+**본 acceptance.md는 SPEC-V3-CONSULT-001 plan phase 산출물의 일부입니다.**

--- a/.moai/specs/SPEC-V3-CONSULT-001/acceptance.md
+++ b/.moai/specs/SPEC-V3-CONSULT-001/acceptance.md
@@ -2,7 +2,7 @@
 
 **작성일**: 2026-07-05
 **SPEC**: SPEC-V3-CONSULT-001 (RA Power Chat, v3 Phase C-5)
-**총 AC**: 7종
+**총 AC**: 8종 (AC-CONS-01, 02, 02b, 03, 04, 05, 06, 07)
 **총 Edge Cases**: 11종
 
 ---
@@ -24,6 +24,7 @@
 }
 ```
 **And** consult_sessions 테이블에 해당 row가 존재하고 deletedAt은 null이다.
+**And** audit_logs 테이블에 `consult.session.create` row가 존재한다 (orgId/sessionId 매칭, REQ-CONS-013).
 
 ### AC-CONS-02: Power Chat 세션 목록 조회 성공
 
@@ -59,6 +60,45 @@
 ```
 **And** 세션 목록은 createdAt 내림차순 정렬된다 (최신 first).
 
+### AC-CONS-02b: Power Chat 세션 상세 조회 성공 (turns 배열 포함, REQ-CONS-003 직접 검증)
+
+**Given** RA Member가 세션을 생성하고 2개의 턴을 추가하고(question→answer exchange 2회)
+**When** GET /api/consult/sessions/:sessionId를 호출하면
+**Then** 시스템은 200 OK와 함께 다음을 반환한다:
+```json
+{
+  "sessionId": "uuid-session",
+  "title": "EU MDR 분석",
+  "projectId": "uuid-proj",
+  "locale": "ko",
+  "createdAt": "2026-07-05T00:00:00Z",
+  "turns": [
+    {
+      "turnId": "uuid-turn-1",
+      "turnNumber": 1,
+      "question": "EU MDR Article 10 요구사항은?",
+      "answer": "<p>EU MDR Article 10은 ...</p>",
+      "confidence": 0.85,
+      "sources": [{ "id": "src-eu-mdr", "citeIndex": 1 }],
+      "citations": [{ "citeIndex": 1, "sourceId": "src-eu-mdr" }],
+      "createdAt": "2026-07-05T01:00:00Z"
+    },
+    {
+      "turnId": "uuid-turn-2",
+      "turnNumber": 2,
+      "question": "Article 11은?",
+      "answer": "<p>...</p>",
+      "confidence": 0.78,
+      "sources": [{ "id": "src-eu-mdr", "citeIndex": 1 }],
+      "citations": [{ "citeIndex": 1, "sourceId": "src-eu-mdr" }],
+      "createdAt": "2026-07-05T02:00:00Z"
+    }
+  ]
+}
+```
+**And** turns 배열은 turnNumber 오름차순(1, 2)으로 정렬된다.
+**And** 각 turn은 question과 answer를 함께 포함한다 (Exchange 모델, role 필드 없음).
+
 ### AC-CONS-03: Power Chat 턴 생성 성공 (citation 포함)
 
 **Given** RA Member가 세션을 생성하고
@@ -86,23 +126,24 @@
   "createdAt": "2026-07-05T02:00:00Z"
 }
 ```
-**And** consult_turns 테이블에 해당 row가 존재하고 role은 'assistant'이다.
+**And** consult_turns 테이블에 해당 row가 존재한다 (Exchange 모델: question + answer가 같은 row에 저장, role 컬럼 없음).
 **And** audit_logs 테이블에 `consult.turn.create` row가 존재한다.
 
-### AC-CONS-04: Power Chat 턴 생성 실패 (citation 없음)
+### AC-CONS-04: Power Chat 턴 생성 실패 (citation 0개 또는 coverage 80% 미만)
 
 **Given** RA Member가 세션을 생성하고
 **When** POST /api/consult/sessions/:sessionId/turns를 호출하고
-**And** RAG 파이프라인이 citation을 포함하지 않은 답변을 생성하면
+**And** RAG 파이프라인이 (a) citation을 0개 포함한 답변을 생성하거나 (b) citation coverage가 80% 미만(uncitedViolationCount/totalSentences > 0.2)인 답변을 생성하면
 **Then** 시스템은 400 Bad Request와 함께 다음을 반환한다:
 ```json
 {
-  "error": "Citations required",
-  "message": "Answer must include at least one cited source"
+  "error": "citation_required",
+  "message": "Answer must include citations with coverage >= 80%"
 }
 ```
 **And** consult_turns 테이블에 새 row가 추가되지 않는다.
 **And** 세션은 turnCount=0 상태로 유지된다 (후속 재시도 가능).
+**And** citation 검증은 `lib/ai/citation-enforce.ts`의 `enforceCitations`를 재사용하여 80% 임계값을 적용한다 (TRIAGE run-triage.ts:91-94 패턴).
 
 ### AC-CONS-05: Power Chat 턴 생성 실패 (타임아웃)
 
@@ -242,7 +283,7 @@
 
 ### Functional Correctness
 
-- [ ] 모든 AC (AC-CONS-01 ~ AC-CONS-07)가 Given-When-Then 형식으로 검증됨
+- [ ] 모든 AC (AC-CONS-01 ~ AC-CONS-07, AC-CONS-02b)가 Given-When-Then 형식으로 검증됨
 - [ ] RAG 파이프라인이 consult.ts 하위 모듈을 재사용하여 회귀 리스크 완화됨
 - [ ] Citation 강제가 Charter [지양-2]를 준수하여 enforceCitations로 검증됨
 - [ ] RBAC이 v3 01_architecture.md:95를 준수하여 ra-member/ra-lead/admin 분리됨
@@ -269,7 +310,7 @@
 
 ### Observability
 
-- [ ] 모든 CRUD 작업이 audit_logs에 기록됨 (REQ-CONS-008, REQ-CONS-009, REQ-CONS-010)
+- [ ] 모든 CRUD 작업이 audit_logs에 기록됨 (REQ-CONS-008, REQ-CONS-009, REQ-CONS-010, REQ-CONS-013)
 - [ ] RAG 실패가 consult.turn.failed audit로 기록됨
 - [ ] Audit meta_json에 sessionId, turnId, confidenceScore, sourceCount 포함됨
 
@@ -279,8 +320,8 @@
 
 ### Code Complete
 
-- [ ] 모든 REQ-CONS-001 ~ REQ-CONS-012가 구현됨
-- [ ] 모든 AC-CONS-01 ~ AC-CONS-07가 Given-When-Then로 검증됨
+- [ ] 모든 REQ-CONS-001 ~ REQ-CONS-013가 구현됨 (REQ-CONS-013: consult.session.create audit log)
+- [ ] 모든 AC-CONS-01 ~ AC-CONS-07, AC-CONS-02b가 Given-When-Then로 검증됨
 - [ ] consult_sessions/turns 테이블이 migration으로 생성됨
 - [ ] run-consult.ts 래퍼가 consult.ts 하위 모듈을 재사용함
 - [ ] RBAC 권한 3종이 permissions.ts에 추가됨

--- a/.moai/specs/SPEC-V3-CONSULT-001/plan.md
+++ b/.moai/specs/SPEC-V3-CONSULT-001/plan.md
@@ -28,7 +28,7 @@ TRIAGE SPEC-V3-TRIAGE-001에서 검증된 패턴을 그대로 재사용하여 �
 
 ### Migration Strategy
 
-**Phase M1: 테이블 생성**
+**Phase M1: 테이블 생성 (Exchange 모델)**
 ```sql
 -- Migration 01_create_consult_tables.sql
 CREATE TABLE consult_sessions (
@@ -42,20 +42,21 @@ CREATE TABLE consult_sessions (
   deleted_at TIMESTAMPTZ
 );
 
+-- Exchange 모델: 한 turn = 한 Q+A pair (role 컬럼 없음)
 CREATE TABLE consult_turns (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   session_id UUID NOT NULL REFERENCES consult_sessions(id),
-  turn_number INTEGER NOT NULL,
-  role TEXT NOT NULL, -- 'user' | 'assistant'
-  question TEXT,
-  answer TEXT,
-  confidence NUMERIC(5,2) NOT NULL,
-  sources JSONB NOT NULL,
+  turn_number INTEGER NOT NULL,              -- 1, 2, 3, ... 단조 증가
+  question TEXT NOT NULL,                    -- 사용자 입력 (항상 존재)
+  answer TEXT,                                -- RAG 결과 HTML prose, 실패 시 NULL
+  citations JSONB,                            -- citation 메타데이터 배열
+  confidence REAL,                            -- 0.00 ~ 1.00, 실패 시 NULL
+  sources JSONB,                              -- RAG source 메타데이터
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX idx_consult_sessions_deleted ON consult_sessions(deleted_at) WHERE deleted_at IS NULL;
-CREATE INDEX idx_consert_turns_session ON consult_turns(session_id, turn_number);
+CREATE INDEX idx_consult_turns_session ON consult_turns(session_id, turn_number);
 ```
 
 **Phase M2: 권한 추가**
@@ -87,8 +88,8 @@ export type PermissionAction =
 **목표**: consult_sessions/turns 테이블 생성 + 기존 호환성 확인
 
 **Tasks**:
-- T-01: Drizzle migration 작성 (01_create_consult_tables.sql)
-- T-02: consult_sessions/turns 스키마 정의 (lib/db/schema.ts)
+- T-01: Drizzle migration 작성 (01_create_consult_tables.sql, Exchange 모델: consult_turns.role 컬럼 없음, question NOT NULL + answer nullable + citations jsonb + confidence real + turnNumber integer NOT NULL)
+- T-02: consult_sessions/turns 스키마 정의 (lib/db/schema.ts, Exchange 모델 반영: role 필드 제거, question/answer/citations 컬럼 구성)
 - T-03: Migration 실행 및 FK 제약조건 검증
 - T-04: 기존 conversations/messages 테이블과의 격리 확인 (v2 호환성)
 
@@ -119,7 +120,7 @@ export type PermissionAction =
 
 **Tasks**:
 - T-10: POST /api/consult/sessions 라우트 생성 (app/api/consult/sessions/route.ts)
-- T-11: consult_sessions CREATE handler (withPermission 'consult.session.create')
+- T-11: consult_sessions CREATE handler (withPermission 'consult.session.create', 성공 시 `consult.session.create` audit log 기록 — 21 CFR Part 11 §11.10(e), REQ-CONS-013. meta_json: `{sessionId, raMemberId, projectId?, locale}`)
 - T-12: GET /api/consult/sessions 라우트 생성 (withPermission 'consult.session.view')
 - T-13: consult_sessions SELECT handler (ra-member: 자신 세션만, ra-lead/admin: 전체)
 - T-14: GET /api/consult/sessions/:sessionId 라우트 생성 (RBAC 검증)
@@ -138,7 +139,7 @@ export type PermissionAction =
 - T-16: POST /api/consult/sessions/:sessionId/turns 라우트 생성
 - T-17: run-consult.ts 호출 및 JSON 직렬화
 - T-18: consult_turns INSERT handler (turnNumber 할당, FK 검증)
-- T-19: Citation 강제 검증 (empty citations → 400)
+- T-19: Citation 강제 검증 (citation 0개 또는 coverage 80% 미만 → 400, `lib/ai/citation-enforce.ts`의 `enforceCitations` 재사용, TRIAGE run-triage.ts:91-94 패턴)
 - T-20: Audit log 기록 (consult.turn.create, consult.turn.failed)
 
 **완료 기준**:
@@ -224,25 +225,25 @@ export type PermissionAction =
 
 | Task ID | Description | Priority | Dependencies | Estimate |
 |---------|-------------|----------|--------------|----------|
-| M1-T01 | Drizzle migration 작성 | High | None | M1 |
-| M1-T02 | consult_sessions/turns 스키마 정의 | High | T01 | M1 |
+| M1-T01 | Drizzle migration 작성 (Exchange 모델: role 컬럼 없음, question/answer/citations 컬럼 구성) | High | None | M1 |
+| M1-T02 | consult_sessions/turns 스키마 정의 (lib/db/schema.ts, Exchange 모델 반영) | High | T01 | M1 |
 | M1-T03 | Migration 실행 및 FK 검증 | High | T02 | M1 |
 | M1-T04 | 기존 conversations/messages 격리 확인 | High | T03 | M1 |
 | M2-T05 | run-consult.ts 래퍼 생성 | High | None | M2 |
 | M2-T06 | consult.ts 하위 모듈 import | High | T05 | M2 |
 | M2-T07 | 15s timeout 구현 | High | T06 | M2 |
-| M2-T08 | Citation 검증 구현 | High | T07 | M2 |
+| M2-T08 | Citation 검증 구현 (enforceCitations 80% coverage 임계값 포함) | High | T07 | M2 |
 | M2-T09 | RAG result → DTO 매핑 | High | T08 | M2 |
 | M3-T10 | POST /api/consult/sessions 라우트 생성 | High | M1 | M3 |
-| M3-T11 | consult_sessions CREATE handler | High | T10 | M3 |
+| M3-T11 | consult_sessions CREATE handler + consult.session.create audit log 기록 (REQ-CONS-013) | High | T10 | M3 |
 | M3-T12 | GET /api/consult/sessions 라우트 생성 | High | T11 | M3 |
 | M3-T13 | consult_sessions SELECT handler | High | T12 | M3 |
 | M3-T14 | GET /api/consult/sessions/:sessionId 라우트 생성 | High | T13 | M3 |
 | M3-T15 | consult_sessions + turns JOIN handler | High | T14 | M3 |
 | M4-T16 | POST /api/consult/sessions/:sessionId/turns 라우트 생성 | High | M2, M3 | M4 |
 | M4-T17 | run-consult.ts 호출 및 JSON 직렬화 | High | T16 | M4 |
-| M4-T18 | consult_turns INSERT handler | High | T17 | M4 |
-| M4-T19 | Citation 강제 검증 | High | T18 | M4 |
+| M4-T18 | consult_turns INSERT handler (Exchange 모델: question+answer 같은 row) | High | T17 | M4 |
+| M4-T19 | Citation 강제 검증 (citation 0개 또는 coverage 80% 미만, enforceCitations 재사용) | High | T18 | M4 |
 | M4-T20 | Audit log 기록 (turn) | High | T19 | M4 |
 | M5-T21 | DELETE /api/consult/sessions/:sessionId 라우트 생성 | Medium | M3, M4 | M5 |
 | M5-T22 | Soft-delete handler | Medium | T21 | M5 |
@@ -264,8 +265,9 @@ export type PermissionAction =
 - `lib/domains/consult/run-consult.test.ts`:
   - Timeout test: 15s 초과 시 error: 'timeout' 반환
   - Citation test: empty citations → error: 'no_citations'
+  - Citation coverage test: uncitedViolationCount/totalSentences > 0.2 → error: 'citation_coverage_below_80' (enforceCitations 80% 임계값)
   - Runtime error test: LLM failure → error: 'runtime_error'
-  - Normal flow test: RAG 성공 → {answer, confidence, sources} 반환
+  - Normal flow test: RAG 성공 → {answer, confidence, sources, citations} 반환
 
 - `lib/db/schema.test.ts`:
   - FK 제약조건 test: consult_turns.session_id → consult_sessions.id
@@ -274,9 +276,9 @@ export type PermissionAction =
 ### Integration Tests (Target: 모든 AC 커버)
 
 - `app/api/consult/sessions/route.test.ts`:
-  - POST /api/consult/sessions: 201 Created (AC-CONS-01)
+  - POST /api/consult/sessions: 201 Created (AC-CONS-01, REQ-CONS-013 audit 단언 포함)
   - GET /api/consult/sessions: 200 OK + 세션 목록 (AC-CONS-02)
-  - GET /api/consult/sessions/:sessionId: 200 OK + turns 배열 (AC-CONS-03)
+  - GET /api/consult/sessions/:sessionId: 200 OK + turns 배열 (AC-CONS-02b 직접 검증, REQ-CONS-003 positive AC)
   - RBAC test: 403 Forbidden (Edge-08, Edge-09)
 
 - `app/api/consult/sessions/[id]/turns/route.test.ts`:

--- a/.moai/specs/SPEC-V3-CONSULT-001/plan.md
+++ b/.moai/specs/SPEC-V3-CONSULT-001/plan.md
@@ -1,0 +1,367 @@
+# Implementation Plan — SPEC-V3-CONSULT-001
+
+**작성일**: 2026-07-05
+**SPEC**: SPEC-V3-CONSULT-001 (RA Power Chat, v3 Phase C-5)
+**의존**: SPEC-V3-TRIAGE-001 (완료)
+**예상 작업 기간**: Priority High (M1..M6, 20-25 tasks)
+
+---
+
+## Technical Approach
+
+### RAG 파이프라인 재사용 전략
+
+TRIAGE SPEC-V3-TRIAGE-001에서 검증된 패턴을 그대로 재사용하여 회귀 리스크를 최소화합니다:
+
+1. **run-consult.ts 래퍼 생성** (run-triage.ts 패턴)
+   - consult.ts 하위 모듈 재사용: classifyIntent, parallelRetrieveAndMerge, composePrompt, streamText, enforceCitations, calculateConfidence
+   - 15s timeout: AbortController + Promise.race
+   - Citation 검증: empty citations → error
+
+2. **SSE → JSON 변환**
+   - consult.ts async generator를 소비하여 JSON 직렬화
+   - StreamEvent 집계: prose_delta → full prose, sources 배열, confidence
+
+3. **DB 스키마 설계**
+   - consult_sessions: 5년 soft-delete (deletedAt)
+   - consult_turns: turnNumber 누적, FK sessionId → consult_sessions.id
+
+### Migration Strategy
+
+**Phase M1: 테이블 생성**
+```sql
+-- Migration 01_create_consult_tables.sql
+CREATE TABLE consult_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ra_member_id UUID NOT NULL REFERENCES users(id),
+  project_id UUID REFERENCES projects(id),
+  title TEXT NOT NULL,
+  locale TEXT NOT NULL DEFAULT 'ko',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE TABLE consult_turns (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id UUID NOT NULL REFERENCES consult_sessions(id),
+  turn_number INTEGER NOT NULL,
+  role TEXT NOT NULL, -- 'user' | 'assistant'
+  question TEXT,
+  answer TEXT,
+  confidence NUMERIC(5,2) NOT NULL,
+  sources JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_consult_sessions_deleted ON consult_sessions(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX idx_consert_turns_session ON consult_turns(session_id, turn_number);
+```
+
+**Phase M2: 권한 추가**
+```typescript
+// lib/auth/permissions.ts
+export type PermissionAction =
+  // ... existing
+  | 'consult.session.create'
+  | 'consult.session.view'
+  | 'consult.session.delete'
+  | 'consult.turn.create';
+```
+
+### RBAC Matrix
+
+| 권한 | ra-member | ra-lead | admin | employee/viewer |
+|------|-----------|---------|-------|------------------|
+| consult.session.create | ✅ | ✅ | ✅ | ❌ |
+| consult.session.view | 자신 세션만 | 전체 | 전체 | ❌ |
+| consult.session.delete | 자신 세션만 | 전체 | 전체 | ❌ |
+| consult.turn.create | ✅ (자신 세션) | ✅ (전체) | ✅ (전체) | ❌ |
+
+---
+
+## Implementation Milestones
+
+### M1: Database Schema & Foundation (Priority High)
+
+**목표**: consult_sessions/turns 테이블 생성 + 기존 호환성 확인
+
+**Tasks**:
+- T-01: Drizzle migration 작성 (01_create_consult_tables.sql)
+- T-02: consult_sessions/turns 스키마 정의 (lib/db/schema.ts)
+- T-03: Migration 실행 및 FK 제약조건 검증
+- T-04: 기존 conversations/messages 테이블과의 격리 확인 (v2 호환성)
+
+**완료 기준**:
+- Migration이 성공적으로 적용되고 rollback 가능
+- consult_sessions/turns 테이블이 정상적으로 생성됨
+- 기존 /api/ra/consult가 여전히 동작함 (regression test)
+
+### M2: RAG Pipeline Wrapper (Priority High)
+
+**목표**: run-consult.ts 래퍼 구현 (TRIAGE 패턴 재사용)
+
+**Tasks**:
+- T-05: run-consult.ts 래퍼 생성 (lib/domains/consult/run-consult.ts)
+- T-06: consult.ts 하위 모듈 import (classifyIntent, parallelRetrieveAndMerge, etc.)
+- T-07: 15s timeout 구현 (AbortController + Promise.race)
+- T-08: Citation 검증 구현 (empty citations → error)
+- T-09: RAG result → consult_turns DTO 매핑
+
+**완료 기준**:
+- run-consult.ts가 consult.ts 하위 모듈을 성공적으로 재사용함
+- Unit test: timeout, citation 검증, 런타임 에러 핸들링
+- run-triage.ts와 동일한 패턴으로 회귀 리스크 완화
+
+### M3: Session CRUD API (Priority High)
+
+**목표**: POST/GET /api/consult/sessions + GET /api/consult/sessions/:id 구현
+
+**Tasks**:
+- T-10: POST /api/consult/sessions 라우트 생성 (app/api/consult/sessions/route.ts)
+- T-11: consult_sessions CREATE handler (withPermission 'consult.session.create')
+- T-12: GET /api/consult/sessions 라우트 생성 (withPermission 'consult.session.view')
+- T-13: consult_sessions SELECT handler (ra-member: 자신 세션만, ra-lead/admin: 전체)
+- T-14: GET /api/consult/sessions/:sessionId 라우트 생성 (RBAC 검증)
+- T-15: consult_sessions + turns JOIN handler (turnCount 서브쿼리)
+
+**완료 기준**:
+- Integration test: 3종 API endpoint 정상 동작
+- RBAC 검증: ra-member/ra-lead/admin 권한 분리 정확
+- Zod validation: title 필수, UUID 형식 검증
+
+### M4: Turn Creation API (Priority High)
+
+**목표**: POST /api/consult/sessions/:sessionId/turns 구현
+
+**Tasks**:
+- T-16: POST /api/consult/sessions/:sessionId/turns 라우트 생성
+- T-17: run-consult.ts 호출 및 JSON 직렬화
+- T-18: consult_turns INSERT handler (turnNumber 할당, FK 검증)
+- T-19: Citation 강제 검증 (empty citations → 400)
+- T-20: Audit log 기록 (consult.turn.create, consult.turn.failed)
+
+**완료 기준**:
+- Integration test: 턴 생성 성공 (AC-CONS-03)
+- Integration test: citation 없는 답변 거부 (AC-CONS-04)
+- Integration test: 타임아웃 핸들링 (AC-CONS-05)
+
+### M5: Session Deletion API (Priority Medium)
+
+**목표**: DELETE /api/consult/sessions/:sessionId 구현 (soft-delete)
+
+**Tasks**:
+- T-21: DELETE /api/consult/sessions/:sessionId 라우트 생성
+- T-22: Soft-delete handler (deletedAt = NOW(), NOT DELETE)
+- T-23: RBAC 검증 (ra-member: 자신 세션만, ra-lead/admin: 전체)
+- T-24: Audit log 기록 (consult.session.delete)
+
+**완료 기준**:
+- Integration test: soft-delete 동작 (AC-CONS-06)
+- Integration test: RBAC 권한 분리 (AC-CONS-07)
+- Deleted 세션이 조회되지 않음 (404)
+
+### M6: Retention Policy & QA (Priority Low)
+
+**목표**: 5년 보관 정책 문서화 + E2E test
+
+**Tasks**:
+- T-25: 5년 보관 정책 문서화 (run phase에서 cron job 구현 여부 결정)
+- T-26: E2E test: RA Member가 세션 생성 → 턴 생성 → 세션 삭제 흐름
+- T-27: Regression test: 기존 /api/ra/consult 여전히 동작
+- T-28: API 문서화 (Swagger/OpenAPI spec 업데이트)
+
+**완료 기준**:
+- E2E test 패스
+- Regression test 패스
+- API 문서 완료
+
+---
+
+## Risk Management
+
+### HIGH Risks
+
+**R-01: 기존 /api/ra/consult 깨짐**
+- 완화: v3 API 경로 분리 (/api/consult/sessions), 기존 1-shot streaming 유지
+- 계획: T-27 regression test로 확인
+
+**R-02: consult_sessions/turns FK 제약조건 위배**
+- 완화: Migration T-03에서 FK 검증, run-consult.ts에서 transaction 롤백
+- 계획: T-03 FK 검증, T-18 transaction 핸들링
+
+**R-03: RBAC 권한 누수**
+- 완화: withPermission 미들웨어 사용, 테스트 커버리지 100%
+- 계획: T-13, T-14, T-23 RBAC 검증 테스트
+
+### MEDIUM Risks
+
+**R-04: RAG 파이프라인 회귀**
+- 완화: TRIAGE 패턴 재사용, consult.ts 하위 모듈만 호출
+- 계획: T-06 하위 모듈 import 검증, T-09 unit test
+
+**R-05: Turn 번호 누적 오류**
+- 완화: MAX(turnNumber) + 1 할당, transaction 격리
+- 계획: T-18 turnNumber 할당 로직 검증
+
+**R-06: Soft-delete 된 세션 참조**
+- 완화: deleted_at IS NULL 필터 추가
+- 계획: T-13, T-14 SELECT에 WHERE deleted_at IS NULL 추가
+
+### LOW Risks
+
+**R-07: 5년 보관 cron job 미구현**
+- 완화: 본 SPEC은 API contract만 명시, run phase에서 구현 여부 결정
+- 계획: T-25 문서화로 대체
+
+**R-08: 성능 저하 (turns JOIN)**
+- 완화: 인덱스 생성 (idx_consult_turns_session)
+- 계획: T-15 서브쿼리 최적화
+
+---
+
+## Task Breakdown (20-28 tasks)
+
+| Task ID | Description | Priority | Dependencies | Estimate |
+|---------|-------------|----------|--------------|----------|
+| M1-T01 | Drizzle migration 작성 | High | None | M1 |
+| M1-T02 | consult_sessions/turns 스키마 정의 | High | T01 | M1 |
+| M1-T03 | Migration 실행 및 FK 검증 | High | T02 | M1 |
+| M1-T04 | 기존 conversations/messages 격리 확인 | High | T03 | M1 |
+| M2-T05 | run-consult.ts 래퍼 생성 | High | None | M2 |
+| M2-T06 | consult.ts 하위 모듈 import | High | T05 | M2 |
+| M2-T07 | 15s timeout 구현 | High | T06 | M2 |
+| M2-T08 | Citation 검증 구현 | High | T07 | M2 |
+| M2-T09 | RAG result → DTO 매핑 | High | T08 | M2 |
+| M3-T10 | POST /api/consult/sessions 라우트 생성 | High | M1 | M3 |
+| M3-T11 | consult_sessions CREATE handler | High | T10 | M3 |
+| M3-T12 | GET /api/consult/sessions 라우트 생성 | High | T11 | M3 |
+| M3-T13 | consult_sessions SELECT handler | High | T12 | M3 |
+| M3-T14 | GET /api/consult/sessions/:sessionId 라우트 생성 | High | T13 | M3 |
+| M3-T15 | consult_sessions + turns JOIN handler | High | T14 | M3 |
+| M4-T16 | POST /api/consult/sessions/:sessionId/turns 라우트 생성 | High | M2, M3 | M4 |
+| M4-T17 | run-consult.ts 호출 및 JSON 직렬화 | High | T16 | M4 |
+| M4-T18 | consult_turns INSERT handler | High | T17 | M4 |
+| M4-T19 | Citation 강제 검증 | High | T18 | M4 |
+| M4-T20 | Audit log 기록 (turn) | High | T19 | M4 |
+| M5-T21 | DELETE /api/consult/sessions/:sessionId 라우트 생성 | Medium | M3, M4 | M5 |
+| M5-T22 | Soft-delete handler | Medium | T21 | M5 |
+| M5-T23 | RBAC 검증 (삭제) | Medium | T22 | M5 |
+| M5-T24 | Audit log 기록 (session.delete) | Medium | T23 | M5 |
+| M6-T25 | 5년 보관 정책 문서화 | Low | M5 | M6 |
+| M6-T26 | E2E test: 전체 흐름 | Low | T25 | M6 |
+| M6-T27 | Regression test: 기존 /api/ra/consult | Low | T26 | M6 |
+| M6-T28 | API 문서화 | Low | T27 | M6 |
+
+**총 Task**: 28 tasks (예상)
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Target: 85%+ coverage)
+
+- `lib/domains/consult/run-consult.test.ts`:
+  - Timeout test: 15s 초과 시 error: 'timeout' 반환
+  - Citation test: empty citations → error: 'no_citations'
+  - Runtime error test: LLM failure → error: 'runtime_error'
+  - Normal flow test: RAG 성공 → {answer, confidence, sources} 반환
+
+- `lib/db/schema.test.ts`:
+  - FK 제약조건 test: consult_turns.session_id → consult_sessions.id
+  - Soft-delete test: deleted_at IS NULL 필터
+
+### Integration Tests (Target: 모든 AC 커버)
+
+- `app/api/consult/sessions/route.test.ts`:
+  - POST /api/consult/sessions: 201 Created (AC-CONS-01)
+  - GET /api/consult/sessions: 200 OK + 세션 목록 (AC-CONS-02)
+  - GET /api/consult/sessions/:sessionId: 200 OK + turns 배열 (AC-CONS-03)
+  - RBAC test: 403 Forbidden (Edge-08, Edge-09)
+
+- `app/api/consult/sessions/[id]/turns/route.test.ts`:
+  - POST /api/consult/sessions/:sessionId/turns: 201 Created (AC-CONS-03)
+  - Citation 없는 답변: 400 Bad Request (AC-CONS-04)
+  - Timeout: 400 Bad Request (AC-CONS-05)
+
+- `app/api/consult/sessions/[id]/route.test.ts`:
+  - DELETE /api/consult/sessions/:sessionId: 200 OK (AC-CONS-06)
+  - RBAC test: 403 Forbidden (AC-CONS-07, Edge-04, Edge-09)
+
+### E2E Tests (Target: 핵심 흐름)
+
+- `tests/e2e/consult-flow.spec.ts`:
+  - RA Member 로그인 → 세션 생성 → 턴 생성 → 세션 삭제
+  - RA Lead 로그인 → 팀원 세션 삭제
+  - Employee 로그인 → 403 Forbidden (Edge-08)
+
+### Regression Tests (Target: v2 호환성)
+
+- `tests/e2e/legacy-consult.spec.ts`:
+  - POST /api/ra/consult (1-shot streaming) 여전히 동작
+  - consult.ts async generator SSE stream 깨지지 않음
+
+---
+
+## Code Authority Verification Checklist
+
+### L-013 직검 요구사항 준수
+
+본 plan.md의 모든 코드 인용은 main HEAD 기준 직검입니다:
+- `lib/ai/consult.ts`: 831줄 (@MX:ANCHOR 확인 완료)
+- `app/api/ra/consult/route.ts`: 262줄 (withPermission 'consult.create' 확인 완료)
+- `lib/domains/triage/run-triage.ts`: 100줄 (@MX:ANCHOR 확인 완료)
+- `lib/db/schema.ts`: 100줄 (pgEnum, pgTable 패턴 확인 완료)
+- `lib/auth/permissions.ts`: 79줄 (consult.create 권한 확인 완료)
+
+### Runtime grep 검증 (run phase 시행)
+
+- **consult.ts fan_in >= 3**: `grep -r "from.*consult" app/ lib/ | wc -l` (예상 >= 3)
+- **run-triage.ts 재사용 패턴**: `grep -r "from.*run-triage" app/ lib/ | wc -l` (예상 0, 본 SPEC에서 생성)
+- **기존 /api/ra/consult 호출처**: `grep -r "api/ra/consult" app/` (예상 1: route.ts만)
+- **permissions.ts consult 권한**: `grep -A 5 "consult.create" lib/auth/permissions.ts` (확인 완료)
+
+### manager-strategy 보고 수치 검증
+
+Run phase에서 다음 수치를 runtime grep으로 검증합니다:
+- consult_sessions/turns 테이블 생성 확인: `drizzle-kit push`
+- run-consult.ts 생성 확인: `ls -la lib/domains/consult/run-consult.ts`
+- API 라우트 생성 확인: `ls -la app/api/consult/sessions/`
+
+---
+
+## Definition of Done
+
+### M1 완료 기준
+- [ ] Migration이 성공적으로 적용되고 rollback 가능
+- [ ] consult_sessions/turns 테이블이 정상적으로 생성됨
+- [ ] 기존 /api/ra/consult가 여전히 동작함 (regression test)
+
+### M2 완료 기준
+- [ ] run-consult.ts가 consult.ts 하위 모듈을 성공적으로 재사용함
+- [ ] Unit test: timeout, citation 검증, 런타임 에러 핸들링
+- [ ] run-triage.ts와 동일한 패턴으로 회귀 리스크 완화
+
+### M3 완료 기준
+- [ ] Integration test: 3종 API endpoint 정상 동작
+- [ ] RBAC 검증: ra-member/ra-lead/admin 권한 분리 정확
+- [ ] Zod validation: title 필수, UUID 형식 검증
+
+### M4 완료 기준
+- [ ] Integration test: 턴 생성 성공 (AC-CONS-03)
+- [ ] Integration test: citation 없는 답변 거부 (AC-CONS-04)
+- [ ] Integration test: 타임아웃 핸들링 (AC-CONS-05)
+
+### M5 완료 기준
+- [ ] Integration test: soft-delete 동작 (AC-CONS-06)
+- [ ] Integration test: RBAC 권한 분리 (AC-CONS-07)
+- [ ] Deleted 세션이 조회되지 않음 (404)
+
+### M6 완료 기준
+- [ ] E2E test 패스
+- [ ] Regression test 패스
+- [ ] API 문서 완료
+
+---
+
+**본 plan.md는 SPEC-V3-CONSULT-001 plan phase 산출물의 일부입니다.**

--- a/.moai/specs/SPEC-V3-CONSULT-001/research.md
+++ b/.moai/specs/SPEC-V3-CONSULT-001/research.md
@@ -1,0 +1,488 @@
+# Research Document — SPEC-V3-CONSULT-001
+
+**작성일**: 2026-07-05
+**분석 대상**: RA Power Chat (v3 Phase C-5)
+**의존 SPEC**: SPEC-V3-TRIAGE-001 (just merged, Phase C-2)
+
+---
+
+## 1. 기존 코드베이스 분석
+
+### 1.1 `lib/ai/consult.ts` (현재 1-shot streaming RAG)
+
+**직검 라인 수**: 831줄
+**핵심 구조**: 8-stage async generator (SSE 제공)
+
+```typescript
+// Stage 1: Intent classification (classifyIntent)
+// Stage 2: Query rewrite (rewriteQuery)
+// Stage 3: Multi-corpus retrieval (classifyAndRoute + parallelRetrieveAndMerge)
+// Stage 4: Extract relevant sections (noop, reranker deferred)
+// Stage 5: Prompt composition (composePrompt + project-memory injection)
+// Stage 6: LLM streaming (streamText)
+// Stage 7: Post-process (enforceCitations + calculateConfidence)
+// Stage 8: Persist (persistMessage to conversations/messages)
+// Stage 9: Capture knowledge gap (captureKnowledgeGap)
+// Stage 10: Project memory extraction (detectDecisions + persistSuggestionsAsPending)
+```
+
+**@MX:ANCHOR 확인**:
+- Line 1: `@MX:ANCHOR RAG pipeline entry point — 8-stage async generator yielding StreamEvents`
+- fan_in >= 3: route.ts, tests, future scheduled tasks
+
+**SSE 이벤트 순서** (consult.ts:101):
+```typescript
+// Phase A: meta → trace*(N)
+// Phase B: prose_delta*(M)
+// Phase C: confidence → sources → [expert_review_required?] → structured blocks → done
+```
+
+**현재 DB 스키마 사용** (consult.ts:19):
+```typescript
+import { conversations, messageBlocks, messages } from '../db/schema';
+```
+
+**주요 side-effects**:
+- `writeAudit` (llm.call, source.access, expert_review.flag)
+- `persistMessage` (conversations/messages INSERT)
+- `captureKnowledgeGap` (unanswered_queue INSERT)
+- `enqueueExpertReview` (expert_reviews INSERT)
+- `persistSuggestionsAsPending` (project_memory INSERT)
+
+**replay mode 지원** (consult.ts:69-75):
+```typescript
+export type ConsultOptions = {
+  mode?: 'replay'; // Skips DB-writing side effects for knowledge-gap replay
+};
+```
+
+### 1.2 `app/api/ra/consult/route.ts` (현재 1회성 스트리밍)
+
+**직검 라인 수**: 262줄
+**핵심 기능**: POST /api/ra/consult (SSE stream)
+
+**RBAC** (route.ts:134):
+```typescript
+export const POST = withPermission('consult.create', async (req, _ctx, session) => {
+```
+
+**Rate limiting** (route.ts:100-123):
+```typescript
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_MAX = 30;
+const RATE_LIMIT_WINDOW_MS = 60_000; // 30 req / 60s per user
+```
+
+**E2E test mode** (route.ts:24-98):
+```typescript
+// Deterministic fake SSE stream — no LLM calls
+// Yields real conversationId/messageId so expert-review FK constraints are satisfied
+```
+
+**현재 응답 contract**:
+```typescript
+// SSE StreamEvent stream:
+// { type: 'meta', conversationId, messageId }
+// { type: 'trace', step, status }*
+// { type: 'prose_delta', delta }*
+// { type: 'confidence', level, score }
+// { type: 'sources', items[] }
+// { type: 'expert_review_required', reason }?
+// { type: 'done', duration_ms }
+```
+
+### 1.3 `lib/domains/triage/run-triage.ts` (TRIAGE RAG 패턴 참조)
+
+**직검 라인 수**: 100줄 (일부)
+**핵심 패턴**: consult.ts 하위 모듈 재사용 + 15s timeout
+
+**@MX:ANCHOR 확인**:
+- Line 1-8: `runTriage — TRIAGE RAG pipeline entry point`
+- fan_in >= 3: /api/ask, future auto-triage, integration tests
+
+**재사용 모듈** (run-triage.ts:11-21):
+```typescript
+import { enforceCitations } from '@/lib/ai/citation-enforce';
+import { calculateConfidence } from '@/lib/ai/confidence';
+import { classifyIntent } from '@/lib/ai/intent';
+import { parallelRetrieveAndMerge } from '@/lib/ai/merge';
+import { composePrompt } from '@/lib/ai/prompt-templates';
+import { classifyAndRoute } from '@/lib/ai/router';
+```
+
+**타임아웃 패턴** (run-triage.ts:51-79):
+```typescript
+const timeoutMs = getEnv().TRIAGE_TIMEOUT_MS;
+const controller = new AbortController();
+const timeoutPromise = new Promise<TriageResult>((resolve) => {
+  timeoutId = setTimeout(() => {
+    controller.abort();
+    resolve({ autoAnswer: null, autoConfidence: null, error: 'timeout' });
+  }, timeoutMs);
+});
+return await Promise.race([runPipeline(input, controller.signal), timeoutPromise]);
+```
+
+**회귀 리스크 완화**:
+- TRIAGE run-triage.ts는 consult.ts와 동일한 하위 모듈을 호출
+- AC-06 (citation 강제) 직접 이행: `citations.length === 0` → `no_citations` error
+- timeout 시 `auto` state 유지 (fallback 전략)
+
+### 1.4 `lib/db/schema.ts` (현재 conversations/messages 테이블)
+
+**직검 라인 수**: 100줄 (일부)
+**테이블 인벤토리**: 18 tables + 11 pgEnums
+
+**현재 conversations 스키마** (schema.ts inferred from consult.ts usage):
+```typescript
+// conversations: { id, userId, projectId, title, createdAt, updatedAt }
+// messages: { id, conversationId, role, contentProse, ... }
+```
+
+**v3 docs 기반 신규 테이블 요구사항** (02_data_model.md:238):
+```markdown
+- `consult_sessions` + `consult_turns` (Power Chat 저장)
+- 보관 기간: 5년 (RA 개인 리서치 · 명시적 삭제 허용)
+```
+
+**비교표**:
+| 테이블 | 기존 (v2) | 신규 (v3) | 보관 정책 |
+|--------|---------|---------|----------|
+| conversations | ✅ 사용 중 | ❌ 미사용 | N/A |
+| messages | ✅ 사용 중 | ❌ 미사용 | N/A |
+| consult_sessions | ❌ 없음 | ✅ 신규 | 5년 |
+| consult_turns | ❌ 없음 | ✅ 신규 | 5년 |
+
+### 1.5 `lib/auth/permissions.ts` (RBAC 권한)
+
+**직검 라인 수**: 79줄
+**현재 consult 관련 권한** (permissions.ts:8):
+```typescript
+export type PermissionAction =
+  | 'consult.create'  // 기존: POST /api/ra/consult
+  // ...
+```
+
+**v3 요구사항** (01_architecture.md:95, 03_api_contract.md:148-149):
+```markdown
+### GET/POST /api/consult/sessions
+### GET /api/consult/sessions/:id
+### POST /api/consult/sessions/:id/turns
+Power Chat CRUD.
+
+## 3.1 RBAC
+`/api/consult` 권한 `ra-member`/`ra-lead`/`admin`.
+```
+
+**필요한 신규 권한 추론**:
+- `consult.session.create` (세션 생성)
+- `consult.session.view` (세션 조회)
+- `consult.turn.create` (턴 생성)
+- 기존 `consult.create` 유지 또는 재정의
+
+### 1.6 데이터 보관 정책 비교
+
+**기존 테이블 보관 정책** (02_data_model.md:252):
+| 테이블 | 보관 기간 | 근거 |
+|---|---|---|
+| `audit_log` | 10년 | 21 CFR Part 11 + MDR Art. 10(8) |
+| `inbox_tickets` (closed) | 7년 | ISO 13485 §4.2.5 |
+| `approved_answers` | 7년 | 위와 동일 |
+| `consult_sessions` | **5년** | **RA 개인 리서치 · 명시적 삭제 허용** |
+
+**audit_logs 10년 보관 패턴 재사용 가능성**:
+- `lib/cron/retention/` 패키지 확인 필요
+- cron job 또는 audit_retention 테이블 패턴 참조
+
+---
+
+## 2. TRIAGE SPEC 구조 참조
+
+### 2.1 SPEC-V3-TRIAGE-001 spec.md 구조
+
+**직검 라인 수**: 100줄 (일부)
+**문서 섹션**:
+```markdown
+## §1 Purpose (목적)
+### 1.1 배경 (Background)
+### 1.2 페르소나 (Personas)
+### 1.3 규제·정책 근거 (Policy Anchor)
+### 1.4 본 SPEC의 범위 (In Scope)
+### 1.5 Out of Scope
+
+## §2 Requirements (EARS Format)
+### RAG 주입 / 자동 답변
+### 응답 계약
+### 감사 로그
+
+## §3 Acceptance Criteria
+```
+
+**EARS 패턴 예시** (spec.md:88-90):
+```markdown
+| REQ-TRI-001 | **WHEN** `/api/ask`가 티켓을 생성한 후 **THEN** the system **SHALL** ...
+| REQ-TRI-002 | **IF** 산출된 `auto_answer`가 존재하나 `citations.length === 0`인 경우 **THEN** the system **SHALL** ...
+```
+
+### 2.2 SPEC-V3-TRIAGE-001 acceptance.md 구조
+
+**GWT 패턴 예시**:
+```markdown
+### AC-TRI-01: /api/ask 자동 답변 주입 성공
+**Given** 사용자가 유효한 `/api/ask` 요청을 보내면
+**When** TRIAGE RAG 파이프라인이 citation을 포함한 답변을 성공적으로 산출하면
+**Then** 시스템은 201 Created와 함께 `{ticketId, triageState: 'needs-review', autoAnswer, autoConfidence}`를 반환한다
+```
+
+---
+
+## 3. 핵심 설계 결정 후보 분석
+
+### 3.1 세션 영속성: 기존 vs 신규 테이블
+
+**옵션 A: 기존 conversations/messages 재사용**
+- 장점: migration 불필요, 기존 consult.ts 그대로 사용
+- 단점: v3 docs 명시적 요구사항 위배 (consult_sessions/turns), RA 전용 Power Chat 개념 모호
+
+**옵션 B: 신규 consult_sessions/turns 테이블 (migration 필요)**
+- 장점: v3 docs 준수, RA 전용 세션 격리, 5년 보관 정책 명확
+- 단점: migration 비용, consult.ts DB 스키마 수정
+
+**권장**: 옵션 B (v3 docs가 single source of truth)
+
+### 3.2 RAG 파이프라인: consult.ts 재사용 vs run-consult.ts
+
+**옵션 A: consult.ts async generator 직접 소비 + 세션 저장 래퍼**
+- 장점: 기존 8-stage 검증됨, TRIAGE 패턴과 동일
+- 단점: SSE 변환 로직 중복, async generator → JSON 변환 overhead
+
+**옵션 B: run-consult.ts 신규 래퍼 (run-triage.ts 패턴)**
+- 장점: TRIAGE와 동일한 패턴, timeout/citation 검증 패턴 재사용, 회귀 리스크 낮음
+- 단점: consult.ts와 중복 코드 발생 가능성
+
+**권장**: 옵션 B (run-consult.ts 래퍼 + consult.ts 하위 모듈 재사용)
+
+### 3.3 권한: consult.create 확장 vs 신규 권한
+
+**옵션 A: 기존 consult.create 확장**
+- 장점: 권한 스키마 안정적
+- 단점: 세션/턴 CRUD 세분화 불명확
+
+**옵션 B: 신규 권한 3종 (session.create, session.view, turn.create)**
+- 장점: v3 API contract 명확히 반영
+- 단점: RBAC matrix 확장
+
+**권장**: 옵션 B (v3 API contract 준수)
+
+### 3.4 보관 정책: 5년 cron 구현
+
+**기존 패턴**: audit_logs 10년 보관
+- `lib/cron/retention/` 패키지 확인 필요
+- cron job 또는 audit_retention 테이블 패턴 참조
+
+**구현 방법 후보**:
+1. cron job (매일 자정 run, deletedAt < 5년 ago DELETE)
+2. audit_retention 테이블 패턴 (retention_year 컬럼)
+3. 수동 정책 (문서화만, run phase 미구현)
+
+**권장**: run phase에서 구현 여부 결정 (plan phase에서는 API contract만 명시)
+
+### 3.5 citation 강제: Charter [지양-2] 준수
+
+**기존 consult.ts 패턴** (consult.ts:342-362):
+```typescript
+const { cleaned, violations } = enforceCitations(fullProse, availableSources);
+const uncitedViolationCount = violations.filter((v) => v.type === 'CLAIM_UNCITED').length;
+const citationCoverageBelow80 = totalSentences > 0 && uncitedViolationCount / totalSentences > 0.2;
+```
+
+**TRIAGE AC-06 직접 이행 패턴** (run-triage.ts:91-94):
+```typescript
+if (mergedResults.length === 0) {
+  return { autoAnswer: null, autoConfidence: null, error: 'no_citations' };
+}
+```
+
+**권장**: TRIAGE 패턴 준용 (citation 없는 답변 저장 거부)
+
+---
+
+## 4. v3 데이터 모델 추론
+
+### 4.1 consult_sessions 테이블 (추론)
+
+```typescript
+// schema.ts 예상 (run phase에서 확정)
+export const consultSessions = pgTable('consult_sessions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  raMemberId: uuid('ra_member_id').notNull().references(() => users.id), // 생성자
+  projectId: uuid('project_id').references(() => projects.id), // optional (프로젝트 context)
+  title: text('title').notNull(), // 세션 제목 (사용자 입력 or LLM 생성)
+  locale: localeEnum('locale').notNull().default('ko'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  deletedAt: timestamp('deleted_at'), // 명시적 삭제 허용 (5년 보관 정책과 연계)
+});
+```
+
+### 4.2 consult_turns 테이블 (추론)
+
+```typescript
+// schema.ts 예상 (run phase에서 확정)
+export const consultTurns = pgTable('consult_turns', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  sessionId: uuid('session_id').notNull().references(() => consultSessions.id),
+  turnNumber: integer('turn_number').notNull(), // 1, 2, 3, ...
+  role: messageRoleEnum('role').notNull(), // 'user' | 'assistant'
+  question: text('question'), // user role only
+  answer: text('answer'), // assistant role only (HTML prose)
+  confidence: numeric('confidence').notNull(), // 0.00 ~ 1.00
+  sources: jsonb('sources').$type<SourceItem[]>(), // 메타데이터
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+```
+
+**messages vs consult_turns 차이**:
+| 컬럼 | messages (v2) | consult_turns (v3) |
+|------|---------------|---------------------|
+| conversationId | ✅ | ❌ sessionId |
+| role | ✅ | ✅ |
+| contentProse | ✅ | ❌ answer/answer 분리 |
+| confidence | ✅ | ✅ |
+| sources | ❌ message_sources 테이블 | ✅ JSONB 직렬 |
+| turnNumber | ❌ | ✅ |
+
+---
+
+## 5. 기술 위험도 평가
+
+### 5.1 회귀 리스크
+
+**HIGH**: 기존 `/api/ra/consult` 깨짐 방지
+- mitigation: v3 API는 신규 경로 (`/api/consult/sessions`)로 분리
+- 기존 1-shot streaming은 v2 API로 유지 (호환성 보장)
+
+**MEDIUM**: consult.ts DB 스키마 호환성
+- mitigation: run-consult.ts 래퍼 사용, consult.ts는 기존 스키마 그대로
+
+**MEDIUM**: TRIAGE 패턴과의 모호성
+- mitigation: TRIAGE는 inbox_tickets, CONSULT는 consult_sessions (명확히 격리)
+
+### 5.2 성능 리스크
+
+**MEDIUM**: consult_sessions/turns JOIN 성능
+- mitigation: sessionId index, turnNumber index
+
+**LOW**: 5년 보관 정책 cron job 영향
+- mitigation: deletedAt < 5년 ago 쿼리 튜닝
+
+### 5.3 보안 리스크
+
+**HIGH**: RA Lead만 세션 삭제 허용 (명시적 삭제)
+- mitigation: `consult.session.delete` 권한 ra-lead 전용
+
+**MEDIUM**: 프로젝트 context 누출
+- mitigation: projectId RBAC 검증
+
+---
+
+## 6. Product Charter 참조
+
+### 6.1 [지양-2] citation 강제
+
+**Charter 인용**:
+> "모든 답변은 출처(source/provenance)를 명확히 제시해야 한다."
+
+**SPEC 구현**:
+- enforceCitations 재사용 (consult.ts:342)
+- citation 없는 답변 저장 거부 (AC-XX)
+
+### 6.2 [지양-4] RA Lead 승인
+
+**Charter 인용**:
+> "자동 판정으로 승인/거절/에스컬레이션을 결정하지 않는다. AI는 초안만 제공한다."
+
+**SPEC 구현**:
+- TRIAGE와 동일: AI는 답변만 생성, RA Lead가 최종 승인
+- 명시적 삭제는 RA Lead 권한
+
+### 6.3 [지양-1] 전사 도우미
+
+**Charter 인용**:
+> "Employee가 질문 즉시 RAG draft 답변을 받아 자주 묻는 인허가 질문을 셀프서비스 해결."
+
+**SPEC 구현**:
+- RA Member만 Power Chat 접근 (ra-member+ 권한)
+- Employee는 TRIAGE auto_answer 사용 (다른 채널)
+
+---
+
+## 7. 구현 방법론 권장
+
+**mode**: TDD (Red-Green-Refactor)
+- 사유: 신규 테이블 + 신규 API → greenfield development
+- coverage target: 85%+
+
+**harness**: thorough
+- 사유: v3 Phase C-5는 core user journey
+- evaluator-active 4-dimension scoring 예상
+
+**development_mode**: tdd
+- 이유: 기존 코드베이스가 테스트 커버리지 높음 (TRIAGE 완료 후)
+
+---
+
+## 8. 코드 직검 L-013 준수 확인
+
+### 8.1 Runtime grep 검증 (run phase 시행)
+
+**manager-strategy 보고 수치 검증**:
+- consult.ts fan_in >= 3 확인: `grep -r "from.*consult" | wc -l`
+- run-triage.ts 재사용 패턴 확인: `grep -r "from.*run-triage" | wc -l`
+- 기존 /api/ra/consult 호출처 확인: `grep -r "api/ra/consult" app/`
+
+### 8.2 코드 라인 인용 (main HEAD 기준)
+
+본 research.md의 모든 코드 인용은 main HEAD 기준 직검입니다:
+- `lib/ai/consult.ts`: 831줄 (실제)
+- `app/api/ra/consult/route.ts`: 262줄 (실제)
+- `lib/domains/triage/run-triage.ts`: 100줄 (실제)
+- `lib/db/schema.ts`: 100줄 (일부, 전체는 더 긺)
+- `lib/auth/permissions.ts`: 79줄 (일부)
+
+---
+
+## 9. 종합 결론
+
+### 9.1 핵심 설계 결정 (확정)
+
+1. **세션 영속성**: 신규 consult_sessions/turns 테이블 (v3 docs 준수)
+2. **RAG 재사용**: run-consult.ts 래퍼 + consult.ts 하위 모듈 재사용 (TRIAGE 패턴)
+3. **권한**: 신규 consult.session.create, consult.session.view, consult.turn.create (ra-member+)
+4. **보관**: 5년 보관 정책 (deletedAt 기반, run phase에서 구현)
+5. **citation**: enforceCitations 재사용 (Charter [지양-2] 준수)
+
+### 9.2 migration 필요 여부
+
+**YES**: 신규 테이블 2종 (consult_sessions, consult_turns) + 신규 권한 3종
+- Migration M1: 테이블 생성 (drizzle-kit push)
+- Migration M2: 권한 데이터 마이그레이션 (기존 consult.create → 신규 권한 분리)
+- Migration M3: audit_retention cron job (선택 사항)
+
+### 9.3 REQ/AC/edge 카운트 예상
+
+- **REQ**: 12종 (세션 CRUD 4 + 턴 CRUD 4 + 보관 1 + 감사 2 + citation 1)
+- **AC**: 7종 (세션 생성/조회/삭제 3 + 턴 생성/조회 2 + citation 검증 1 + soft-delete 1)
+- **edge cases**: 8종 (빈 세션, citation 없는 답변, 타임아웃, 권한 없는 유저, etc.)
+
+### 9.4 risks/blockers
+
+**blockers**: 없음 (TRIAGE 완료로 의존 해소)
+
+**risks**:
+- consult_sessions/turns 스키마 설계 변경 (run phase에서 재검토 가능)
+- v3 API contract와 기존 /api/ra/consult 충돌 (경로 분리로 완화)
+
+---
+
+**본 research.md는 SPEC-V3-CONSULT-001 plan phase 산출물의 일부입니다.**

--- a/.moai/specs/SPEC-V3-CONSULT-001/research.md
+++ b/.moai/specs/SPEC-V3-CONSULT-001/research.md
@@ -325,29 +325,31 @@ export const consultSessions = pgTable('consult_sessions', {
 });
 ```
 
-### 4.2 consult_turns 테이블 (추론)
+### 4.2 consult_turns 테이블 (Exchange 모델 확정)
 
 ```typescript
-// schema.ts 예상 (run phase에서 확정)
+// schema.ts (run phase에서 확정)
+// Exchange 모델: 한 turn = 한 Q+A pair. role 필드 없음.
 export const consultTurns = pgTable('consult_turns', {
   id: uuid('id').primaryKey().defaultRandom(),
   sessionId: uuid('session_id').notNull().references(() => consultSessions.id),
-  turnNumber: integer('turn_number').notNull(), // 1, 2, 3, ...
-  role: messageRoleEnum('role').notNull(), // 'user' | 'assistant'
-  question: text('question'), // user role only
-  answer: text('answer'), // assistant role only (HTML prose)
-  confidence: numeric('confidence').notNull(), // 0.00 ~ 1.00
-  sources: jsonb('sources').$type<SourceItem[]>(), // 메타데이터
+  turnNumber: integer('turn_number').notNull(), // 1, 2, 3, ... 단조 증가
+  question: text('question').notNull(),          // 사용자 입력 (항상 존재)
+  answer: text('answer'),                         // RAG 결과 HTML prose, 실패 시 null
+  citations: jsonb('citations').$type<Citation[]>(), // citation 메타데이터 배열
+  confidence: real('confidence'),                 // 0.00 ~ 1.00, 실패 시 null
+  sources: jsonb('sources').$type<SourceItem[]>(), // RAG source 메타데이터
   createdAt: timestamp('created_at').notNull().defaultNow(),
 });
 ```
 
-**messages vs consult_turns 차이**:
-| 컬럼 | messages (v2) | consult_turns (v3) |
-|------|---------------|---------------------|
+**Exchange 모델 vs 기존 messages 모델 차이**:
+| 컬럼 | messages (v2, role 기반) | consult_turns (v3, Exchange) |
+|------|--------------------------|-------------------------------|
 | conversationId | ✅ | ❌ sessionId |
-| role | ✅ | ✅ |
-| contentProse | ✅ | ❌ answer/answer 분리 |
+| role | ✅ ('user'/'assistant') | ❌ (제거됨, 의미 없음) |
+| contentProse | ✅ (role에 따라 question/answer 분리) | ❌ question + answer 같은 row |
+| citations | ❌ | ✅ JSONB |
 | confidence | ✅ | ✅ |
 | sources | ❌ message_sources 테이블 | ✅ JSONB 직렬 |
 | turnNumber | ❌ | ✅ |

--- a/.moai/specs/SPEC-V3-CONSULT-001/spec.md
+++ b/.moai/specs/SPEC-V3-CONSULT-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-V3-CONSULT-001
-version: 1.0.0
+version: 1.1.0
 status: planned
 phase: C-5
 priority: High
@@ -29,6 +29,7 @@ labels:
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 1.0.0 | 2026-07-05 | manager-spec | 초기 작성. TRIAGE 완료 후 Power Chat 세션 저장 기능 구현. 신규 consult_sessions/turns 테이블, RA 전용 권한, 5년 보관 정책. REQ 12종, AC 7종. 코드 직검 기반 (L-013). |
+| 1.1.0 | 2026-07-05 | manager-spec | plan-auditor 감사 결과 Critical 1 + High 3건 개정. (C-1) REQ-CONS-013 신설로 `consult.session.create` audit log 자기모순 해소, AC-CONS-01에 audit 단언 추가. (H-1) REQ-CONS-004 Exchange 모델 확정(role 필드 제거, question+answer 동일 row), AC-CONS-03 role 단언 수정. (H-2) AC-CONS-02b 신설로 REQ-CONS-003 positive AC 보강. (H-3) REQ-CONS-005 + AC-CONS-04 citation coverage 80% 임계값 강화(enforceCitations 재사용 명시). REQ 13종, AC 8종. |
 
 ---
 
@@ -95,14 +96,14 @@ TRIAGE SPEC-V3-TRIAGE-001 (C-2)가 완료되어 consult.ts 하위 모듈 재사�
 |----|----------------|----------|
 | REQ-CONS-001 | **WHEN** RA Member가 POST /api/consult/sessions를 호출하여 `{title, projectId?, locale?}`를 전달하면 **THEN** the system **SHALL** consult_sessions 테이블에 새로운 세션을 생성하고 `{sessionId, title, projectId, locale, createdAt}`를 반환한다. sessionId는 UUID v4, title은 사용자 입력 또는 LLM 생성 기본값, locale는 'ko' 기본값 | High |
 | REQ-CONS-002 | **WHEN** RA Member가 GET /api/consult/sessions를 호출하면 **THEN** the system **SHALL** 해당 RA Member가 생성한 모든 세션 목록을 `{sessionId, title, projectId, createdAt, turnCount}` 형태로 최신순 정렬하여 반환한다. (ra-member는 자신의 세션만 조회, ra-lead/admin는 전체 조회) | High |
-| REQ-CONS-003 | **WHEN** RA Member가 GET /api/consult/sessions/:sessionId를 호출하면 **THEN** the system **SHALL** 해당 세션이 존재하고 RBAC 권한이 있으면 `{sessionId, title, projectId, locale, createdAt, turns: [{turnId, role, question?, answer?, confidence, sources, createdAt}]}` 형태로 반환한다. turns는 turnNumber 오름차순 정렬 | High |
+| REQ-CONS-003 | **WHEN** RA Member가 GET /api/consult/sessions/:sessionId를 호출하면 **THEN** the system **SHALL** 해당 세션이 존재하고 RBAC 권한이 있으면 `{sessionId, title, projectId, locale, createdAt, turns: [{turnId, turnNumber, question, answer, confidence, sources, citations, createdAt}]}` 형태로 반환한다. turns는 turnNumber 오름차순 정렬 | High |
 
 ### 턴 생성 / 추가
 
 | ID | EARS Statement | Priority |
 |----|----------------|----------|
-| REQ-CONS-004 | **WHEN** RA Member가 POST /api/consult/sessions/:sessionId/turns를 호출하여 `{question, locale?}`를 전달하면 **THEN** the system **SHALL** run-consult.ts RAG 파이프라인을 호출하여 답변을 생성하고 consult_turns 테이블에 새로운 턴을 삽입한다. RAG 파이프라인은 consult.ts 하위 모듈 재사용 (classifyIntent, parallelRetrieveAndMerge, composePrompt, streamText, enforceCitations, calculateConfidence). 턴 번호는 해당 세션의 마지막 turnNumber + 1 | High |
-| REQ-CONS-005 | **IF** 생성된 답변이 citation을 포함하지 않거나(또는) RAG 파이프라인이 타임아웃/런타임 에러로 실패하면 **THEN** the system **SHALL** 400 Bad Request를 반환하고 해당 턴을 저장하지 않는다 (Charter [지양-2] citation 강제). 단, 세션 자체는 유지하여 후속 재시도를 허용한다 | High |
+| REQ-CONS-004 | **WHEN** RA Member가 POST /api/consult/sessions/:sessionId/turns를 호출하여 `{question, locale?}`를 전달하면 **THEN** the system **SHALL** run-consult.ts RAG 파이프라인을 호출하여 답변을 생성하고 consult_turns 테이블에 새로운 턴을 삽입한다. RAG 파이프라인은 consult.ts 하위 모듈 재사용 (classifyIntent, parallelRetrieveAndMerge, composePrompt, streamText, enforceCitations, calculateConfidence). 턴 번호는 해당 세션의 마지막 turnNumber + 1. **데이터 모델(Exchange)**: 한 turn은 하나의 exchange(question→answer pair)로 저장된다. `role` 필드는 존재하지 않는다. 컬럼 구성: `question` (text NOT NULL, 사용자 입력), `answer` (text, RAG 결과 HTML prose, RAG 실패 시 null), `citations` (jsonb, citation 메타데이터 배열), `confidence` (real, 0.00~1.00), `turnNumber` (integer NOT NULL, 1부터 단조 증가) | High |
+| REQ-CONS-005 | **IF** 생성된 답변이 citation을 0개 포함하거나 citation coverage가 80% 미만(uncitedViolationCount/totalSentences > 0.2)이면, 또는 RAG 파이프라인이 타임아웃/런타임 에러로 실패하면 **THEN** the system **SHALL** 400 Bad Request를 반환하고 해당 턴을 저장하지 않는다 (Charter [지양-2] citation 강제, 기존 `lib/ai/citation-enforce.ts`의 `enforceCitations` 80% 임계값 회귀 방지). 단, 세션 자체는 유지하여 후속 재시도를 허용한다 | High |
 
 ### 세션 삭제 (명시적 삭제)
 
@@ -123,6 +124,7 @@ TRIAGE SPEC-V3-TRIAGE-001 (C-2)가 완료되어 consult.ts 하위 모듈 재사�
 | REQ-CONS-008 | **WHEN** POST /api/consult/sessions/:sessionId/turns가 성공하면 **THEN** the system **SHALL** `consult.turn.create` audit log를 기록한다. meta_json에는 `{sessionId, turnId, questionHash, confidenceScore, sourceCount}`를 포함한다 (21 CFR Part 11 §11.10(e)) | High |
 | REQ-CONS-009 | **WHEN** DELETE /api/consult/sessions/:sessionId가 성공하면 **THEN** the system **SHALL** `consult.session.delete` audit log를 기록한다. meta_json에는 `{sessionId, deletedBy, deletedAt}`를 포함한다 (21 CFR Part 11 §11.10(e)) | High |
 | REQ-CONS-010 | **IF** RAG 파이프라인이 타임아웃 또는 런타임 에러로 실패하면 **THEN** the system **SHALL** `consult.turn.failed` audit log를 기록하고 error 메타를 포함한다 (디버깅용) | Medium |
+| REQ-CONS-013 | **WHEN** POST /api/consult/sessions가 성공(201 Created)하면 **THEN** the system **SHALL** `consult.session.create` audit log를 기록한다. meta_json에는 `{sessionId, raMemberId, projectId?, locale}`를 포함한다 (21 CFR Part 11 §11.10(e)). 본 REQ는 §1.3 Policy Anchor에서 명시한 audit log 3종(create/turn.create/delete) 중 create 축을 채운다 | High |
 
 ### 기술 제약사항
 
@@ -150,6 +152,7 @@ TRIAGE SPEC-V3-TRIAGE-001 (C-2)가 완료되어 consult.ts 하위 모듈 재사�
 }
 ```
 **And** consult_sessions 테이블에 해당 row가 존재하고 deletedAt은 null이다.
+**And** audit_logs 테이블에 `consult.session.create` row가 존재한다 (orgId/sessionId 매칭, REQ-CONS-013).
 
 ### AC-CONS-02: Power Chat 세션 목록 조회 성공
 
@@ -185,6 +188,45 @@ TRIAGE SPEC-V3-TRIAGE-001 (C-2)가 완료되어 consult.ts 하위 모듈 재사�
 ```
 **And** 세션 목록은 createdAt 내림차순 정렬된다 (최신 세션 first).
 
+### AC-CONS-02b: Power Chat 세션 상세 조회 성공 (turns 배열 포함, REQ-CONS-003 직접 검증)
+
+**Given** RA Member가 세션을 생성하고 2개의 턴을 추가하고(question→answer exchange 2회)
+**When** GET /api/consult/sessions/:sessionId를 호출하면
+**Then** 시스템은 200 OK와 함께 다음을 반환한다:
+```json
+{
+  "sessionId": "uuid-session",
+  "title": "EU MDR 분석",
+  "projectId": "uuid-proj",
+  "locale": "ko",
+  "createdAt": "2026-07-05T00:00:00Z",
+  "turns": [
+    {
+      "turnId": "uuid-turn-1",
+      "turnNumber": 1,
+      "question": "EU MDR Article 10 요구사항은?",
+      "answer": "<p>EU MDR Article 10은 ...</p>",
+      "confidence": 0.85,
+      "sources": [{ "id": "src-eu-mdr", "citeIndex": 1 }],
+      "citations": [{ "citeIndex": 1, "sourceId": "src-eu-mdr" }],
+      "createdAt": "2026-07-05T01:00:00Z"
+    },
+    {
+      "turnId": "uuid-turn-2",
+      "turnNumber": 2,
+      "question": "Article 11은?",
+      "answer": "<p>...</p>",
+      "confidence": 0.78,
+      "sources": [{ "id": "src-eu-mdr", "citeIndex": 1 }],
+      "citations": [{ "citeIndex": 1, "sourceId": "src-eu-mdr" }],
+      "createdAt": "2026-07-05T02:00:00Z"
+    }
+  ]
+}
+```
+**And** turns 배열은 turnNumber 오름차순(1, 2)으로 정렬된다.
+**And** 각 turn은 question과 answer를 함께 포함한다 (Exchange 모델, role 필드 없음).
+
 ### AC-CONS-03: Power Chat 턴 생성 성공 (citation 포함)
 
 **Given** RA Member가 세션을 생성하고
@@ -212,23 +254,24 @@ TRIAGE SPEC-V3-TRIAGE-001 (C-2)가 완료되어 consult.ts 하위 모듈 재사�
   "createdAt": "2026-07-05T02:00:00Z"
 }
 ```
-**And** consult_turns 테이블에 해당 row가 존재하고 role은 'assistant'이다.
+**And** consult_turns 테이블에 해당 row가 존재한다 (Exchange 모델: question + answer가 같은 row에 저장, role 컬럼 없음).
 **And** audit_logs 테이블에 `consult.turn.create` row가 존재한다.
 
-### AC-CONS-04: Power Chat 턴 생성 실패 (citation 없음)
+### AC-CONS-04: Power Chat 턴 생성 실패 (citation 0개 또는 coverage 80% 미만)
 
 **Given** RA Member가 세션을 생성하고
 **When** POST /api/consult/sessions/:sessionId/turns를 호출하고
-**And** RAG 파이프라인이 citation을 포함하지 않은 답변을 생성하면
+**And** RAG 파이프라인이 (a) citation을 0개 포함한 답변을 생성하거나 (b) citation coverage가 80% 미만(uncitedViolationCount/totalSentences > 0.2)인 답변을 생성하면
 **Then** 시스템은 400 Bad Request와 함께 다음을 반환한다:
 ```json
 {
-  "error": "Citations required",
-  "message": "Answer must include at least one cited source"
+  "error": "citation_required",
+  "message": "Answer must include citations with coverage >= 80%"
 }
 ```
 **And** consult_turns 테이블에 새 row가 추가되지 않는다.
 **And** 세션은 turnCount=0 상태로 유지된다 (후속 재시도 가능).
+**And** citation 검증은 `lib/ai/citation-enforce.ts`의 `enforceCitations`를 재사용하여 80% 임계값을 적용한다 (TRIAGE run-triage.ts:91-94 패턴).
 
 ### AC-CONS-05: Power Chat 턴 생성 실패 (타임아웃)
 

--- a/.moai/specs/SPEC-V3-CONSULT-001/spec.md
+++ b/.moai/specs/SPEC-V3-CONSULT-001/spec.md
@@ -1,0 +1,279 @@
+---
+id: SPEC-V3-CONSULT-001
+version: 1.0.0
+status: planned
+phase: C-5
+priority: High
+created: 2026-07-05
+updated: 2026-07-05
+author: manager-spec
+issue_number: 341
+depends_on:
+  - SPEC-V3-TRIAGE-001
+blocks:
+  - SPEC-V3-UI-001
+parent_spec: null
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - component/ai
+  - component/api
+  - domain/consult
+  - type/v3-new
+---
+
+# SPEC-V3-CONSULT-001 — RA Power Chat (v3 Phase C-5)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-07-05 | manager-spec | 초기 작성. TRIAGE 완료 후 Power Chat 세션 저장 기능 구현. 신규 consult_sessions/turns 테이블, RA 전용 권한, 5년 보관 정책. REQ 12종, AC 7종. 코드 직검 기반 (L-013). |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+현재 `/api/ra/consult`는 1-shot streaming RAG만 제공하며 세션 저장이 없다 (`app/api/ra/consult/route.ts:217` 직검). 사용자는 매 질문마다 새로운 conversation을 생성하며 이전 답변을 참조할 방법이 없다. v3 Phase C-5에서는 **RA Member를 위한 Power Chat 세션 저장 기능**을 구현하여 다음을 가능하게 한다:
+
+- 규제 딥리서치 세션을 영구 저장 (5년 보관)
+- 관할권 다중 비교 질문 지원 (턴별 누적 context)
+- 세션 명시적 삭제 (RA Lead 권한)
+- LLM citation 강제 (Charter [지양-2])
+
+TRIAGE SPEC-V3-TRIAGE-001 (C-2)가 완료되어 consult.ts 하위 모듈 재사용 패턴이 검증되었다. 본 SPEC은 TRIAGE와 동일한 패턴으로 **신규 consult_sessions/turns 테이블 + CRUD API**를 구현한다.
+
+### 1.2 페르소나 (Personas)
+
+| 페르소나 | 역할 | Power Chat 관점 |
+|---|---|---|
+| RA Member | `ra-member` | Power Chat 세션 생성/조회, 턴 추가, 자신의 세션만 관리 (RBAC) |
+| RA Lead | `ra-lead` | 팀원 세션 조회, 세션 삭제 (명시적 삭제), 권한 검증 |
+| Admin | `admin` | 감사 로그 조회, 전체 세션 모니터링 |
+| Employee / Viewer | `employee`, `viewer` | Power Chat 접근 불가 (TRIAGE auto_answer 사용) |
+
+### 1.3 규제·정책 근거 (Policy Anchor)
+
+- **Charter [지양-2] citation 강제**: Power Chat 답변은 반드시 citation(source/provenance)을 포함한다. citation 없는 답변 저장 시 400 Bad Request (AC-07).
+- **Charter [지양-4] RA Lead 승인**: AI는 초안만 제공한다. 자동 판정으로 승인/거절/에스컬레이션을 결정하지 않는다.
+- **Charter [지양-1] 전사 도우미**: Employee는 TRIAGE auto_answer 사용. Power Chat은 RA Member 전용 (Charter [지양-3] RA 중심).
+- **v3 01_architecture.md:95**: `/api/consult` 권한 `ra-member`/`ra-lead`/`admin`.
+- **v3 02_data_model.md:238**: `consult_sessions` + `consult_turns` (Power Chat 저장), 5년 보관 (RA 개인 리서치 · 명시적 삭제 허용).
+- **v3 03_api_contract.md:148-149**: `GET/POST /api/consult/sessions`, `GET /api/consult/sessions/:id`, `POST /api/consult/sessions/:id/turns`.
+- **21 CFR Part 11 §11.10(e)**: Power Chat CRUD 시 `consult.session.create`, `consult.turn.create`, `consult.session.delete` audit log 기록.
+- **21 CFR Part 11 §11.70**: Power Chat 답변은 ESIG 서명 대상이 아님 (draft). RA Lead 최종 승인은 별도 워크플로우 (run phase 미구현, SPEC 확장 가능).
+
+### 1.4 본 SPEC의 범위 (In Scope)
+
+- **신규 테이블 2종**: `consult_sessions` (세션), `consult_turns` (턴) — 5년 보관, soft-delete
+- **Power Chat CRUD API**: 4종 (GET/POST /api/consult/sessions, GET /api/consult/sessions/:id, POST /api/consult/sessions/:id/turns)
+- **RAG 파이프라인 재사용**: consult.ts 하위 모듈 → run-consult.ts 래퍼 (TRIAGE 패턴)
+- **RBAC**: 신규 권한 3종 (consult.session.create, consult.session.view, consult.turn.create) — ra-member+
+- **보관 정책**: 5년 retention (deletedAt 기반, cron job 또는 수동 정책)
+- **Citation 강제**: enforceCitations 재사용 (Charter [지양-2])
+- **명시적 삭제**: RA Lead 권한, deletedAt timestamp (명시적 삭제 허용)
+
+### 1.5 Out of Scope
+
+- **TRIAGE 자동 답변 주입**: SPEC-V3-TRIAGE-001 (C-2) 완료. 본 SPEC은 Power Chat 세션만.
+- **Kanban UI 표시**: SPEC-V3-UI-001 (Phase D).
+- **승인 워크플로우**: run phase 미구현. Power Chat은 draft 답변만 제공.
+- **프로젝트 메모리 연동**: SPEC-V3-PROJECT-MEMORY-001 (이후 SPEC).
+- **관할권 다중 비교 UI**: Power Chat backend만 제공. 프론트엔드 정렬은 SPEC-V3-UI-001.
+- **Knowledge gap replay**: SPEC-V3-KNOWLEDGE-GAP-001 (이후 SPEC).
+- **Inngest 비동기 잡**: run phase 미구현. 동기 API 기준.
+
+---
+
+## §2 Requirements (EARS Format)
+
+### 세션 생성 / 조회
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-CONS-001 | **WHEN** RA Member가 POST /api/consult/sessions를 호출하여 `{title, projectId?, locale?}`를 전달하면 **THEN** the system **SHALL** consult_sessions 테이블에 새로운 세션을 생성하고 `{sessionId, title, projectId, locale, createdAt}`를 반환한다. sessionId는 UUID v4, title은 사용자 입력 또는 LLM 생성 기본값, locale는 'ko' 기본값 | High |
+| REQ-CONS-002 | **WHEN** RA Member가 GET /api/consult/sessions를 호출하면 **THEN** the system **SHALL** 해당 RA Member가 생성한 모든 세션 목록을 `{sessionId, title, projectId, createdAt, turnCount}` 형태로 최신순 정렬하여 반환한다. (ra-member는 자신의 세션만 조회, ra-lead/admin는 전체 조회) | High |
+| REQ-CONS-003 | **WHEN** RA Member가 GET /api/consult/sessions/:sessionId를 호출하면 **THEN** the system **SHALL** 해당 세션이 존재하고 RBAC 권한이 있으면 `{sessionId, title, projectId, locale, createdAt, turns: [{turnId, role, question?, answer?, confidence, sources, createdAt}]}` 형태로 반환한다. turns는 turnNumber 오름차순 정렬 | High |
+
+### 턴 생성 / 추가
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-CONS-004 | **WHEN** RA Member가 POST /api/consult/sessions/:sessionId/turns를 호출하여 `{question, locale?}`를 전달하면 **THEN** the system **SHALL** run-consult.ts RAG 파이프라인을 호출하여 답변을 생성하고 consult_turns 테이블에 새로운 턴을 삽입한다. RAG 파이프라인은 consult.ts 하위 모듈 재사용 (classifyIntent, parallelRetrieveAndMerge, composePrompt, streamText, enforceCitations, calculateConfidence). 턴 번호는 해당 세션의 마지막 turnNumber + 1 | High |
+| REQ-CONS-005 | **IF** 생성된 답변이 citation을 포함하지 않거나(또는) RAG 파이프라인이 타임아웃/런타임 에러로 실패하면 **THEN** the system **SHALL** 400 Bad Request를 반환하고 해당 턴을 저장하지 않는다 (Charter [지양-2] citation 강제). 단, 세션 자체는 유지하여 후속 재시도를 허용한다 | High |
+
+### 세션 삭제 (명시적 삭제)
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-CONS-006 | **WHILE** RA Lead가 DELETE /api/consult/sessions/:sessionId를 호출할 때 **THEN** the system **SHALL** 해당 세션의 deletedAt을 현재 timestamp로 설정하고 200 OK를 반환한다. (실제 row는 삭제하지 않음 — soft-delete). RBAC 검증: ra-member는 자신의 세션만 삭제, ra-lead/admin는 모든 세션 삭제 가능 | Medium |
+
+### 보관 정책
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-CONS-007 | **THE SYSTEM SHALL** consult_sessions/turns 테이블의 deletedAt이 5년 이상인 row를 자동으로 삭제하는 retention 정책을 갖는다. (run phase에서 cron job 또는 수동 정책으로 구현, 본 SPEC은 API contract만 명시) | Low |
+
+### 감사 로그
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-CONS-008 | **WHEN** POST /api/consult/sessions/:sessionId/turns가 성공하면 **THEN** the system **SHALL** `consult.turn.create` audit log를 기록한다. meta_json에는 `{sessionId, turnId, questionHash, confidenceScore, sourceCount}`를 포함한다 (21 CFR Part 11 §11.10(e)) | High |
+| REQ-CONS-009 | **WHEN** DELETE /api/consult/sessions/:sessionId가 성공하면 **THEN** the system **SHALL** `consult.session.delete` audit log를 기록한다. meta_json에는 `{sessionId, deletedBy, deletedAt}`를 포함한다 (21 CFR Part 11 §11.10(e)) | High |
+| REQ-CONS-010 | **IF** RAG 파이프라인이 타임아웃 또는 런타임 에러로 실패하면 **THEN** the system **SHALL** `consult.turn.failed` audit log를 기록하고 error 메타를 포함한다 (디버깅용) | Medium |
+
+### 기술 제약사항
+
+| ID | EARS Statement | Priority |
+|----|----------------|----------|
+| REQ-CONS-011 | **THE SYSTEM SHALL** run-consult.ts 래퍼를 사용하여 RAG 파이프라인을 호출하고, 그 결과를 JSON 직렬화하여 consult_turns 테이블에 저장한다. run-consult.ts는 consult.ts와 동일한 하위 모듈을 재사용하며 (TRIAGE 패턴), 15s timeout + citation 검증 로직을 포함한다 (TRIAGE run-triage.ts:51-79 패턴 재사용) | High |
+| REQ-CONS-012 | **THE SYSTEM SHALL** consult_sessions/turns 테이블의 FK 제약조건을 준수한다. consult_turns.sessionId → consult_sessions.id, consult_sessions.raMemberId → users.id, consult_sessions.projectId → projects.id (nullable) | High |
+
+---
+
+## §3 Acceptance Criteria
+
+### AC-CONS-01: Power Chat 세션 생성 성공
+
+**Given** RA Member가 로그인되어 있고
+**When** POST /api/consult/sessions를 `{title: "EU MDR 분석", projectId: "uuid-proj", locale: "ko"}`로 호출하면
+**Then** 시스템은 201 Created와 함께 다음을 반환한다:
+```json
+{
+  "sessionId": "uuid-v4",
+  "title": "EU MDR 분석",
+  "projectId": "uuid-proj",
+  "locale": "ko",
+  "createdAt": "2026-07-05T00:00:00Z"
+}
+```
+**And** consult_sessions 테이블에 해당 row가 존재하고 deletedAt은 null이다.
+
+### AC-CONS-02: Power Chat 세션 목록 조회 성공
+
+**Given** RA Member가 3개의 세션을 생성하고
+**When** GET /api/consult/sessions를 호출하면
+**Then** 시스템은 200 OK와 함께 다음을 반환한다:
+```json
+{
+  "sessions": [
+    {
+      "sessionId": "uuid-1",
+      "title": "세션 1",
+      "projectId": "uuid-proj",
+      "createdAt": "2026-07-05T01:00:00Z",
+      "turnCount": 5
+    },
+    {
+      "sessionId": "uuid-2",
+      "title": "세션 2",
+      "projectId": null,
+      "createdAt": "2026-07-04T12:00:00Z",
+      "turnCount": 2
+    },
+    {
+      "sessionId": "uuid-3",
+      "Title": "세션 3",
+      "projectId": "uuid-proj",
+      "createdAt": "2026-07-03T10:00:00Z",
+      "turnCount": 0
+    }
+  ]
+}
+```
+**And** 세션 목록은 createdAt 내림차순 정렬된다 (최신 세션 first).
+
+### AC-CONS-03: Power Chat 턴 생성 성공 (citation 포함)
+
+**Given** RA Member가 세션을 생성하고
+**When** POST /api/consult/sessions/:sessionId/turns를 `{question: "EU MDR 2017/745 Article 10 요구사항은?"}`로 호출하고
+**And** RAG 파이프라인이 citation을 포함한 답변을 성공적으로 생성하면
+**Then** 시스템은 201 Created와 함께 다음을 반환한다:
+```json
+{
+  "turnId": "uuid-turn",
+  "sessionId": "uuid-session",
+  "turnNumber": 1,
+  "answer": "<p>EU MDR Article 10은 <sup class=\"cite\" data-source=\"1\">제조사는 품질경영시스템을 수립해야 한다</sup>를 요구한다...</p>",
+  "confidence": 0.85,
+  "sources": [
+    {
+      "id": "src-eu-mdr",
+      "citeIndex": 1,
+      "orgLabel": "EU MDR",
+      "title": "Regulation (EU) 2017/745",
+      "year": 2017,
+      "type": "Regulation",
+      "anchor": "Article 10"
+    }
+  ],
+  "createdAt": "2026-07-05T02:00:00Z"
+}
+```
+**And** consult_turns 테이블에 해당 row가 존재하고 role은 'assistant'이다.
+**And** audit_logs 테이블에 `consult.turn.create` row가 존재한다.
+
+### AC-CONS-04: Power Chat 턴 생성 실패 (citation 없음)
+
+**Given** RA Member가 세션을 생성하고
+**When** POST /api/consult/sessions/:sessionId/turns를 호출하고
+**And** RAG 파이프라인이 citation을 포함하지 않은 답변을 생성하면
+**Then** 시스템은 400 Bad Request와 함께 다음을 반환한다:
+```json
+{
+  "error": "Citations required",
+  "message": "Answer must include at least one cited source"
+}
+```
+**And** consult_turns 테이블에 새 row가 추가되지 않는다.
+**And** 세션은 turnCount=0 상태로 유지된다 (후속 재시도 가능).
+
+### AC-CONS-05: Power Chat 턴 생성 실패 (타임아웃)
+
+**Given** RA Member가 세션을 생성하고
+**When** POST /api/consult/sessions/:sessionId/turns를 호출하고
+**And** RAG 파이프라인이 15s 타임아웃으로 실패하면
+**Then** 시스템은 400 Bad Request와 함께 다음을 반환한다:
+```json
+{
+  "error": "RAG timeout",
+  "message": "RAG pipeline timed out after 15s"
+}
+```
+**And** audit_logs 테이블에 `consult.turn.failed` row가 존재하고 meta_json에는 error: 'timeout'을 포함한다.
+
+### AC-CONS-06: Power Chat 세션 삭제 성공 (RA Lead)
+
+**Given** RA Lead가 세션을 생성하고
+**When** DELETE /api/consult/sessions/:sessionId를 호출하면
+**Then** 시스템은 200 OK와 함께 다음을 반환한다:
+```json
+{
+  "sessionId": "uuid-session",
+  "deletedAt": "2026-07-05T03:00:00Z"
+}
+```
+**And** consult_sessions 테이블의 해당 row에서 deletedAt이 현재 timestamp로 설정되고 실제 row는 삭제되지 않는다 (soft-delete).
+**And** audit_logs 테이블에 `consult.session.delete` row가 존재한다.
+
+### AC-CONS-07: RBAC 권한 검증
+
+**Given** RA Member가 다른 RA Member의 세션을 생성하고
+**When** DELETE /api/consult/sessions/:sessionId를 호출하면
+**Then** 시스템은 403 Forbidden를 반환한다.
+**And** audit_logs 테이블에 `consult.session.delete` row가 존재하지 않는다.
+
+---
+
+## §4 Exclusions (What NOT to Build)
+
+- [E-001] **TRIAGE 자동 답변**: SPEC-V3-TRIAGE-001 (C-2)에서 이미 구현됨. 본 SPEC은 Power Chat 세션 저장만.
+- [E-002] **Kanban UI**: SPEC-V3-UI-001 (Phase D). 본 SPEC은 backend API만 제공.
+- [E-003] **승인 워크플로우**: run phase 미구현. Power Chat은 draft 답변만 제공.
+- [E-004] **프로젝트 메모리**: SPEC-V3-PROJECT-MEMORY-001 (이후 SPEC).
+- [E-005] **Knowledge gap replay**: SPEC-V3-KNOWLEDGE-GAP-001 (이후 SPEC).
+- [E-006] **Inngest 비동기 잡**: run phase 미구현. 동기 API 기준.
+- [E-007] **5년 보관 cron job**: 본 SPEC은 API contract만 명시. run phase에서 구현 여부 결정.
+- [E-008] **관할권 다중 비교 정렬**: 프론트엔드 정책. backend는 턴 순서만 반환.


### PR DESCRIPTION
## SPEC-V3-CONSULT-001 — RA Power Chat (v3 Phase C-5) plan phase

Refs #341. v3 Phase C-5. RA 전용 딥리서치 세션(Power Chat) — `consult_sessions`/`consult_turns` 테이블 + 세션 단위 다발 영속화 + RBAC.

### 선행 (해금 조건)
- SPEC-V3-TRIAGE-001 — main `631465f` (#340) ✅
- SPEC-V3-INBOX-001 — main ✅

### 산출물 4종 (1,447줄)
- `research.md` (488) — 기존 `lib/ai/consult.ts`(33KB SSE generator) + v3 데이터 모델 직검, 재사용 매핑
- `spec.md` (279) — EARS REQ 12종 + AC 7종 (AC-CONS-01~07)
- `acceptance.md` (313) — AC 상세 (세션 생성/조회/턴 생성/삭제/RBAC/citation/timeout)
- `plan.md` (367) — M1~M6 마일스톤, 28 tasks, HIGH Risks 3종 완화

### 핵심 설계 (TRIAGE 패턴 재사용)
- 신규 테이블: `consult_sessions`(title/project/org/user) + `consult_turns`(turnNumber/citations/jsonb result) — 기존 `conversations`/`messages`와 **격리** (v2 호환성, R-01 완화)
- `lib/domains/consult/run-consult.ts` 래퍼 — TRIAGE `run-triage.ts` 패턴 (Promise.race + AbortSignal 15s timeout)
- citation 강제 (empty → error, Charter [지양-2])
- RBAC 3종 신규 (`consult.session.create/view`, `consult.turn.create`) — ra-member+/ra-lead/admin (Charter [지양-4])
- 21 CFR Part 11 audit (session.create/turn.create/session.delete)
- 5년 보관 (MDR Art. 10(8)) — 문서화 정책 (M6)
- 기존 `/api/ra/consult/route.ts` (1회성 SSE) 유지 — v3는 `/api/consult/sessions` 별도 경로

### migration 예정 (run phase)
- `0107_create_consult_tables.sql` (테이블 + RLS + audit enum)
- `0108_consult_permissions.sql` (RBAC 3종)
- (M3 cron은 별도 검토)

### run phase 진입 계획
main 머지 후 `feat/spec-v3-consult-001-run` 분기 → manager-tdd M1~M6 (28 tasks).

🗿 MoAI <email@mo.ai.kr>