### PR TITLE
fix(qa): #346 model-gov-eval-gate noConsole biome-ignore

### DIFF
--- a/scripts/qa/model-gov-eval-gate.ts
+++ b/scripts/qa/model-gov-eval-gate.ts
@@ -39,6 +39,7 @@ function main(): void {
   const thresholdPct = `${(result.threshold * 100).toFixed(1)}%`;
 
   if (result.passed) {
+    // biome-ignore lint/suspicious/noConsole: CI QA gate script — PASS message on stdout is intentional for release gate diagnostics (mirrors scripts/health-check.ts pattern).
     console.log(`[model-gov-eval-gate] PASS: score ${pct} >= threshold ${thresholdPct}`);
     process.exit(0);
   }


### PR DESCRIPTION
## Summary

Issue #346 해결 — `scripts/qa/model-gov-eval-gate.ts:42` `console.log` noConsole 위반으로 인한 `ci:lint` EXIT 1 수정.

## Root Cause

PR #260 (SPEC-REGULA-MODEL-GOVERNANCE-001) 도입. biome `noConsole` 위반. `biome.json` 설정 `allow: ["warn","error"]`이므로 `console.error` 3건은 허용되나, line 42 `console.log`(PASS 메시지)만 위반.

## Fix

기존 확립 패턴 준용 (이전 결함 #345 M6 ci:lint 직검 중 포착 후 이슈화):

```ts
// biome-ignore lint/suspicious/noConsole: CI QA gate script — PASS message on stdout is intentional for release gate diagnostics (mirrors scripts/health-check.ts pattern).
console.log(`[model-gov-eval-gate] PASS: score ${pct} >= threshold ${thresholdPct}`);
```

## Verification

- `pnpm ci:lint` (biome check . + lint:hex): **EXIT 0** 직검 (1149 files clean)
- 기존 `console.error` 3건(line 24/33/46)은 `allow: ["warn","error"]`로 이미 허용 → 변경 없음

## Impact

main 머지 시 ci:lint 게이트 green 복구 → 이후 PR(#345 등) CI Gates 통과 가능.

Closes #346

🗿 MoAI <email@mo.ai.kr>