### PR TITLE
docs(spec): SPEC-V3-IMPACT-001 plan phase 산출물 4종 (Phase C-3)

### DIFF
--- a/.moai/specs/SPEC-V3-IMPACT-001/acceptance.md
+++ b/.moai/specs/SPEC-V3-IMPACT-001/acceptance.md
@@ -1,0 +1,471 @@
+# SPEC-V3-IMPACT-001: Change Impact 4-Layer Wizard
+
+## Acceptance Criteria Document
+
+---
+**SPEC ID:** SPEC-V3-IMPACT-001
+**Version:** 1.0.0
+**Status:** planned
+**Created:** 2026-07-05
+---
+
+## Acceptance Criteria (AC)
+
+### AC-IMP-01: 위저드 Step 1 - 제품 선택
+
+**Given:** Employee가 위저드를 시작하고 Step 1에 도달했을 때
+**When:** 제품 목록을 로드할 때
+**Then:**
+- 제품 목록이 표시된다 (product.id, product.name, product.type, product_markets)
+- 최소 1개 이상의 제품이 표시된다 (등록된 제품이 있는 경우)
+- 제품이 없으면 안내 메시지가 표시된다
+
+**Given:** 제품을 선택했을 때
+**When:** Step 2로 이동할 때
+**Then:**
+- 선택된 제품의 등록된 시장 정보가 Step 4로 전달된다
+
+### AC-IMP-02: 위저드 Step 2 - 변경 카테고리 선택
+
+**Given:** Employee가 Step 2에 도달했을 때
+**When:** 카테고리 목록을 표시할 때
+**Then:**
+- 7개 카테고리가 표시된다 (BOM, SW, SW-minor, label, warn, process, sterile)
+- 각 카테고리에 설명이 제공된다
+
+**Given:** 카테고리를 선택했을 때
+**When:** Step 3로 이동할 때
+**Then:**
+- 선택된 카테고리 ID가 Step 3으로 전달된다
+
+### AC-IMP-03: 위저드 Step 3 - 변경 상세 입력
+
+**Given:** Employee가 Step 3에 도달했을 때
+**When:** 자유 텍스트 입력 필드를 표시할 때
+**Then:**
+- 입력 필드가 표시된다 (최소 10자, 최대 2000자)
+- 안내 메시지가 표시된다 ("변경 내용을 구체적으로 기술하세요")
+
+**Given:** 변경 상세를 입력했을 때
+**When:** Step 4로 이동할 때
+**Then:**
+- 입력된 텍스트가 Layer 2 LLM 분석으로 전달된다
+
+### AC-IMP-04: 위저드 Step 4 - 영향 시장 선택
+
+**Given:** Employee가 Step 4에 도달했을 때
+**When:** 시장 목록을 표시할 때
+**Then:**
+- 5개 시장이 표시된다 (FDA/US, MDR/EU, MFDS/KR, NMPA/CN, PMDA/JP)
+- Step 1에서 선택한 제품의 등록된 시장이 기본값으로 설정된다
+
+**Given:** 시장을 선택하고 "평가 시작"을 클릭했을 때
+**When:** 4계층 평가를 트리거할 때
+**Then:**
+- 선택된 시장 목록이 평가 엔진으로 전달된다
+
+### AC-IMP-05: Layer 1 - retestMatrix 룰 조회
+
+**Given:** changeType='bom'이고 market='us'일 때
+**When:** Layer 1 retestMatrix 조회를 수행할 때
+**Then:**
+- 'bom-us' 셀이 조회된다
+- level='conditional', ref='FDA Design Change §III.A', note='Special 510(k) 검토 필요'가 반환된다
+
+**Given:** changeType='sw'이고 market='eu'일 때
+**When:** Layer 1 retestMatrix 조회를 수행할 때
+**Then:**
+- 'sw-eu' 셀이 조회된다
+- level='required', ref='MDR Art. 10(9), MDCG 2024-9', note='CIP 없으면 TR 개정 필수'가 반환된다
+
+**Given:** 선택된 모든 시장에 대해 조회할 때
+**When:** Layer 1이 완료될 때
+**Then:**
+- 5개 시장 모두에 대한 retestMatrix 셀 값이 반환된다
+- 조회 시간이 < 10ms이다 (in-memory 데이터)
+
+### AC-IMP-06: Layer 2 - LLM 카테고리 분류
+
+**Given:** Step 3에서 입력한 change_detail="BLE 4.2 → 5.3 SoC 교체 및 안테나 재설계"일 때
+**When:** Layer 2 LLM 분류를 수행할 때
+**Then:**
+- gx10 Ollama API가 호출된다
+- 응답: {"category": "bom", "confidence": 92, "reason": "SoC 교체는 BOM 변경 패턴"}
+- confidence >= 80이므로 Layer 4로 진행한다
+
+**Given:** confidence < 80일 때 (예: confidence=65)
+**When:** Layer 2가 완료될 때
+**Then:**
+- 사용자에게 재확인 요청 메시지가 표시된다
+- Layer 3 티켓 생성이 트리거된다
+
+**Given:** LLM API 호출이 실패했을 때
+**When:** 재시도 3회 모두 실패할 때
+**Then:**
+- 에러 메시지가 표시된다
+- 사용자에게 수동 RA 상담 제안이 표시된다
+
+### AC-IMP-07: Layer 3 - RA Inbox 자동 티켓 생성
+
+**Given:** Layer 2 confidence < 80일 때
+**When:** Layer 3 티켓 생성을 수행할 때
+**Then:**
+- domains/inbox 티켓 생성 API가 호출된다
+- 티켓 state='needs-review'
+- 티켓 question="confidence < 80% 자동 분류 실패. RA 전문가 검토 필요."
+- 티켓 context에 모든 위저드 입력이 포함된다
+
+**Given:** 티켓 생성이 성공했을 때
+**When:** audit 로깅을 수행할 때
+**Then:**
+- `impact.ticket.create` audit 로그가 기록된다
+- 티켓 ID가 사용자에게 표시된다
+
+**Given:** 티켓 생성이 실패했을 때 (예: inbox API 다운)
+**When:** 에러 처리를 수행할 때
+**Then:**
+- 에러 메시지가 표시된다
+- 위저드 결과는 여전히 표시된다 (티켓 생성 실패는 평가 결과에 영향하지 않음)
+
+### AC-IMP-08: Layer 4 - ra-llm-wiki RAG 유사 사례 조회
+
+**Given:** confidence >= 80이고 product_id='xray-src'일 때
+**When:** Layer 4 RAG 조회를 수행할 때
+**Then:**
+- embeddings 테이블이 pgvector 코사인 유사도 검색으로 쿼리된다
+- 필터: source_repo='ra-llm-wiki', product_id='xray-src'
+- 최대 3건의 유사 사례가 반환된다
+- 각 사례에 chunk_text, source_path, change_type, similarity가 포함된다
+
+**Given:** RAG 조회가 완료되었을 때
+**When:** SimilarCasesCard를 렌더링할 때
+**Then:**
+- 각 유사 사례에 출처 인용이 표시된다 (<sup class="cite">1</sup>)
+- 출처를 클릭하면 원본 문서 링크로 이동한다
+
+**Given:** RAG 조회가 타임아웃(10초)했을 때
+**When:** 에러 처리를 수행할 때
+**Then:**
+- 빈 결과가 반환된다
+- 위저드는 계속 진행된다
+- 사용자에게 "유사 사례 조회 실패" 메시지가 표시된다
+
+### AC-IMP-09: 최종 결과 페이지 - 신호등 계산
+
+**Given:** 모든 시장 where level='not-required'일 때
+**When:** 신호등을 계산할 때
+**Then:**
+- 결과는 **Green**이다
+- "모든 시장에서 재시험 불필요" 메시지가 표시된다
+
+**Given:** 일부 시장 where level='conditional' 또는 confidence < 90일 때
+**When:** 신호등을 계산할 때
+**Then:**
+- 결과는 **Yellow**이다
+- "일부 시장에서 조건부 재시험 필요" 메시지가 표시된다
+
+**Given:** 어떤 시장 where level='required' 또는 confidence < 70일 때
+**When:** 신호등을 계산할 때
+**Then:**
+- 결과는 **Red**이다
+- "적어도 하나의 시장에서 필수 재시험 필요" 메시지가 표시된다
+
+**Given:** 신호든 결과가 계산되었을 때
+**When:** 최종 결과 페이지를 표시할 때
+**Then:**
+- 신호등 색상이 표시된다 (Green/Yellow/Red)
+- retestMatrix 셀이 표시된다 (시장별 level, ref, note)
+- LLM 분석 결과가 표시된다 (category, confidence, reason)
+- 유사 사례 3건이 표시된다 (Layer 4 결과)
+- (필요 시) 티켓 CTA가 표시된다
+
+### AC-IMP-10: retestMatrix 데이터 코드 임베드
+
+**Given:** 애플리케이션이 시작될 때
+**When:** retestMatrix 데이터를 로드할 때
+**Then:**
+- `lib/domains/impact/retest-matrix-data.ts`가 로드된다
+- 7 changeTypes가 정의된다
+- 5 markets가 정의된다
+- 35개 셀 (7 × 5)이 정의된다
+
+**Given:** retestMatrix 셀을 조회할 때
+**When:** 'bom-us' 키로 조회할 때
+**Then:**
+- 해당 셀 값이 반환된다 (level, ref, note)
+- 조회 시간이 < 1ms이다 (in-memory object)
+
+**Given:** retestMatrix 데이터에 누락된 셀이 있을 때
+**When:** 런타임에 조회할 때
+**Then:**
+- 런타임 에러가 발생한다
+- 관리자에게 알림이 생성된다
+
+### AC-IMP-11: DB 테이블 확장
+
+**Given:** migration 0109가 실행될 때
+**When:** regulatory_impact_assessments 테이블을 확장할 때
+**Then:**
+- 7개 신규 컬럼이 추가된다 (wizard_type, change_category, change_detail, markets, retest_matrix_results, llm_category, rag_similar_cases)
+- 모든 신규 컬럼은 nullable이다
+- 기존 레코드는 모든 신규 컬럼이 NULL이다
+
+**Given:** 기존 regulatory_impact_assessments 레코드가 있을 때
+**When:** migration 0109를 실행할 때
+**Then:**
+- 기존 레코드가 보존된다 (삭제/변경 없음)
+- wizard_type = NULL (기존 레코는 radar-auto임)
+- 신규 컬럼 모두 NULL
+
+**Given:** 신규 컬럼이 추가된 후
+**When:** Drizzle Kit check를 실행할 때
+**Then:**
+- 타입 검증이 통과한다
+- FK 관계가 깨지지 않는다
+
+### AC-IMP-12: 21 CFR Part 11 감사 로깅
+
+**Given:** Employee가 위저드를 실행했을 때
+**When:** audit 로깅을 수행할 때
+**Then:**
+- `impact.check` audit 로그가 기록된다
+- user_id가 실행자 UUID로 기록된다
+- context에 product_id, wizard_type, change_category, markets, result가 포함된다
+- previous_hash가 이전 레코드의 SHA-256 해시로 설정된다
+
+**Given:** Layer 3에서 티켓이 생성되었을 때
+**When:** audit 로깅을 수행할 때
+**Then:**
+- `impact.ticket.create` audit 로그가 기록된다
+- context에 ticket_id가 포함된다
+
+**Given:** 신호등이 Red일 때
+**When:** audit 로깅을 수행할 때
+**Then:**
+- `impact.critical_detected` audit 로그가 기록된다
+- context에 critical_reason이 포함된다
+
+### AC-IMP-13: RBAC 권한 검사
+
+**Given:** Employee 역할이 impact.view 권한이 있을 때
+**When:** 위저드에 접근할 때
+**Then:**
+- 접근이 허용된다
+- 위저드 Step 1이 표시된다
+
+**Given:** Employee 역할이 impact.view 권한이 없을 때
+**When:** 위저드에 접근할 때
+**Then:**
+- 403 Forbidden 응답이 반환된다
+- `auth.forbidden` audit 로그가 기록된다
+
+**Given:** Employee 역할이 impact.self_check 권한이 있을 때
+**When:** POST /api/impact-check를 호출할 때
+**Then:**
+- 요청이 처리된다
+- 4계층 평가가 수행된다
+
+**Given:** Employee 역할이 impact.self_check 권한이 없을 때
+**When:** POST /api/impact-check를 호출할 때
+**Then:**
+- 403 Forbidden 응답이 반환된다
+
+### AC-IMP-14: RAG Citation 강제 (Charter [지양-2])
+
+**Given:** Layer 4 유사 사례가 조회되었을 때
+**When:** SimilarCasesCard를 렌더링할 때
+**Then:**
+- 모든 유사 사례에 출처 인용이 포함된다 (<sup class="cite" data-src="...">번호</sup>)
+- 출처를 클릭하면 원본 문서로 이동한다
+
+**Given:** 출처가 누락된 유사 사례가 있을 때
+**When:** SimilarCasesCard를 렌더링할 때
+**Then:**
+- 해당 사례는 제외된다
+- "출처 없는 사례는 신뢰도가 낮습니다" 메시지가 표시된다
+
+**Given:** 모든 유사 사례에 출처가 있을 때
+**When:** SimilarCasesCard를 렌더링할 때
+**Then:**
+- 최대 3건의 유사 사례가 표시된다
+- 각 사례에 출처 인용이 표시된다
+
+### AC-IMP-15: 기존 SPEC-REGULA-IMPACT-001 비회귀
+
+**Given:** 기존 `/api/ra/impact` API가 존재할 때
+**When:** lib/impact/ → lib/domains/impact/ 이동 후
+**Then:**
+- `/api/ra/impact` API가 여전히 동작한다
+- 기존 클라이언트가 깨지지 않는다
+- 기존 테스트 79개가 전체 통과한다
+
+**Given:** 기존 regulatory_impact_assessments 레코드가 있을 때
+**When:** migration 0109를 실행할 때
+**Then:**
+- 기존 레코드가 보존된다
+- 기존 컬럼이 삭제되지 않는다
+- 신규 컬럼이 NULL로 추가된다
+
+**Given:** 기존 audit action enum이 있을 때
+**When:** 신규 audit action을 추가할 때
+**Then:**
+- 기존 action (impact.assessment_created, impact.critical_detected, impact.action_item_created)이 유지된다
+- 신규 action만 추가된다
+
+## Edge Cases
+
+### Edge Case 1: 빈 포트폴리오
+
+**Given:** 제품이 등록되어 있지 않을 때
+**When:** Employee가 위저드를 시작할 때
+**Then:**
+- Step 1에 "등록된 제품이 없습니다" 메시지가 표시된다
+- 위저드가 진행되지 않는다
+
+### Edge Case 2: retestMatrix 셀 누락
+
+**Given:** retestMatrix 데이터에 'process-kr' 셀이 누락되었을 때
+**When:** changeType='process', market='kr'로 조회할 때
+**Then:**
+- 런타임 에러가 발생한다
+- 관리자에게 "retestMatrix 셀 누락: process-kr" 알림이 생성된다
+
+### Edge Case 3: RAG 타임아웃
+
+**Given:** RAG查询가 10초 이상 소요할 때
+**When:** 타임아웃이 발생할 때
+**Then:**
+- 빈 결과가 반환된다
+- 위저드는 계속 진행된다
+- "유사 사례 조회 시간 초과" 메시지가 표시된다
+
+### Edge Case 4: Cross-org 접근
+
+**Given:** Organization A의 Employee가 Organization B의 제품에 접근하려 할 때
+**When:** 위저드를 실행할 때
+**Then:**
+- RBAC 권한 검사가 실패한다
+- 403 Forbidden 응답이 반환된다
+- `auth.forbidden` audit 로그가 기록된다
+
+### Edge Case 5: 동시 변경 평가
+
+**Given:** 동일한 제품에 대해 2명의 Employee가 동시에 위저드를 실행할 때
+**When:** 4계층 평가를 수행할 때
+**Then:**
+- 각 평가가 독립적으로 수행된다
+- 각 평가가 별도의 regulatory_impact_assessments 레코드를 생성한다
+- DB 트랜잭션 충돌이 발생하지 않는다
+
+### Edge Case 6: LLM API Rate Limit
+
+**Given:** LLM API가 rate limit에 도달했을 때
+**When:** Layer 2 분류를 수행할 때
+**Then:**
+- 재시도가 수행된다 (최대 3회)
+- 3회 모두 실패하면 에러 메시지가 표시된다
+- "LLM API 일시 오류, 나중에 다시 시도하세요" 메시지가 표시된다
+
+### Edge Case 7: 등록되지 않은 시장 선택
+
+**Given:** 제품이 US, EU에만 등록되어 있을 때
+**When:** Employee가 KR, CN, JP를 선택할 때
+**Then:**
+- 경고 메시지가 표시된다 ("선택한 시장에 제품이 등록되어 있지 않습니다")
+- 확인 대화상자가 표시된다
+- 확인 시 계속 진행, 취소 시 시장 선택 화면으로 돌아간다
+
+### Edge Case 8: change_detail 2000자 초과
+
+**Given:** Employee가 change_detail에 2500자를 입력했을 때
+**When:** Step 3에서 "다음"을 클릭할 때
+**Then:**
+- 입력 검증이 실패한다
+- "최대 2000자까지 입력 가능합니다" 에러가 표시된다
+- Step 3에 머물러 있다
+
+## Quality Gate Criteria
+
+### Definition of Done (DoD)
+
+**SPEC-V3-IMPACT-001은 다음 조건을 모두 충족할 때 "완료"로 간주한다:**
+
+1. **기능 완료:**
+   - [ ] 15개 AC (AC-IMP-01 ~ AC-IMP-15)가 모두 통과한다
+   - [ ] 4계층 평가 엔진이 정상 동작한다
+   - [ ] retestMatrix 35셀 데이터가 코드 임베드되었다
+   - [ ] Layer 4 RAG 조회가 정상 동작한다
+   - [ ] Layer 3 RA Inbox 티켓 생성이 정상 동작한다
+
+2. **데이터베이스:**
+   - [ ] Migration 0109가 성공적으로 적용되었다
+   - [ ] 기존 regulatory_impact_assessments 레코드가 보존되었다
+   - [ ] Drizzle Kit check가 통과한다
+
+3. **감사 로깅:**
+   - [ ] `impact.check` audit 로그가 정상 기록된다
+   - [ ] `impact.ticket.create` audit 로그가 정상 기록된다
+   - [ ] `impact.critical_detected` audit 로그가 정상 기록된다
+   - [ ] previous_hash 체인이 정상 동작한다
+
+4. **RBAC:**
+   - [ ] impact.view 권한 검사가 정상 동작한다
+   - [ ] impact.self_check 권한 검사가 정상 동작한다
+   - [ ] 권한 없는 사용자 접근이 403로 차단된다
+
+5. **비회귀:**
+   - [ ] 기존 `/api/ra/impact` API가 여전히 동작한다
+   - [ ] 기존 테스트 79개가 전체 통과한다
+   - [ ] 기존 audit action enum이 유지되었다
+
+6. **성능:**
+   - [ ] retestMatrix 조회 < 10ms
+   - [ ] Layer 2 LLM 분류 < 5초
+   - [ ] Layer 4 RAG 조회 < 10초
+   - [ ] 전체 위저드 응답 < 20초
+
+7. **보안:**
+   - [ ] SQL Injection 방지 (Drizzle ORM)
+   - [ ] XSS 방지 (입력 sanitization)
+   - [ ] RBAC 권한 검사
+   - [ ] Audit 로깅
+
+8. **테스트:**
+   - [ ] 단위 테스트 커버리지 85% 이상
+   - [ ] 통합 테스트 통과
+   - [ ] Edge Case 테스트 통과 (8개 edge cases)
+
+### 테스트 전략
+
+**단위 테스트 (Unit Tests):**
+- `lib/domains/impact/retest-matrix-data.ts`: 35셀 데이터 구조 검증
+- `lib/domains/impact/layer1-matrix-lookup.ts`: retestMatrix 조회 로직
+- `lib/domains/impact/layer2-llm-classifier.ts`: LLM 분류 파싱
+- `lib/domains/impact/layer3-ticket-creator.ts`: 티켓 생성 로직
+- `lib/domains/impact/layer4-rag-similar-cases.ts`: RAG 조회 로직
+- `lib/domains/impact/signal-calculator.ts`: 신호등 계산 로직
+
+**통합 테스트 (Integration Tests):**
+- POST /api/impact-check end-to-end 테스트
+- 4계층 순차 실행 테스트
+- DB transaction 테스트
+- Audit 로깅 테스트
+- RBAC 권한 검사 테스트
+
+**Edge Case 테스트:**
+- 빈 포트폴리오 시나리오
+- retestMatrix 셀 누락 시나리오
+- RAG 타임아웃 시나리오
+- Cross-org 접근 시나리오
+- 동시 변경 평가 시나리오
+- LLM API rate limit 시나리오
+- 등록되지 않은 시장 선택 시나리오
+- change_detail 2000자 초과 시나리오
+
+---
+
+**생성일:** 2026-07-05  
+**버전:** 1.0.0  
+**상태:** planned  
+**총 AC 개수:** 15개  
+**총 Edge Cases:** 8개

