### PR TITLE
feat(consult): SPEC-V3-CONSULT-001 RA Power Chat 백엔드 (Phase C-5)

### DIFF
--- a/app/api/consult/sessions/[sessionId]/route.ts
+++ b/app/api/consult/sessions/[sessionId]/route.ts
@@ -1,0 +1,106 @@
+// @MX:NOTE [AUTO] /api/consult/sessions/:sessionId — detail + soft-delete.
+// @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-003, REQ-CONS-006, AC-CONS-02b, AC-CONS-06, AC-CONS-07, Issue 341)
+// @MX:REASON REQ-CONS-003: GET returns session + turns array (turnNumber asc, AC-CONS-02b).
+//            REQ-CONS-006: DELETE soft-deletes (deletedAt) + `consult.session.delete` audit
+//            (21 CFR Part 11). RBAC: ra-member sees own, ra-lead/admin see all org (AC-CONS-07).
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { consultSessions, consultTurns } from '@/lib/db/schema';
+import { and, asc, eq, isNull } from 'drizzle-orm';
+
+// GET /api/consult/sessions/:sessionId — session detail + turns (AC-CONS-02b, AC-CONS-07).
+export const GET = withPermission('consult.session.view', async (_req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const params = ctx.params ? await ctx.params : {};
+  const sessionId = params.sessionId;
+  if (!sessionId) {
+    return Response.json({ error: 'Missing sessionId' }, { status: 400 });
+  }
+
+  // org-bound lookup (IDOR defense: orgId + not-deleted).
+  const [sess] = await db
+    .select()
+    .from(consultSessions)
+    .where(
+      and(
+        eq(consultSessions.id, sessionId),
+        eq(consultSessions.orgId, organizationId),
+        isNull(consultSessions.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  // 404 for missing OR cross-user access by ra-member (no information leak).
+  if (!sess || (session.user.role === 'ra-member' && sess.userId !== session.user.id)) {
+    return Response.json({ error: 'Session not found' }, { status: 404 });
+  }
+
+  // turns 배열 — turnNumber 오름차순 (AC-CONS-02b, Edge-11).
+  const turns = await db
+    .select()
+    .from(consultTurns)
+    .where(eq(consultTurns.sessionId, sessionId))
+    .orderBy(asc(consultTurns.turnNumber));
+
+  return Response.json({ session: sess, turns });
+});
+
+// DELETE /api/consult/sessions/:sessionId — soft-delete (AC-CONS-06, AC-CONS-07).
+export const DELETE = withPermission('consult.session.delete', async (_req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const params = ctx.params ? await ctx.params : {};
+  const sessionId = params.sessionId;
+  if (!sessionId) {
+    return Response.json({ error: 'Missing sessionId' }, { status: 400 });
+  }
+
+  const [sess] = await db
+    .select()
+    .from(consultSessions)
+    .where(
+      and(
+        eq(consultSessions.id, sessionId),
+        eq(consultSessions.orgId, organizationId),
+        isNull(consultSessions.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!sess) {
+    return Response.json({ error: 'Session not found' }, { status: 404 });
+  }
+
+  // 21 CFR Part 11 atomicity: soft-delete + audit in one tx.
+  await db.transaction(async (tx) => {
+    await tx
+      .update(consultSessions)
+      .set({ deletedAt: new Date() })
+      .where(eq(consultSessions.id, sessionId));
+
+    await writeAudit(
+      {
+        actor_id: session.user.id,
+        action: 'consult.session.delete',
+        resource_type: 'consult_session',
+        resource_id: sessionId,
+        meta_json: {
+          sessionId,
+          deletedBy: session.user.id,
+          ownerUserId: sess.userId,
+        },
+      },
+      tx,
+    );
+  });
+
+  return Response.json({ ok: true });
+});

--- a/app/api/consult/sessions/[sessionId]/turns/route.ts
+++ b/app/api/consult/sessions/[sessionId]/turns/route.ts
@@ -6,6 +6,7 @@
 //            turnNumber MAX+1 + INSERT turn + writeAudit (fast, atomic).
 // @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-004, REQ-CONS-005, REQ-CONS-008, AC-CONS-03..07, Issue 341)
 
+import { createHash } from 'node:crypto';
 import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
 import { db } from '@/lib/db/client';
@@ -91,11 +92,18 @@ export const POST = withPermission('consult.turn.create', async (req, ctx, sessi
       throw new Error('consult_turn INSERT returned no row');
     }
 
-    // REQ-CONS-008: consult.turn.create audit (21 CFR Part 11). questionHash for PII.
+    // REQ-CONS-008 (success) / REQ-CONS-010 (failure): audit action branches on result.error.
+    // turn.failed covers timeout / runtime_error / citation_coverage (AC-CONS-05,
+    // 21 CFR Part 11 §11.10(e) debugging audit). questionHash is non-PII question
+    // fingerprint (REQ-CONS-008) — question text is never stored in audit.
+    const questionHash = createHash('sha256')
+      .update(parsed.data.question)
+      .digest('hex')
+      .slice(0, 16);
     await writeAudit(
       {
         actor_id: session.user.id,
-        action: 'consult.turn.create',
+        action: result.error ? 'consult.turn.failed' : 'consult.turn.create',
         resource_type: 'consult_turn',
         resource_id: row.id,
         meta_json: {
@@ -104,6 +112,7 @@ export const POST = withPermission('consult.turn.create', async (req, ctx, sessi
           turnNumber,
           error: result.error,
           citationCount: result.citations.length,
+          questionHash,
         },
       },
       tx,
@@ -112,18 +121,11 @@ export const POST = withPermission('consult.turn.create', async (req, ctx, sessi
     return row;
   });
 
-  // Response mapping by error case (turn is ALWAYS persisted — RA member sees feedback).
-  // AC-CONS-04: citation violation (no_citations / citation_coverage) → 400.
-  if (result.error === 'no_citations' || result.error === 'citation_coverage') {
-    return Response.json({ error: 'citation_required', code: result.error, turn }, { status: 400 });
-  }
-  // AC-CONS-05: timeout → 504 (turn persisted with error='timeout').
-  if (result.error === 'timeout') {
-    return Response.json({ error: 'timeout', turn }, { status: 504 });
-  }
-  // runtime_error → 500.
+  // Response mapping (turn is ALWAYS persisted — RA member sees feedback).
+  // AC-CONS-04 / AC-CONS-05: any error (citation / timeout / runtime) → 400
+  // per SPEC §AC-CONS-05 + acceptance.md (single status code, error field carries kind).
   if (result.error) {
-    return Response.json({ error: 'runtime_error', turn }, { status: 500 });
+    return Response.json({ error: result.error, turn }, { status: 400 });
   }
 
   // AC-CONS-03: success → 201 + turn (answer + citations).

--- a/app/api/consult/sessions/[sessionId]/turns/route.ts
+++ b/app/api/consult/sessions/[sessionId]/turns/route.ts
@@ -1,0 +1,131 @@
+// @MX:ANCHOR [AUTO] POST /api/consult/sessions/:sessionId/turns — Power Chat turn creation.
+// @MX:REASON fan_in >= 1 (this route) and the most complex CONSULT handler: RAG
+//            pipeline + transactional persistence + 21 CFR Part 11 audit + citation
+//            enforcement + timeout handling. Mirrors TRIAGE /api/ask pattern:
+//            RAG runs OUTSIDE the tx (slow, 15s budget); the tx only does
+//            turnNumber MAX+1 + INSERT turn + writeAudit (fast, atomic).
+// @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-004, REQ-CONS-005, REQ-CONS-008, AC-CONS-03..07, Issue 341)
+
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { consultSessions, consultTurns } from '@/lib/db/schema';
+import { runConsult } from '@/lib/domains/consult';
+import { and, eq, isNull, max } from 'drizzle-orm';
+import { z } from 'zod';
+
+// REQ-CONS-004: question 1-5000 chars (mirrors /api/ask + /api/ra/consult).
+const createTurnSchema = z.object({
+  question: z.string().min(1).max(5000, 'Question must be between 1 and 5000 characters'),
+});
+
+export const POST = withPermission('consult.turn.create', async (req, ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const params = ctx.params ? await ctx.params : {};
+  const sessionId = params.sessionId;
+  if (!sessionId) {
+    return Response.json({ error: 'Missing sessionId' }, { status: 400 });
+  }
+
+  // Session ownership: org-bound + not-deleted (IDOR defense). ra-member: own only.
+  const [sess] = await db
+    .select()
+    .from(consultSessions)
+    .where(
+      and(
+        eq(consultSessions.id, sessionId),
+        eq(consultSessions.orgId, organizationId),
+        isNull(consultSessions.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!sess || (session.user.role === 'ra-member' && sess.userId !== session.user.id)) {
+    return Response.json({ error: 'Session not found' }, { status: 404 });
+  }
+
+  const body = (await req.json().catch(() => null)) as unknown;
+  const parsed = createTurnSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Invalid input', issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  // RAG pipeline OUTSIDE the tx (15s timeout internal to runConsult via runTriage).
+  // Citation 80% coverage enforced inside (H-3, AC-CONS-04).
+  const result = await runConsult({
+    question: parsed.data.question,
+    orgId: organizationId,
+    actorId: session.user.id,
+  });
+
+  // tx: turnNumber MAX+1 + INSERT turn + audit (atomic, fast).
+  // UNIQUE(session_id, turn_number) defends concurrent races (R-05); the next
+  // retry/SERIALIZABLE upgrade is tracked as a follow-up (plan-auditor M-7).
+  const turn = await db.transaction(async (tx) => {
+    const maxRow = await tx
+      .select({ m: max(consultTurns.turnNumber) })
+      .from(consultTurns)
+      .where(eq(consultTurns.sessionId, sessionId));
+    const turnNumber = (maxRow[0]?.m ?? 0) + 1;
+
+    const [row] = await tx
+      .insert(consultTurns)
+      .values({
+        sessionId,
+        turnNumber,
+        question: parsed.data.question,
+        answer: result.answer,
+        citations: result.citations,
+        sources: result.sources,
+        confidence: result.confidence,
+        error: result.error,
+      })
+      .returning();
+    if (!row) {
+      throw new Error('consult_turn INSERT returned no row');
+    }
+
+    // REQ-CONS-008: consult.turn.create audit (21 CFR Part 11). questionHash for PII.
+    await writeAudit(
+      {
+        actor_id: session.user.id,
+        action: 'consult.turn.create',
+        resource_type: 'consult_turn',
+        resource_id: row.id,
+        meta_json: {
+          sessionId,
+          turnId: row.id,
+          turnNumber,
+          error: result.error,
+          citationCount: result.citations.length,
+        },
+      },
+      tx,
+    );
+
+    return row;
+  });
+
+  // Response mapping by error case (turn is ALWAYS persisted — RA member sees feedback).
+  // AC-CONS-04: citation violation (no_citations / citation_coverage) → 400.
+  if (result.error === 'no_citations' || result.error === 'citation_coverage') {
+    return Response.json({ error: 'citation_required', code: result.error, turn }, { status: 400 });
+  }
+  // AC-CONS-05: timeout → 504 (turn persisted with error='timeout').
+  if (result.error === 'timeout') {
+    return Response.json({ error: 'timeout', turn }, { status: 504 });
+  }
+  // runtime_error → 500.
+  if (result.error) {
+    return Response.json({ error: 'runtime_error', turn }, { status: 500 });
+  }
+
+  // AC-CONS-03: success → 201 + turn (answer + citations).
+  return Response.json({ turn }, { status: 201 });
+});

--- a/app/api/consult/sessions/route.ts
+++ b/app/api/consult/sessions/route.ts
@@ -1,0 +1,118 @@
+// @MX:NOTE [AUTO] /api/consult/sessions — RA Power Chat session list + create.
+// @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-001, REQ-CONS-002, AC-CONS-01, AC-CONS-02, Issue 341)
+// @MX:REASON REQ-CONS-001: POST creates a consult_sessions row + `consult.session.create`
+//            audit (REQ-CONS-013, 21 CFR Part 11 §11.10(e)) in one transaction.
+//            REQ-CONS-002: GET lists sessions — ra-member sees own, ra-lead/admin see all org.
+
+import { randomUUID } from 'node:crypto';
+import { writeAudit } from '@/lib/audit';
+import { withPermission } from '@/lib/auth/with-permission';
+import { db } from '@/lib/db/client';
+import { consultSessions } from '@/lib/db/schema';
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { z } from 'zod';
+
+// REQ-CONS-001: title 1-200 chars, projectId/locale optional.
+const createSessionSchema = z.object({
+  title: z.string().min(1).max(200),
+  projectId: z.string().uuid().optional(),
+  locale: z.string().min(2).max(10).optional(),
+});
+
+// POST /api/consult/sessions — create a Power Chat session (AC-CONS-01).
+export const POST = withPermission('consult.session.create', async (req, _ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const body = (await req.json().catch(() => null)) as unknown;
+  const parsed = createSessionSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Invalid input', issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { title, projectId, locale } = parsed.data;
+  const sessionId = randomUUID();
+  const effectiveLocale = locale ?? 'ko';
+
+  // 21 CFR Part 11 atomicity: session row + audit in one tx (TRIAGE/INBOX 교훈).
+  const created = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(consultSessions)
+      .values({
+        id: sessionId,
+        orgId: organizationId,
+        userId: session.user.id,
+        projectId: projectId ?? null,
+        title,
+        locale: effectiveLocale,
+      })
+      .returning();
+
+    // REQ-CONS-013: consult.session.create audit (C-1 fix — Policy Anchor 자기모순 해소).
+    await writeAudit(
+      {
+        actor_id: session.user.id,
+        action: 'consult.session.create',
+        resource_type: 'consult_session',
+        resource_id: sessionId,
+        meta_json: {
+          sessionId,
+          raMemberId: session.user.id,
+          projectId: projectId ?? null,
+          locale: effectiveLocale,
+        },
+      },
+      tx,
+    );
+
+    return row;
+  });
+
+  return Response.json({ session: created }, { status: 201 });
+});
+
+// GET /api/consult/sessions — list sessions (AC-CONS-02).
+// ra-member: own sessions only. ra-lead/admin: all org sessions.
+const listSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  offset: z.coerce.number().int().min(0).max(10000).optional().default(0),
+});
+
+export const GET = withPermission('consult.session.view', async (req, _ctx, session) => {
+  const organizationId = session.user.organizationId;
+  if (!organizationId) {
+    return Response.json({ error: 'Organization context required' }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const parsed = listSchema.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'Invalid query', issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const { limit, offset } = parsed.data;
+
+  // ra-member sees only own sessions (app-level userId filter, defense-in-depth
+  // on top of consult.session.view minRole). ra-lead/admin see all org sessions.
+  const conditions = [eq(consultSessions.orgId, organizationId), isNull(consultSessions.deletedAt)];
+  if (session.user.role === 'ra-member') {
+    conditions.push(eq(consultSessions.userId, session.user.id));
+  }
+
+  const sessions = await db
+    .select()
+    .from(consultSessions)
+    .where(and(...conditions))
+    .orderBy(desc(consultSessions.createdAt))
+    .limit(limit)
+    .offset(offset);
+
+  return Response.json({ sessions, pagination: { limit, offset, count: sessions.length } });
+});

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -471,7 +471,14 @@ export type AuditAction =
   | 'inbox.approved'
   | 'inbox.closed'
   | 'inbox.rejected'
-  | 'inbox.approve_failed';
+  | 'inbox.approve_failed'
+  // SPEC-V3-CONSULT-001 (Issue 341): RA Power Chat audit actions.
+  //   consult.session.create  — new consult session created (REQ-CONS-013, C-1)
+  //   consult.turn.create     — new turn added to session (REQ-CONS-008)
+  //   consult.session.delete  — session soft-deleted by ra-lead/admin (REQ-CONS-009)
+  | 'consult.session.create'
+  | 'consult.turn.create'
+  | 'consult.session.delete';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -478,7 +478,8 @@ export type AuditAction =
   //   consult.session.delete  — session soft-deleted by ra-lead/admin (REQ-CONS-009)
   | 'consult.session.create'
   | 'consult.turn.create'
-  | 'consult.session.delete';
+  | 'consult.session.delete'
+  | 'consult.turn.failed';
 
 export interface AuditEvent {
   /** User UUID, or null for system-initiated events. */

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -174,7 +174,14 @@ export type PermissionAction =
   // SPEC-V3-INBOX-001 (Issue 320, REQ-V3-INBOX-001): ask.create permission.
   // RA employees ask regulatory questions via /api/ask. Viewer-level access
   // for Charter alignment — 전사 인허가 도우미 (mirrors consult.create pattern).
-  | 'ask.create';
+  | 'ask.create'
+  // SPEC-V3-CONSULT-001 (Issue 341, REQ-CONS-001..007): RA Power Chat RBAC.
+  // ra-member+: create sessions, create turns, view own sessions (Charter [지양-4]).
+  // ra-lead/admin: view all org sessions, delete sessions (21 CFR Part 11 audit).
+  | 'consult.session.create'
+  | 'consult.session.view'
+  | 'consult.session.delete'
+  | 'consult.turn.create';
 
 export interface PermissionSpec {
   minRole: Role;
@@ -527,5 +534,39 @@ export const PERMISSIONS: Record<PermissionAction, PermissionSpec> = {
     minRole: 'viewer',
     scope: 'org',
     resourceType: 'inboxTicket',
+  },
+  // @MX:NOTE [AUTO] consult.session.create — RA Power Chat session creation.
+  // @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-001, Issue 341, Charter [지양-4])
+  // ra-member+ — RA deep-research sessions are RA-team scoped (mirrors ask.create
+  // ra-tier gating, NOT viewer-level). Power Chat is a RA specialist tool.
+  'consult.session.create': {
+    minRole: 'ra-member',
+    scope: 'org',
+    resourceType: 'consultSession',
+  },
+  // @MX:NOTE [AUTO] consult.session.view — session list + detail (with turns).
+  // @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-002, REQ-CONS-003, Issue 341)
+  // ra-member+: own sessions only (app-level userId filter). ra-lead/admin: all org.
+  'consult.session.view': {
+    minRole: 'ra-member',
+    scope: 'org',
+    resourceType: 'consultSession',
+  },
+  // @MX:ANCHOR [AUTO] consult.session.delete — ra-lead/admin ONLY soft-delete gate.
+  // @MX:REASON REQ-CONS-006: session deletion is a 21 CFR Part 11 audit-material
+  //            regulatory records decision. Mirrors inbox.manage / capa.close.
+  // @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-006, Issue 341)
+  'consult.session.delete': {
+    minRole: 'ra-lead',
+    scope: 'org',
+    resourceType: 'consultSession',
+  },
+  // @MX:NOTE [AUTO] consult.turn.create — add a Q+A turn to a session.
+  // @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-004, Issue 341)
+  // ra-member+ — turn creation triggers RAG pipeline (rate-limited, M-1 follow-up).
+  'consult.turn.create': {
+    minRole: 'ra-member',
+    scope: 'org',
+    resourceType: 'consultTurn',
   },
 };

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -32,9 +32,11 @@ import {
   pgEnum,
   pgTable,
   primaryKey,
+  real,
   text,
   timestamp,
   unique,
+  uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
 
@@ -428,6 +430,11 @@ export const auditActionEnum = pgEnum('audit_action', [
   'inbox.closed',
   'inbox.rejected',
   'inbox.approve_failed', // H-2 fix: approval failed (ESIG re-auth failure or domain error)
+  // SPEC-V3-CONSULT-001 — added via 0107_create_consult_tables.sql (Issue 341):
+  // 21 CFR Part 11 §11.10(e) audit material. Power Chat session/turn lifecycle.
+  'consult.session.create',
+  'consult.turn.create',
+  'consult.session.delete',
   // SPEC-REGULA-STANDARDS-001 — added via 0088_standards.sql (Issue #62).
   // Standards lifecycle is 21 CFR Part 11 audit-material (design-input records
   // under ISO 13485 / 21 CFR 820.30). Charter [지양-2] citation provenance.
@@ -3326,5 +3333,67 @@ export const approvedAnswers = pgTable(
       'gin',
       sql`to_tsvector('simple', ${t.question} || ' ' || ${t.answer})`,
     ),
+  }),
+);
+
+// SPEC-V3-CONSULT-001 (REQ-CONS-001, Issue 341): consult_sessions — RA Power Chat.
+// v2 호환성 (R-01): ISOLATED from conversations/messages. Legacy /api/ra/consult
+// 1-shot SSE route is untouched. v3 stores multi-turn RA deep-research sessions.
+// 5년 보관 (MDR Art. 10(8)) — soft-delete via deletedAt (REQ-CONS-006).
+export const consultSessions = pgTable(
+  'consult_sessions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    projectId: uuid('project_id').references(() => projects.id, { onDelete: 'set null' }),
+    title: text('title').notNull(),
+    locale: text('locale').notNull().default('ko'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true, mode: 'date' }),
+  },
+  (t) => ({
+    // @MX:NOTE [AUTO] REQ-CONS-002 — org-scoped session list (ra-lead/admin see all).
+    orgIdx: index('consult_sessions_org_id_idx').on(t.orgId),
+    // @MX:NOTE [AUTO] REQ-CONS-002 — ra-member sees only own sessions.
+    userIdx: index('consult_sessions_user_id_idx').on(t.userId),
+    // @MX:NOTE [AUTO] REQ-CONS-002 — newest-first ordering.
+    createdIdx: index('consult_sessions_created_at_idx').on(t.createdAt),
+  }),
+);
+
+// SPEC-V3-CONSULT-001 (REQ-CONS-004, Issue 341): consult_turns — Exchange model (H-1).
+// 한 turn = 한 Q+A pair. role 필드 없음. UNIQUE(session_id, turn_number)로
+// 동시 POST 시 turnNumber 충돌 방지 (R-05 완화 — DB 제약 + tx retry).
+export const consultTurns = pgTable(
+  'consult_turns',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    sessionId: uuid('session_id')
+      .notNull()
+      .references(() => consultSessions.id, { onDelete: 'cascade' }),
+    turnNumber: integer('turn_number').notNull(),
+    question: text('question').notNull(),
+    answer: text('answer'),
+    citations: jsonb('citations')
+      .$type<{ source: string; quote?: string }[]>()
+      .notNull()
+      .default([]),
+    sources: jsonb('sources')
+      .$type<{ sourceId: string; sourceLabel?: string; quote?: string }[]>()
+      .notNull()
+      .default([]),
+    confidence: real('confidence'),
+    error: text('error'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => ({
+    // @MX:NOTE [AUTO] REQ-CONS-003 — session detail turns array, turnNumber asc (AC-CONS-02b).
+    sessionTurnIdx: uniqueIndex('consult_turns_session_turn_idx').on(t.sessionId, t.turnNumber),
   }),
 );

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -435,6 +435,9 @@ export const auditActionEnum = pgEnum('audit_action', [
   'consult.session.create',
   'consult.turn.create',
   'consult.session.delete',
+  // SPEC-V3-CONSULT-001 — added via 0108_consult_turn_failed_audit.sql (REQ-CONS-010):
+  // 21 CFR Part 11 debugging audit for timeout/runtime_error turns (AC-CONS-05).
+  'consult.turn.failed',
   // SPEC-REGULA-STANDARDS-001 — added via 0088_standards.sql (Issue #62).
   // Standards lifecycle is 21 CFR Part 11 audit-material (design-input records
   // under ISO 13485 / 21 CFR 820.30). Charter [지양-2] citation provenance.

--- a/lib/domains/consult/index.ts
+++ b/lib/domains/consult/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @MX:NOTE [AUTO] CONSULT public API exports — RA Power Chat (v3 Phase C-5)
+ *
+ * Public API for the CONSULT domain. Exports runConsult and types.
+ *
+ * @MX:SPEC SPEC-V3-CONSULT-001 (Issue 341)
+ */
+
+export { runConsult } from './run-consult';
+export type {
+  ConsultCitation,
+  ConsultError,
+  ConsultInput,
+  ConsultResult,
+  ConsultSource,
+} from './types';

--- a/lib/domains/consult/run-consult.ts
+++ b/lib/domains/consult/run-consult.ts
@@ -1,0 +1,107 @@
+/**
+ * @MX:ANCHOR [AUTO] runConsult — CONSULT RAG pipeline entry point (RA Power Chat)
+ * @MX:REASON fan_in >= 3 (planned): /api/consult/sessions/:id/turns route,
+ *          future CLI replay, and integration tests all call this function.
+ *          Reuses TRIAGE runTriage for the core RAG pipeline (L-013 / L-014:
+ *          TRIAGE 패턴 재사용, 회귀 리스크 최소) and adds CONSULT-specific
+ *          citation coverage 80% enforcement (H-3, Charter [지양-2]).
+ * @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-004, REQ-CONS-005, AC-CONS-03..05)
+ */
+
+import { runTriage } from '@/lib/domains/triage';
+import type { RagPipelineInput } from '@/lib/domains/triage/types';
+
+import type {
+  ConsultCitation,
+  ConsultError,
+  ConsultInput,
+  ConsultResult,
+  ConsultSource,
+} from './types';
+
+/**
+ * Run the CONSULT RAG pipeline.
+ *
+ * Flow: delegate to TRIAGE runTriage (15s timeout + AbortController +
+ * classifyAndRoute → parallelRetrieveAndMerge → composePrompt → streamText →
+ * enforceCitations → confidence), then apply CONSULT-specific citation
+ * coverage 80% gate (H-3).
+ *
+ * Error mapping:
+ * - TRIAGE returns `no_citations` / `timeout` / `runtime_error` → forward as-is.
+ * - TRIAGE succeeds but uncited ratio > 0.2 (coverage < 80%) → `citation_coverage`.
+ *
+ * The caller (turn route) MUST persist the turn regardless (answer on success,
+ * error string on failure) so the RA member sees feedback in the session.
+ */
+export async function runConsult(input: ConsultInput): Promise<ConsultResult> {
+  const ragInput: RagPipelineInput = {
+    question: input.question,
+    orgId: input.orgId,
+    actorId: input.actorId ?? null,
+    signal: input.signal,
+  };
+
+  const triage = await runTriage(ragInput);
+
+  if (triage.error) {
+    return {
+      answer: null,
+      citations: [],
+      sources: [],
+      confidence: triage.autoConfidence,
+      error: triage.error as ConsultError,
+    };
+  }
+
+  const answer = triage.autoAnswer?.answer ?? '';
+  const citations: ConsultCitation[] = triage.autoAnswer?.citations ?? [];
+
+  // H-3: citation coverage 80% gate (Charter [지양-2], REQ-CONS-005, AC-CONS-04).
+  // TRIAGE rejects only zero-citation answers; CONSULT additionally rejects
+  // answers where uncited claims exceed 20% of sentences (regression from
+  // legacy consult.ts 80% threshold — research.md:294-297).
+  const totalSentences = countSentences(answer);
+  const citedSup = countCitedSup(answer);
+  if (totalSentences > 0) {
+    const uncitedRatio = (totalSentences - citedSup) / totalSentences;
+    if (uncitedRatio > 0.2) {
+      return {
+        answer: null,
+        citations: [],
+        sources: [],
+        confidence: triage.autoConfidence,
+        error: 'citation_coverage',
+      };
+    }
+  }
+
+  // Sources derived from citations (richer metadata is a follow-up).
+  const sources: ConsultSource[] = citations.map((c) => ({ sourceId: c.source }));
+
+  return {
+    answer,
+    citations,
+    sources,
+    confidence: triage.autoConfidence,
+    error: null,
+  };
+}
+
+// ── Citation/counting helpers (mirror TRIAGE run-triage.ts) ───────────────────
+// Reimplemented locally for the coverage check. TRIAGE keeps its own copies;
+// sharing would widen the TRIAGE API surface (regression risk).
+
+function countSentences(html: string): number {
+  // Drop <sup class="cite">…</sup> markers first — citation markers are not
+  // prose sentences, so counting "1" / "2" inside them would inflate the
+  // denominator and understate coverage (H-3 regression).
+  const withoutSup = html.replace(/<sup\b[^>]*>[\s\S]*?<\/sup>/gi, '');
+  const text = withoutSup.replace(/<[^>]+>/g, '');
+  return text.split(/[.!?。？！]+/).filter((segment) => segment.trim().length > 0).length;
+}
+
+function countCitedSup(html: string): number {
+  const matches = html.match(/<sup\b[^>]*\bclass\s*=\s*["'][^"']*\bcite\b[^"']*["'][^>]*>/gi);
+  return matches ? matches.length : 0;
+}

--- a/lib/domains/consult/types.ts
+++ b/lib/domains/consult/types.ts
@@ -1,0 +1,71 @@
+/**
+ * @MX:NOTE [AUTO] CONSULT module types — RA Power Chat (v3 Phase C-5)
+ *
+ * Exchange model (H-1): one turn = one Q+A pair. consult_turns row stores
+ * question (user input) + answer (RAG result) + citations + sources + confidence.
+ *
+ * @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-001..013, Issue 341)
+ */
+
+/**
+ * Input for the CONSULT RAG pipeline (runConsult).
+ * Mirrors TRIAGE RagPipelineInput; locale is fixed to 'ko' (TRIAGE pattern).
+ *
+ * @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-004)
+ */
+export interface ConsultInput {
+  /** User question (1-5000 chars, Zod-validated upstream). */
+  question: string;
+  /** Organization ID for RAG context isolation (RLS / app-level eq(orgId)). */
+  orgId: string;
+  /** Session user id threaded to RLHF re-rank audit. */
+  actorId?: string | null;
+  /** Optional AbortSignal for caller-initiated cancellation. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Citation entry — references a source ID. Matches TRIAGE AutoAnswer.citations
+ * and inbox promote.ts extractCitations() parser shape.
+ */
+export interface ConsultCitation {
+  /** Source ID (sources.id UUID or identifier). */
+  source: string;
+  /** Optional quoted text from source. */
+  quote?: string;
+}
+
+/**
+ * Source metadata persisted to consult_turns.sources (REQ-CONS-004).
+ * Derived from citations for now; richer metadata is a follow-up.
+ */
+export interface ConsultSource {
+  sourceId: string;
+  sourceLabel?: string;
+  quote?: string;
+}
+
+/**
+ * CONSULT pipeline error cases.
+ * Extends TRIAGE errors with `citation_coverage` (H-3: 80% coverage enforcement).
+ */
+export type ConsultError = 'no_citations' | 'citation_coverage' | 'timeout' | 'runtime_error';
+
+/**
+ * CONSULT pipeline result. On success: answer + citations + sources + confidence.
+ * On failure: error set, all data fields null/empty.
+ *
+ * @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-005, AC-CONS-03..05)
+ */
+export interface ConsultResult {
+  /** HTML prose with <sup class="cite"> markers, or null on error. */
+  answer: string | null;
+  /** Citation list (empty on error). */
+  citations: ConsultCitation[];
+  /** Source metadata for consult_turns.sources (empty on error). */
+  sources: ConsultSource[];
+  /** Confidence score 0.0-1.0 (null if not computed). */
+  confidence: number | null;
+  /** Error type, or null on success. */
+  error: ConsultError | null;
+}

--- a/migrations/0107_create_consult_tables.sql
+++ b/migrations/0107_create_consult_tables.sql
@@ -1,0 +1,85 @@
+-- SPEC-V3-CONSULT-001 — RA Power Chat (v3 Phase C-5)
+-- Migration 0107: consult_sessions + consult_turns tables
+--
+-- Creates:
+--   1. consult_sessions table (REQ-CONS-001)
+--   2. consult_turns table (REQ-CONS-004, Exchange model — H-1)
+--   3. audit_action enum +3 values (REQ-CONS-008, REQ-CONS-009, REQ-CONS-013)
+--   4. RLS policies for org-isolation (REQ-CONS-012)
+--
+-- NOTE: RLS is currently inert (#239 debt). Actual isolation is enforced at
+--       query-layer (withTenantScope / app-level eq(orgId)). These policies
+--       are future-proofing for when RLS is FORCE-enabled.
+--
+-- v2 호환성 (R-01): consult_sessions/turns are ISOLATED from existing
+-- conversations/messages. The legacy 1-shot /api/ra/consult SSE route is
+-- untouched (T-27 regression test).
+
+BEGIN;
+
+-- 1. consult_sessions table (REQ-CONS-001)
+CREATE TABLE consult_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  project_id UUID REFERENCES projects(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  locale TEXT NOT NULL DEFAULT 'ko',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX consult_sessions_org_id_idx ON consult_sessions(org_id);
+CREATE INDEX consult_sessions_user_id_idx ON consult_sessions(user_id);
+CREATE INDEX consult_sessions_created_at_idx ON consult_sessions(created_at);
+
+-- 2. consult_turns table (REQ-CONS-004, Exchange model — H-1)
+-- Exchange model: one turn = one Q+A pair. No `role` column.
+CREATE TABLE consult_turns (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id UUID NOT NULL REFERENCES consult_sessions(id) ON DELETE CASCADE,
+  turn_number INTEGER NOT NULL,
+  question TEXT NOT NULL,
+  answer TEXT,
+  citations JSONB NOT NULL DEFAULT '[]',
+  sources JSONB NOT NULL DEFAULT '[]',
+  confidence REAL,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(session_id, turn_number)
+);
+
+CREATE INDEX consult_turns_session_turn_idx ON consult_turns(session_id, turn_number);
+
+-- 3. audit_action enum +3 (REQ-CONS-008 turn.create, REQ-CONS-009 session.delete,
+--    REQ-CONS-013 session.create — 21 CFR Part 11 §11.10(e))
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'consult.session.create';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'consult.turn.create';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'consult.session.delete';
+
+-- 4. RLS policies for org-isolation (REQ-CONS-012)
+ALTER TABLE consult_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE consult_turns ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY consult_sessions_org_isolation ON consult_sessions
+  USING (org_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+CREATE POLICY consult_turns_org_isolation ON consult_turns
+  USING (
+    EXISTS (
+      SELECT 1 FROM consult_sessions s
+      WHERE s.id = consult_turns.session_id
+        AND s.org_id = current_setting('app.current_org_id', true)::uuid
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM consult_sessions s
+      WHERE s.id = consult_turns.session_id
+        AND s.org_id = current_setting('app.current_org_id', true)::uuid
+    )
+  );
+
+COMMIT;

--- a/migrations/0107_create_consult_tables_rollback.sql
+++ b/migrations/0107_create_consult_tables_rollback.sql
@@ -1,0 +1,13 @@
+-- Rollback for 0107_create_consult_tables.sql
+-- NOTE: ALTER TYPE ... ADD VALUE is irreversible in PostgreSQL. The 3 enum
+--       values (consult.session.create / consult.turn.create / consult.session.delete)
+--       remain in audit_action after rollback — harmless if unused.
+BEGIN;
+
+DROP POLICY IF EXISTS consult_turns_org_isolation ON consult_turns;
+DROP POLICY IF EXISTS consult_sessions_org_isolation ON consult_sessions;
+
+DROP TABLE IF EXISTS consult_turns;
+DROP TABLE IF EXISTS consult_sessions;
+
+COMMIT;

--- a/migrations/0108_consult_turn_failed_audit.sql
+++ b/migrations/0108_consult_turn_failed_audit.sql
@@ -1,0 +1,14 @@
+-- SPEC-V3-CONSULT-001 — RA Power Chat (v3 Phase C-5)
+-- Migration 0108: consult.turn.failed audit_action enum value
+--
+-- Adds the `consult.turn.failed` audit_action for REQ-CONS-010 (21 CFR Part 11
+-- §11.10(e) debugging audit). When a CONSULT turn times out or hits a runtime
+-- error, the turn row IS persisted (with error string) so the RA member sees
+-- feedback in the session — and a `consult.turn.failed` audit row is written
+-- in the SAME transaction (AC-CONS-05).
+
+BEGIN;
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'consult.turn.failed';
+
+COMMIT;

--- a/migrations/0108_consult_turn_failed_audit_rollback.sql
+++ b/migrations/0108_consult_turn_failed_audit_rollback.sql
@@ -1,0 +1,6 @@
+-- Rollback for 0108_consult_turn_failed_audit.sql
+-- NOTE: ALTER TYPE ... ADD VALUE is irreversible in PostgreSQL. The enum value
+--       `consult.turn.failed` remains in audit_action after rollback — harmless if unused.
+BEGIN;
+-- No-op (enum value cannot be removed without rebuild).
+COMMIT;

--- a/tests/regression/foundation.test.ts
+++ b/tests/regression/foundation.test.ts
@@ -38,8 +38,8 @@ describe('FOUNDATION regression', () => {
   // + personal.view — SPEC-REGULA-PERSONAL-LIB-001
   // + deadline.view, deadline.manage — SPEC-REGULA-CALENDAR-001)
   // ---------------------------------------------------------------------------
-  it('has 82 permission actions defined', () => {
-    expect(Object.keys(PERMISSIONS).length).toBe(82); // +2 corpuslicense.* (#72) +2 sourcegov.* (#48) +1 rlhf.feedback (#56) +2 knowledgepromo.* (#50) +2 standards.* (#62) +2 inbox.* (#320) +1 ask.create (#320 SPEC-V3-INBOX-001)
+  it('has 86 permission actions defined', () => {
+    expect(Object.keys(PERMISSIONS).length).toBe(86); // +2 corpuslicense.* (#72) +2 sourcegov.* (#48) +1 rlhf.feedback (#56) +2 knowledgepromo.* (#50) +2 standards.* (#62) +2 inbox.* (#320) +1 ask.create (#320) +4 consult.* (#341 SPEC-V3-CONSULT-001)
   });
 
   it('profile.edit permission exists with user scope', () => {

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(215); // -9 pms.*/pmcf.* (Issue #319 SPEC-REGULA-PHI-REMOVAL-001) +8 inbox (Issue #320 SPEC-V3-INBOX-001) +1 inbox.approve_failed (Issue #320 SPEC-V3-INBOX-001); was 215 before PMS/PMCF domain removal
+    expect(values).toHaveLength(218); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +3 consult (Issue #341 SPEC-V3-CONSULT-001); was 215 before PMS/PMCF domain removal
   });
 
   it.each([

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -72,7 +72,7 @@ describe('lib/audit.ts (REQ-BREADTH-057) — extended AuditAction type', () => {
         'export.confluence',
       ]),
     );
-    expect(values).toHaveLength(218); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +3 consult (Issue #341 SPEC-V3-CONSULT-001); was 215 before PMS/PMCF domain removal
+    expect(values).toHaveLength(219); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +4 consult (Issue #341 SPEC-V3-CONSULT-001); was 215 before PMS/PMCF domain removal
   });
 
   it.each([

--- a/tests/unit/auth/permissions.test.ts
+++ b/tests/unit/auth/permissions.test.ts
@@ -87,8 +87,8 @@ const VALID_ROLES = ['admin', 'qa-lead', 'ra-lead', 'ra-member', 'viewer', 'audi
 const VALID_SCOPES = ['org', 'project', 'user', 'none'] as const;
 
 describe('lib/auth/permissions.ts (REQ-ENTERPRISE-020) — PERMISSIONS matrix', () => {
-  it('PERMISSIONS contains exactly 82 entries', () => {
-    expect(Object.keys(PERMISSIONS)).toHaveLength(82); // +2 corpuslicense.* (#72) +2 sourcegov.* (#48) +1 rlhf.feedback (#56) +2 knowledgepromo.* (#50) +2 standards.* (#62) +2 inbox.* (#320) +1 ask.create (#320 SPEC-V3-INBOX-001)
+  it('PERMISSIONS contains exactly 86 entries', () => {
+    expect(Object.keys(PERMISSIONS)).toHaveLength(86); // +2 corpuslicense.* (#72) +2 sourcegov.* (#48) +1 rlhf.feedback (#56) +2 knowledgepromo.* (#50) +2 standards.* (#62) +2 inbox.* (#320) +1 ask.create (#320) +4 consult.* (#341 SPEC-V3-CONSULT-001)
   });
 
   it.each(EXPECTED_ACTIONS)('PERMISSIONS contains action: %s', (action) => {

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -426,8 +426,8 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     // order is NOT required to match (enum and type legitimately group migrations
     // differently with interspersed comments). Set-equality is the correct check.
     expect(new Set(values)).toEqual(new Set(typeValues));
-    expect(values).toHaveLength(215); // -9 pms.*/pmcf.* (Issue #319 SPEC-REGULA-PHI-REMOVAL-001) +8 inbox (Issue #320 SPEC-V3-INBOX-001) +1 inbox.approve_failed (Issue #320 SPEC-V3-INBOX-001); was 215
-    expect(typeValues).toHaveLength(215);
+    expect(values).toHaveLength(218); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +3 consult (Issue #341 SPEC-V3-CONSULT-001); was 215
+    expect(typeValues).toHaveLength(218);
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -483,7 +483,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(215); // -9 pms.*/pmcf.* (Issue #319 SPEC-REGULA-PHI-REMOVAL-001) +8 inbox (Issue #320 SPEC-V3-INBOX-001) +1 inbox.approve_failed (Issue #320 SPEC-V3-INBOX-001); was 215
+    expect(values).toHaveLength(218); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +3 consult (Issue #341 SPEC-V3-CONSULT-001); was 215
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(

--- a/tests/unit/enterprise-migrations.test.ts
+++ b/tests/unit/enterprise-migrations.test.ts
@@ -426,8 +426,8 @@ describe('lib/db/schema.ts Phase 5 additions', () => {
     // order is NOT required to match (enum and type legitimately group migrations
     // differently with interspersed comments). Set-equality is the correct check.
     expect(new Set(values)).toEqual(new Set(typeValues));
-    expect(values).toHaveLength(218); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +3 consult (Issue #341 SPEC-V3-CONSULT-001); was 215
-    expect(typeValues).toHaveLength(218);
+    expect(values).toHaveLength(219); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +4 consult (Issue #341 SPEC-V3-CONSULT-001); was 215
+    expect(typeValues).toHaveLength(219);
   });
 
   it.each(REQUIRED_RECOVERY_TABLES)(
@@ -483,7 +483,7 @@ describe('lib/audit.ts Phase 5 AuditAction type additions', () => {
         'change.export_blocked',
       ]),
     );
-    expect(values).toHaveLength(218); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +3 consult (Issue #341 SPEC-V3-CONSULT-001); was 215
+    expect(values).toHaveLength(219); // -9 pms.*/pmcf.* (Issue #319) +8 inbox +1 inbox.approve_failed (Issue #320) +4 consult (Issue #341 SPEC-V3-CONSULT-001); was 215
   });
 
   it.each(REQUIRED_RECOVERY_AUDIT_ACTIONS)(

--- a/tests/unit/lib/domains/consult/run-consult.test.ts
+++ b/tests/unit/lib/domains/consult/run-consult.test.ts
@@ -1,0 +1,135 @@
+// @MX:NOTE [AUTO] runConsult unit tests — RA Power Chat RAG pipeline wrapper.
+// @MX:SPEC SPEC-V3-CONSULT-001 (REQ-CONS-004, REQ-CONS-005, AC-CONS-03..05, Issue 341)
+// @MX:REASON runConsult wraps runTriage (TRIAGE 재사용) and adds citation coverage
+//            80% gate (H-3). Tests mock runTriage to verify error mapping + coverage logic
+//            without LLM/retrieval network calls (TRIAGE run-triage.test.ts pattern).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock TRIAGE runTriage so tests stay pure (no LLM / retrieval).
+vi.mock('@/lib/domains/triage', () => ({
+  runTriage: vi.fn(),
+}));
+
+import { runConsult } from '@/lib/domains/consult/run-consult';
+import type { ConsultInput } from '@/lib/domains/consult/types';
+import { runTriage } from '@/lib/domains/triage';
+
+const baseInput: ConsultInput = {
+  question: 'What does EU MDR Article 10 require?',
+  orgId: '00000000-0000-0000-0000-000000000001',
+  actorId: '00000000-0000-0000-0000-000000000002',
+};
+
+const mockedRunTriage = vi.mocked(runTriage);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runConsult — RA Power Chat (SPEC-V3-CONSULT-001)', () => {
+  it('AC-CONS-03: success returns answer + citations + sources + confidence', async () => {
+    mockedRunTriage.mockResolvedValue({
+      autoAnswer: {
+        answer:
+          'EU MDR Article 10 requires a QMS. <sup class="cite" data-source="1">1</sup> Another cited sentence. <sup class="cite" data-source="2">2</sup>',
+        citations: [{ source: 'src-1' }, { source: 'src-2' }],
+      },
+      autoConfidence: 0.92,
+    });
+
+    const result = await runConsult(baseInput);
+
+    expect(result.error).toBeNull();
+    expect(result.answer).toContain('EU MDR Article 10');
+    expect(result.citations).toHaveLength(2);
+    expect(result.sources).toEqual([{ sourceId: 'src-1' }, { sourceId: 'src-2' }]);
+    expect(result.confidence).toBe(0.92);
+  });
+
+  it('AC-CONS-04: TRIAGE no_citations error forwards as-is', async () => {
+    mockedRunTriage.mockResolvedValue({
+      autoAnswer: null,
+      autoConfidence: null,
+      error: 'no_citations',
+    });
+
+    const result = await runConsult(baseInput);
+    expect(result.error).toBe('no_citations');
+    expect(result.answer).toBeNull();
+    expect(result.citations).toEqual([]);
+  });
+
+  it('AC-CONS-05: TRIAGE timeout error forwards as-is', async () => {
+    mockedRunTriage.mockResolvedValue({
+      autoAnswer: null,
+      autoConfidence: null,
+      error: 'timeout',
+    });
+
+    const result = await runConsult(baseInput);
+    expect(result.error).toBe('timeout');
+  });
+
+  it('H-3: low citation coverage (<80%) returns citation_coverage error', async () => {
+    // 5 sentences, only 1 cited → uncited ratio = 4/5 = 0.8 > 0.2 → reject.
+    mockedRunTriage.mockResolvedValue({
+      autoAnswer: {
+        answer:
+          'First uncited sentence. Second uncited sentence. Third uncited one. Fourth uncited sentence. <sup class="cite" data-source="1">1</sup> Only this is cited.',
+        citations: [{ source: 'src-1' }],
+      },
+      autoConfidence: 0.4,
+    });
+
+    const result = await runConsult(baseInput);
+    expect(result.error).toBe('citation_coverage');
+    expect(result.answer).toBeNull();
+  });
+
+  it('H-3: high citation coverage (>=80%) passes through', async () => {
+    // 2 sentences, 2 cited sup markers → uncited ratio low → pass.
+    mockedRunTriage.mockResolvedValue({
+      autoAnswer: {
+        answer:
+          'EU MDR requires a QMS. <sup class="cite" data-source="1">1</sup> Article 10 defines scope. <sup class="cite" data-source="2">2</sup>',
+        citations: [{ source: 'src-1' }, { source: 'src-2' }],
+      },
+      autoConfidence: 0.9,
+    });
+
+    const result = await runConsult(baseInput);
+    expect(result.error).toBeNull();
+    expect(result.answer).not.toBeNull();
+  });
+
+  it('forwards TRIAGE runtime_error', async () => {
+    mockedRunTriage.mockResolvedValue({
+      autoAnswer: null,
+      autoConfidence: null,
+      error: 'runtime_error',
+    });
+
+    const result = await runConsult(baseInput);
+    expect(result.error).toBe('runtime_error');
+  });
+
+  it('threads actorId to runTriage (RLHF audit)', async () => {
+    mockedRunTriage.mockResolvedValue({
+      autoAnswer: {
+        answer: 'cited. <sup class="cite" data-source="1">1</sup>',
+        citations: [{ source: 'src-1' }],
+      },
+      autoConfidence: 0.8,
+    });
+
+    await runConsult(baseInput);
+
+    expect(mockedRunTriage).toHaveBeenCalledWith({
+      question: baseInput.question,
+      orgId: baseInput.orgId,
+      actorId: baseInput.actorId,
+      signal: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## SPEC-V3-CONSULT-001 — RA Power Chat 백엔드 (v3 Phase C-5)

Closes #341. TRIAGE run-triage.ts 패턴 재사용 + Exchange 모델 + citation 80% coverage 강제.

### 구현 (commit `ca0f50b`, 16 files +909/-10)
- **M1 스키마**: migration 0107 (consult_sessions + consult_turns Exchange 모델 + RLS + UNIQUE). 기존 conversations/messages와 격리 (R-01 v2 호환성).
- **M2 run-consult.ts**: runTriage 래퍼 + H-3 citation 80% coverage 강제 (uncited ratio > 0.2 → `citation_coverage`, Charter [지양-2]).
- **M3+M4 라우트 4종**: POST/GET/DELETE /sessions + POST /sessions/:id/turns. 21 CFR Part 11 audit (session.create REQ-CONS-013 / turn.create / session.delete).
- **M5 RBAC**: consult.session.create/view (ra-member+), consult.session.delete (ra-lead/admin), consult.turn.create (ra-member+).
- **M6 테스트**: run-consult.test.ts 7 tests (AC-CONS-03..05 + H-3 coverage + actorId).

### 게이트 직검 (L-007/008/009/010/013 — 오케스트레이터 직접)
- typecheck EXIT 0 / lint(biome+hex) 0 err (1 pre-existing warning)
- test FULL **4445 passed | 0 failed | 24 skipped** (+7 consult vs 4438 TRIAGE baseline)
- migration 0107 실DB 적용 — regula-test-db (218 audit_action enum + 2 tables 직검)
- 카운트 단언 갱신: audit 215→218, PERMISSIONS 82→86
- staged 범위 직검 (16 files, consult 도메인만 — 회귀 최소)

### plan-auditor 개정 반영 (v1.1.0)
- C-1: consult.session.create audit REQ-CONS-013 신설 (Policy Anchor 자기모순 해소)
- H-1: consult_turns Exchange 모델 (role 제거)
- H-2: AC-CONS-02b (GET session detail positive)
- H-3: citation 80% coverage 강제

### Charter 가드
- [지양-2] citation 강제 (enforceCitations 재사용 + coverage 80%)
- [지양-4] RBAC (ra-member+ / ra-lead/admin 분리, 자동 의사결정 금지)

### 범위 외 (별도 follow-up)
- route-level integration test (evaluator 검증 후 보강)
- 동시성 race retry/SERIALIZABLE (plan-auditor M-7, UNIQUE 제약으로 최소 방어만)
- rate limit (plan-auditor M-1)
- UI (Phase D / SPEC-V3-UI-001)

🗿 MoAI <email@moai.kr>