### PR TITLE
docs(spec): SPEC-V3-IMPACT-UI-001 Change Impact Wizard UI plan 산출물 4종 (Phase C-4)

### DIFF
--- a/.moai/specs/SPEC-V3-IMPACT-UI-001/acceptance.md
+++ b/.moai/specs/SPEC-V3-IMPACT-UI-001/acceptance.md
@@ -1,0 +1,333 @@
+# SPEC-V3-IMPACT-UI-001 — Acceptance Criteria
+
+---
+**SPEC ID:** SPEC-V3-IMPACT-UI-001
+**Version:** 0.1.0
+**Status:** planned
+**Phase:** C-4
+**Created:** 2026-07-06
+---
+
+## §1 Acceptance Criteria
+
+> 모든 AC는 observable evidence를 포함한다. 백엔드 계약 필드는 camelCase, confidence는 0..1 float (`app/api/impact-check/route.ts` 직검).
+
+### AC-IMP-UI-01: 위저드 라우트 RBAC 게이트 (REQ-IMP-UI-001)
+
+**Given** `impact.view` 권한이 없는 역할(viewer 미만 또는 비활성)의 사용자가
+**When** `/impact` 경로로 접근하면
+**Then** 서버 컴포넌트가 `auth()`를 호출해 역할을 읽고 `/?error=access_denied`로 리다이렉트한다.
+
+**Given** `employee` 이상 권한(`employee`, `viewer`, `ra-member`, `ra-lead`, `admin`) 사용자가
+**When** `/impact` 경로로 접근하면
+**Then** 클라이언트 위저드 컴포넌트가 렌더링되고 Step 1이 보인다.
+
+**Evidence:** Playwright E2E + RTL 단위 테스트에서 `auth()` mock으로 역할별 분기 검증.
+
+### AC-IMP-UI-02: Step 1 제품 식별자 입력 (REQ-IMP-UI-002)
+
+**Given** Step 1이 렌더링되었을 때
+**When** `productId` 입력 필드가 비어 있으면
+**Then** "다음" 버튼이 비활성화되어 있다.
+
+**Given** 사용자가 `productId`에 "xray-src-001"을 입력하면
+**When** 입력값이 1자 이상일 때
+**Then** "다음" 버튼이 활성화되고 클릭 시 Step 2로 이동한다.
+
+**Evidence:** RTL — `screen.getByRole('button', {name:/next/i})`의 `disabled` 속성 변화.
+
+### AC-IMP-UI-03: Step 2 카테고리 7종 선택 (REQ-IMP-UI-003)
+
+**Given** Step 2가 렌더링되었을 때
+**When** 카테고리 목록이 표시되면
+**Then** 정확히 7개 항목(`bom`, `sw`, `sw-minor`, `label`, `warn`, `process`, `sterile`)이 라디오/카드 UI로 표시된다.
+
+**Given** 어떤 카테고리도 선택되지 않았을 때
+**When** 사용자가 "다음"을 시도하면
+**Then** 버튼이 비활성화되어 있다.
+
+**Given** 사용자가 `bom` 카드를 클릭하면
+**When** 선택 이벤트가 발생하면
+**Then** `changeType='bom'` 상태가 저장되고 설명 툴팁(i18n 키 `impact.categories.bom.description`)이 표시되며 "다음" 버튼이 활성화된다.
+
+**Evidence:** RTL — 7개 라디오 role 조회 + 클릭 후 상태 검증.
+
+### AC-IMP-UI-04: Step 3 변경 상세 입력 및 길이 검증 (REQ-IMP-UI-004)
+
+**Given** Step 3가 렌더링되었을 때
+**When** textarea가 비어 있을 때
+**Then** "최소 10자 이상 입력하세요" 에러가 표시되고 "다음"이 비활성화된다.
+
+**Given** 사용자가 5자("hello")를 입력하면
+**When** 글자 수가 10 미만일 때
+**Then** 카운터에 "5 / 2000"이 표시되고 에러가 유지된다.
+
+**Given** 사용자가 10자 이상 입력하면
+**When** 길이가 10..2000 범위일 때
+**Then** 에러가 사라지고 "다음"이 활성화된다.
+
+**Given** 사용자가 2000자를 초과 시도하면
+**When** 2001번째 문자 입력 시
+**Then** 추가 입력이 차단되고 "최대 2000자까지 입력 가능합니다" 에러가 표시된다.
+
+**Evidence:** RTL — ` fireEvent.change` + 카운터/에러 메시지 단언.
+
+### AC-IMP-UI-05: Step 4 시장 다중 선택 (REQ-IMP-UI-005)
+
+**Given** Step 4가 렌더링되었을 때
+**When** 체크박스 5종(us, eu, kr, cn, jp)이 표시될 때
+**Then** 아무것도 선택되지 않은 상태에서 "평가 시작"이 비활성화되어 있다.
+
+**Given** 사용자가 `us`, `eu`를 선택하면
+**When** 선택된 시장이 1개 이상일 때
+**Then** "평가 시작" 버튼이 활성화된다.
+
+**Evidence:** RTL — 체크박스 클릭 후 버튼 활성 상태 단언.
+
+### AC-IMP-UI-06: API 호출 및 로딩/에러 상태 (REQ-IMP-UI-006)
+
+**Given** 모든 단계 입력이 완료되고 "평가 시작"이 클릭되었을 때
+**When** `useImpactCheck` mutation이 pending 상태이면
+**Then** 로딩 스피너 + "4계층 평가 수행 중..." 메시지가 표시되고 "뒤로"/"재전송" 버튼이 비활성화된다.
+
+**Given** 백엔드가 200 OK를 반환하면
+**When** mutation이 성공하면
+**Then** 결과 페이지가 렌더링된다.
+
+**Given** 백엔드가 403 Forbidden을 반환하면
+**When** mutation이 403 에러를 throw하면
+**Then** "권한이 없습니다. 관리자에게 문의하세요" 에러 메시지가 표시된다.
+
+**Given** 백엔드가 400 Bad Request를 반환하면
+**When** Zod 에러 메시지가 응답 본문에 있으면
+**Then** 에러 메시지가 파싱되어 사용자에게 표시된다.
+
+**Given** 네트워크 오류 또는 500이 발생하면
+**When** mutation이 일반 에러를 throw하면
+**Then** "일시 오류. 나중에 다시 시도하세요" 메시지 + "다시 시도" 버튼이 표시된다.
+
+**Evidence:** RTL + MSW (또는 `vi.mock('@/lib/queries/useImpactCheck')`)로 mutation 상태별 렌더링 검증.
+
+### AC-IMP-UI-07: 결과 페이지 — 신호등 및 매트릭스 (REQ-IMP-UI-007)
+
+**Given** 백엔드 응답의 `signal='green'`이면
+**When** 결과 페이지가 렌더링되면
+**Then** SignalLight 컴포넌트가 green 상태로 표시된다.
+
+**Given** 백엔드 응답의 `signal='red'`이고 `matrix`에 `market='us', level='required'` 셀이 포함되어 있으면
+**When** 매트릭스 표가 렌더링되면
+**Then** `us` 행의 셀이 red 강조 스타일로 표시되고 `ref` / `note`가 보인다.
+
+**Given** SignalLight가 렌더링될 때
+**When** 컴포넌트가 신호 값을 계산하면
+**Then** 백엔드 `signal` 필드를 직접 사용하고 재계산하지 않는다 (코드 검사로 검증 — `calculateSignal` import 없음).
+
+**Evidence:** RTL — 다양한 `signal` 값으로 렌더링 + 스타일/텍스트 단언.
+
+### AC-IMP-UI-08: 결과 페이지 — LLM 분류 (REQ-IMP-UI-008)
+
+**Given** 응답의 `classification={category:'bom', confidence:0.85, reason:'SoC 교체는 BOM 패턴'}`이면
+**When** 결과 페이지가 렌더링되면
+**Then** category="bom", confidence="85%", reason 텍스트가 표시된다.
+
+**Given** `confidence=0.65`이면
+**When** 결과 페이지가 렌더링되면
+**Then** "신뢰도 낮음 — RA 검토 권장" 경고 배지가 표시된다.
+
+**Evidence:** RTL — float → 백분율 변환 렌더링 + 임계값 배지 검증.
+
+### AC-IMP-UI-09: 결과 페이지 — 유사 사례 RAG (REQ-IMP-UI-009)
+
+**Given** 응답에 `similarCases=[{id,title,content,similarity}]` 배열이 존재하고 비어 있지 않으면
+**When** SimilarCasesCard가 렌더링되면
+**Then** 각 사례가 카드로 표시되고 출처 인용 `<sup class="cite" data-src="...">번호</sup>`가 포함된다.
+
+**Given** 응답에 `similarCases=[]`(빈 배열)이면
+**When** SimilarCasesCard가 렌더링되면
+**Then** "유사 사례가 없습니다" 메시지가 표시된다.
+
+**Given** 응답에 `similarCases` 필드 자체가 undefined이면(low-confidence 분기)
+**When** 결과 페이지가 렌더링되면
+**Then** 유사 사례 섹션이 렌더링되지 않고 "신뢰도 낮아 유사 사례 조회를 생략했습니다" 안내가 표시된다.
+
+**Evidence:** RTL — `similarCases` undefined / [] / 비어있지 않은 배열 3가지 케이스 렌더링 분기 검증.
+
+### AC-IMP-UI-10: 결과 페이지 — 티켓 CTA 분기 (REQ-IMP-UI-010)
+
+**Given** 응답에 `ticketId='abc-123'`이 존재하면
+**When** 결과 페이지가 렌더링되면
+**Then** "RA 티켓 #abc-123 생성됨" CTA가 `/inbox/abc-123` 링크로 표시된다.
+
+**Given** `ticketId`가 없고 `recommendation='low-confidence-manual-review'`이면
+**When** 결과 페이지가 렌더링되면
+**Then** "RA 검토 권장 — RA 큐에 문의하세요" CTA가 `/inbox` 링크로 표시된다.
+
+**Given** `recommendation='high-confidence-auto-approve'`이면
+**When** 결과 페이지가 렌더링되면
+**Then** 티켓 CTA가 렌더링되지 않는다.
+
+**Evidence:** RTL — `recommendation` 분기별 CTA 렌더링 단언.
+
+### AC-IMP-UI-11: 국제화 및 접근성 (REQ-IMP-UI-011)
+
+**Given** `messages/ko.json`에 `impact.title`, `impact.steps.*`, `impact.categories.*.description` 키가 정의되어 있으면
+**When** 한국어 로켈로 위저드가 렌더링되면
+**Then** 모든 가시 문자열이 한국어로 표시된다.
+
+**Given** `messages/en.json`에 동일한 키가 정의되어 있으면
+**When** 영어 로켈로 렌더링되면
+**Then** 모든 문자열이 영어로 표시된다.
+
+**Given** 사용자가 Tab 키로 위저드를 탐색하면
+**When** Step이 전환되면
+**Then** 첫 번째 입력 요소로 포커스가 이동한다.
+
+**Given** 모든 폼 입력이 렌더링될 때
+**When** 접근성 audit을 실행하면
+**Then** `aria-label` / `<label>` 연결이 100%이고 WCAG 2.1 AA 색상 대비를 만족한다 (`ci:contrast` 통과).
+
+**Evidence:** RTL — next-intl mock 으로 키 lookup 검증 + axe accessibility audit.
+
+---
+
+## §2 Edge Cases
+
+### Edge Case 1: 빈 productId로 폼 제출 시도
+
+**Given** Step 1의 "다음" 버튼이 비활성화된 상태에서
+**When** 사용자가 강제로 폼을 submit하려 하면
+**Then** 버튼이 비활성화되어 있어 submit이 발생하지 않는다. API 호출은 일어나지 않는다.
+
+### Edge Case 2: changeDetail 2000자 경계
+
+**Given** 사용자가 정확히 2000자를 입력하면
+**When** 길이가 max 경계일 때
+**Then** 에러 없이 "다음"이 활성화된다.
+
+**Given** 2001자를 시도하면
+**When** 입력 차단이 발동하면
+**Then** 2000자에서 멈추고 에러 메시지가 표시된다.
+
+### Edge Case 3: 시장 전체 선택 / 전체 해제
+
+**Given** 5개 시장 모두 선택 후
+**When** "전체 해제" 버튼(또는 개별 해제)을 클릭하면
+**Then** 선택된 시장이 0개가 되고 "평가 시작"이 다시 비활성화된다.
+
+### Edge Case 4: 403 Forbidden 응답
+
+**Given** 권한이 있는 사용자가 API를 호출했으나 백엔드 `withPermission` 래퍼가 403을 반환하면 (예: 권한 캐시 만료)
+**When** mutation이 403을 throw하면
+**Then** "권한이 없습니다" 에러가 표시되고 자동 리다이렉트는 발생하지 않는다 (사용자가 새로고침/재로그인 선택).
+
+### Edge Case 5: 백엔드 타임아웃 (long-running)
+
+**Given** 백엔드 응답이 20초 이상 소요되면 (parent SPEC NFR 상한)
+**When** 사용자가 대기 중일 때
+**Then** 로딩 UI가 계속 표시되고 "뒤로"/"재전송" 버튼이 비활성화를 유지한다. (명시적 타임아웃 UI는 v1 범위 외 — 백엔드가 응답하거나 네트워크 에러날 때까지 대기.)
+
+### Edge Case 6: 중복 제출 방지
+
+**Given** 사용자가 "평가 시작"을 클릭한 직후
+**When** mutation이 pending 중일 때 다시 클릭을 시도하면
+**Then** 버튼이 비활성화되어 있어 중복 API 호출이 발생하지 않는다.
+
+### Edge Case 7: 네트워크 끊김 → "다시 시도"
+
+**Given** 네트워크 오류로 mutation이 실패하면
+**When** "다시 시도" 버튼이 표시될 때
+**Then** 동일 입력값으로 mutation을 재시도하고 네트워크 복귀 시 성공한다.
+
+### Edge Case 8: low-confidence 응답에서 similarCases undefined 처리
+
+**Given** 백엔드가 `confidence=0.65`로 인해 `similarCases`를 생략한 응답을 반환하면
+**When** 결과 페이지가 렌더링될 때
+**Then** SimilarCasesCard 컴포넌트가 "유사 사례 조회 생략" 안내를 렌더링하고 빈 카드로 깨지지 않는다.
+
+### Edge Case 9: 키보드 전용 탐색
+
+**Given** 사용자가 마우스 없이 Tab/Enter/Space로만 위저드를 완료하면
+**When** 모든 단계를 키보드로 진행하면
+**Then** 4단계 입력 + "평가 시작" + 결과 확인까지 완료 가능하다.
+
+### Edge Case 10: 다크 모드 렌더링
+
+**Given** 사용자가 다크 모드를 활성화하면
+**When** 위저드가 렌더링되면
+**Then** 신호등 색상이 다크 모드에서도 WCAG AA 대비를 유지한다 (`ci:contrast` 통과).
+
+---
+
+## §3 Quality Gate Criteria
+
+### Definition of Done (DoD)
+
+**SPEC-V3-IMPACT-UI-001은 다음 조건을 모두 충족할 때 "완료"로 간주한다:**
+
+1. **기능 완료:**
+   - [ ] 11개 AC (AC-IMP-UI-01 ~ AC-IMP-UI-11)가 모두 통과한다
+   - [ ] 4단계 위저드 입력 플로우가 동작한다
+   - [ ] 결과 페이지(신호등 / 매트릭스 / LLM 분류 / 유사 사례 / 티켓 CTA)가 정상 렌더링된다
+   - [ ] 모든 에러 상태(403, 400, 500, 네트워크)가 적절히 처리된다
+
+2. **i18n:**
+   - [ ] `messages/ko.json`에 `impact.*` 키가 모두 정의되었다
+   - [ ] `messages/en.json`에 동일 키가 정의되었다
+   - [ ] 컴포넌트 내 하드코딩 문자열이 없다
+
+3. **접근성:**
+   - [ ] 모든 폼 입력이 `<label>` 또는 `aria-label`과 연결된다
+   - [ ] 키보드 전용 탐색이 가능하다
+   - [ ] `ci:contrast` 게이트가 통과한다 (WCAG 2.1 AA)
+   - [ ] 다크 모드에서 색상 대비가 유지된다
+
+4. **성능:**
+   - [ ] 초기 렌더링 < 1초
+   - [ ] 로딩 UI가 즉시 표시된다
+   - [ ] 백엔드 응답 대기 중 중복 제출이 방지된다
+
+5. **비회귀:**
+   - [ ] 기존 consult UI 테스트가 전체 통과한다
+   - [ ] 신규 파일이 지정된 디렉토리에만 생성되었다 (`components/impact/`, `lib/queries/useImpactCheck.ts`, `app/(app)/impact/`, `messages/*.json`)
+   - [ ] 기존 컴포넌트가 수정되지 않았다 (parent SPEC 비회귀)
+
+6. **보안:**
+   - [ ] `dangerouslySetInnerHTML` 미사용
+   - [ ] `<sup>` 인용의 `data-src` 속성 sanitization
+   - [ ] XSS 방지 (React 기본 이스케이핑)
+
+7. **테스트:**
+   - [ ] 단위 테스트 커버리지 85% 이상 (`components/impact/__tests__/`)
+   - [ ] 10개 edge case 시나리오 테스트 포함
+   - [ ] 백엔드 200/400/403/500/네트워크 에러 분기 테스트 포함
+
+### 테스트 전략
+
+**단위 테스트 (Unit Tests, Vitest + RTL):**
+- `components/impact/__tests__/ImpactWizard.test.tsx` — 단계 전환/상태
+- `components/impact/__tests__/Step1Product.test.tsx` — productId 입력 검증
+- `components/impact/__tests__/Step2Category.test.tsx` — 7 카테고리 선택
+- `components/impact/__tests__/Step3Detail.test.tsx` — 10..2000자 검증
+- `components/impact/__tests__/Step4Markets.test.tsx` — 시장 다중 선택
+- `components/impact/__tests__/ImpactResult.test.tsx` — 결과 렌더링
+- `components/impact/__tests__/SignalLight.test.tsx` — 신호등 표시
+- `components/impact/__tests__/SimilarCasesCard.test.tsx` — undefined/[]/비어있지 않음 분기
+- `lib/queries/__tests__/useImpactCheck.test.ts` — mutation hook
+
+**Mock 패턴** (`components/consult/__tests__` 직검 기반):
+- `vi.mock('next-intl')` — `useTranslations`
+- `vi.mock('@/lib/queries/useImpactCheck')` — mutation 상태별 반환값
+- `vi.mock('next/navigation')` — `useRouter`
+- `vi.mock('@/lib/auth')` — 역할별 `auth()` 반환
+
+**접근성 테스트:**
+- `axe` 라이브러리로 자동 audit (consult 패턴 준용)
+- 키보드 탐색 RTL 시뮬레이션
+
+---
+
+**생성일:** 2026-07-06
+**버전:** 0.1.0
+**상태:** planned
+**총 AC 개수:** 11개
+**총 Edge Cases:** 10개