--- a/.moai/specs/SPEC-V3-IMPACT-001/plan.md
+++ b/.moai/specs/SPEC-V3-IMPACT-001/plan.md
@@ -1,0 +1,648 @@
+# SPEC-V3-IMPACT-001: Change Impact 4-Layer Wizard
+
+## Implementation Plan
+
+---
+**SPEC ID:** SPEC-V3-IMPACT-001
+**Version:** 1.0.0
+**Status:** planned
+**Created:** 2026-07-05
+**Phase:** Wave 3 Phase C-3
+---
+
+## Overview
+
+v3 Phase C-3 **Change Impact 4-Layer Wizard** 구현 계획. 기존 SPEC-REGULA-IMPACT-001(RADAR 기반 자동 평가)를 확장하여 Employee-facing 자가진단 위저드를 구현.
+
+**핵심 목표:**
+- 4계층 평가 엔진 구현 (retestMatrix → LLM → 티켓 → RAG)
+- 신호등 결과 시스템 (green/yellow/red)
+- 기존 기능 비회귀 (API 호환성, DB 보존)
+- 백엔드 도메인 전용 구현 (UI는 Phase D 이월)
+
+## Implementation Milestones
+
+### Milestone 1: Foundation (Priority: High)
+
+**목표:** 기본 구조 마련 및 기존 코드 이전
+
+**작업 항목:**
+1. `lib/domains/impact/` 디렉토리 생성
+2. 기존 `lib/impact/` 6개 파일 이전 및 재사용:
+   - `types.ts`: 공통 타입 확장
+   - `audit-wiring.ts`: 감사 추적 레이어 재사용
+   - `action-queue.ts`: 액션 아이템 생성 로직 재사용
+3. `lib/domains/impact/` re-export 레이어 생성 (기존 API 호환성)
+4. 기존 테스트 79개 통과 검증
+
+**산출물:**
+- `lib/domains/impact/` 디렉토리 구조
+- 기존 기능 비회귀 검증 테스트 결과
+
+**완료 기준:**
+- [ ] 기존 `/api/ra/impact` API가 여전히 동작한다
+- [ ] 기존 테스트 79개가 전체 통과한다
+- [ ] Drizzle Kit check가 통과한다
+
+**의존성:**
+- SPEC-REGULA-IMPACT-001 기존 코드
+- kernel/db (Drizzle ORM)
+
+### Milestone 2: retestMatrix Data Embedding (Priority: High)
+
+**목표:** retestMatrix 35셀 데이터 코드 임베드
+
+**작업 항목:**
+1. `docs/v3/reference/data.jsx:1203`에서 retestMatrix 데이터 추출
+2. `lib/domains/impact/retest-matrix-data.ts` 생성:
+   - 7 changeTypes (bom, sw, sw-minor, label, warn, process, sterile)
+   - 5 markets (us, eu, kr, cn, jp)
+   - 35셀 (7 × 5) 셀 데이터
+3. TypeScript 타입 정의:
+   - `RetestMatrixCell` 인터페이스
+   - `RetestMatrixData` 인터페이스
+4. 단위 테스트 작성:
+   - 35셀 데이터 구조 검증
+   - 셀 조회 < 1ms 성능 검증
+
+**산출물:**
+- `lib/domains/impact/retest-matrix-data.ts` (결정론 데이터)
+- `lib/domains/impact/__tests__/retest-matrix-data.test.ts`
+
+**완료 기준:**
+- [ ] 35셀 데이터가 모두 정의되었다
+- [ ] 단위 테스트가 통과한다
+- [ ] 조회 성능 < 1ms
+
+**의존성:**
+- docs/v3/reference/data.jsx
+
+### Milestone 3: Layer 1 - retestMatrix Lookup Engine (Priority: High)
+
+**목표:** Layer 1 결정론 룰 조회 엔진 구현
+
+**작업 항목:**
+1. `lib/domains/impact/layer1-matrix-lookup.ts` 생성:
+   - `lookupRetestMatrix(changeType, market)` 함수
+   - 35셀 조회 로직
+   - 누락 셀 검증 및 에러 처리
+2. 신호등 계산 로직:
+   - `calculateSignal(matrixResults)` 함수
+   - green/yellow/red 규칙 구현
+3. 단위 테스트 작성:
+   - 모든 35셀 조회 테스트
+   - 누락 셀 에러 처리 테스트
+   - 신호등 계산 테스트 (green/yellow/red)
+
+**산출물:**
+- `lib/domains/impact/layer1-matrix-lookup.ts`
+- `lib/domains/impact/signal-calculator.ts`
+- `lib/domains/impact/__tests__/layer1.test.ts`
+
+**완료 기준:**
+- [ ] 35셀 모두 정상 조회된다
+- [ ] 누락 셀 시 런타임 에러 발생
+- [ ] 신호등 계산이 정확하다
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- Milestone 2 (retest-matrix-data.ts)
+
+### Milestone 4: Layer 2 - LLM Category Classification (Priority: High)
+
+**목표:** Layer 2 LLM 카테고리 분류 구현
+
+**작업 항목:**
+1. `lib/domains/impact/layer2-llm-classifier.ts` 생성:
+   - `classifyChangeCategory(changeDetail)` 함수
+   - gx10 Ollama (gpt-oss:120b via lib/ai/llm-provider.ts getLlmModel()) 호출
+   - 응답 파싱 (category, confidence, reason)
+   - confidence < 80 재시도 로직
+2. gx10 Ollama 프롬프트 작성:
+   - 시스템 프롬프트 정의
+   - 카테고리 분류 지시어 작성
+3. 에러 처리:
+   - LLM API 실패 재시도 (최대 3회)
+   - 타임아웃 핸들링
+4. 단위 테스트 작성:
+   - LLM 호출 성공 시나리오
+   - LLM 호출 실패 시나리오
+   - confidence < 80 시나리오
+
+**산출물:**
+- `lib/domains/impact/layer2-llm-classifier.ts`
+- `lib/domains/impact/__tests__/layer2.test.ts`
+
+**완료 기준:**
+- [ ] gx10 Ollama API가 정상 호출된다
+- [ ] 응답 파싱이 정확하다
+- [ ] confidence < 80 시 재확인 요청
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- gx10 Ollama (gpt-oss:120b via lib/ai/llm-provider.ts)
+- lib/domains/ai/ (LLM 클라이언트 래퍼)
+
+### Milestone 5: Layer 3 - RA Inbox Ticket Auto-Creation (Priority: Medium)
+
+**목표:** Layer 3 RA Inbox 자동 티켓 생성 구현
+
+**작업 항목:**
+1. `lib/domains/impact/layer3-ticket-creator.ts` 생성:
+   - `createInboxTicket(context)` 함수
+   - domains/inbox 티켓 생성 API 호출
+   - 티켓 상태: 'needs-review'
+   - 티켓 컨텍스트: 모든 위저드 입력 포함
+2. domains/inbox API 연동:
+   - `POST /api/inbox` 호출
+   - 티켓 생성 성공/실패 처리
+3. audit 로깅:
+   - `impact.ticket.create` audit 로그 기록
+4. 단위 테스트 작성:
+   - 티켓 생성 성공 시나리오
+   - 티켓 생성 실패 시나리오
+   - audit 로깅 검증
+
+**산출물:**
+- `lib/domains/impact/layer3-ticket-creator.ts`
+- `lib/domains/impact/__tests__/layer3.test.ts`
+
+**완료 기준:**
+- [ ] RA Inbox 티켓이 정상 생성된다
+- [ ] 티켓 ID가 반환된다
+- [ ] `impact.ticket.create` audit 로그가 기록된다
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- SPEC-V3-INBOX-001 (domains/inbox)
+- kernel/audit
+
+### Milestone 6: Layer 4 - RAG Similar Cases Lookup (Priority: Medium)
+
+**목표:** Layer 4 ra-llm-wiki RAG 유사 사례 조회 구현
+
+**작업 항목:**
+1. `lib/domains/impact/layer4-rag-similar-cases.ts` 생성:
+   - `lookupSimilarCases(productId, changeCategory, markets)` 함수
+   - embeddings 테이블 pgvector 코사인 유사도 검색
+   - 필터: source_repo='ra-llm-wiki', product_id, change_type
+   - 최대 3건 반환
+2. RAG 패턴 재사용:
+   - domains/ai/run-rag-query.ts 패턴 참조
+   - pgvector 검색 쿼리 작성
+3. Citation 강제:
+   - 출처 인용 포맷팅 (<sup class="cite">)
+   - 출처 누락 시 제외 로직
+4. 에러 처리:
+   - 타임아웃 (10초)
+   - 빈 결과 반환 및 계속 진행
+5. 단위 테스트 작성:
+   - RAG 조회 성공 시나리오
+   - RAG 조회 타임아웃 시나리오
+   - 출처 누락 처리 시나리오
+
+**산출물:**
+- `lib/domains/impact/layer4-rag-similar-cases.ts`
+- `lib/domains/impact/__tests__/layer4.test.ts`
+
+**완료 기준:**
+- [ ] RAG 조회가 정상 동작한다
+- [ ] 최대 3건의 유사 사례가 반환된다
+- [ ] 모든 사례에 출처 인용이 포함된다
+- [ ] 타임아웃 시 빈 결과 반환
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- SPEC-V3-INBOX-001 (embeddings 테이블)
+- domains/ai (RAG 쿼리 래퍼)
+- pgvector (PostgreSQL 확장)
+
+### Milestone 7: API Routes Implementation (Priority: High)
+
+**목표:** 위저드 API 엔드포인트 구현
+
+**작업 항목:**
+1. `app/api/impact-check/route.ts` 생성:
+   - `POST /api/impact-check` 엔드포인트
+   - 요청 바디 검증 (Zod schema)
+   - RBAC 권한 검사 (impact.self_check)
+2. 4계층 순차 실행 오케스트레이션:
+   - Layer 1 → Layer 2 → Layer 3/4 (confidence 분기)
+   - 각 레이어 에러 처리
+3. 응답 포맷팅:
+   - 신호등 결과
+   - retestMatrix 셀
+   - LLM 분석 결과
+   - 유사 사례 3건
+   - 티켓 ID (있으면)
+4. 통합 테스트 작성:
+   - end-to-end 시나리오
+   - 권한 검사 시나리오
+   - 에러 처리 시나리오
+
+**산출물:**
+- `app/api/impact-check/route.ts`
+- `app/api/impact-check/__tests__/route.test.ts`
+
+**완료 기준:**
+- [ ] POST /api/impact-check가 정상 동작한다
+- [ ] 4계층이 순차적으로 실행된다
+- [ ] confidence < 80 시 티켓이 생성된다
+- [ ] confidence >= 80 시 유사 사례가 조회된다
+- [ ] RBAC 권한 검사가 동작한다
+- [ ] 통합 테스트 통과
+
+**의존성:**
+- Milestone 3, 4, 5, 6 (각 레이어 구현)
+
+### Milestone 8: Database Migration (Priority: High)
+
+**목표:** regulatory_impact_assessments 테이블 확장 및 audit_logs.previous_hash 추가
+
+**작업 항목:**
+1. `migrations/0109_impact_wizard_columns.sql` 생성:
+   - ALTER TABLE regulatory_impact_assessments
+   - 7개 신규 컬럼 추가 (nullable)
+   - 2개 인덱스 추가
+   - audit_logs.previous_hash BYTEA 추가 (SPEC-V3-AUDIT-CHAIN-001 자체 구현)
+2. Drizzle Kit migration:
+   - `drizzle-kit generate` 실행
+   - migration SQL 검증
+3. 비회귀 검증:
+   - 기존 레코드 보존 확인
+   - Drizzle Kit check 통과
+4. 롤백크 테스트:
+   - migration 적용 전/후 DB 상태 확인
+   - 롤백크 SQL 준비
+
+**산출물:**
+- `migrations/0109_impact_wizard_columns.sql`
+- `lib/db/schema.ts` (신규 컬럼 정의)
+
+**완료 기준:**
+- [ ] Migration이 성공적으로 적용된다
+- [ ] 기존 레코드가 보존된다
+- [ ] 신규 컬럼이 NULL로 추가된다
+- [ ] Drizzle Kit check가 통과한다
+- [ ] 롤백크 SQL이 준비된다
+
+**의존성:**
+- kernel/db (Drizzle ORM)
+- PostgreSQL 15+
+
+### Milestone 9: Audit Logging (Priority: High)
+
+**목표:** 21 CFR Part 11 감사 로깅 구현
+
+**작업 항목:**
+1. `lib/domains/impact/audit-logger.ts` 생성 (또는 기존 audit-wiring.ts 확장):
+   - `logImpactCheck()` 함수
+   - `logTicketCreate()` 함수
+   - `logCriticalDetected()` 함수
+2. audit_log 레코드 삽입:
+   - audit_action enum 활용
+   - user_id, context, previous_hash 포함
+3. previous_hash 체인 구현 (자체 구현, 의존성 제거):
+   - audit_logs.previous_hash BYTEA 컬럼 (migration 0109에 포함)
+   - 이전 레코드 SHA-256 해시 조회
+   - append-only 체인 보장
+   - SPEC-V3-AUDIT-CHAIN-001 완료 전까지 nullable/optional 동작
+4. 단위 테스트 작성:
+   - audit 로깅 검증
+   - previous_hash 체인 검증
+
+**산출물:**
+- `lib/domains/impact/audit-logger.ts`
+- `lib/domains/impact/__tests__/audit-logger.test.ts`
+
+**완료 기준:**
+- [ ] `impact.check` audit 로그가 기록된다
+- [ ] `impact.ticket.create` audit 로그가 기록된다
+- [ ] `impact.critical_detected` audit 로그가 기록된다
+- [ ] previous_hash 체인이 정상 동작한다
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- kernel/audit
+- SPEC-V3-AUDIT-CHAIN-001 (previous_hash 체인 - AUDIT-CHAIN-001 완료 전까지 previous_hash는 nullable/optional)
+
+### Milestone 10: RBAC Integration (Priority: High)
+
+**목표:** RBAC 권한 검사 구현 및 audit_action enum 확장
+
+**작업 항목:**
+1. Migration 0110 생성 (별도 파일):
+   - `migrations/0110_audit_impact_actions.sql`
+   - `ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'impact.check'`
+   - `ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'impact.ticket.create'`
+   - PostgreSQL 트랜잭션 분리 규칙 준수 (ALTER TYPE ... ADD VALUE는 트랜잭션 내 불가)
+2. `lib/auth/permissions.ts` PERMISSION_MAP 추가 (신규 권한 3종):
+   - `impact.view`: 위저드 실행 권한 (employee, viewer, ra-member, ra-lead, admin)
+   - `impact.self_check`: 자가진단 권한 (employee, viewer)
+   - `impact.ra_escalate`: RA 티켓 에스컬레이션 권한 (ra-member, ra-lead, admin)
+3. `permissions.test.ts` EXPECTED_ACTIONS 카운트 갱신
+4. API 라우트 권한 미들웨어:
+   - `impact.view` 검증
+   - `impact.self_check` 검증
+5. 403 에러 처리:
+   - 권한 없는 접근 차단
+   - `auth.forbidden` audit 로그
+6. 단위 테스트 작성:
+   - 권한 있는 사용자 접근
+   - 권한 없는 사용자 접근 (403)
+   - Cross-org 접근 시도
+
+**산출물:**
+- `lib/auth/permissions.ts` (수정)
+- `app/api/impact-check/route.ts` (권한 미들웨어 추가)
+- `app/api/impact-check/__tests__/rbac.test.ts`
+
+**완료 기준:**
+- [ ] `impact.view` 권한이 정상 동작한다
+- [ ] `impact.self_check` 권한이 정상 동작한다
+- [ ] 권한 없는 접근이 403로 차단된다
+- [ ] `auth.forbidden` audit 로그가 기록된다
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- kernel/auth
+- lib/auth/permissions.ts
+- migrations/0104 (audit_action enum 기존 값)
+- enterprise-migrations (audit_action enum lock-step 게이트)
+
+## New and Modified Files
+
+### 신규 파일 (New Files)
+
+**도메인 로직:**
+```
+lib/domains/impact/
+├── retest-matrix-data.ts              # M2: retestMatrix 35셀 데이터
+├── layer1-matrix-lookup.ts           # M3: Layer 1 조회 엔진
+├── layer2-llm-classifier.ts          # M4: Layer 2 LLM 분류
+├── layer3-ticket-creator.ts          # M5: Layer 3 티켓 생성
+├── layer4-rag-similar-cases.ts       # M6: Layer 4 RAG 조회
+├── signal-calculator.ts              # M3: 신호등 계산
+├── audit-logger.ts                   # M9: audit 로깅
+├── types.ts                         # 도메인 타입 (확장)
+└── index.ts                         # re-export 레이어
+```
+
+**API 라우트:**
+```
+app/api/impact-check/
+├── route.ts                          # M7: POST /api/impact-check
+└── __tests__/
+    └── route.test.ts                 # 통합 테스트
+```
+
+**단위 테스트:**
+```
+lib/domains/impact/__tests__/
+├── retest-matrix-data.test.ts        # M2
+├── layer1.test.ts                    # M3
+├── layer2.test.ts                    # M4
+├── layer3.test.ts                    # M5
+├── layer4.test.ts                    # M6
+└── audit-logger.test.ts              # M9
+```
+
+**마이그레이션:**
+```
+migrations/
+├── 0109_impact_wizard_columns.sql    # M8
+└── 0110_audit_impact_actions.sql    # M10 (audit_action enum)
+```
+
+### 수정 파일 (Modified Files)
+
+**DB 스키마:**
+```
+lib/db/schema.ts                       # M8: regulatory_impact_assessments 확장
+```
+
+**권한 (필요 시):**
+```
+lib/auth/permissions.ts               # M10: 신규 권한 추가
+```
+
+**기존 코드 이전:**
+```
+lib/impact/ → lib/domains/impact/
+├── portfolio-scanner.ts              # M1: 이전 (재사용 보존)
+├── section-mapper.ts                 # M1: 이전 (재사용 보존)
+├── action-queue.ts                   # M1: 이전 (재사용 보존)
+├── audit-wiring.ts                   # M1: 이전 (재사용, 확장)
+├── analyzer.ts                       # M1: 이전 (재사용 보존)
+└── types.ts                          # M1: 이전 (확장)
+```
+
+## Technical Approach
+
+### 아키텍처 패턴
+
+**계층형 아키텍처 (Layered Architecture):**
+```
+API Layer (app/api/impact-check/)
+    ↓
+Service Layer (lib/domains/impact/)
+    ↓ 4계층 순차 실행
+Layer 1: retestMatrix Lookup
+    ↓
+Layer 2: LLM Classification
+    ↓ confidence 분기
+Layer 3: Ticket Creation (confidence < 80)
+Layer 4: RAG Similar Cases (confidence >= 80)
+    ↓
+Data Layer (kernel/db, domains/ai)
+```
+
+**의존성 주입 (Dependency Injection):**
+- LLM 클라이언트: domains/ai 래퍼 재사용
+- RAG 쿼리: domains/ai/run-rag-query 패턴 재사용
+- 티켓 생성: domains/inbox API 호출
+- Audit 로깅: kernel/audit 래퍼 재사용
+
+### 데이터 흐름 (Data Flow)
+
+**Normal Flow (confidence >= 80):**
+```
+User Input → Step 1~4
+    ↓
+Layer 1: retestMatrix Lookup (35셀)
+    ↓
+Layer 2: LLM Classification (confidence >= 80)
+    ↓
+Layer 4: RAG Similar Cases (3건)
+    ↓
+Signal Calculator (green/yellow/red)
+    ↓
+Result Page + SimilarCasesCard
+```
+
+**Low Confidence Flow (confidence < 80):**
+```
+User Input → Step 1~4
+    ↓
+Layer 1: retestMatrix Lookup (35셀)
+    ↓
+Layer 2: LLM Classification (confidence < 80)
+    ↓
+Layer 3: RA Inbox Ticket Creation
+    ↓
+Result Page + Ticket CTA
+```
+
+### 에러 처리 전략
+
+**Layer 1 (retestMatrix):**
+- 셀 누락: 런타임 에러 → 관리자 알림
+- 데이터 오류: 기본값 반환 → 계속 진행
+
+**Layer 2 (LLM):**
+- API 실패: 재시도 3회 → 에러 메시지
+- 타임아웃: 에러 메시지 → 수동 RA 상담 제안
+
+**Layer 3 (Ticket):**
+- API 실패: 에러 메시지 → 위저드 결과는 계속 표시
+- 타임아웃: 티켓 생성 스킵 → 위저드 결과는 계속 표시
+
+**Layer 4 (RAG):**
+- 타임아웃 (10초): 빈 결과 반환 → 계속 진행
+- 조회 실패: 빈 결과 반환 → 계속 진행
+
+## Testing Strategy
+
+### 단위 테스트 (Unit Tests)
+
+**커버리지 목표:** 85% 이상
+
+**테스트 대상:**
+- retestMatrix 데이터 구조 (M2)
+- Layer 1 조회 로직 (M3)
+- Layer 2 LLM 파싱 (M4)
+- Layer 3 티켓 생성 (M5)
+- Layer 4 RAG 조회 (M6)
+- 신호등 계산 (M3)
+- Audit 로깅 (M9)
+- RBAC 권한 검사 (M10)
+
+**테스트 프레임워크:** Vitest
+
+### 통합 테스트 (Integration Tests)
+
+**테스트 시나리오:**
+1. **Happy Path:** confidence >= 80, RAG 성공
+2. **Low Confidence Path:** confidence < 80, 티켓 생성
+3. **RAG Timeout:** RAG 타임아웃, 빈 결과 반환
+4. **LLM Failure:** LLM API 실패, 재시도 후 에러
+5. **RBAC Block:** 권한 없는 사용자 접근
+6. **Cross-org Attempt:** 다른 조직 사용자 접근
+
+**테스트 프레임워크:** Vitest + MSW (Mock Service Worker)
+
+### Edge Case 테스트
+
+**8개 Edge Cases:**
+1. 빈 포트폴리오
+2. retestMatrix 셀 누락
+3. RAG 타임아웃
+4. Cross-org 접근
+5. 동시 변경 평가
+6. LLM API rate limit
+7. 등록되지 않은 시장 선택
+8. change_detail 2000자 초과
+
+## Risk Mitigation
+
+### 위험 1: 기존 API 깨짐
+
+**완화:**
+- lib/impact/ → lib/domains/impact/ 이동 시 re-export 레이어 유지
+- 기존 테스트 79개 전체 통과 검증
+- Drizzle Kit check 실행
+
+**검증:**
+- M1 완료 후 기존 API 동작 확인
+
+### 위험 2: DB 마이그레이션 실패
+
+**완화:**
+- 모든 신규 컬럼 nullable
+- 롤백크 SQL 준비
+- 기존 레코드 보존 확인
+
+**검증:**
+- M8 완료 후 롤백크 테스트
+
+### 위험 3: RAG 타임아웃
+
+**완화:**
+- 타임아웃 10초 설정
+- 빈 결과 반환 후 계속 진행
+- 에러 메시지 표시
+
+**검증:**
+- M6 완료 후 타임아웃 시나리오 테스트
+
+## Dependencies Mapping
+
+### 내부 의존성
+
+| 의존 대상 | 용도 | Milestone |
+|-----------|------|------------|
+| `kernel/db` | DB 쿼리, 트랜잭션 | M1, M8 |
+| `kernel/audit` | 21 CFR Part 11 로깅 | M9 |
+| `domains/ai` (LLM) | gx10 Ollama 클라이언트 | M4 |
+| `domains/ai` (RAG) | RAG 쿼리 래퍼 | M6 |
+| `domains/inbox` | 티켓 생성 API | M5 |
+| `domains/registry` | 제품/시장 데이터 | M7 |
+| `lib/auth/permissions` | RBAC 권한 검사 | M10 |
+
+### 외부 의존성
+
+| 의존 대상 | 용도 | 버전 |
+|-----------|------|------|
+| gx10 Ollama (gpt-oss:120b) | LLM 분류 | via lib/ai/llm-provider.ts |
+| pgvector | RAG 벡터 검색 | PostgreSQL 15+ |
+| Drizzle ORM | DB 쿼리 빌더 | 최신 버전 |
+
+## Success Metrics
+
+### 기능 메트릭
+
+- [ ] 15개 AC (AC-IMP-01 ~ AC-IMP-15) 전체 통과
+- [ ] 4계층 평가 엔진 정상 동작
+- [ ] retestMatrix 35셀 정확도 100%
+- [ ] 신호등 계산 정확도 100%
+- [ ] RAG 유사 사례 조회 정상 동작
+
+### 성능 메트릭
+
+- [ ] retestMatrix 조회 < 10ms
+- [ ] Layer 2 LLM 분류 < 5초
+- [ ] Layer 4 RAG 조회 < 10초
+- [ ] 전체 위저드 응답 < 20초
+
+### 품질 메트릭
+
+- [ ] 단위 테스트 커버리지 85% 이상
+- [ ] 통합 테스트 전체 통과
+- [ ] Edge Case 테스트 전체 통과
+- [ ] Drizzle Kit check 통과
+- [ ] 기존 테스트 79개 통과 (비회귀)
+
+### 보안 메트릭
+
+- [ ] RBAC 권한 검사 100%
+- [ ] Audit 로깅 100%
+- [ ] SQL Injection 방지
+- [ ] XSS 방지
+
+---
+
+**생성일:** 2026-07-05  
+**버전:** 1.0.0  
+**상태:** planned  
+**총 Milestones:** 10개  
+**예상 완료:** Phase C-3 종료 시점