--- a/.moai/specs/SPEC-V3-IMPACT-UI-001/acceptance.md
+++ b/.moai/specs/SPEC-V3-IMPACT-UI-001/acceptance.md
@@ -14,15 +14,17 @@
 
 ### AC-IMP-UI-01: 위저드 라우트 RBAC 게이트 (REQ-IMP-UI-001)
 
-**Given** `impact.view` 권한이 없는 역할(viewer 미만 또는 비활성)의 사용자가
-**When** `/impact` 경로로 접근하면
-**Then** 서버 컴포넌트가 `auth()`를 호출해 역할을 읽고 `/?error=access_denied`로 리다이렉트한다.
+> **역할 래더 (verified):** `admin` > `qa-lead` (2.5) > `ra-lead` > `ra-member` > `viewer` > `auditor` (0.5). `employee` 역할은 존재하지 않는다 (`lib/auth/rbac.ts:14`).
 
-**Given** `employee` 이상 권한(`employee`, `viewer`, `ra-member`, `ra-lead`, `admin`) 사용자가
+**Given** `impact.view` 권한 미달 역할 — `auditor`, `viewer`, 또는 익명/비활성 사용자 — 이
+**When** `/impact` 경로로 접근하면
+**Then** 서버 컴포넌트가 `auth()`를 호출해 역할을 읽고 `hasRole(userRole, 'ra-member')`가 false이면 `/?error=access_denied`로 리다이렉트한다.
+
+**Given** `ra-member` 이상 권한(`ra-member`, `qa-lead`, `ra-lead`, `admin`) 사용자가
 **When** `/impact` 경로로 접근하면
 **Then** 클라이언트 위저드 컴포넌트가 렌더링되고 Step 1이 보인다.
 
-**Evidence:** Playwright E2E + RTL 단위 테스트에서 `auth()` mock으로 역할별 분기 검증.
+**Evidence:** Playwright E2E + RTL 단위 테스트에서 `auth()` mock으로 `{auditor, viewer, ra-member, qa-lead, ra-lead, admin}` 6종 역할 + 익명 분기 검증. 특히 consult 게이트(`viewer`만 거부)와 달리 impact 게이트는 `viewer`와 `auditor` 모두 거부함을 단언.
 
 ### AC-IMP-UI-02: Step 1 제품 식별자 입력 (REQ-IMP-UI-002)
 
@@ -117,6 +119,14 @@
 **Given** 백엔드 응답의 `signal='red'`이고 `matrix`에 `market='us', level='required'` 셀이 포함되어 있으면
 **When** 매트릭스 표가 렌더링되면
 **Then** `us` 행의 셀이 red 강조 스타일로 표시되고 `ref` / `note`가 보인다.
+
+**Given** 백엔드 응답의 `matrix`에 `market='eu', level='conditional'` 셀이 포함되어 있으면
+**When** 매트릭스 표가 렌더링되면
+**Then** `eu` 행의 셀이 yellow 강조 스타일로 표시되고 `ref` / `note`가 보인다.
+
+**Given** 백엔드 응답의 `matrix`에 `market='kr', level='not-required'` 셀이 포함되어 있으면
+**When** 매트릭스 표가 렌더링되면
+**Then** `kr` 행의 셀이 neutral(강조 없음) 스타일로 표시된다.
 
 **Given** SignalLight가 렌더링될 때
 **When** 컴포넌트가 신호 값을 계산하면
@@ -220,11 +230,19 @@
 **When** mutation이 403을 throw하면
 **Then** "권한이 없습니다" 에러가 표시되고 자동 리다이렉트는 발생하지 않는다 (사용자가 새로고침/재로그인 선택).
 
-### Edge Case 5: 백엔드 타임아웃 (long-running)
+### Edge Case 4b: confidence=0.80 경계 (RAG 분기 + 표시 배지)
+
+**Given** 백엔드 응답의 `classification.confidence=0.80`이면 (백엔드는 `>= 0.8` 임계값 사용 — `route.ts:92`)
+**When** 결과 페이지가 렌더링되면
+**Then** (a) `similarCases`가 fetch되어 렌더링되고 (high-confidence 분기), (b) `recommendation='high-confidence-auto-approve'`이며, (c) "신뢰도 낮음" 배지는 미표시된다 (REQ-IMP-UI-008의 `< 0.8` 조건 미충족). 백엔드 임계값이 `>`가 아닌 `>=`임을 확인하는 회귀 방지 케이스.
+
+### Edge Case 5: 백엔드 타임아웃 (non-functional observation)
+
+> v1에는 명시적 타임아웃 UI가 없다. 이 케이스는 automated-test 의무가 아닌 관측 항목이다.
 
 **Given** 백엔드 응답이 20초 이상 소요되면 (parent SPEC NFR 상한)
 **When** 사용자가 대기 중일 때
-**Then** 로딩 UI가 계속 표시되고 "뒤로"/"재전송" 버튼이 비활성화를 유지한다. (명시적 타임아웃 UI는 v1 범위 외 — 백엔드가 응답하거나 네트워크 에러날 때까지 대기.)
+**Then** (관측) 로딩 UI가 계속 표시되고 "뒤로"/"재전송" 버튼이 비활성화를 유지한다. 별도 타임아웃 컴포넌트는 렌더링되지 않는다 — 백엔드가 응답하거나 네트워크 에러가 발생할 때까지 대기한다.
 
 ### Edge Case 6: 중복 제출 방지
 
@@ -327,7 +345,7 @@
 ---
 
 **생성일:** 2026-07-06
-**버전:** 0.1.0
+**버전:** 0.2.0
 **상태:** planned
-**총 AC 개수:** 11개
-**총 Edge Cases:** 10개
+**총 AC 개수:** 11개 (서브 케이스 확장 — AC-IMP-UI-07에 conditional/not-required 추가)
+**총 Edge Cases:** 11개 (Edge Case 4b confidence=0.80 경계 추가)