--- a/.moai/specs/SPEC-V3-IMPACT-001/research.md
+++ b/.moai/specs/SPEC-V3-IMPACT-001/research.md
@@ -1,0 +1,369 @@
+# SPEC-V3-IMPACT-001: Change Impact 4-Layer Wizard
+
+## Research Document
+
+### 1. 기존 Impact 코드 분석 (SPEC-REGULA-IMPACT-001)
+
+#### 1.1 기존 파일 구조 (lib/impact/)
+
+SPEC-REGULA-IMPACT-001 (v1.0.0, completed, PR #134)에서 구현된 6개 파일:
+
+```
+lib/impact/
+├── portfolio-scanner.ts    # 포트폴리오 전체 스캔
+├── section-mapper.ts       # 규제 섹션 매핑
+├── action-queue.ts         # 대응 큐 관리
+├── audit-wiring.ts         # 21 CFR Part 11 감사 추적
+├── analyzer.ts             # 영향 분석 엔진
+└── types.ts                # 도메인 타입 정의
+```
+
+**재사용 가능성:**
+- `types.ts`: 공통 타입 확장 (ImpactLevel, ActionItemStatus 등 유지)
+- `audit-wiring.ts`: 감사 추적 레이어 재사용
+- `action-queue.ts`: 액션 아이템 생성 로직 재사용
+
+**보존 필요성:**
+- 기존 API 경로 호환성 유지 (`/api/ra/impact`, `/api/admin/radar/impact`)
+- 기존 DB 테이블 구조 유지 (regulatory_impact_assessments, impact_action_items)
+- 기존 audit action enum 값 유지 (impact.assessment_created, impact.critical_detected, impact.action_item_created)
+
+#### 1.2 기존 DB 테이블 (lib/db/schema.ts)
+
+**regulatory_impact_assessments** (line 1542-1567):
+```typescript
+{
+  id: uuid (PK),
+  regulatoryUpdateId: uuid (FK → regulatory_updates.id),
+  projectId: uuid (FK → products.id),
+  impactLevel: text,  // 'critical' | 'high' | 'medium' | 'info'
+  affectedSections: jsonb,
+  analysisSummary: text,
+  confidence: numeric(3,2),
+  createdBy: uuid (FK → users.id),
+  createdAt: timestamp
+}
+```
+
+**impact_action_items** (line 1569-1585):
+```typescript
+{
+  id: uuid (PK),
+  assessmentId: uuid (FK → regulatory_impact_assessments.id),
+  projectId: uuid (FK → products.id),
+  priority: text,
+  documentType: text,
+  sectionReference: text,
+  description: text,
+  status: text,  // 'open' | 'in_progress' | 'resolved'
+  assignedTo: uuid (FK → users.id),
+  createdAt: timestamp,
+  resolvedAt: timestamp
+}
+```
+
+**Migration history:**
+- 0033_impact_tables.sql: 초기 테이블 생성
+- 0034_impact_indexes.sql: 인덱스 추가
+
+#### 1.3 기존 Audit Actions
+
+`audit_action` enum (lib/db/schema.ts line 185-188):
+- `impact.assessment_created`
+- `impact.critical_detected`
+- `impact.action_item_created`
+
+### 2. v3 4-Layer Wizard 정의 (docs/v3/README.md §3.2)
+
+#### 2.1 Wizard Steps (4단계)
+
+```
+Step 1: 제품 선택 (products 테이블)
+Step 2: 변경 카테고리 (sw/hw/label/process/sterilize 등)
+Step 3: 변경 상세 (자유 텍스트)
+Step 4: 영향 시장 선택
+```
+
+#### 2.2 Evaluation Layers (4계층)
+
+**Layer 1: retestMatrix 룰 조회 (결정론)**
+- 7 변경유형 × 5 시장 = 35셀
+- 각 셀: level (required/conditional/not-required) + ref (규정 참조) + note (설명)
+- 계층 1은 결정론 데이터 → 즉시 구현 가능
+
+**Layer 2: LLM 카테고리 분류 (gx10 Ollama gpt-oss:120b)**
+- 자유 텍스트 → 카테고리 confidence 계산
+- 입력: Step 3의 자유 텍스트
+- 출력: JSON {"category": string, "confidence": 0-100, "reason": string}
+- confidence < 80% 시 재확인 요청
+
+**Layer 3: RA Inbox 자동 티켓 생성**
+- 조건: confidence < 80%
+- 동작: RA Inbox 티켓 자동 생성 (needs-review 상태)
+- 연동: 직접 DB INSERT (lib/db/schema.ts inboxTickets 테이블)
+- 참고: domains/inbox는 조회용 API만 제공 (app/api/inbox/route.ts GET)
+- 이유: inbox_tickets 테이블 직접 INSERT 패턴 (migrations/0104_inbox_tickets_and_approved_answers.sql 참조)
+
+**Layer 4: ra-llm-wiki RAG 조회**
+- 기능: 과거 유사 사례 3건 인용
+- 출력: SimilarCasesCard (과거 변경 사례 카드)
+- 데이터 소스: ra-llm-wiki (사내 NAS) RAG 검색
+
+#### 2.3 결과 페이지
+
+- 신호등 결과 (green/yellow/red)
+- retestMatrix 셀 표시
+- 유사 사례 3건 인용
+- (필요 시) 티켓 생성 CTA
+
+### 3. retestMatrix 데이터 구조 (docs/v3/reference/data.jsx:1203)
+
+#### 3.1 ChangeTypes (7개)
+
+```javascript
+changeTypes: [
+  { id: 'bom', label: 'BOM 변경 (부품 교체)' },
+  { id: 'sw', label: 'SW 알고리즘 재학습' },
+  { id: 'sw-minor', label: 'SW 마이너 (버그픽스)' },
+  { id: 'label', label: '라벨 문구 변경' },
+  { id: 'warn', label: 'Critical Warning 개정' },
+  { id: 'process', label: '생산공정 변경' },
+  { id: 'sterile', label: '멸균 조건 변경' },
+]
+```
+
+#### 3.2 Markets (5개)
+
+```javascript
+markets: [
+  { id: 'us', label: 'FDA (US)', color: 'var(--brand-700)' },
+  { id: 'eu', label: 'MDR (EU)', color: 'var(--d-pms)' },
+  { id: 'kr', label: 'MFDS (KR)', color: 'var(--brand-800)' },
+  { id: 'cn', label: 'NMPA (CN)', color: 'var(--danger)' },
+  { id: 'jp', label: 'PMDA (JP)', color: 'var(--d-cc)' },
+]
+```
+
+#### 3.3 Cell Structure (35셀 = 7 × 5)
+
+각 셀 키: `{changeType}-{market}`
+예: `bom-us`, `sw-eu`, `label-kr`
+
+각 셀 값:
+```typescript
+{
+  level: 'required' | 'conditional' | 'not-required',
+  ref: string,      // 규정 참조 (예: "FDA Design Change §III.A")
+  note: string     // 설명 (예: "Special 510(k) 검토 필요")
+}
+```
+
+**예시 셀 (bom-us):**
+```javascript
+'bom-us': {
+  level: 'conditional',
+  ref: 'FDA Design Change §III.A',
+  note: 'Special 510(k) 검토 필요 · Letter to File 가능 케이스'
+}
+```
+
+### 4. SPEC-REGULA-IMPACT-001과의 관계
+
+#### 4.1 확장 vs 교체
+
+SPEC-V3-IMPACT-001은 SPEC-REGULA-IMPACT-001의 **확장**이지 교체가 아님:
+
+| 측면 | SPEC-REGULA-IMPACT-001 (기존) | SPEC-V3-IMPACT-001 (신규) |
+|------|-------------------------------|---------------------------|
+| 사용자 | RA 전문가 (ra-member, ra-lead) | Employee 포함 (모든 역할) |
+| 트리거 | RADAR 규제 업데이트 감지 | Employee 자가진단 위저드 |
+| 대상 | 포트폴리오 전체 자동 스캔 | 특정 제품 변경 영향 평가 |
+| 입력 | 규제 업데이트 ID | 제품 + 변경 카테고리 + 상세 + 시장 |
+| 출력 | 자동 영향 평가 + 액션 아이템 | 4계층 판정 + 신호등 결과 |
+| DB | regulatory_impact_assessments 테이블 사용 | 동일 테이블 확장 (신규 컬럼 가능) |
+
+#### 4.2 비회귀 보존 전략
+
+기존 기능 보존:
+- `/api/ra/impact` API 경로 유지
+- `/api/admin/radar/impact` 어드민 트리거 유지
+- `lib/impact/portfolio-scanner.ts` 포트폴리오 스캔 로직 유지
+- `regulatory_impact_assessments` 테이블 기존 컬럼 유지
+
+신규 기능 추가:
+- `POST /api/impact-check` Employee 위저드 엔드포인트
+- `lib/domains/impact/` 디렉토리 확장 (기존 `lib/impact/` → `lib/domains/impact/`)
+- retestMatrix 코드 임베드 (`lib/domains/impact/retest-matrix-data.ts`)
+
+### 5. RAG 연동 지점
+
+#### 5.1 Layer 4: ra-llm-wiki RAG
+
+데이터 소스:
+- 사내 NAS: `10.11.1.40:7001/DR_RnD/ra-llm-wiki.git`
+- 임베딩: `embeddings` 테이블 (기존 pgvector 사용)
+- 검색 쿼리: changeType + market 필터
+
+RAG 패턴 (TRIAGE/CONSULT 도메인 참조):
+```typescript
+// lib/domains/ai/run-rag-query.ts 패턴 재사용
+const similarCases = await ragQuery({
+  query: `${changeType} ${market} 변경 사례`,
+  filter: {
+    sourceRepo: 'ra-llm-wiki',
+    changeType: changeType,
+    market: market
+  },
+  limit: 3
+});
+```
+
+#### 5.2 Citation 강제 (Charter [지양-2])
+
+모든 RAG 응답은 반드시 출처 인용:
+- `<sup class="cite" data-src="...">번호</sup>` 형식
+- 출처 없는 응답 금지 (가짜 신뢰 방지)
+
+### 6. 의존성 매트릭스
+
+#### 6.1 내부 의존성
+
+| 의존 대상 | 용도 | 중요도 |
+|-----------|------|--------|
+| `kernel/db` | DB 쿼리, 트랜잭션 | 필수 |
+| `kernel/audit` | 21 CFR Part 11 로깅 | 필수 |
+| `domains/ai` (RAG) | Layer 4 유사 사례 검색 | 필수 |
+| `domains/radar` | (향후) Radar 연동 | 선택 |
+| `domains/inbox` | Layer 3 티켓 생성 | 필수 |
+| `domains/registry` | 제품/시장 데이터 조회 | 필수 |
+
+#### 6.2 외부 의존성
+
+| 의존 대상 | 용도 | 버전 |
+|-----------|------|------|
+| gx10 Ollama (gpt-oss:120b) | Layer 2 카테고리 분류 | via lib/ai/llm-provider.ts |
+| pgvector | RAG 벡터 검색 | PostgreSQL 15+ 확장 |
+| Drizzle ORM | DB 쿼리 빌더 | 최신 버전 |
+
+### 7. 보안 및 규정 준수
+
+#### 7.1 21 CFR Part 11
+
+요구 사항:
+- 모든 위저드 실행 감사 로깅 (`audit_log`에 INSERT)
+- 이전 해시 체인 (previous_hash BYTEA) - SPEC-V3-AUDIT-CHAIN-001 참조
+- 전자 서명 (ESIG) - 향후 Phase D 구현
+
+#### 7.2 RBAC (Role-Based Access Control)
+
+신규 권한 (`lib/auth/permissions.ts` PERMISSION_MAP 추가 필요):
+- `impact.view`: 위저드 실행 권한 (employee, viewer, ra-member, ra-lead, admin) [신규]
+- `impact.self_check`: 자가진단 권한 (employee, viewer) [신규]
+- `impact.ra_escalate`: RA 티켓 에스컬레이션 권한 (ra-member, ra-lead, admin) [신규]
+
+기존 권한과의 관계:
+- `traceability.impact` (L255): 전혀 다른 권한 (규정 추적 관련)
+- 신규 impact.* 권한 3종은 기존 권한과 무관하게 추가
+
+신규 권한 (추가 검토 필요):
+- `impact.self_check`: employee, viewer (자가진단 위저드 실행)
+- `impact.ra_escalate`: ra-member, ra-lead (RA 티켓 에스컬레이션)
+
+### 8. 마이그레이션 필요 여부
+
+#### 8.1 기존 테이블 확장 검토
+
+**regulatory_impact_assessments** 테이블:
+- 기존 컬럼: id, regulatoryUpdateId, projectId, impactLevel, affectedSections, analysisSummary, confidence, createdBy, createdAt
+- 신규 컬럼 검토:
+  - `wizard_type`: text ('radar-auto' | 'employee-self-check')
+  - `change_category`: text (bom | sw | sw-minor | label | warn | process | sterile)
+  - `change_detail`: text
+  - `markets`: jsonb (['us', 'eu', 'kr', 'cn', 'jp'])
+  - `retest_matrix_results`: jsonb (계층 1 결과)
+  - `llm_category`: jsonb (계층 2 결과)
+  - `rag_similar_cases`: jsonb (계층 4 결과)
+
+**Migration 번호:** 0109+ (v3 데이터 모델 참조)
+
+#### 8.2 마이그레이션 전략
+
+1. 기존 데이터 비회귀: 기존 regulatory_impact_assessments 레코드는 wizard_type = NULL
+2. 신규 컬럼 nullable: 모든 신규 컬럼은 nullable로 추가
+3. 인덱스 추가: wizard_type, change_category 조회 최적화
+
+### 9. 구현 경계 (Phase C-3)
+
+#### 9.1 IN SCOPE (백엔드 도메인 전용)
+
+- `lib/domains/impact/` 확장
+- `app/api/impact/` 라우트 신규 생성
+- retestMatrix 데이터 코드 임베드
+- 4계층 평가 엔진 구현
+- Layer 4 RAG 연동
+- 21 CFR Part 11 audit 로깅
+- RBAC 권한 검사
+
+#### 9.2 OUT OF SCOPE (Phase D 이월)
+
+- UI 컴포넌트 (`components/impact-wizard/`)
+- 프론트엔드 상태 관리
+- ESIG 전자서명 (Phase D-2)
+- 실시간 알림 (Slack, 이메일)
+
+### 10. 잠재 리스크 및 완화
+
+#### 10.1 회귀 위험
+
+**위험 1:** 기존 `/api/ra/impact` API 깨짐
+- **완화:** lib/impact/ → lib/domains/impact/ 이동 시 re-export 레이어 유지
+- **검증:** 기존 테스트 79개 전체 통과 확인
+
+**위험 2:** DB 마이그레이션 시 기존 데이터 깨짐
+- **완화:** 모든 신규 컬럼 nullable, 기본값 NULL
+- **검증:** migration 0109 적용 후 `pnpm drizzle-kit check` 실행
+
+**위험 3:** RAG 타임아웃으로 위저드 응답 지연
+- **완화:** Layer 4 비동기 처리, 타임아웃 10초 설정
+- **검증:** RAG 쿼리 타임아웃 핸들링 테스트
+
+#### 10.2 L-013 교훈 적용
+
+코드/DB/schema 직검 기반:
+- spec 서술 vs 코드 충돌 시 **코드 우선**
+- 실 DB `\d regulatory_impact_assessments` 직접 확인
+- 실 DB `\d impact_action_items` 직접 확인
+- migration 0033, 0034 DDL 검증
+
+---
+
+## 참조 문서
+
+1. v3 마스터 계획: `docs/proposals/v3-architecture-revamp-plan-2026-07-02.md`
+   - §5.1: SPEC-V3-IMPACT-001 정의
+   - §5.3: retestMatrix 데이터 통합 전략
+   - §8: Phase별 산출물 요약
+
+2. v3 원본 문서: `docs/v3/`
+   - `README.md` §3.2: 4-layer wizard 정의
+   - `reference/data.jsx`: retestMatrix 35셀 데이터
+
+3. 기존 SPEC: `.moai/specs/SPEC-REGULA-IMPACT-001/spec.md`
+
+4. Product Charter: `.moai/project/product.md`
+   - [지양-2]: citation 강제
+   - [지양-4]: RA Lead 승인 요구
+
+5. Project Tech Constitution: `.moai/project/tech.md`
+   - 기술 스택 제약 조건
+
+6. DB Schema: `lib/db/schema.ts`
+   - regulatory_impact_assessments 테이블 정의
+   - impact_action_items 테이블 정의
+   - audit_action enum 정의
+
+---
+
+**생성일:** 2026-07-05  
+**분석 범위:** v3 Phase C-3 (Change Impact 4-Layer Wizard)
+**의존 SPEC:** SPEC-REGULA-IMPACT-001 (v1.0.0, completed)

--- a/.moai/specs/SPEC-V3-IMPACT-001/spec.md
+++ b/.moai/specs/SPEC-V3-IMPACT-001/spec.md
@@ -1,0 +1,520 @@
+---
+id: SPEC-V3-IMPACT-001
+version: 0.1.0
+status: planned
+phase: C-3
+priority: High
+created: 2026-07-05
+updated: 2026-07-05
+author: manager-spec
+issue_number: TBD
+depends_on:
+  - SPEC-REGULA-IMPACT-001
+  - SPEC-V3-INBOX-001
+  - SPEC-V3-REGISTRY-001
+blocks: []
+parent_spec: SPEC-REGULA-IMPACT-001
+---
+
+# SPEC-V3-IMPACT-001: Change Impact 4-Layer Wizard
+
+## Specification Document
+
+> SPEC-V3-AUDIT-CHAIN-001 의존성: M9 previous_hash 체인은 자체 구현(옵션 B)하므로 depends_on에서 제외. AUDIT-CHAIN-001 완료 전까지 previous_hash nullable/optional.
+
+## 개요 (Overview)
+
+의료기기 규제 전문가(Regulatory Affairs)가 제품 변경이 시장별 규제에 미치는 영향을 자가진단하는 4계층 워크벤치. RADAR 기반 자동 평가(SPEC-REGULA-IMPACT-001)를 확장하여 Employee가 직접 변경 영향을 평가할 수 있는 위저드를 제공.
+
+**핵심 가치:**
+- **자가진단:** RA 전문가뿐만 아니라 모든 역할이 변경 영향 평가 가능
+- **신호등 결과:** 즉시 시각적 피드백 (green/yellow/red)
+- **유사 사례:** 과거 변경 사례 RAG 검색으로 결정 근거 제공
+- **자동 티켓:** confidence < 80% 시 RA Inbox 자동 생성
+
+## 배경 (Context)
+
+### 문제 정의
+
+현재 Regula 시스템은 RADAR 규제 업데이트를 기반으로 포트폴리오 전체에 대한 영향 평가를 자동으로 수행하지만, Employee가 특정 제품 변경을 자가진단하는 워크벤치가 부족함.
+
+**기존 한계 (SPEC-REGULA-IMPACT-001):**
+- RA 전문가만 사용 가능 (ra-member, ra-lead)
+- RADAR 감지 트리거에만 의존
+- Employee가 특정 변경을 미리 평가하는 수단 부족
+- 유사 사례 참조 없이 즉시 결정 필요
+
+### 해결 방안
+
+Employee-facing 4-layer wizard 도입:
+
+1. **Layer 1:** retestMatrix 결정론 룰 (7 × 5 = 35셀)
+2. **Layer 2:** LLM 카테고리 분류 (gx10 Ollama gpt-oss:120b)
+3. **Layer 3:** confidence < 80% 시 RA Inbox 자동 티켓
+4. **Layer 4:** ra-llm-wiki RAG 유사 사례 3건
+
+## 기능 요구사항 (Functional Requirements)
+
+### REQ-V3-IMP-001: 위저드 Step 1 - 제품 선택
+
+**WHEN** Employee가 위저드를 시작하고 Step 1에 도달하면, **THE SYSTEM SHALL** 제품 선택 UI를 제공하고 제품 목록을 표시한다.
+
+**WHILE** 제품 목록을 표시할 때, **THE SYSTEM SHALL** 다음 필드를 포함한다:
+- 제품 ID (product.id)
+- 제품명 (product.name)
+- 제품 타입 (product.type)
+- 등록된 시장 목록 (product_markets 테이블)
+
+**IF** 제품 목록이 비어 있으면, **THE SYSTEM SHALL** 안내 메시지를 표시하고 등록된 제품이 없음을 알린다.
+
+**WHERE** 제품을 선택했을 때, **THE SYSTEM SHALL** 선택된 제품의 등록된 시장 정보를 Step 4로 전달한다.
+
+### REQ-V3-IMP-002: 위저드 Step 2 - 변경 카테고리 선택
+
+**WHEN** Employee가 Step 2에 도달하면, **THE SYSTEM SHALL** 변경 카테고리 선택 UI를 제공하고 다음 7개 카테고리를 표시한다:
+1. BOM 변경 (부품 교체)
+2. SW 알고리즘 재학습
+3. SW 마이너 (버그픽스)
+4. 라벨 문구 변경
+5. Critical Warning 개정
+6. 생산공정 변경
+7. 멸균 조건 변경
+
+**WHILE** 카테고리를 선택할 때, **THE SYSTEM SHALL** 각 카테고리에 대한 설명을 제공한다.
+
+**IF** 카테고리 선택이 완료되면, **THE SYSTEM SHALL** 선택된 카테고리 ID를 Step 3으로 전달한다.
+
+### REQ-V3-IMP-003: 위저드 Step 3 - 변경 상세 입력
+
+**WHEN** Employee가 Step 3에 도달하면, **THE SYSTEM SHALL** 자유 텍스트 입력 필드를 제공한다.
+
+**WHILE** Employee가 변경 상세를 입력할 때, **THE SYSTEM SHALL** 다음 안내를 제공한다:
+- "변경 내용을 구체적으로 기술하세요 (예: 부품 모델번호, 변경 사유, 영향 범위)"
+- 최소 10자, 최대 2000자 제한
+
+**IF** 입력이 완료되면, **THE SYSTEM SHALL** 입력된 텍스트를 Layer 2 LLM 분석으로 전달한다.
+
+### REQ-V3-IMP-004: 위저드 Step 4 - 영향 시장 선택
+
+**WHEN** Employee가 Step 4에 도달하면, **THE SYSTEM SHALL** 영향 시장 다중 선택 UI를 제공하고 다음 5개 시장을 표시한다:
+1. FDA (US)
+2. MDR (EU)
+3. MFDS (KR)
+4. NMPA (CN)
+5. PMDA (JP)
+
+**WHILE** 시장을 선택할 때, **THE SYSTEM SHALL** Step 1에서 선택한 제품의 등록된 시장 정보를 기반으로 기본값을 설정한다.
+
+**IF** 등록되지 않은 시장을 선택하면, **THE SYSTEM SHALL** 경고 메시지를 표시하고 확인을 요구한다.
+
+**WHEN** 시장 선택이 완료되면, **THE SYSTEM SHALL** 4계층 평가를 트리거한다.
+
+### REQ-V3-IMP-005: Layer 1 - retestMatrix 룰 조회
+
+**WHEN** 4계층 평가가 트리거되면, **THE SYSTEM SHALL** Layer 1 retestMatrix 룰 조회를 수행한다.
+
+**THE SYSTEM SHALL** 선택된 changeType과 market 조합에 해당하는 retestMatrix 셀을 조회한다:
+- 셀 키: `{changeType}-{market}` (예: `bom-us`, `sw-eu`)
+- 셀 값: `{ level, ref, note }`
+
+**THE SYSTEM SHALL** 각 시장별 다음 정보를 계산한다:
+- **level:** `required` | `conditional` | `not-required`
+- **ref:** 규정 참조 (예: "FDA Design Change §III.A")
+- **note:** 설명 (예: "Special 510(k) 검토 필요")
+
+**IF** retestMatrix 셀이 누락되면, **THE SYSTEM SHALL** `level: 'unknown'`으로 처리하고 관리자에게 알림을 생성한다.
+
+**WHERE** 모든 시장 조회가 완료되면, **THE SYSTEM SHALL** 결과를 Layer 2로 전달한다.
+
+### REQ-V3-IMP-006: Layer 2 - LLM 카테고리 분류
+
+**WHEN** Layer 1이 완료되면, **THE SYSTEM SHALL** Layer 2 LLM 카테고리 분류를 수행한다.
+
+**THE SYSTEM SHALL** gx10 Ollama (gpt-oss:120b via lib/ai/llm-provider.ts getLlmModel())를 호출하고 다음 프롬프트를 전달한다:
+```
+사용자가 입력한 변경 상세를 다음 카테고리로 분류:
+[bom, sw, sw-minor, label, warn, process, sterile]
+출력: JSON {"category": string, "confidence": 0-100, "reason": string}
+```
+
+**THE SYSTEM SHALL** LLM 응답에서 다음 필드를 추출한다:
+- `category`: 분류된 카테고리 (Step 2 선택과 일치 여부 검증)
+- `confidence`: 0-100 사이 신뢰도 점수
+- `reason`: 분류 사유
+
+**IF** confidence < 80이면, **THE SYSTEM SHALL** 사용자에게 재확인 요청 메시지를 표시하고 Layer 3 티켓 생성을 트리거한다.
+
+**WHERE** confidence >= 80이면, **THE SYSTEM SHALL** 결과를 Layer 4로 전달한다.
+
+### REQ-V3-IMP-007: Layer 3 - RA Inbox 자동 티켓 생성
+
+**WHEN** Layer 2 confidence < 80이면, **THE SYSTEM SHALL** Layer 3 RA Inbox 자동 티켓 생성을 수행한다.
+
+**THE SYSTEM SHALL** domains/inbox 티켓 생성 API를 호출하고 다음 정보를 전달한다:
+- `source`: 'impact-wizard'
+- `state`: 'needs-review'
+- `question`: `"confidence < 80% 자동 분류 실패. RA 전문가 검토 필요."`
+- `context`: {
+    `product_id`: 선택된 제품 ID,
+    `change_category`: 선택된 카테고리,
+    `change_detail`: 입력된 변경 상세,
+    `markets`: 선택된 시장 목록,
+    `llm_result`: Layer 2 분석 결과,
+    `retest_matrix_results`: Layer 1 결과
+  }
+
+**IF** 티켓 생성이 성공하면, **THE SYSTEM SHALL** 티켓 ID를 사용자에게 표시하고 `impact.ticket.create` audit 로그를 기록한다.
+
+**WHERE** 티켓 생성이 완료되면, **THE SYSTEM SHALL** 최종 결과 페이지에 티켓 CTA를 표시한다.
+
+### REQ-V3-IMP-008: Layer 4 - ra-llm-wiki RAG 유사 사례 조회
+
+**WHEN** Layer 2 confidence >= 80이면, **THE SYSTEM SHALL** Layer 4 ra-llm-wiki RAG 유사 사례 조회를 수행한다.
+
+**THE SYSTEM SHALL** embeddings 테이블을 pgvector 코사인 유사도 검색으로 쿼리한다:
+- 필터: `source_repo = 'ra-llm-wiki'`
+- 필터: `chunk_meta->>'product_id'` = 선택된 제품 ID
+- 필터: `chunk_meta ? 'change_type'` (변경 이력이 있는 청크만)
+- 정렬: embedding <=> 쿼리 벡터 (코사인 유사도)
+- 제한: LIMIT 3
+
+**THE SYSTEM SHALL** 각 유사 사례에서 다음 정보를 추출한다:
+- `chunk_text`: 사례 내용
+- `chunk_meta->>'change_type'`: 변경 유형
+- `chunk_meta->>'source_path'`: 출처 문서 경로
+- 유사도 점수
+
+**IF** RAG 조회가 실패하거나 타임아웃(10초)이면, **THE SYSTEM SHALL** 빈 결과를 반환하고 계속 진행한다.
+
+**WHERE** 유사 사례 조회가 완료되면, **THE SYSTEM SHALL** SimilarCasesCard 형식으로 결과를 정리하고 최종 결과 페이지로 전달한다.
+
+### REQ-V3-IMP-009: 최종 결과 페이지 - 신호등 계산
+
+**WHEN** 모든 4계층 평가가 완료되면, **THE SYSTEM SHALL** 최종 결과 페이지를 생성하고 신호등 결과를 계산한다.
+
+**THE SYSTEM SHALL** 다음 규칙으로 신호등 색상을 결정한다:
+- **Green:** 모든 시장 where `level = 'not-required'`
+- **Yellow:** 일부 시장 where `level = 'conditional'` OR confidence < 90
+- **Red:** 어떤 시장 where `level = 'required'` OR confidence < 70
+
+**THE SYSTEM SHALL** 결과 페이지에 다음을 표시한다:
+1. 신호등 결과 (green/yellow/red)
+2. retestMatrix 셀 표시 (시장별 level, ref, note)
+3. LLM 분석 결과 (category, confidence, reason)
+4. 유사 사례 3건 (Layer 4 결과)
+5. (필요 시) 티켓 CTA (Layer 3에서 생성된 티켓 링크)
+
+**IF** 신호등이 yellow 또는 red이면, **THE SYSTEM SHALL** `impact.check` audit 로그를 기록한다.
+
+### REQ-V3-IMP-010: retestMatrix 데이터 코드 임베드
+
+**THE SYSTEM SHALL** retestMatrix 데이터를 `lib/domains/impact/retest-matrix-data.ts`로 코드 임베드한다.
+
+**THE SYSTEM SHALL** 다음 구조로 데이터를 정의한다:
+```typescript
+export const RETEST_MATRIX = {
+  changeTypes: [
+    { id: 'bom', label: 'BOM 변경 (부품 교체)' },
+    { id: 'sw', label: 'SW 알고리즘 재학습' },
+    { id: 'sw-minor', label: 'SW 마이너 (버그픽스)' },
+    { id: 'label', label: '라벨 문구 변경' },
+    { id: 'warn', label: 'Critical Warning 개정' },
+    { id: 'process', label: '생산공정 변경' },
+    { id: 'sterile', label: '멸균 조건 변경' },
+  ],
+  markets: [
+    { id: 'us', label: 'FDA (US)', color: 'var(--brand-700)' },
+    { id: 'eu', label: 'MDR (EU)', color: 'var(--d-pms)' },
+    { id: 'kr', label: 'MFDS (KR)', color: 'var(--brand-800)' },
+    { id: 'cn', label: 'NMPA (CN)', color: 'var(--danger)' },
+    { id: 'jp', label: 'PMDA (JP)', color: 'var(--d-cc)' },
+  ],
+  cells: {
+    // 35셀 (7 × 5)
+    'bom-us': { level: 'conditional', ref: 'FDA Design Change §III.A', note: 'Special 510(k) 검토 필요 · Letter to File 가능 케이스' },
+    'bom-eu': { level: 'required', ref: 'MDR Art. 120(3), Annex II', note: 'NB 통보 · TR 개정 · 성능시험 재수행' },
+    // ... 나머지 33셀
+  }
+};
+```
+
+**THE SYSTEM SHALL** DB 저장 없이 코드로만 데이터를 제공한다 (결정론 데이터).
+
+**IF** retestMatrix 데이터가 누락된 셀이 있으면, **THE SYSTEM SHALL** 런타임 에러를 발생시키고 관리자에게 알림을 생성한다.
+
+### REQ-V3-IMP-011: DB 테이블 확장
+
+**THE SYSTEM SHALL** regulatory_impact_assessments 테이블을 확장하고 다음 신규 컬럼을 추가한다 (nullable):
+- `wizard_type`: text ('radar-auto' | 'employee-self-check' | NULL)
+- `change_category`: text (bom | sw | sw-minor | label | warn | process | sterile | NULL)
+- `change_detail`: text (NULL)
+- `markets`: jsonb (['us', 'eu', 'kr', 'cn', 'jp'] | NULL)
+- `retest_matrix_results`: jsonb (Layer 1 결과 | NULL)
+- `llm_category`: jsonb (Layer 2 결과 | NULL)
+- `rag_similar_cases`: jsonb (Layer 4 결과 | NULL)
+
+**THE SYSTEM SHALL** migration 0109를 생성하고 ALTER TABLE 문으로 컬럼을 추가한다.
+
+**THE SYSTEM SHALL** migration 0109에 audit_logs.previous_hash BYTEA 컬럼 추가를 포함한다 (SPEC-V3-AUDIT-CHAIN-001 자체 구현, 의존성 제거).
+
+**IF** 기존 레코드가 있으면, **THE SYSTEM SHALL** 모든 신규 컬럼을 NULL로 설정하고 데이터를 보존한다.
+
+**THE SYSTEM SHALL** 다음 인덱스를 추가한다:
+- `idx_wizard_type`: wizard_type
+- `idx_change_category`: change_category
+
+### REQ-V3-IMP-012: 21 CFR Part 11 감사 로깅
+
+**WHEN** 위저드가 실행되면, **THE SYSTEM SHALL** 21 CFR Part 11 감사 로그를 기록한다.
+
+**THE SYSTEM SHALL** 다음 audit 이벤트를 기록한다:
+- `impact.check`: 위저드 실행 (Employee 자가진단) [신규, migration 0110]
+- `impact.ticket.create`: RA Inbox 티켓 생성 (Layer 3) [신규, migration 0110]
+- `impact.critical_detected`: critical 영향 감지 (신호등 red) [기존, migration 0104]
+
+**THE SYSTEM SHALL** 각 audit 레코드에 다음 정보를 포함한다:
+- `action`: audit_action enum 값
+- `user_id`: 실행자 UUID
+- `context`: {
+    `product_id`: 제품 ID,
+    `wizard_type`: 'employee-self-check',
+    `change_category`: 변경 카테고리,
+    `markets`: 시장 목록,
+    `result`: 신호등 결과
+  }
+- `previous_hash`: 이전 레코드의 SHA-256 해시 (append-only 체인)
+
+**WHERE** audit 로깅이 완료되면, **THE SYSTEM SHALL** audit_log 테이블에 INSERT하고 previous_hash를 업데이트한다.
+
+### REQ-V3-IMP-013: RBAC 권한 검사
+
+**WHEN** Employee가 위저드에 접근하면, **THE SYSTEM SHALL** RBAC 권한 검사를 수행한다.
+
+**THE SYSTEM SHALL** 다음 권한을 검사한다:
+- `impact.view`: 위저드 실행 권한 (employee, viewer, ra-member, ra-lead, admin) [신규]
+- `impact.self_check`: 자가진단 권한 (employee, viewer) [신규]
+- `impact.ra_escalate`: RA 티켓 에스컬레이션 권한 (ra-member, ra-lead, admin) [신규]
+
+**IF** 권한이 없으면, **THE SYSTEM SHALL** 403 Forbidden 응답을 반환하고 `auth.forbidden` audit 로그를 기록한다.
+
+**WHERE** 권한 검사가 통과하면, **THE SYSTEM SHALL** 위저드를 계속 진행한다.
+
+### REQ-V3-IMP-014: RAG Citation 강제 (Charter [지양-2])
+
+**WHEN** Layer 4 RAG 조회가 완료되면, **THE SYSTEM SHALL** 모든 유사 사례에 출처 인용을 포함한다.
+
+**THE SYSTEM SHALL** 각 유사 사례에 다음 형식으로 출처를 표기한다:
+```html
+<sup class="cite" data-src="{source_path}">{번호}</sup>
+```
+
+**IF** 출처가 없는 유사 사례가 있으면, **THE SYSTEM SHALL** 해당 사례를 제외하고 "출처 없는 사례는 신뢰도가 낮습니다" 메시지를 표시한다.
+
+**WHERE** 모든 유사 사례에 출처 인용이 완료되면, **THE SYSTEM SHALL** SimilarCasesCard를 렌더링한다.
+
+### REQ-V3-IMP-015: 기존 SPEC-REGULA-IMPACT-001 비회귀
+
+**THE SYSTEM SHALL** 기존 SPEC-REGULA-IMPACT-001 기능을 보존한다.
+
+**THE SYSTEM SHALL** 기존 API 경로를 유지한다:
+- `GET /api/ra/impact`: 영향 평가 목록
+- `GET /api/ra/impact/[assessmentId]`: 상세 조회
+- `POST /api/admin/radar/impact`: 어드민 트리거
+
+**THE SYSTEM SHALL** 기존 DB 테이블 구조를 보존한다:
+- regulatory_impact_assessments 기존 컬럼 유지
+- impact_action_items 기존 컬럼 유지
+- 기존 audit action enum 값 유지
+
+**IF** 신규 컬럼 추가가 필요하면, **THE SYSTEM SHALL** nullable로 추가하고 기존 레코드를 NULL로 설정한다.
+
+**WHERE** 기존 기능과 신규 기능이 공존할 수 있도록 **THE SYSTEM SHALL** re-export 레이어를 유지한다 (lib/impact/ → lib/domains/impact/).
+
+## 비기능 요구사항 (Non-Functional Requirements)
+
+### REQ-V3-IMP-NFR-001: 성능
+
+**THE SYSTEM SHALL** 다음 성능 목표를 달성한다:
+- retestMatrix 조회: < 10ms (in-memory)
+- Layer 2 LLM 분류: < 5초 (gx10 Ollama API 호출)
+- Layer 4 RAG 조회: < 10초 (pgvector 검색, 타임아웃)
+- 전체 위저드 응답 시간: < 20초 (4계층 포함)
+
+### REQ-V3-IMP-NFR-002: 보안
+
+**THE SYSTEM SHALL** 다음 보안 요구사항을 준수한다:
+- 모든 위저드 실행은 audit 로깅 (21 CFR Part 11)
+- RBAC 권한 검사 (impact.view, impact.self_check)
+- SQL Injection 방지 (Drizzle ORM parameterized queries)
+- XSS 방지 (자유 텍스트 입력 sanitization)
+
+### REQ-V3-IMP-NFR-003: 신뢰성
+
+**THE SYSTEM SHALL** 다음 신뢰성 요구사항을 준수한다:
+- RAG 타임아웃 시 빈 결과 반환하고 계속 진행
+- LLM API 실패 시 재시도 최대 3회
+- DB 트랜잭션 실패 시 rollback 에러 처리
+- 모든 에러는 사용자에게 명확한 메시지로 표시
+
+### REQ-V3-IMP-NFR-004: 유지보수성
+
+**THE SYSTEM SHALL** 다음 유지보수성 요구사항을 준수한다:
+- retestMatrix 데이터는 코드 임베드 (DB 아님)
+- 타입 안전 TypeScript (strict mode)
+- 단위 테스트 커버리지 85% 이상
+- Drizzle ORM 타입 안전 쿼리
+
+## 제외 사항 (Exclusions)
+
+### [HARD] 제외 항목 (Phase D 이월)
+
+1. **UI 컴포넌트** (`components/impact-wizard/`)
+   - 이유: Phase D-2 SPEC-V3-UI-001에서 통합 구현
+   - 백엔드 API만 제공
+
+2. **실시간 알림** (Slack, 이메일)
+   - 이유: Phase C 범위 초과
+   - 향후 별도 SPEC으로 구현
+
+3. **외부 크롤러** (Radar 웹사이트 크롤링)
+   - 이유: domains/radar 도메인 책임
+   - RADAR 데이터는 기존 방식대로 공급
+
+4. **ESIG 전자서명**
+   - 이유: Phase D-2 구현
+   - 현재는 audit 로깅만 수행
+
+### [HARD] 기존 기능 비회귀
+
+1. **기존 API 호환성**
+   - `/api/ra/impact` 경로 유지
+   - `/api/admin/radar/impact` 경로 유지
+   - 기존 클라이언트 깨짐 방지
+
+2. **기존 DB 테이블 구조**
+   - regulatory_impact_assessments 기존 컬럼 삭제 금지
+   - impact_action_items 기존 컬럼 삭제 금지
+   - 신규 컬럼만 nullable 추가
+
+3. **기존 audit action enum**
+   - `impact.assessment_created` 유지
+   - `impact.critical_detected` 유지
+   - `impact.action_item_created` 유지
+   - 신규 action만 추가
+
+## 데이터 모델 (Data Model)
+
+### 신규 컬럼 (regulatory_impact_assessments)
+
+| 컬럼명 | 타입 | NULL | 설명 |
+|--------|------|------|------|
+| wizard_type | text | Y | 'radar-auto' \| 'employee-self-check' |
+| change_category | text | Y | bom \| sw \| sw-minor \| label \| warn \| process \| sterile |
+| change_detail | text | Y | 변경 상세 자유 텍스트 |
+| markets | jsonb | Y | ['us', 'eu', 'kr', 'cn', 'jp'] |
+| retest_matrix_results | jsonb | Y | Layer 1 결과 (35셀) |
+| llm_category | jsonb | Y | Layer 2 결과 (category, confidence, reason) |
+| rag_similar_cases | jsonb | Y | Layer 4 결과 (유사 사례 3건) |
+
+### retestMatrix 데이터 구조
+
+```typescript
+interface RetestMatrixCell {
+  level: 'required' | 'conditional' | 'not-required';
+  ref: string;  // 규정 참조
+  note: string; // 설명
+}
+
+interface RetestMatrixData {
+  changeTypes: Array<{ id: string; label: string }>;
+  markets: Array<{ id: string; label: string; color: string }>;
+  cells: Record<string, RetestMatrixCell>;  // Key: '{changeType}-{market}'
+}
+```
+
+## API 계약 (API Contract)
+
+### POST /api/impact-check
+
+**Request:**
+```json
+{
+  "product_id": "uuid",
+  "change_category": "bom | sw | sw-minor | label | warn | process | sterile",
+  "change_detail": "string (10-2000자)",
+  "markets": ["us", "eu", "kr", "cn", "jp"]
+}
+```
+
+**Response:**
+```json
+{
+  "assessment_id": "uuid",
+  "result": {
+    "signal": "green | yellow | red",
+    "retest_matrix": {
+      "us": { "level": "conditional", "ref": "...", "note": "..." },
+      "eu": { "level": "required", "ref": "...", "note": "..." },
+      // ... 나머지 시장
+    },
+    "llm_analysis": {
+      "category": "bom",
+      "confidence": 85,
+      "reason": "BOM 변경 패턴 일치"
+    },
+    "similar_cases": [
+      {
+        "text": "과거 변경 사례 내용",
+        "source": "ra-llm-wiki/doc123.md",
+        "similarity": 0.92,
+        "change_type": "bom",
+        "market": "us"
+      }
+      // ... 최대 3건
+    ],
+    "ticket_id": "uuid | null"  // Layer 3에서 생성된 티켓 ID
+  }
+}
+```
+
+## 의존성 (Dependencies)
+
+### 내부 의존성
+
+- `kernel/db`: DB 쿼리, 트랜잭션
+- `kernel/audit`: 21 CFR Part 11 로깅
+- `domains/ai` (RAG): Layer 4 유사 사례 검색
+- `domains/inbox`: Layer 3 티켓 생성
+- `domains/registry`: 제품/시장 데이터 조회
+
+### 외부 의존성
+
+- gx10 Ollama (gpt-oss:120b via lib/ai/llm-provider.ts getLlmModel()): Layer 2 LLM 분류
+- pgvector: RAG 벡터 검색
+- Drizzle ORM: DB 쿼리 빌더
+
+## 마이그레이션 (Migration)
+
+### Migration 0109: impact_wizard_columns
+
+```sql
+-- Note: SPEC-V3-AUDIT-CHAIN-001 previous_hash 컬럼 추가 (자체 구현, 의존성 제거)
+ALTER TABLE regulatory_impact_assessments
+  ADD COLUMN wizard_type text,
+  ADD COLUMN change_category text,
+  ADD COLUMN change_detail text,
+  ADD COLUMN markets jsonb,
+  ADD COLUMN retest_matrix_results jsonb,
+  ADD COLUMN llm_category jsonb,
+  ADD COLUMN rag_similar_cases jsonb;
+
+CREATE INDEX idx_wizard_type ON regulatory_impact_assessments(wizard_type);
+CREATE INDEX idx_change_category ON regulatory_impact_assessments(change_category);
+```
+
+---
+
+**생성일:** 2026-07-05  
+**버전:** 1.0.0  
+**상태:** planned  
+**다음 단계:** plan.md 구현 계획 수립


### PR DESCRIPTION
## Summary

v3 Phase C-3 **SPEC-V3-IMPACT-001 — Change Impact 4-Layer Wizard** plan 산출물 4종(research/spec/acceptance/plan). manager-spec 작성 → plan-auditor 감사 → 개정 8/8 → frontmatter 표준화.

## 산출물 (1978줄)

- `research.md` (362): 기존 `lib/impact/` 6 files 분석 + retestMatrix 7×5 구조 + v3 4-layer wizard 정의(docs/v3/README.md §3.2 BK-034)
- `spec.md` (512): REQ-V3-IMP-001~015 (15 functional) + NFR 4종, EARS 형식
- `acceptance.md` (470): AC-IMP-01~15 + Edge Cases 8종
- `plan.md` (634): Milestone 1-10 (Foundation → retestMatrix → Layer 1-4 → API → Audit → RBAC → Migration)

## 4-Layer Wizard (BK-034)

| Layer | 기능 | 기술 |
|---|---|---|
| 1 | retestMatrix 결정론 룰 조회 | 7 changeTypes × 5 markets = 35셀 (코드 임베드) |
| 2 | LLM 카테고리 분류 | gx10 Ollama gpt-oss:120b (`lib/ai/llm-provider.ts`) |
| 3 | RA Inbox 자동 티켓 | confidence < 80% 시 direct DB INSERT |
| 4 | ra-llm-wiki RAG 유사 사례 | 3건, Charter [지양-2] citation 강제 |

## plan-auditor 감사 → 개정 8/8 (orchestrator 진실원 직검)

| 결함 | 심각도 | 해결 |
|---|---|---|
| D-1 migration 0108 충돌 | Critical | → 0109 (CONSULT 0108 사용) |
| D-2 Layer 2 Claude API | Critical | → gx10 Ollama (#318 단일화 위반) |
| D-3 impact.* 권한 기존 허위 | High | → 신규 3종(impact.view/self_check/ra_escalate) |
| D-4 Layer 2 카테고리 불일치 | Major | hw-bom → bom (step2 정합) |
| D-5 AUDIT-CHAIN 의존성 | Major | 자체 구현(previous_hash nullable) |
| D-6 INBOX 티켓 API 미검증 | Major | direct DB INSERT 확정 |
| D-7 audit_action enum | Major | 별도 migration 0110 (PostgreSQL 제약) |
| MP-3 frontmatter | Low | CONSULT 표준(--- 블록, created, phase C-3) |

## Migration

- `0109_impact_wizard_columns.sql`: regulatory_impact_assessments 7컬럼 + audit_logs.previous_hash BYTEA
- `0110_audit_impact_actions.sql`: `ALTER TYPE audit_action ADD VALUE` (impact.check, impact.ticket.create)

## 비회귀

기존 SPEC-REGULA-IMPACT-001 (completed, PR #134) 비회귀 보장:
- `lib/impact/` 6 files → `lib/domains/impact/` re-export 레이어(기존 API 호환)
- 기존 컬럼 보존, 신규 컬럼 전부 nullable
- 기존 audit actions(impact.assessment_created/critical_detected/action_item_created) 유지

## 제외 (Phase D 이월)

UI(3-tier PersonaBar, SPEC-V3-UI-001), 외부 크롤러(Radar 도메인), 실시간 알림.

## 다음 단계 (run phase)

annotation cycle 완료 후 본 PR 머지 → `feat/spec-v3-impact-001-run` 브랜치에서 manager-tdd 진입 가능. Milestone 1-10 순차.

Refs SPEC-V3-IMPACT-001, SPEC-REGULA-IMPACT-001, SPEC-V3-INBOX-001

🗿 MoAI <email@mo.ai.kr>