--- a/.moai/specs/SPEC-V3-IMPACT-UI-001/plan.md
+++ b/.moai/specs/SPEC-V3-IMPACT-UI-001/plan.md
@@ -1,0 +1,494 @@
+# SPEC-V3-IMPACT-UI-001 — Implementation Plan
+
+---
+**SPEC ID:** SPEC-V3-IMPACT-UI-001
+**Version:** 0.1.0
+**Status:** planned
+**Phase:** C-4
+**Created:** 2026-07-06
+---
+
+## §1 Overview
+
+v3 Phase C-4 **Change Impact Wizard UI** 구현 계획. SPEC-V3-IMPACT-001 백엔드(`POST /api/impact-check`, PR #349 merged)를 소비하는 4-step 위저드 + 결과 페이지를 구축한다.
+
+**핵심 목표:**
+- 4단계 입력 위저드 (제품 → 카테고리 → 상세 → 시장)
+- 결과 페이지 (신호등 / 매트릭스 / LLM 분류 / 유사 사례 / 티켓 CTA)
+- consult UI 패턴 준용 (`components/consult/`, `app/(app)/consult/`)
+- i18n + WCAG 2.1 AA 접근성
+- UI 전용 (백엔드 변경 없음)
+
+**TDD 기본:** quality.yaml `development_mode: tdd` 에 따라 RED-GREEN-REFACTOR. brownfieldEnhancement: 기존 consult 컴포넌트 패턴 사전 독해 (Pre-RED).
+
+---
+
+## §2 Implementation Milestones
+
+### Milestone 1: Foundation — Route + RBAC Gate + Hook (Priority: High)
+
+**목표:** 위저드 라우트, RBAC 게이트, `useImpactCheck` mutation hook 마련
+
+**작업 항목:**
+1. `app/(app)/impact/page.tsx` 신규 — 서버 컴포넌트, `auth()` 호출, 역할 게이트, 클라이언트 위저드 wrapper 렌더링 (`app/(app)/consult/page.tsx` 패턴).
+2. `app/(app)/impact/ImpactWizardClient.tsx` 신규 — `'use client'` wrapper.
+3. `lib/queries/useImpactCheck.ts` 신규 — TanStack Query `useMutation` 정의:
+   - request/response 타입(`ImpactCheckRequest`, `ImpactCheckResponse` — spec.md §5)
+   - `fetch('/api/impact-check', {method:'POST', body: JSON.stringify(input)})`
+   - 400/403/500 에러 분기 throw
+4. 단위 테스트:
+   - `app/(app)/impact/__tests__/page.test.tsx` — RBAC 리다이렉트 분기
+   - `lib/queries/__tests__/useImpactCheck.test.ts` — mutation 성공/실패
+
+**산출물:**
+- `app/(app)/impact/page.tsx`, `ImpactWizardClient.tsx`
+- `lib/queries/useImpactCheck.ts`
+- 단위 테스트 2종
+
+**완료 기준:**
+- [ ] `/impact` 라우트가 렌더링된다
+- [ ] `impact.view` 미권한 역할이 `/?error=access_denied`로 리다이렉트된다
+- [ ] `useImpactCheck` mutation이 POST를 정상 호출한다
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- `@/lib/auth` (`auth()`)
+- TanStack Query
+- 백엔드 `POST /api/impact-check` (frozen)
+
+### Milestone 2: i18n + Design Tokens (Priority: High)
+
+**목표:** 모든 위저드 문자열 키 + 신호등 토큰 준비
+
+**작업 항목:**
+1. `messages/ko.json`에 `impact` 네임스페이스 추가:
+   - `impact.title`, `impact.steps.{1..4}.title`, `impact.steps.{1..4}.description`
+   - `impact.categories.{bom|sw|sw-minor|label|warn|process|sterile}.label`
+   - `impact.categories.{...}.description`
+   - `impact.markets.{us|eu|kr|cn|jp}.label`
+   - `impact.form.{productId.label, changeDetail.label, changeDetail.placeholder, changeDetail.counter, charMinError, charMaxError}`
+   - `impact.button.{next, back, startEvaluation, retry}`
+   - `impact.result.{signalLabel, matrixHeader, llmHeader, similarHeader, ticketCta, contactRaCta, noSimilarCases, similarCasesSkipped, lowConfidenceBadge, loadingMessage}`
+   - `impact.error.{forbidden, badRequest, network}`
+2. `messages/en.json` 동일 키 추가.
+3. 신호등 색상 토큰 — `app/globals.css`에 `--signal-green`, `--signal-yellow`, `--signal-red` semantic 토큰 정의 (light/dark 모드 각각). 기존 `--color-brand-*`와 `--danger` 재사용. `ci:contrast` 통과 검증.
+
+**산출물:**
+- `messages/ko.json`, `messages/en.json` 확장
+- `app/globals.css` 신호등 토큰 (필요 시)
+
+**완료 기준:**
+- [ ] 모든 위저드 가시 문자열이 키로 관리된다
+- [ ] 한국어/영어 전환이 동작한다
+- [ ] 신호등 색상이 light/dark 모두에서 AA 대비 통과한다
+
+**의존성:**
+- next-intl
+- Tailwind v4 @theme
+
+### Milestone 3: Step 1-4 위저드 컴포넌트 (Priority: High)
+
+**목표:** 4단계 입력 UI + 단계 전환 로직
+
+**작업 항목:**
+1. `components/impact/ImpactWizard.tsx` — 오케스트레이터:
+   - `step` state (1..4)
+   - `productId`, `changeType`, `changeDetail`, `markets` state
+   - Step 전환 + 포커스 관리
+   - 완료 시 `useImpactCheck().mutate(input)`
+2. `components/impact/Step1Product.tsx` — productId 자유 텍스트 입력 (REQ-IMP-UI-002):
+   - 입력값 1자 이상 시 "다음" 활성화
+   - i18n 키 lookup
+3. `components/impact/Step2Category.tsx` — 7개 라디오/카드 (REQ-IMP-UI-003):
+   - 7 카테고리 라디오 그룹
+   - 선택 시 설명 툴팁 표시
+4. `components/impact/Step3Detail.tsx` — textarea + 카운터 (REQ-IMP-UI-004):
+   - 10..2000자 검증
+   - 실시간 카운터 렌더링
+5. `components/impact/Step4Markets.tsx` — 체크박스 5종 (REQ-IMP-UI-005):
+   - 1개 이상 선택 시 "평가 시작" 활성화
+6. 단위 테스트:
+   - `ImpactWizard.test.tsx` — 단계 전환 + 상태
+   - `Step1Product.test.tsx` — 빈 입력/활성 입력 분기
+   - `Step2Category.test.tsx` — 7 카테고리 라디오 + 선택 단일성
+   - `Step3Detail.test.tsx` — 10자 미만/2000자 초과/정상 분기
+   - `Step4Markets.test.tsx` — 0개 선택/1개 이상 선택 분기
+
+**산출물:**
+- `components/impact/ImpactWizard.tsx`, `Step1Product.tsx`, `Step2Category.tsx`, `Step3Detail.tsx`, `Step4Markets.tsx`
+- 단위 테스트 5종
+
+**완료 기준:**
+- [ ] 4단계 입력 플로우가 동작한다
+- [ ] 각 단계 검증 로직이 AC-IMP-UI-02..05를 만족한다
+- [ ] "평가 시작" 클릭 시 `useImpactCheck` mutation이 호출된다
+- [ ] 키보드 탐색이 가능하다
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- Milestone 1 (`useImpactCheck`)
+- Milestone 2 (i18n 키)
+- Radix UI primitives (라디오/체크박스)
+
+### Milestone 4: 로딩 및 에러 상태 (Priority: High)
+
+**목표:** mutation pending/error 상태 UI (REQ-IMP-UI-006)
+
+**작업 항목:**
+1. `ImpactWizard.tsx`에 mutation 상태 분기 추가:
+   - `isPending`: 로딩 스피너 + "4계층 평가 수행 중..." + "뒤로"/"재전송" 비활성화
+   - `isError` + 403: "권한이 없습니다. 관리자에게 문의하세요"
+   - `isError` + 400: 백엔드 에러 메시지 파싱 표시
+   - `isError` + 네트워크/500: "일시 오류. 나중에 다시 시도하세요" + "다시 시도" 버튼
+   - `isSuccess`: 결과 페이지 렌더링 (Milestone 5)
+2. 중복 제출 방지 — pending 중 "평가 시작" 버튼 비활성화.
+3. 단위 테스트:
+   - `ImpactWizard.test.tsx`에 pending/403/400/500/네트워크 분기 케이스 추가 (MSW 또는 mutation mock)
+
+**산출물:**
+- `ImpactWizard.tsx` 상태 분기
+- 단위 테스트 케이스 5종 추가
+
+**완료 기준:**
+- [ ] 모든 에러 상태가 AC-IMP-UI-06을 만족한다
+- [ ] 중복 제출이 방지된다
+- [ ] "다시 시도" 버튼이 동작한다
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- Milestone 3
+
+### Milestone 5: 결과 페이지 컴포넌트 (Priority: High)
+
+**목표:** 신호등 / 매트릭스 / LLM 분류 / 유사 사례 / 티켓 CTA 렌더링
+
+**작업 항목:**
+1. `components/impact/SignalLight.tsx` (REQ-IMP-UI-007):
+   - props: `signal: 'green'|'yellow'|'red'`
+   - 백엔드 값 직접 소비 (재계산 X)
+   - 신호등 semantic 토큰 사용
+2. `components/impact/ImpactMatrixTable.tsx` (REQ-IMP-UI-007):
+   - props: `matrix: Array<{level, ref, note, market}>`
+   - market별 그룹화 렌더링
+   - `level='required'` 셀 강조 스타일
+3. `components/impact/LlmClassification.tsx` (REQ-IMP-UI-008):
+   - props: `classification: {category, confidence, reason}`
+   - confidence float → 백분율 표시
+   - `confidence < 0.8` 경고 배지
+4. `components/impact/SimilarCasesCard.tsx` (REQ-IMP-UI-009):
+   - props: `similarCases?: Array<...>` (undefined / [] / 비어있지 않음 분기)
+   - 출처 인용 `<sup class="cite" data-src="...">번호</sup>` 포함
+   - undefined 시 "조회 생략" 안내
+   - 빈 배열 시 "유사 사례 없음"
+5. `components/impact/ImpactResult.tsx` (REQ-IMP-UI-007..010):
+   - SignalLight + MatrixTable + LlmClassification + SimilarCasesCard 조합
+   - `recommendation` 분기 티켓 CTA 렌더링
+   - `ticketId` 존재 시 `/inbox/{ticketId}`, 미존재 + low-confidence 시 `/inbox` 정적 CTA
+6. 단위 테스트:
+   - `SignalLight.test.tsx`, `ImpactMatrixTable.test.tsx`, `LlmClassification.test.tsx`, `SimilarCasesCard.test.tsx`, `ImpactResult.test.tsx`
+   - 특히 SimilarCasesCard 3분기(undefined/[]/비어있지 않음) 집중 검증
+
+**산출물:**
+- 결과 컴포넌트 5종
+- 단위 테스트 5종
+
+**완료 기준:**
+- [ ] 결과 페이지가 AC-IMP-UI-07..10을 만족한다
+- [ ] 신호등 재계산이 없다 (코드 검사)
+- [ ] `similarCases` undefined vs [] 분기가 정확하다
+- [ ] 출처 인용 `<sup>`가 모든 유사 사례에 포함된다
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- Milestone 4
+
+### Milestone 6: 접근성 + 다크 모드 + 통합 테스트 (Priority: Medium)
+
+**목표:** WCAG 2.1 AA + 다크 모드 검증 + E2E
+
+**작업 항목:**
+1. 모든 폼 입력에 `<label htmlFor>` 또는 `aria-label` 연결
+2. Step 전환 시 첫 입력으로 포커스 이동
+3. 다크 모드 렌더링 검증 — SignalLight, 매트릭스 강조 스타일
+4. `ci:contrast` 게이트 통과 검증
+5. axe 자동 접근성 audit (`@axe-core/playwright` 또는 `jest-axe`)
+6. 통합 시나리오 테스트:
+   - happy path (high-confidence → 결과 + 유사 사례)
+   - low-confidence path (결과 + RA 검토 CTA, similarCases 생략)
+   - 네트워크 오류 → 재시도 → 성공
+   - 권한 없는 사용자 → 리다이렉트
+
+**산출물:**
+- 접근성 개선 (기존 컴포넌트 수정)
+- 통합 테스트 케이스
+
+**완료 기준:**
+- [ ] AC-IMP-UI-11 (i18n + 접근성) 통과
+- [ ] 다크 모드에서 WCAG AA 대비 유지
+- [ ] 통합 시나리오 4종 통과
+- [ ] `ci:contrast` 게이트 통과
+
+**의존성:**
+- Milestone 5
+
+---
+
+## §3 New and Modified Files
+
+### 신규 파일 (New Files)
+
+**라우트:**
+```
+app/(app)/impact/
+├── page.tsx                          # M1: 서버 컴포넌트 + RBAC 게이트
+├── ImpactWizardClient.tsx           # M1: 'use client' wrapper
+└── __tests__/
+    └── page.test.tsx                 # M1: RBAC 리다이렉트
+```
+
+**컴포넌트:**
+```
+components/impact/
+├── ImpactWizard.tsx                  # M3: 오케스트레이터 (M4에서 상태 분기 확장)
+├── Step1Product.tsx                  # M3
+├── Step2Category.tsx                 # M3
+├── Step3Detail.tsx                   # M3
+├── Step4Markets.tsx                  # M3
+├── ImpactResult.tsx                  # M5: 결과 페이지 조합
+├── SignalLight.tsx                   # M5
+├── ImpactMatrixTable.tsx             # M5
+├── LlmClassification.tsx             # M5
+├── SimilarCasesCard.tsx              # M5
+└── __tests__/
+    ├── ImpactWizard.test.tsx         # M3+M4
+    ├── Step1Product.test.tsx         # M3
+    ├── Step2Category.test.tsx        # M3
+    ├── Step3Detail.test.tsx          # M3
+    ├── Step4Markets.test.tsx         # M3
+    ├── ImpactResult.test.tsx         # M5
+    ├── SignalLight.test.tsx          # M5
+    ├── ImpactMatrixTable.test.tsx    # M5
+    ├── LlmClassification.test.tsx    # M5
+    └── SimilarCasesCard.test.tsx     # M5
+```
+
+**쿼리 훅:**
+```
+lib/queries/
+├── useImpactCheck.ts                 # M1: TanStack Query mutation
+└── __tests__/
+    └── useImpactCheck.test.ts        # M1
+```
+
+### 수정 파일 (Modified Files)
+
+**i18n:**
+```
+messages/ko.json                      # M2: impact 네임스페이스 추가
+messages/en.json                      # M2: 동일
+```
+
+**디자인 토큰 (필요 시):**
+```
+app/globals.css                       # M2: 신호등 semantic 토큰 (light/dark)
+```
+
+### 수정 금지 (Out of Scope)
+
+- `app/api/impact-check/route.ts` — frozen
+- `lib/domains/impact/*` — frozen
+- `lib/db/schema.ts` — frozen
+- 기존 consult 컴포넌트 — 비회귀
+
+---
+
+## §4 Technical Approach
+
+### 아키텍처 패턴
+
+**서버/클라이언트 분리 (consult 패턴 준용):**
+```
+app/(app)/impact/page.tsx (server)
+    ↓ auth() + role gate
+ImpactWizardClient.tsx ('use client')
+    ↓
+components/impact/ImpactWizard.tsx
+    ↓ step state + useImpactCheck mutation
+Step1Product / Step2Category / Step3Detail / Step4Markets
+    ↓ on submit
+useImpactCheck → POST /api/impact-check
+    ↓ response
+ImpactResult (SignalLight + MatrixTable + LlmClassification + SimilarCasesCard + TicketCTA)
+```
+
+**상태 관리:**
+- 위저드 입력값: React `useState` (ImpactWizard 내부) — 다른 페이지와 공유 필요 없음.
+- API mutation: TanStack Query `useMutation` (`useImpactCheck`).
+- 전역 상태(Zustand/Jotai) 불필요 — 과잉 추상화 방지 (Charter [지양-5]).
+
+### 데이터 흐름
+
+**정상 플로우 (high-confidence):**
+```
+Step 1..4 입력 → "평가 시작" 클릭
+    ↓
+useImpactCheck.mutate(input)
+    ↓ POST /api/impact-check
+백엔드 4계층 실행 (retestMatrix → LLM → RAG → signal)
+    ↓ 200 OK {matrix, signal, classification, similarCases, recommendation}
+ImpactResult 렌더링 (SignalLight green/yellow, SimilarCasesCard 카드 N건)
+```
+
+**Low-confidence 플로우:**
+```
+Step 1..4 입력 → "평가 시작"
+    ↓
+useImpactCheck.mutate
+    ↓ 200 OK {matrix, signal, classification, recommendation='low-confidence-manual-review'}
+    ↓ similarCases 생략, ticketId 생략 (assigneeId 미전송)
+ImpactResult 렌더링 (SignalLight, 유사 사례 생략 안내, RA 검토 CTA /inbox)
+```
+
+### 에러 처리 전략
+
+| 상황 | 사용자 UX |
+|---|---|
+| 403 Forbidden | "권한 없음" 에러 메시지 (자동 리다이렉트 X) |
+| 400 Bad Request | 백엔드 Zod 메시지 파싱 표시 |
+| 500 / 네트워크 | "일시 오류" + "다시 시도" 버튼 |
+| pending 중복 클릭 | 버튼 비활성화로 차단 |
+
+### 백엔드 계약 준수 체크리스트 (코드 리뷰 게이트)
+
+- [ ] request field names: camelCase (`orgId`, `productId`, `changeType`, `markets`, `changeDetail`) — snake_case 금지
+- [ ] `confidence` 0..1 float 처리 (백분율 변환은 표시 레이어에서만)
+- [ ] `similarCases` undefined vs [] 구분
+- [ ] `signal` 재계산 금지 (백엔드 값 직접 소비)
+- [ ] `assigneeId` v1에서 미전송 (low-confidence 시 티켓 미생성 정상)
+
+---
+
+## §5 Testing Strategy
+
+### 단위 테스트 (Vitest + RTL)
+
+**목표 커버리지:** 85% 이상
+
+**Mock 패턴** (`components/consult/__tests__/` 직검 기반):
+```ts
+vi.mock('next-intl', () => ({ useTranslations: () => (key) => key }));
+vi.mock('@/lib/queries/useImpactCheck', () => ({
+  useImpactCheck: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+  }),
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+```
+
+**테스트 대상:** plan.md §3 단위 테스트 파일 목록 참조.
+
+### 접근성 테스트
+
+- `jest-axe` 또는 `@axe-core/playwright` 자동 audit
+- 키보드 탐색 RTL 시뮬레이션 (`fireEvent.keyDown` Tab/Enter)
+- `ci:contrast` CI 게이트 통과
+
+### 비회귀 테스트
+
+- 기존 `pnpm test` (full suite) 통과 — 특히 consult 테스트가 깨지지 않는지 (L-009).
+- `pnpm lint` (lint:hex) full 실행 (L-008).
+
+---
+
+## §6 Risk Mitigation
+
+### 위험 1: 백엔드 계약 drift (camelCase vs snake_case)
+
+**완화:**
+- research.md §2.2에 직검 검증된 camelCase 필드명을 spec.md §5 + 모든 테스트 단언에 고정.
+- 코드 리뷰 게이트(§4 체크리스트)에서 필드명 단언.
+
+**검증:** M1 mutation hook 테스트에서 request body camelCase 단언.
+
+### 위험 2: similarCases undefined 처리 누락
+
+**완화:**
+- AC-IMP-UI-09에서 undefined / [] / 비어있지 않음 3분기를 명시적 단언.
+- SimilarCasesCard 단위 테스트에서 3분기 집중 검증.
+
+**검증:** M5 SimilarCasesCard.test.tsx 3분기 통과.
+
+### 위험 3: 제품 목록 데이터 소스 부재 (research.md §6-A1)
+
+**완화:**
+- v1은 자유 텍스트 productId 입력 (백엔드 Zod `z.string()` 호환).
+- 제품 피커는 별도 follow-up SPEC으로 이월 (spec.md §8).
+
+**검증:** M3 Step1Product가 단순 텍스트 입력으로 동작.
+
+### 위험 4: 신호등 재계산 drift
+
+**완화:**
+- REQ-IMP-UI-007에 "백엔드 값 직접 소비, 재계산 X" 명시.
+- 코드 검사에서 `calculateSignal` import 부재 단언.
+
+**검증:** M5 SignalLight 테스트 + 코드 리뷰.
+
+### 위험 5: low-confidence 티켓 미생성 사용자 혼란
+
+**완화:**
+- v1은 `assigneeId` 미전송 → `recommendation='low-confidence-manual-review'` 시 `/inbox` 정적 CTA (research.md §6-A2).
+- AC-IMP-UI-10에 명시적 CTA 분기 단언.
+
+**검증:** M5 ImpactResult.test.tsx recommendation 분기.
+
+---
+
+## §7 Dependencies Mapping
+
+### 내부 의존성
+
+| 의존 대상 | 용도 | Milestone |
+|---|---|---|
+| `POST /api/impact-check` | 4계층 평가 백엔드 | M1 (frozen) |
+| `@/lib/auth` (`auth()`) | 페이지 RBAC 게이트 | M1 |
+| TanStack Query | mutation hook | M1 |
+| `next-intl` | i18n | M2 |
+| Tailwind v4 `@theme` | 디자인 토큰 | M2 |
+| 기존 consult 패턴 | 컴포넌트/테스트 참조 | M3 (참고용) |
+
+### 외부 의존성
+
+| 의존 대상 | 용도 | 버전 |
+|---|---|---|
+| Radix UI primitives | 라디오/체크박스/dialog (접근성) | 기존 consult 사용 버전 |
+| `jest-axe` 또는 `@axe-core/playwright` | 접근성 audit | 기존 설정 준용 |
+
+### 외부 의존성이 아닌 것 (NOT Imported)
+
+- `useStreamingAnswer` — consult SSE 전용 (impact는 동기 POST)
+- `/api/products` — 존재하지 않음
+- `/api/ra/assignees` — 존재하지 않음
+
+---
+
+## §8 Open Questions (Run-Phase Resolution)
+
+| ID | Question | Default | Owner |
+|---|---|---|---|
+| OQ-1 | 제품 목록 출처 (research.md §6-A1) | 자유 텍스트 productId | run phase: UX 확정 |
+| OQ-2 | low-confidence 티켓 CTA (research.md §6-A2) | `/inbox` 정적 CTA | run phase: UX 확정 |
+| OQ-3 | `phase: C-4` 라벨 roadmap 교차 검증 | orchestrator 지시 따름 | plan-auditor |
+
+---
+
+**생성일:** 2026-07-06
+**버전:** 0.1.0
+**상태:** planned
+**총 Milestones:** 6개
+**예상 완료:** Phase C-4 종료 시점

--- a/.moai/specs/SPEC-V3-IMPACT-UI-001/plan.md
+++ b/.moai/specs/SPEC-V3-IMPACT-UI-001/plan.md
@@ -2,7 +2,7 @@
 
 ---
 **SPEC ID:** SPEC-V3-IMPACT-UI-001
-**Version:** 0.1.0
+**Version:** 0.2.0
 **Status:** planned
 **Phase:** C-4
 **Created:** 2026-07-06
@@ -29,15 +29,19 @@ v3 Phase C-4 **Change Impact Wizard UI** 구현 계획. SPEC-V3-IMPACT-001 백�
 
 **목표:** 위저드 라우트, RBAC 게이트, `useImpactCheck` mutation hook 마련
 
+> **H4 — 게이트 엄격도 주의:** Impact 페이지 게이트(`impact.view`, minRole=`ra-member`)는 consult 페이지 게이트(`viewer`만 거부)보다 **엄격**하다. run-phase에서 consult의 `if (!userRole || userRole === 'viewer') redirect(...)` 패턴을 copy-paste하지 말 것 — 그 패턴은 `auditor`를 허용해버려 impact 보안이 깨진다. 반드시 `lib/auth/rbac.ts`의 `hasRole(userRole, 'ra-member')` 헬퍼를 사용할 것.
+
 **작업 항목:**
-1. `app/(app)/impact/page.tsx` 신규 — 서버 컴포넌트, `auth()` 호출, 역할 게이트, 클라이언트 위저드 wrapper 렌더링 (`app/(app)/consult/page.tsx` 패턴).
-2. `app/(app)/impact/ImpactWizardClient.tsx` 신규 — `'use client'` wrapper.
+1. `app/(app)/impact/page.tsx` 신규 — 서버 컴포넌트, `auth()` 호출, **`hasRole(userRole, 'ra-member')` 기반 역할 게이트** (consult의 `=== 'viewer'` 하드코드 금지), 클라이언트 위저드 wrapper 렌더링.
+   - 거부 집합: `{auditor, viewer, undefined/anonymous}` → `/?error=access_denied` 리다이렉트.
+   - 허용 집합: `{ra-member, qa-lead, ra-lead, admin}` → 위저드 렌더링.
+2. `app/(app)/impact/ImpactWizardClient.tsx` 신규 — `'use client'` wrapper. props로 `orgId`를 받아 mutation 호출 시 전달 (REQ-IMP-UI-006a).
 3. `lib/queries/useImpactCheck.ts` 신규 — TanStack Query `useMutation` 정의:
    - request/response 타입(`ImpactCheckRequest`, `ImpactCheckResponse` — spec.md §5)
-   - `fetch('/api/impact-check', {method:'POST', body: JSON.stringify(input)})`
+   - `fetch('/api/impact-check', {method:'POST', body: JSON.stringify(input)})` — `orgId` 필수 (route.ts:21 Zod non-optional)
    - 400/403/500 에러 분기 throw
 4. 단위 테스트:
-   - `app/(app)/impact/__tests__/page.test.tsx` — RBAC 리다이렉트 분기
+   - `app/(app)/impact/__tests__/page.test.tsx` — RBAC 리다이렉트 분기 (6종 역할 + 익명)
    - `lib/queries/__tests__/useImpactCheck.test.ts` — mutation 성공/실패
 
 **산출물:**
@@ -47,12 +51,13 @@ v3 Phase C-4 **Change Impact Wizard UI** 구현 계획. SPEC-V3-IMPACT-001 백�
 
 **완료 기준:**
 - [ ] `/impact` 라우트가 렌더링된다
-- [ ] `impact.view` 미권한 역할이 `/?error=access_denied`로 리다이렉트된다
+- [ ] `hasRole(userRole, 'ra-member')`로 거부 집합 `{auditor, viewer, anonymous}`가 `/?error=access_denied`로 리다이렉트된다
+- [ ] 허용 집합 `{ra-member, qa-lead, ra-lead, admin}`이 위저드를 본다
 - [ ] `useImpactCheck` mutation이 POST를 정상 호출한다
 - [ ] 단위 테스트 통과
 
 **의존성:**
-- `@/lib/auth` (`auth()`)
+- `@/lib/auth` (`auth()`, `hasRole`)
 - TanStack Query
 - 백엔드 `POST /api/impact-check` (frozen)
 
@@ -456,7 +461,7 @@ vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 | 의존 대상 | 용도 | Milestone |
 |---|---|---|
 | `POST /api/impact-check` | 4계층 평가 백엔드 | M1 (frozen) |
-| `@/lib/auth` (`auth()`) | 페이지 RBAC 게이트 | M1 |
+| `@/lib/auth` (`auth()`, `hasRole`) | 페이지 RBAC 게이트 (consult보다 엄격 — M1 H4 메모) | M1 |
 | TanStack Query | mutation hook | M1 |
 | `next-intl` | i18n | M2 |
 | Tailwind v4 `@theme` | 디자인 토큰 | M2 |

--- a/.moai/specs/SPEC-V3-IMPACT-UI-001/research.md
+++ b/.moai/specs/SPEC-V3-IMPACT-UI-001/research.md
@@ -2,7 +2,7 @@
 
 ---
 **SPEC ID:** SPEC-V3-IMPACT-UI-001
-**Version:** 0.1.0
+**Version:** 0.2.0
 **Status:** planned
 **Phase:** C-4
 **Created:** 2026-07-06
@@ -80,13 +80,17 @@ parse → Layer 1 (matrix loop) → Layer 2 (LLM classify)
 
 The UI's SignalLight component must consume the `signal` field directly (backend-computed) — the UI MUST NOT re-compute, to avoid drift.
 
-### 2.6 RBAC (route.ts:32 + parent SPEC REQ-V3-IMP-013)
+### 2.6 RBAC (route.ts:32 + `permissions.ts:582-596` 직검)
 
-| Permission | Granted roles | Enforced where |
-|---|---|---|
-| `impact.view` | employee, viewer, ra-member, ra-lead, admin | Page route (server-side gate, REQ-IMP-UI-002) |
-| `impact.self_check` | viewer, employee, ra-member, ra-lead, admin | API route wrapper |
-| `impact.ra_escalate` | ra-member, ra-lead, admin | Future: ticket CTA escalation (not in v1 UI) |
+> **Role ladder (verified, `lib/auth/rbac.ts:14`):** `Role = 'admin' | 'qa-lead' | 'ra-lead' | 'ra-member' | 'viewer' | 'auditor'`. `employee` 역할은 **존재하지 않는다** — 이전 버전의 본 문서와 parent SPEC prose가 사용한 `employee`는 fabricated. `auditor` (`ROLE_HIERARCHY=0.5`)는 외부 감사자 전용 읽기 전용 역할로 기존 모든 minRole 게이트에서 거부됨.
+
+| Permission | minRole | Granted roles (ladder 기준) | Enforced where |
+|---|---|---|---|
+| `impact.view` | `ra-member` | ra-member, qa-lead, ra-lead, admin | Page route (server-side gate, REQ-IMP-UI-001). **auditor, viewer는 거부됨.** |
+| `impact.self_check` | `viewer` | viewer, ra-member, qa-lead, ra-lead, admin | API route wrapper (withPermission) |
+| `impact.ra_escalate` | `ra-member` | ra-member, qa-lead, ra-lead, admin | Future: ticket CTA escalation (not in v1 UI) |
+
+> **게이트 엄격도 역설 (H4):** 페이지 게이트(`impact.view`, minRole=`ra-member`)가 API 게이트(`impact.self_check`, minRole=`viewer`)보다 엄격하다. 따라서 viewer/auditor는 위저드 페이지 자체에 진입할 수 없어 API 호출 기회가 없다. 이는 의도된 동작 — UI는 더 안전한 서버 사이드 게이트를 신뢰한다.
 
 **Page-level gate convention** (verified in `app/(app)/consult/page.tsx:8-13`): server component calls `auth()`, reads `session.user.role`, redirects on insufficient role. The Impact page MUST follow the same pattern.
 
@@ -177,7 +181,7 @@ The backend accepts `productId: z.string()` but there is **no products list API*
 **SPEC resolution:** Default to (b) free-text `productId` input for v1, with a NOTE that (a)/(c) are follow-up enhancements. This keeps the UI self-contained and avoids inventing a product list that doesn't exist (L-002 anti-pattern guardrail).
 
 ### A2. `assigneeId` and Layer 3 ticket creation — UX DECISION NEEDED
-Backend creates a ticket only if `assigneeId` is present (route.ts:90). For viewer/employee roles, who should the assignee be?
+Backend creates a ticket only if `assigneeId` is present (route.ts:90). For ra-member/qa-lead/ra-lead/admin roles (위저드 진입 가능 역할), who should the assignee be?
 
 **Options:**
 - (a) The UI omits `assigneeId` → low-confidence runs produce no ticket → user sees "RA review recommended" CTA without a created ticket.

--- a/.moai/specs/SPEC-V3-IMPACT-UI-001/research.md
+++ b/.moai/specs/SPEC-V3-IMPACT-UI-001/research.md
@@ -1,0 +1,207 @@
+# SPEC-V3-IMPACT-UI-001 — Research (Codebase Analysis)
+
+---
+**SPEC ID:** SPEC-V3-IMPACT-UI-001
+**Version:** 0.1.0
+**Status:** planned
+**Phase:** C-4
+**Created:** 2026-07-06
+**Author:** manager-spec
+**Method:** L-013 direct code inspection (no self-report)
+---
+
+## §1 Research Scope
+
+Plan-phase deep codebase analysis to ground the Impact Wizard **frontend** SPEC in verified facts. The backend (SPEC-V3-IMPACT-001, PR #349 merged) is the contract this UI consumes. Every API field, RBAC permission, route, and component pattern referenced in `spec.md` is traceable to a line in this document.
+
+**Out of scope:** backend changes (the backend is FROZEN contract — `app/api/impact-check/route.ts` is post-merge).
+
+## §2 Backend Contract (VERIFIED — `app/api/impact-check/route.ts`)
+
+### 2.1 Endpoint
+
+`POST /api/impact-check` — wrapped by `withPermission('impact.self_check')` (route.ts:32). Anonymous callers are rejected by the auth wrapper before Zod runs.
+
+### 2.2 Request body (Zod schema, route.ts:21-28)
+
+```ts
+z.object({
+  orgId: z.string(),
+  productId: z.string(),
+  changeType: z.enum(['bom','sw','sw-minor','label','warn','process','sterile']),
+  markets: z.array(z.enum(['us','eu','kr','cn','jp'])),
+  changeDetail: z.string().min(1).max(2000),
+  assigneeId: z.string().optional(),
+})
+```
+
+**NOTE:** Backend uses camelCase (`orgId`, `productId`, `changeType`, `changeDetail`, `assigneeId`), NOT the snake_case (`product_id`, `change_category`) that appears in the parent SPEC-V3-IMPACT-001 §API Contract. The UI MUST send camelCase. This is a verified contract drift between the parent SPEC prose and the merged implementation; the UI follows the implementation.
+
+**NOTE:** `changeDetail.min(1)` — backend accepts 1 char minimum. Parent SPEC prose says "10..2000자". The UI will enforce a stricter minimum (10 chars) for usability guidance, but the hard validation floor is 1 char per backend.
+
+### 2.3 Response shape (route.ts:30-44 + response assembly)
+
+```ts
+interface ImpactCheckResponse {
+  matrix: Array<{ level: string; ref: string; note: string; market: string }>;
+  signal: 'green' | 'yellow' | 'red';
+  classification: { category: string; confidence: number; reason: string };
+  similarCases?: Array<{ id: string; title: string; content: string; similarity: number }>;
+  ticketId?: string;
+  recommendation: string;  // 'high-confidence-auto-approve' | 'low-confidence-manual-review'
+}
+```
+
+**Key observations:**
+- `matrix` is an **array** (not a keyed object) — each cell carries its own `market` field. UI must index by `market` to render the per-market table.
+- `classification.confidence` is a **0..1 float** (route.ts:71 multiplies by 100 only when passing to `calculateSignal`). The UI signal-light logic that compares to 0.7 / 0.9 thresholds MUST use the float directly, NOT multiply.
+- `similarCases` is **absent** when `confidence < 0.8` (low-confidence branch). UI must treat absent `similarCases` as "not fetched", distinct from an empty array.
+- `ticketId` is **absent** when no `assigneeId` was sent OR confidence ≥ 0.8. UI ticket CTA shows only when `ticketId` is present.
+- `recommendation` is the canonical branch indicator — UI should branch on this string, not re-derive from confidence.
+
+### 2.4 Layer flow (route.ts:48-110, verified)
+
+```
+parse → Layer 1 (matrix loop) → Layer 2 (LLM classify)
+  → calculateSignal(matrix, confidence*100)
+  → writeAudit('impact.check')
+  → IF confidence >= 0.8: Layer 4 RAG (similarCases)
+    ELSE IF assigneeId: Layer 3 ticket (ticketId)
+  → response
+```
+
+**NOTE:** Layer 3 ticket creation is **gated on `assigneeId` being present** (route.ts:90). If the UI sends no `assigneeId`, low-confidence evaluations return no `ticketId`. The UI MUST either (a) require an assignee selection in the wizard, or (b) accept that low-confidence runs produce no ticket. This is a UX decision the SPEC must surface (see §6 Ambiguities).
+
+### 2.5 Signal rules (verified via AC-IMP-09 + calculateSignal signature)
+
+- **green:** all markets `level='not-required'` AND confidence ≥ 0.9
+- **yellow:** some market `level='conditional'` OR 0.7 ≤ confidence < 0.9
+- **red:** any market `level='required'` OR confidence < 0.7
+
+The UI's SignalLight component must consume the `signal` field directly (backend-computed) — the UI MUST NOT re-compute, to avoid drift.
+
+### 2.6 RBAC (route.ts:32 + parent SPEC REQ-V3-IMP-013)
+
+| Permission | Granted roles | Enforced where |
+|---|---|---|
+| `impact.view` | employee, viewer, ra-member, ra-lead, admin | Page route (server-side gate, REQ-IMP-UI-002) |
+| `impact.self_check` | viewer, employee, ra-member, ra-lead, admin | API route wrapper |
+| `impact.ra_escalate` | ra-member, ra-lead, admin | Future: ticket CTA escalation (not in v1 UI) |
+
+**Page-level gate convention** (verified in `app/(app)/consult/page.tsx:8-13`): server component calls `auth()`, reads `session.user.role`, redirects on insufficient role. The Impact page MUST follow the same pattern.
+
+### 2.7 Audit side-effects (route.ts:73-84)
+
+The route writes `impact.check` audit log on every successful run. The UI does not write audit logs directly. No UI-side audit code is required.
+
+## §3 UI Pattern References (verified)
+
+### 3.1 Consult component pattern (`components/consult/`)
+
+Existing components: `ConsultSessionCard`, `ConsultSessionDetail`, `ConsultSessionList`, `NewSessionDialog`, `QuestionComposer`, `TurnHistoryItem`.
+
+**Conventions observed:**
+- Each component is a single `.tsx` file under `components/consult/`.
+- Tests live in `components/consult/__tests__/*.test.tsx`.
+- Tests use `@vitest-environment jsdom` + RTL + `vi.mock('next-intl')` + `vi.mock('@/lib/queries/useConsult')` pattern (see `ConsultSessionList.test.tsx:14-36`).
+- Data fetching via TanStack Query hooks in `lib/queries/useConsult.ts` (not raw `fetch` in components).
+- Client/server split: server component page (`app/(app)/consult/page.tsx`) → client component (`ConsultSessionListClient.tsx`) → presentational components.
+
+The Impact wizard MUST mirror this structure: `components/impact/` for presentational pieces, `lib/queries/useImpactCheck.ts` for the POST mutation, server page → client wrapper → wizard component.
+
+### 3.2 Consult page route pattern (`app/(app)/consult/page.tsx`)
+
+```tsx
+export default async function ConsultPage() {
+  const session = await auth();
+  const userRole = (session?.user as { role?: string })?.role;
+  if (!userRole || userRole === 'viewer') redirect('/?error=access_denied');
+  return <ConsultSessionListClient />;
+}
+```
+
+Impact page MUST follow: server component, `auth()`, role gate against `impact.view` roles, render client wrapper.
+
+### 3.3 i18n (`next-intl`)
+
+- Messages live in `messages/ko.json` and `messages/en.json`.
+- Consult tests mock `useTranslations` (ConsultSessionList.test.tsx:18-20).
+- The Impact wizard MUST add an `impact` top-level key to both message files.
+- All wizard copy MUST be keyed — no inline Korean/English strings in components (L-008 style discipline).
+
+### 3.4 Design system / tokens
+
+- Tailwind v4 `@theme` tokens in `app/globals.css`: `--color-brand-{50..900}`, plus `--d-pms`, `--d-cc`, `--danger` referenced in parent SPEC retestMatrix market colors.
+- Light/dark mode is active (consult components support both).
+- Serif/Sans discipline: page titles serif, body sans (consult pattern).
+- WCAG 2.1 AA enforced by `ci:contrast` gate.
+
+Signal-light colors: green/yellow/red. The UI MUST NOT use raw `green-500`/`red-500` — it MUST use semantic tokens that map to the brand palette and pass contrast in both light/dark. Exact token names to be chosen at run phase (deferred per "WHAT not HOW" rule).
+
+### 3.5 Test framework
+
+- Vitest + React Testing Library + jsdom.
+- Tests live alongside components: `components/impact/__tests__/*.test.tsx`.
+- Mock patterns: `vi.mock('next-intl')`, `vi.mock('@/lib/queries/useImpactCheck')`, `vi.mock('next/navigation')`.
+- Coverage gate: 85% (parent SPEC quality.yaml).
+
+## §4 Greenfield Status
+
+**Verified:** No `components/impact/` directory exists. No `app/(app)/impact/` route exists. No `useImpactCheck` hook exists. This is a pure greenfield build — no regression risk for UI (backend non-regression was handled in parent SPEC).
+
+## §5 Dependencies
+
+### 5.1 Internal (consumed)
+- `POST /api/impact-check` — sole backend dependency (frozen contract, §2).
+- `auth()` + role types from `@/lib/auth` — for page-level gate.
+- TanStack Query — for the `useImpactCheck` mutation hook.
+- `next-intl` — for i18n.
+
+### 5.2 External (UI)
+- Radix UI primitives — for accessible multi-step wizard navigation, dialogs, checkboxes (consistent with consult UI).
+- Tailwind v4 — styling.
+
+### 5.3 NOT imported
+- No SSE/streaming client — the `/api/impact-check` route is a synchronous JSON POST (verified: no `ReadableStream` / `EventSource` in route.ts). The wizard result page is a normal loading → success state, NOT a streaming answer. Do not copy `useStreamingAnswer` from consult — that pattern is for the chat SSE endpoint only.
+
+## §6 Ambiguities & Blockers (must surface in spec.md)
+
+### A1. Product data source — UNRESOLVED
+The backend accepts `productId: z.string()` but there is **no products list API** in the codebase and no `products` table in `lib/db/schema.ts` (only `labeling_documents.product_name` text column at schema.ts:2469, and `productStandardsCompliance.productId` text at schema.ts:3231). The wizard Step 1 needs a product picker, but the source of the product list is unclear.
+
+**Options:**
+- (a) Step 1 reads from an existing project/portfolio list (e.g., `projects` table or `labeling_documents` distinct `product_name`). **Not verified — needs confirmation.**
+- (b) Step 1 is a free-text `productId` input (matches backend's loose schema). Lowest risk, poorest UX.
+- (c) A new `GET /api/products` endpoint is added — but that is **out of scope** (backend changes belong to a follow-up SPEC).
+
+**SPEC resolution:** Default to (b) free-text `productId` input for v1, with a NOTE that (a)/(c) are follow-up enhancements. This keeps the UI self-contained and avoids inventing a product list that doesn't exist (L-002 anti-pattern guardrail).
+
+### A2. `assigneeId` and Layer 3 ticket creation — UX DECISION NEEDED
+Backend creates a ticket only if `assigneeId` is present (route.ts:90). For viewer/employee roles, who should the assignee be?
+
+**Options:**
+- (a) The UI omits `assigneeId` → low-confidence runs produce no ticket → user sees "RA review recommended" CTA without a created ticket.
+- (b) The UI auto-assigns to a default RA queue (requires a backend route to resolve default assignee — out of scope).
+- (c) The UI shows an optional "Assign to" picker visible only to `ra-member+` roles (who can pick themselves or a teammate).
+
+**SPEC resolution:** Default to (a) for v1 — the UI omits `assigneeId` and surfaces the `recommendation='low-confidence-manual-review'` result with a static "Contact RA" CTA. This avoids inventing an assignee-resolution backend. The ticket CTA in the result page links to `/inbox` (existing) rather than a created ticket.
+
+### A3. Phase C-4 label — needs roadmap confirmation
+Parent SPEC is C-3. `docs/v3/README.md` lists "Phase 3 · Impact Check" with items 12-14 but does not explicitly label the UI follow-up as "C-4". The orchestrator's task brief assigns `phase: C-4`. Treated as correct per orchestrator instruction; flagged for plan-auditor cross-check.
+
+### A4. `changeDetail` minimum length drift
+Parent SPEC prose says 10..2000 chars; backend Zod is `min(1).max(2000)`. UI will enforce 10..2000 client-side (stricter) and surface a helpful counter. If the user pastes <10 chars the UI blocks submit; the backend's `min(1)` is a defense-in-depth floor, not the UX target.
+
+## §7 Plan-auditor Focus Areas
+
+1. **Contract fidelity** — every field name, type, and branch in spec.md MUST trace to §2 of this research. Watch for accidental snake_case drift from the parent SPEC prose.
+2. **No streaming** — the result page is a normal async mutation, NOT SSE. Reject any spec language implying `useStreamingAnswer` or `EventSource`.
+3. **`similarCases` absent vs empty** — spec MUST distinguish "low-confidence branch (field omitted)" from "high-confidence branch with zero matches (empty array)".
+4. **Confidence units** — spec MUST state confidence is 0..1 float, NOT percentage.
+5. **No invented endpoints** — the spec MUST NOT reference `/api/products`, `/api/ra/assignees`, or any endpoint not present in the codebase.
+6. **Scope discipline** — UI only. Any backend change suggested by §6 ambiguities is out of scope and deferred.
+
+---
+
+**Generated:** 2026-07-06
+**Inspection basis:** `app/api/impact-check/route.ts` (post-PR-#349), `components/consult/`, `app/(app)/consult/page.tsx`, `lib/domains/impact/index.ts`, `lib/db/schema.ts`, `messages/ko.json`, parent SPEC `.moai/specs/SPEC-V3-IMPACT-001/{spec,plan,acceptance}.md`.

--- a/.moai/specs/SPEC-V3-IMPACT-UI-001/spec.md
+++ b/.moai/specs/SPEC-V3-IMPACT-UI-001/spec.md
@@ -1,0 +1,324 @@
+---
+id: SPEC-V3-IMPACT-UI-001
+version: 0.1.0
+status: planned
+phase: C-4
+priority: High
+created: 2026-07-06
+updated: 2026-07-06
+author: manager-spec
+issue_number: TBD
+depends_on:
+  - SPEC-V3-IMPACT-001
+  - SPEC-V3-UI-001
+blocks: []
+parent_spec: SPEC-V3-IMPACT-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/ui
+  - domain/impact
+  - type/v3-new
+---
+
+# SPEC-V3-IMPACT-UI-001 — Change Impact Wizard UI (v3 Phase C-4)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-07-06 | manager-spec | 초기 작성. SPEC-V3-IMPACT-001 백엔드(POST /api/impact-check)를 소비하는 4-step 위저드 + 결과 페이지 UI. research.md 직검 기반 (L-013). REQ 11종. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-check` 4계층 평가 백엔드를 소비하는 Employee-facing 위저드 UI를 구현한다. 백엔드는 retestMatrix 결정론 → LLM 분류 → (confidence 분기) RAG / 티켓 → 신호등 결과를 동기 JSON으로 반환한다 (`app/api/impact-check/route.ts` 직검).
+
+현재 코드베이스에는 `components/impact/` 디렉토리와 `app/(app)/impact/` 라우트가 존재하지 않는다 (research.md §4 greenfield 검증). 본 SPEC은 4단계 입력 위저드 + 결과 페이지를 새로 구축하며, 기존 consult UI 패턴 (`components/consult/`, `app/(app)/consult/`)을 따른다.
+
+### 1.2 핵심 가치
+
+- **자가진단 워크플로우:** Employee가 4단계(제품 → 카테고리 → 상세 → 시장) 입력으로 변경 영향 평가를 실행.
+- **즉각적 시각 피드백:** 신호등(green/yellow/red) + 시장별 매트릭스 셀 + LLM 분류를 한 화면에 렌더링.
+- **RAG citation 강제:** 유사 사례 렌더링 시 출처 인용을 필수화 (Charter [지양-2]).
+- **백엔드 계약 엄수:** UI는 신호등/매트릭스를 재계산하지 않고 백엔드 응답을 그대로 표시 (drift 방지).
+
+### 1.3 페르소나 (Personas)
+
+| 페르소나 | 역할 | Impact 위저드 관점 |
+|---|---|---|
+| Employee / Viewer | `employee`, `viewer` | 위저드 실행 권한 (`impact.self_check`). 변경 영향 자가진단. low-confidence 시 "RA 문의" CTA 노출. |
+| RA Member / Lead | `ra-member`, `ra-lead` | 동일한 위저드 + 결과에서 `recommendation` 값으로 수동 검토 큐 유도. `impact.ra_escalate`는 본 SPEC 범위 외 (future). |
+| Admin | `admin` | 모든 권한. 위저드 자체는 동일. |
+
+### 1.4 비목표 (Charter [지양-2 / 지양-5] 정렬)
+
+- 실시간 스트리밍 답변 X — `/api/impact-check`는 동기 JSON POST이므로 SSE 불필요.
+- 자체 위저드 프레임워크 도입 X — 기존 4-step form 패턴으로 충분 (과잉 추상화 금지).
+- 백엔드 변경 X — 모든 백엔드 계약은 frozen.
+
+---
+
+## §2 Scope
+
+### 2.1 In Scope
+
+1. `app/(app)/impact/page.tsx` 신규 라우트 (server component, RBAC gate).
+2. `components/impact/` 신규 디렉토리 — 위저드 컴포넌트 6종 + 결과 컴포넌트.
+3. `lib/queries/useImpactCheck.ts` — TanStack Query mutation hook.
+4. `messages/ko.json` / `messages/en.json` — `impact` 키 신규 추가.
+5. `components/impact/__tests__/` — Vitest + RTL 단위 테스트.
+
+### 2.2 Out of Scope (Exclusions)
+
+- 백엔드 4계층 로직, 마이그레이션, RBAC enum 추가 — SPEC-V3-IMPACT-001 완료.
+- ESIG 전자서명 UI — Phase D 이월 (parent SPEC Exclusions).
+- Slack/이메일 실시간 알림 — Phase D 이월.
+- `impact.ra_escalate` 권한 기반 에스컬레이션 워크플로우 — future SPEC.
+- 제품 목록 조회 API (`/api/products`) — 본 SPEC 범위 외 (research.md §6-A1).
+- 위저드 실행 히스토리 목록 페이지 — consult `ConsultSessionList` 패턴과 별개; future SPEC.
+
+---
+
+## §3 Functional Requirements (EARS)
+
+> **Backend contract reference:** 모든 REQ는 `POST /api/impact-check` (route.ts 직검)의 request/response 필드와 정확히 일치해야 한다. 필드명은 camelCase (`orgId`, `productId`, `changeType`, `changeDetail`, `markets`, `assigneeId`). confidence는 0..1 float.
+
+### REQ-IMP-UI-001: 위저드 라우트 및 RBAC 게이트
+
+**WHEN** 인증되지 않은 사용자가 `/impact` 경로로 접근하면, **THE SYSTEM SHALL** 로그인 페이지로 리다이렉트한다.
+
+**WHILE** `impact.view` 권한이 없는 역할(employee 미만 / 비활성 사용자)이 `/impact`에 접근할 때, **THE SYSTEM SHALL** `/?error=access_denied`로 리다이렉트한다 (`app/(app)/consult/page.tsx` 패턴 준용).
+
+**WHERE** 권한이 있는 사용자가 접근하면, **THE SYSTEM SHALL** 서버 컴포넌트에서 `auth()`를 호출해 역할을 읽고 클라이언트 위저드를 렌더링한다.
+
+### REQ-IMP-UI-002: Step 1 — 제품 식별자 입력
+
+**WHEN** 위저드 Step 1이 렌더링되면, **THE SYSTEM SHALL** 제품 식별자 입력 UI를 제공한다.
+
+**THE SYSTEM SHALL** 사용자가 `productId`를 자유 텍스트로 입력할 수 있도록 한다 (백엔드 Zod `z.string()` 계약 준수 — research.md §6-A1 해석).
+
+**WHILE** 입력이 비어 있을 때, **THE SYSTEM SHALL** "다음" 버튼을 비활성화한다.
+
+**IF** 사용자가 1자 이상 입력하면, **THE SYSTEM SHALL** "다음" 버튼을 활성화하고 Step 2로 진행 가능하게 한다.
+
+**NOTE:** v1은 자유 텍스트 입력을 사용한다. 제품 목록 피커(drdown)는 제품 목록 API가 별도 SPEC으로 추가된 이후 후속 SPEC에서 도입한다 (research.md §6-A1).
+
+### REQ-IMP-UI-003: Step 2 — 변경 카테고리 선택
+
+**WHEN** Step 2가 렌더링되면, **THE SYSTEM SHALL** 다음 7개 카테고리를 라디오/카드 선택 UI로 표시한다:
+1. `bom` — BOM 변경 (부품 교체)
+2. `sw` — SW 알고리즘 재학습
+3. `sw-minor` — SW 마이너 (버그픽스)
+4. `label` — 라벨 문구 변경
+5. `warn` — Critical Warning 개정
+6. `process` — 생산공정 변경
+7. `sterile` — 멸균 조건 변경
+
+**WHILE** 카테고리를 선택할 때, **THE SYSTEM SHALL** 각 카테고리에 대한 설명(Tooltip 또는 보조 텍스트)을 i18n 키(`impact.categories.{id}.description`)로 표시한다.
+
+**IF** 정확히 하나의 카테고리가 선택되면, **THE SYSTEM SHALL** `changeType` 값을 Step 3로 전달하고 "다음" 버튼을 활성화한다.
+
+### REQ-IMP-UI-004: Step 3 — 변경 상세 입력
+
+**WHEN** Step 3이 렌더링되면, **THE SYSTEM SHALL** 자유 텍스트 입력 필드(textarea)를 제공한다.
+
+**THE SYSTEM SHALL** 안내 문구("변경 내용을 구체적으로 기술하세요: 부품 모델번호, 변경 사유, 영향 범위 등")를 i18n 키로 표시한다.
+
+**WHILE** 사용자가 입력할 때, **THE SYSTEM SHALL** 글자 수 카운터(예: "247 / 2000")를 실시간으로 표시한다.
+
+**IF** 입력 길이가 10자 미만이면, **THE SYSTEM SHALL** 에러 메시지("최소 10자 이상 입력하세요")를 표시하고 "다음" 버튼을 비활성화한다.
+
+**IF** 입력 길이가 2000자를 초과하면, **THE SYSTEM SHALL** 추가 입력을 차단하고 "최대 2000자까지 입력 가능합니다" 에러를 표시한다.
+
+**WHERE** 입력이 10..2000자이면, **THE SYSTEM SHALL** `changeDetail` 값을 Step 4로 전달한다.
+
+### REQ-IMP-UI-005: Step 4 — 영향 시장 다중 선택
+
+**WHEN** Step 4가 렌더링되면, **THE SYSTEM SHALL** 다음 5개 시장을 체크박스/칩 다중 선택 UI로 표시한다:
+- `us` — FDA (US)
+- `eu` — MDR (EU)
+- `kr` — MFDS (KR)
+- `cn` — NMPA (CN)
+- `jp` — PMDA (JP)
+
+**THE SYSTEM SHALL** 최소 1개 시장 선택을 요구한다.
+
+**IF** 선택된 시장이 0개이면, **THE SYSTEM SHALL** "평가 시작" 버튼을 비활성화한다.
+
+**WHERE** 1개 이상 선택되면, **THE SYSTEM SHALL** "평가 시작" 버튼을 활성화한다.
+
+**WHEN** "평가 시작"이 클릭되면, **THE SYSTEM SHALL** `orgId`, `productId`, `changeType`, `markets`, `changeDetail`을 `POST /api/impact-check`로 전송한다.
+
+**NOTE:** v1은 `assigneeId`를 전송하지 않는다 (research.md §6-A2). low-confidence 결과에서 티켓이 생성되지 않음을 사용자에게 안내한다.
+
+### REQ-IMP-UI-006: API 호출 및 로딩 상태
+
+**WHEN** "평가 시작"이 클릭되면, **THE SYSTEM SHALL** `useImpactCheck` mutation을 호출하고 로딩 스피너 + "4계층 평가 수행 중..." 메시지를 표시한다.
+
+**THE SYSTEM SHALL** 백엔드 응답 대기 중 "뒤로" / 재전송 버튼을 비활성화하여 중복 제출을 방지한다.
+
+**IF** 백엔드 응답이 200 OK이면, **THE SYSTEM SHALL** 결과 페이지를 렌더링한다.
+
+**IF** 백엔드 응답이 403 Forbidden이면, **THE SYSTEM SHALL** "권한이 없습니다. 관리자에게 문의하세요" 에러를 표시한다.
+
+**IF** 백엔드 응답이 400 Bad Request이면, **THE SYSTEM SHALL** Zod 검증 에러 메시지를 파싱하여 사용자에게 표시한다.
+
+**IF** 네트워크 오류 또는 500이면, **THE SYSTEM SHALL** "일시 오류. 나중에 다시 시도하세요" 메시지와 "다시 시도" 버튼을 표시한다.
+
+### REQ-IMP-UI-007: 결과 페이지 — 신호등 및 매트릭스
+
+**WHEN** 결과 응답이 도착하면, **THE SYSTEM SHALL** `signal` 필드(`green` | `yellow` | `red`)에 따라 색상화된 SignalLight 컴포넌트를 렌더링한다.
+
+**THE SYSTEM SHALL** 신호등 색상을 **재계산하지 않고** 백엔드 `signal` 값을 그대로 사용한다 (drift 방지).
+
+**THE SYSTEM SHALL** `matrix` 배열의 각 셀을 시장(`market` 필드)별로 그룹화하여 표 형태로 렌더링하고 각 셀에 `level` / `ref` / `note`를 표시한다.
+
+**WHILE** `level='required'`인 셀을 렌더링할 때, **THE SYSTEM SHALL** 해당 셀을 신호등 색상과 동일한 강조 스타일로 표시한다.
+
+### REQ-IMP-UI-008: 결과 페이지 — LLM 분류 표시
+
+**WHEN** 결과 페이지가 렌더링되면, **THE SYSTEM SHALL** `classification` 객체의 `category`, `confidence`, `reason`을 표시한다.
+
+**THE SYSTEM SHALL** `confidence`를 0..1 float으로 수신받아 백분율(예: 0.85 → "85%")로 표시한다.
+
+**IF** `confidence < 0.8`이면, **THE SYSTEM SHALL** "신뢰도 낮음 — RA 검토 권장" 경고 배지를 표시한다.
+
+### REQ-IMP-UI-009: 결과 페이지 — 유사 사례 (RAG)
+
+**IF** 응답에 `similarCases` 배열이 **존재하고**(high-confidence 분기), 배열이 비어 있지 않으면, **THE SYSTEM SHALL** 각 사례를 카드로 렌더링하고 `title`, `content`, `similarity`를 표시한다.
+
+**THE SYSTEM SHALL** 각 유사 사례 카드에 출처 인용을 `<sup class="cite" data-src="{source}">{번호}</sup>` 형식으로 표시한다 (Charter [지양-2] 강제).
+
+**IF** `similarCases`가 빈 배열이면, **THE SYSTEM SHALL** "유사 사례가 없습니다" 메시지를 표시한다.
+
+**IF** 응답에 `similarCases` 필드가 **존재하지 않으면**(low-confidence 분기 — 백엔드가 RAG을 건너뜀), **THE SYSTEM SHALL** 유사 사례 섹션을 렌더링하지 않고 "신뢰도 낮아 유사 사례 조회를 생략했습니다" 안내를 표시한다.
+
+**NOTE:** 백엔드는 low-confidence 시 `similarCases`를 `undefined`로 반환한다 (route.ts 직검). 빈 배열 `[]`과 `undefined`를 구분해서 렌더링해야 한다.
+
+### REQ-IMP-UI-010: 결과 페이지 — 티켓 CTA
+
+**IF** 응답에 `ticketId`가 존재하면, **THE SYSTEM SHALL** "RA 티켓 #{ticketId} 생성됨" CTA를 표시하고 `/inbox/{ticketId}`로 링크한다.
+
+**IF** 응답에 `ticketId`가 존재하지 않고 `recommendation='low-confidence-manual-review'`이면, **THE SYSTEM SHALL** "RA 검토 권장 — RA 큐에 문의하세요" 정적 CTA를 `/inbox`로 링크하여 표시한다 (v1은 assigneeId 미전송이므로 이 분기가 기본 — research.md §6-A2).
+
+**IF** `recommendation='high-confidence-auto-approve'`이면, **THE SYSTEM SHALL** 티켓 CTA를 표시하지 않는다.
+
+### REQ-IMP-UI-011: 국제화 (i18n) 및 접근성
+
+**THE SYSTEM SHALL** 모든 사용자 가시 문자열을 `next-intl`의 `impact.*` 네임스페이스 키로 관리한다 (`messages/ko.json` + `messages/en.json`).
+
+**WHEN** 사용자가 키보드로 위저드를 탐색할 때, **THE SYSTEM SHALL** Step 간 합리적인 포커스 관리(Tab/Shift+Tab 순서, Step 진입 시 첫 입력으로 포커스 이동)를 제공한다.
+
+**THE SYSTEM SHALL** 모든 폼 입력에 `aria-label` / `<label>` 연결을 제공하고 WCAG 2.1 AA 색상 대비를 만족한다 (`ci:contrast` 게이트).
+
+---
+
+## §4 Non-Functional Requirements
+
+### REQ-IMP-UI-NFR-001: 성능
+
+**THE SYSTEM SHALL** 위저드 초기 렌더링을 1초 이내에 완료한다 (서버 컴포넌트 + 클라이언트 hydration).
+
+**THE SYSTEM SHALL** 백엔드 응답 대기 중 로딩 UI를 즉시 표시한다. 백엔드 응답 시간(parent SPEC NFR: < 20초) 동안 사용자가 대기 상태를 인지할 수 있어야 한다.
+
+### REQ-IMP-UI-NFR-002: 보안
+
+**THE SYSTEM SHALL** `productId`, `changeDetail` 입력값을 렌더링할 때 React의 기본 XSS 이스케이핑에 의존하고 `dangerouslySetInnerHTML`을 사용하지 않는다.
+
+**THE SYSTEM SHALL** 유사 사례 카드의 출처 인용 `<sup>`을 렌더링할 때 `data-src` 속성값을 sanitization한다.
+
+### REQ-IMP-UI-NFR-003: 유지보수성
+
+**THE SYSTEM SHALL** 컴포넌트를 단일 책임 원칙으로 분리한다: `ImpactWizard` (오케스트레이터), `Step1Product` / `Step2Category` / `Step3Detail` / `Step4Markets` (각 단계), `ImpactResult` / `SignalLight` / `SimilarCasesCard` (결과 표시).
+
+**THE SYSTEM SHALL** 컴포넌트 테스트 커버리지 85% 이상을 달성한다 (parent SPEC quality.yaml).
+
+### REQ-IMP-UI-NFR-004: 비회귀
+
+**THE SYSTEM SHALL** 기존 consult UI, 트리age UI, 기타 v3 컴포넌트에 영향을 주지 않는다. 모든 신규 파일은 `components/impact/`, `lib/queries/useImpactCheck.ts`, `app/(app)/impact/`, `messages/*.json` 신규 키로 한정된다.
+
+---
+
+## §5 Data Model
+
+본 SPEC은 신규 DB 스키마를 정의하지 않는다 (백엔드가 이미 SPEC-V3-IMPACT-001에서 확장 완료). UI는 다음 타입만 사용한다:
+
+```ts
+// lib/queries/useImpactCheck.ts
+type ImpactCheckRequest = {
+  orgId: string;
+  productId: string;
+  changeType: 'bom'|'sw'|'sw-minor'|'label'|'warn'|'process'|'sterile';
+  markets: Array<'us'|'eu'|'kr'|'cn'|'jp'>;
+  changeDetail: string;
+  // assigneeId는 v1에서 생략 (research.md §6-A2)
+};
+
+type ImpactCheckResponse = {
+  matrix: Array<{ level: string; ref: string; note: string; market: string }>;
+  signal: 'green'|'yellow'|'red';
+  classification: { category: string; confidence: number; reason: string };
+  similarCases?: Array<{ id: string; title: string; content: string; similarity: number }>;
+  ticketId?: string;
+  recommendation: string;
+};
+```
+
+---
+
+## §6 API Contract (Consumed)
+
+본 SPEC은 API를 정의하지 않는다. `POST /api/impact-check`는 SPEC-V3-IMPACT-001 (PR #349 merged)에서 정의되었으며 본 SPEC은 이를 소비(consume)만 한다. 필드 계약은 research.md §2에 직검 검증되어 있다.
+
+---
+
+## §7 Dependencies
+
+### 7.1 Internal
+- `POST /api/impact-check` (frozen contract, SPEC-V3-IMPACT-001).
+- `@/lib/auth` (`auth()`, role types) — page-level RBAC.
+- TanStack Query — `useImpactCheck` mutation.
+- `next-intl` — i18n.
+- Tailwind v4 `@theme` design tokens.
+
+### 7.2 External
+- Radix UI primitives — accessible checkboxes / radio / dialog (consult UI와 동일 라이브러리).
+
+### 7.3 NOT Imported
+- `useStreamingAnswer` (consult SSE 전용 — impact API는 동기 POST).
+- `/api/products`, `/api/ra/assignees` (존재하지 않음 — research.md §6).
+
+---
+
+## §8 Exclusions (What NOT to Build)
+
+[HARD] 본 SPEC의 제외 항목:
+
+1. **백엔드 4계층 로직 / 마이그레이션 / RBAC enum** — parent SPEC-V3-IMPACT-001 completed.
+2. **제품 목록 피커 API (`/api/products`)** — 제품 목록 데이터 소스가 코드베이스에 없다 (research.md §6-A1). v1은 자유 텍스트 입력. 제품 피커는 별도 SPEC 필요.
+3. **자동 티켓 에스컬레이션 (`assigneeId` 자동 지정)** — assignee resolution 백엔드가 없다 (research.md §6-A2). v1은 정적 CTA만.
+4. **위저드 실행 히스토리 / 재실행 목록 페이지** — consult `ConsultSessionList`와 별개 스펙. future.
+5. **실시간 스트리밍 결과** — `/api/impact-check`는 동기 JSON. SSE 불필요.
+6. **ESIG 전자서명 플로우** — Phase D 이월 (parent SPEC Exclusions).
+
+---
+
+## §9 Open Questions (Run-Phase Resolution)
+
+| ID | Question | Default | Plan-auditor focus |
+|---|---|---|---|
+| OQ-1 | 제품 목록 출처 확정 필요 (A1) | 자유 텍스트 productId | scope creep 여부 |
+| OQ-2 | low-confidence 티켓 CTA UX 확정 (A2) | `/inbox` 정적 링크 | backend contract 정확성 |
+| OQ-3 | `phase: C-4` 라벨 roadmap 교차 검증 | orchestrator 지시 따름 | — |
+
+---
+
+**생성일:** 2026-07-06
+**버전:** 0.1.0
+**상태:** planned
+**총 REQ:** 11 functional + 4 NFR
+**다음 단계:** plan.md 구현 계획 수립 → acceptance.md 검증 시나리오 → plan-auditor 감사

--- a/.moai/specs/SPEC-V3-IMPACT-UI-001/spec.md
+++ b/.moai/specs/SPEC-V3-IMPACT-UI-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-V3-IMPACT-UI-001
-version: 0.1.0
+version: 0.2.0
 status: planned
 phase: C-4
 priority: High
@@ -10,7 +10,7 @@ author: manager-spec
 issue_number: TBD
 depends_on:
   - SPEC-V3-IMPACT-001
-  - SPEC-V3-UI-001
+# SPEC-V3-UI-001은 hard contract dependency가 아님 — consult UI 패턴 참조용 (TanStack Query provider, design tokens, i18n 네임스페이스 관례). run-phase가 consult 컴포넌트 구조/테스트 mock 패턴을 상속받으나 API 계약 의존성은 없음.
 blocks: []
 parent_spec: SPEC-V3-IMPACT-001
 lifecycle_level: spec-anchored
@@ -28,6 +28,7 @@ labels:
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 0.1.0 | 2026-07-06 | manager-spec | 초기 작성. SPEC-V3-IMPACT-001 백엔드(POST /api/impact-check)를 소비하는 4-step 위저드 + 결과 페이지 UI. research.md 직검 기반 (L-013). REQ 11종. |
+| 0.2.0 | 2026-07-06 | manager-spec | plan-auditor FAIL findings 수정. C1/C2/H2: `employee` 역할 제거 (verified Role union), RBAC 게이트 `ra-member+`로 정정. C3: `**NOTE:**` prose 4종 EARS sub-REQ로 전환. H1: REQ-IMP-UI-006a orgId provenance 추가. H3: `level='conditional'` 렌더링 REQ 추가. H4: consult보다 엄격한 게이트 명시. H5: confidence 임계값 3종 정리. M2/M3/m2/m4 기타 정정. |
 
 ---
 
@@ -35,24 +36,30 @@ labels:
 
 ### 1.1 배경 (Background)
 
-SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-check` 4계층 평가 백엔드를 소비하는 Employee-facing 위저드 UI를 구현한다. 백엔드는 retestMatrix 결정론 → LLM 분류 → (confidence 분기) RAG / 티켓 → 신호등 결과를 동기 JSON으로 반환한다 (`app/api/impact-check/route.ts` 직검).
+SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-check` 4계층 평가 백엔드를 소비하는 `ra-member+` facing 위저드 UI를 구현한다. 백엔드는 retestMatrix 결정론 → LLM 분류 → (confidence 분기) RAG / 티켓 → 신호등 결과를 동기 JSON으로 반환한다 (`app/api/impact-check/route.ts` 직검).
 
 현재 코드베이스에는 `components/impact/` 디렉토리와 `app/(app)/impact/` 라우트가 존재하지 않는다 (research.md §4 greenfield 검증). 본 SPEC은 4단계 입력 위저드 + 결과 페이지를 새로 구축하며, 기존 consult UI 패턴 (`components/consult/`, `app/(app)/consult/`)을 따른다.
 
 ### 1.2 핵심 가치
 
-- **자가진단 워크플로우:** Employee가 4단계(제품 → 카테고리 → 상세 → 시장) 입력으로 변경 영향 평가를 실행.
+- **자가진단 워크플로우:** `ra-member+` 사용자가 4단계(제품 → 카테고리 → 상세 → 시장) 입력으로 변경 영향 평가를 실행.
 - **즉각적 시각 피드백:** 신호등(green/yellow/red) + 시장별 매트릭스 셀 + LLM 분류를 한 화면에 렌더링.
 - **RAG citation 강제:** 유사 사례 렌더링 시 출처 인용을 필수화 (Charter [지양-2]).
 - **백엔드 계약 엄수:** UI는 신호등/매트릭스를 재계산하지 않고 백엔드 응답을 그대로 표시 (drift 방지).
 
 ### 1.3 페르소나 (Personas)
 
+> **역할 래더 (verified, `lib/auth/rbac.ts:14`):** `Role = 'admin' | 'qa-lead' | 'ra-lead' | 'ra-member' | 'viewer' | 'auditor'`. `employee` 역할은 존재하지 않는다. `auditor`는 외부 감사자 전용 읽기 전용 역할 (`ROLE_HIERARCHY.auditor = 0.5`)로 impact 접근이 거부된다.
+
 | 페르소나 | 역할 | Impact 위저드 관점 |
 |---|---|---|
-| Employee / Viewer | `employee`, `viewer` | 위저드 실행 권한 (`impact.self_check`). 변경 영향 자가진단. low-confidence 시 "RA 문의" CTA 노출. |
-| RA Member / Lead | `ra-member`, `ra-lead` | 동일한 위저드 + 결과에서 `recommendation` 값으로 수동 검토 큐 유도. `impact.ra_escalate`는 본 SPEC 범위 외 (future). |
+| RA Member | `ra-member` | 위저드 실행 권한 (`impact.view` + `impact.self_check`). 변경 영향 자가진단. low-confidence 시 "RA 문의" CTA 노출. |
+| RA Lead | `ra-lead` | 동일 위저드 + 결과에서 `recommendation` 값으로 수동 검토 큐 유도. |
+| QA Lead | `qa-lead` | 동일 위저드 (QA가 member-level 업무 수행 가능 — `ROLE_HIERARCHY['qa-lead'] = 2.5`). |
 | Admin | `admin` | 모든 권한. 위저드 자체는 동일. |
+| Viewer / Auditor (차단) | `viewer`, `auditor` | `impact.view` 권한 미달 (`minRole: 'ra-member'`). `/impact` 접근 시 `/?error=access_denied` 리다이렉트. |
+
+> `impact.self_check`는 `minRole: 'viewer'`이지만, 페이지 진입 게이트(`impact.view`)가 더 엄격하므로 viewer/auditor는 위저드 페이지 자체에 진입할 수 없다 (H4 참조).
 
 ### 1.4 비목표 (Charter [지양-2 / 지양-5] 정렬)
 
@@ -89,11 +96,13 @@ SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-ch
 
 ### REQ-IMP-UI-001: 위저드 라우트 및 RBAC 게이트
 
-**WHEN** 인증되지 않은 사용자가 `/impact` 경로로 접근하면, **THE SYSTEM SHALL** 로그인 페이지로 리다이렉트한다.
+**WHEN** 인증되지 않은 사용자(anonymous)가 `/impact` 경로로 접근하면, **THE SYSTEM SHALL** 로그인 페이지로 리다이렉트한다.
 
-**WHILE** `impact.view` 권한이 없는 역할(employee 미만 / 비활성 사용자)이 `/impact`에 접근할 때, **THE SYSTEM SHALL** `/?error=access_denied`로 리다이렉트한다 (`app/(app)/consult/page.tsx` 패턴 준용).
+**WHILE** `impact.view` 권한이 없는 역할 — 즉 `ra-member` 미만인 `viewer`, `auditor`, 또는 비활성 사용자 — 이 `/impact`에 접근할 때, **THE SYSTEM SHALL** `/?error=access_denied`로 리다이렉트한다. 페이지 게이트는 `lib/auth/rbac.ts`의 `hasRole(userRole, 'ra-member')` 헬퍼를 사용해 판정한다 (`impact.view`의 `minRole: 'ra-member'`, `permissions.ts:582-596` 직검).
 
-**WHERE** 권한이 있는 사용자가 접근하면, **THE SYSTEM SHALL** 서버 컴포넌트에서 `auth()`를 호출해 역할을 읽고 클라이언트 위저드를 렌더링한다.
+**WHERE** 권한이 있는 사용자(`ra-member` 이상)가 접근하면, **THE SYSTEM SHALL** 서버 컴포넌트에서 `auth()`를 호출해 역할을 읽고 클라이언트 위저드를 렌더링한다.
+
+> **H4 — consult 게이트보다 엄격 (run-phase 주의):** consult 페이지 (`app/(app)/consult/page.tsx`)는 `viewer`만 거부한다. Impact 페이지는 더 엄격하게 `ra-member` 미만 전체(viewer + auditor + 비활성)를 거부한다. run-phase에서 consult 게이트를 copy-paste 하지 말 것 — `hasRole(userRole, 'ra-member')` 사용 필수.
 
 ### REQ-IMP-UI-002: Step 1 — 제품 식별자 입력
 
@@ -104,8 +113,6 @@ SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-ch
 **WHILE** 입력이 비어 있을 때, **THE SYSTEM SHALL** "다음" 버튼을 비활성화한다.
 
 **IF** 사용자가 1자 이상 입력하면, **THE SYSTEM SHALL** "다음" 버튼을 활성화하고 Step 2로 진행 가능하게 한다.
-
-**NOTE:** v1은 자유 텍스트 입력을 사용한다. 제품 목록 피커(drdown)는 제품 목록 API가 별도 SPEC으로 추가된 이후 후속 SPEC에서 도입한다 (research.md §6-A1).
 
 ### REQ-IMP-UI-003: Step 2 — 변경 카테고리 선택
 
@@ -151,9 +158,15 @@ SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-ch
 
 **WHERE** 1개 이상 선택되면, **THE SYSTEM SHALL** "평가 시작" 버튼을 활성화한다.
 
-**WHEN** "평가 시작"이 클릭되면, **THE SYSTEM SHALL** `orgId`, `productId`, `changeType`, `markets`, `changeDetail`을 `POST /api/impact-check`로 전송한다.
+**WHEN** "평가 시작"이 클릭되면, **THE SYSTEM SHALL** `orgId`, `productId`, `changeType`, `markets`, `changeDetail`을 `POST /api/impact-check`로 전송한다. v1에서 `assigneeId`는 생략한다 (research.md §6-A2).
 
-**NOTE:** v1은 `assigneeId`를 전송하지 않는다 (research.md §6-A2). low-confidence 결과에서 티켓이 생성되지 않음을 사용자에게 안내한다.
+**IF** 백엔드 응답의 `recommendation='low-confidence-manual-review'`이면, **THE SYSTEM SHALL** 사용자에게 "자동 티켓이 생성되지 않았습니다 — RA 큐에 문의하세요" 안내를 표시한다 (v1은 `assigneeId` 미전송이므로 low-confidence 시 티켓이 생성되지 않음).
+
+### REQ-IMP-UI-006a: orgId 출처 (Provenance)
+
+**WHEN** 위저드 페이지가 서버에서 로드될 때, **THE SYSTEM SHALL** `session.user.orgId`를 읽어 클라이언트 위저드로 전달하고, "평가 시작" 클릭 시 요청 본문의 `orgId` 필드로 전송한다 (백엔드 Zod가 `orgId: z.string()` non-optional을 요구 — `route.ts:21`).
+
+> **세션 shape 가정:** `auth()` 반환의 `session.user.orgId`가 존재한다고 가정한다. consult 페이지가 동일 가정으로 동작 중 (`app/(app)/consult/page.tsx`). run-phase에서 세션 타입 확장 필요 시 `lib/auth` 수정은 별도 SPEC으로 분리.
 
 ### REQ-IMP-UI-006: API 호출 및 로딩 상태
 
@@ -177,7 +190,11 @@ SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-ch
 
 **THE SYSTEM SHALL** `matrix` 배열의 각 셀을 시장(`market` 필드)별로 그룹화하여 표 형태로 렌더링하고 각 셀에 `level` / `ref` / `note`를 표시한다.
 
-**WHILE** `level='required'`인 셀을 렌더링할 때, **THE SYSTEM SHALL** 해당 셀을 신호등 색상과 동일한 강조 스타일로 표시한다.
+**WHILE** `level='required'`인 셀을 렌더링할 때, **THE SYSTEM SHALL** 해당 셀을 red 강조 스타일로 표시한다.
+
+**WHILE** `level='conditional'`인 셀을 렌더링할 때, **THE SYSTEM SHALL** 해당 셀을 yellow 강조 스타일로 표시한다.
+
+**WHILE** `level='not-required'`인 셀을 렌더링할 때, **THE SYSTEM SHALL** 해당 셀을 neutral(강조 없음) 스타일로 표시한다.
 
 ### REQ-IMP-UI-008: 결과 페이지 — LLM 분류 표시
 
@@ -187,6 +204,12 @@ SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-ch
 
 **IF** `confidence < 0.8`이면, **THE SYSTEM SHALL** "신뢰도 낮음 — RA 검토 권장" 경고 배지를 표시한다.
 
+> **Confidence 임계값 3종 정리 (H5 — drift 방지):** 본 SPEC에는 서로 다른 3개 confidence 임계값이 등장하며, 각각 목적과 소비 경로가 다르다.
+>
+> 1. **백엔드 신호등 임계값 (0.7 / 0.9)** — `calculateSignal`이 `confidence*100`으로 신호등 색상 산정에 사용 (`route.ts:71`). UI는 이 값을 직접 비교하지 **않는다**. UI는 백엔드가 산정한 `signal` 필드를 그대로 소비 (REQ-IMP-UI-007).
+> 2. **백엔드 RAG 분기 임계값 (0.8)** — `confidence >= 0.8`일 때만 Layer 4 RAG가 실행되어 `similarCases`가 응답에 포함되고 `recommendation='high-confidence-auto-approve'`가 설정됨 (`route.ts:92`). UI는 이 임계값 자체를 검사하지 않고 `recommendation` 필드와 `similarCases`의 존재 여부로 분기 (REQ-IMP-UI-009/010).
+> 3. **UI 표시 배지 임계값 (0.8)** — REQ-IMP-UI-008의 "신뢰도 낮음" 배지 표시용. cosmetic-only 결정이며 signal 색상과 독립적임 (예: confidence=0.82 → signal은 green/yellow일 수 있지만 배지는 미표시).
+
 ### REQ-IMP-UI-009: 결과 페이지 — 유사 사례 (RAG)
 
 **IF** 응답에 `similarCases` 배열이 **존재하고**(high-confidence 분기), 배열이 비어 있지 않으면, **THE SYSTEM SHALL** 각 사례를 카드로 렌더링하고 `title`, `content`, `similarity`를 표시한다.
@@ -195,9 +218,7 @@ SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-ch
 
 **IF** `similarCases`가 빈 배열이면, **THE SYSTEM SHALL** "유사 사례가 없습니다" 메시지를 표시한다.
 
-**IF** 응답에 `similarCases` 필드가 **존재하지 않으면**(low-confidence 분기 — 백엔드가 RAG을 건너뜀), **THE SYSTEM SHALL** 유사 사례 섹션을 렌더링하지 않고 "신뢰도 낮아 유사 사례 조회를 생략했습니다" 안내를 표시한다.
-
-**NOTE:** 백엔드는 low-confidence 시 `similarCases`를 `undefined`로 반환한다 (route.ts 직검). 빈 배열 `[]`과 `undefined`를 구분해서 렌더링해야 한다.
+**IF** 응답에 `similarCases` 필드가 **존재하지 않으면**(low-confidence 분기 — 백엔드가 RAG을 건너뜀), **THE SYSTEM SHALL** 유사 사례 섹션을 렌더링하지 않고 "신뢰도 낮아 유사 사례 조회를 생략했습니다" 안내를 표시한다. 백엔드는 low-confidence 시 `similarCases`를 `undefined`로 반환한다 (route.ts 직검) — UI는 빈 배열 `[]`과 `undefined`를 반드시 구분해서 렌더링해야 한다.
 
 ### REQ-IMP-UI-010: 결과 페이지 — 티켓 CTA
 
@@ -211,7 +232,7 @@ SPEC-V3-IMPACT-001 (Phase C-3, PR #349 merged)이 제공한 `POST /api/impact-ch
 
 **THE SYSTEM SHALL** 모든 사용자 가시 문자열을 `next-intl`의 `impact.*` 네임스페이스 키로 관리한다 (`messages/ko.json` + `messages/en.json`).
 
-**WHEN** 사용자가 키보드로 위저드를 탐색할 때, **THE SYSTEM SHALL** Step 간 합리적인 포커스 관리(Tab/Shift+Tab 순서, Step 진입 시 첫 입력으로 포커스 이동)를 제공한다.
+**WHEN** 사용자가 키보드로 위저드를 탐색할 때, **THE SYSTEM SHALL** Tab/Shift+Tab 논리적 순서를 유지하고, Step 진입 시 `focus()`를 해당 Step의 첫 번째 입력 요소에 호출한다.
 
 **THE SYSTEM SHALL** 모든 폼 입력에 `aria-label` / `<label>` 연결을 제공하고 WCAG 2.1 AA 색상 대비를 만족한다 (`ci:contrast` 게이트).
 
@@ -318,7 +339,7 @@ type ImpactCheckResponse = {
 ---
 
 **생성일:** 2026-07-06
-**버전:** 0.1.0
+**버전:** 0.2.0
 **상태:** planned
-**총 REQ:** 11 functional + 4 NFR
+**총 REQ:** 12 functional (REQ-IMP-UI-006a 추가) + 4 NFR
 **다음 단계:** plan.md 구현 계획 수립 → acceptance.md 검증 시나리오 → plan-auditor 감사


### PR DESCRIPTION
## SPEC-V3-IMPACT-UI-001 — Change Impact 4-Layer Wizard UI (Plan Phase, C-4)

SPEC-V3-IMPACT-001 백엔드(PR #349 merged)를 소비하는 위저드 프론트엔드 plan 산출물 4종.

### 산출물 (4종, 0.2.0)
- `research.md` — 코드베이스 분석 (consult/triage UI 패턴, design tokens, 백엔드 계약 직검)
- `spec.md` — 16개 REQ (EARS), persona/RBAC, 4-step 위저드 + 결과 페이지
- `acceptance.md` — 11개 AC + edge cases (RBAC 차단, confidence=0.80 경계, RAG timeout 등)
- `plan.md` — 6개 Milestone (Foundation/gate → Step 1-4 → Result → i18n/a11y)

### 백엔드 계약 소비 (VERIFIED — PR #349)
- `POST /api/impact-check` (orgId/productId/changeType/markets/changeDetail/assigneeId) → matrix/signal/classification/similarCases?/ticketId?
- RBAC: `impact.view` ra-member+ (viewer/auditor 차단), `impact.self_check` viewer+
- Signal: green(all not-required)/yellow(conditional|conf<90)/red(required|conf<70)
- confidence>=0.8 → Layer4 similarCases / <0.8 → Layer3 ticketId

### plan-auditor 감사 (FAIL → 개정)
1차 FAIL(Critical 2 + High 5 + Major 4 + Minor 4) → manager-spec 전 항목 개정:
- **C1/C2/H2**: `employee` role 허구 제거 → 실제 Role union + `impact.view` ra-member+ 정정 (4파일)
- **C3**: REQ 내 `**NOTE:**` prose 4종 EARS sub-REQ로 전환
- **H1**: orgId provenance REQ 추가 (session.user.orgId)
- **H3**: `level='conditional'` 렌더링 REQ/AC 추가
- **H4**: consult gate보다 엄격한 hasRole('ra-member') 명시
- **H5**: confidence 임계값 3종(0.7/0.8/0.9) 정리

### 머지 후 후속
- 별도 run phase PR에서 구현 (manager-tdd, Phase C-4)

🗿 MoAI <email@mo.ai.kr>