### PR TITLE
docs(spec): SPEC-V3-PERSONA-001 Phase D 3-tier PersonaBar plan 산출물 4종

### DIFF
--- a/.moai/specs/SPEC-V3-PERSONA-001/acceptance.md
+++ b/.moai/specs/SPEC-V3-PERSONA-001/acceptance.md
@@ -1,0 +1,279 @@
+# SPEC-V3-PERSONA-001 — Acceptance Criteria
+
+---
+**SPEC ID:** SPEC-V3-PERSONA-001
+**Version:** 0.1.0
+**Status:** planned
+**Phase:** D
+**Created:** 2026-07-06
+---
+
+## §1 Acceptance Criteria
+
+> 모든 AC는 observable evidence를 포함한다. Tier derivation은 `lib/auth/rbac.ts:16-26`의 `ROLE_HIERARCHY`에 근거한다 (research.md §2.3 직검 검증).
+
+### AC-PER-01: PersonaBar 3-Tier 렌더링 (REQ-V3-PER-001)
+
+**Given** `ra-member` 역할 사용자가 인증된 상태에서
+**When** 앱 셸(`/`)에 진입하면
+**Then** PersonaBar가 3개 tier 버튼(Employee / RA / Admin)을 렌더링하고, RA 버튼이 `aria-selected="true"` 활성 상태로 표시된다.
+
+**Given** `viewer` 역할 사용자가
+**When** PersonaBar가 렌더링되면
+**Then** Employee 버튼만 활성화되고 RA/Admin 버튼은 `disabled` 속성과 "권한 없음" 툴팁(i18n 키 `persona.tierLocked`)을 표시한다.
+
+**Given** `admin` 역할 사용자가
+**When** PersonaBar가 렌더링되면
+**Then** 세 tier 버튼 모두 활성화된다.
+
+**Evidence:** RTL — 6종 역할(`auditor`, `viewer`, `ra-member`, `qa-lead`, `ra-lead`, `admin`) 각각에 대해 PersonaBar 렌더링 + 버튼 활성/비활성 상태 단언. 특히 `qa-lead`가 RA tier(Admin 아님), `auditor`가 Employee tier(RA 아님)로 매핑됨을 단언.
+
+### AC-PER-02: Persona 전환 동작 (REQ-V3-PER-001, PER-005)
+
+**Given** `ra-member` 사용자가 RA tier에서 Employee tier 버튼을 클릭하면
+**When** 전환 이벤트가 발생하면
+**Then** `regula-persona=employee` 쿠키가 설정되고, Sidebar가 Employee 대상 항목으로 필터링되며, 활성 tier가 Employee로 변경된다.
+
+**Given** `ra-member` 사용자가 Admin tier 버튼을 클릭하면
+**When** 버튼이 `disabled` 상태이면
+**Then** 클릭이 무시되고 쿠키/Sidebar/활성 tier가 변경되지 않는다.
+
+**Given** 사용자가 페이지를 새로고침하면
+**When** SSR이 `regula-persona` 쿠키를 읽으면
+**Then** 이전에 선택한 tier가 복원되고 hydration mismatch 없이 렌더링된다.
+
+**Evidence:** RTL — `fireEvent.click` + `document.cookie` 단언 + `rerender`로 새로고침 시뮬레이션. SSR 단언은 layout 테스트에서 `cookies()` mock으로 검증.
+
+### AC-PER-03: Tier별 랜딩 분기 (REQ-V3-PER-003)
+
+**Given** `viewer` 역할 사용자가 `/`에 진입하면
+**When** `personaTier('viewer') === 'employee'`이면
+**Then** Employee 랜딩 섹션(Ask / Impact / Products 진입점)이 렌더링된다.
+
+**Given** `ra-lead` 역할 사용자가 `/`에 진입하면
+**When** `personaTier('ra-lead') === 'ra'`이면
+**Then** RA 랜딩 섹션(Inbox / Consult / Triage 진입점)이 렌더링된다.
+
+**Given** `admin` 역할 사용자가 `/`에 진입하면
+**When** `personaTier('admin') === 'admin'`이면
+**Then** Admin 랜딩 섹션(Users / Corpus / Audit 진입점)이 렌더링된다.
+
+**Given** 사용자가 PersonaBar로 tier를 전환하면
+**When** 홈 `/`로 이동하면
+**Then** 전환된 tier에 해당하는 랜딩 섹션이 렌더링된다 (기존 `ROLE_ENTRIES` 위에 tier 분기 추가).
+
+**Evidence:** RTL + `app/(app)/__tests__/page.test.tsx` — 각 tier별 렌더링 단언. 기존 `ROLE_ENTRIES`가 깨지지 않음을 회귀 단언.
+
+### AC-PER-04: Persona 인지 Sidebar 필터 (REQ-V3-PER-002)
+
+**Given** Sidebar가 `tier="employee"` prop으로 렌더링되면
+**When** Employee tier 필터가 적용되면
+**Then** Employee 대상 NAV(Ask, MyQuestions, Products, Guides)가 우선 노출되고, RA 전용 항목(Inbox, Consult)은 숨김 또는 비활성 배지로 표시된다.
+
+**Given** Sidebar가 `tier="ra"` prop으로 렌더링되면
+**When** RA tier 필터가 적용되면
+**Then** RA 대상 NAV(Inbox, Consult, Impact, Knowledge)가 노출되고, Admin 전용 항목(Users, Audit)은 비활성 배지로 표시된다.
+
+**Given** Sidebar가 `tier="admin"` prop으로 렌더링되면
+**When** Admin tier 필터가 적용되면
+**Then** 모든 항목이 노출된다.
+
+**Given** 기존 `NAV_ITEMS`(홈/새상담/히스토리/설정)와 `show*` props가 전달되면
+**When** Sidebar가 렌더링되면
+**Then** 기존 항목이 **삭제되지 않고** 그대로 유지되며, tier 필터는 additive하게 적용된다 (비파괴 — H3).
+
+**Evidence:** RTL — `tier` prop별 NAV 렌더링 필터 단언 + 기존 `frontend-shell.test.ts` 통과 단언(비회귀).
+
+### AC-PER-05: 서버 사이드 RBAC 불변 (REQ-V3-PER-004) — 보안 핵심
+
+**Given** `viewer` 역할 사용자가 PersonaBar로 "RA" tier를 선택하고(또는 `regula-persona=ra` 쿠키를 수동으로 변조하고)
+**When** `/inbox` (RA 전용, `inbox.view` `minRole: ra-member`)로 직접 진입하면
+**Then** 서버 사이드 RBAC 게이트가 `hasRole('viewer', 'ra-member') === false`로 판정하여 `/?error=access_denied`로 리다이렉트한다 — PersonaBar 전환 상태와 무관.
+
+**Given** 쿠키 `regula-persona=admin`을 가진 `viewer` 역할 사용자가
+**When** `/admin` 라우트로 진입하면
+**Then** 서버가 쿠키를 무시하고 역할 기반 게이트(`admin` 전용)로 거부한다.
+
+**Evidence:** E2E (Playwright) + RTL — 쿠키 변조 시나리오에서 RBAC 게이트가 여전히 동작함을 단언. 이 테스트는 **보안 불변량**이며 실패 시 머지 불가.
+
+### AC-PER-06: 접근성 — WCAG 2.1 AA (REQ-V3-PER-006)
+
+**Given** PersonaBar가 렌더링될 때
+**When** 접근성 audit을 실행하면
+**Then** `role="tablist"` / `role="tab"` / `aria-selected` ARIA 구조가 준수되고, 키보드 Tab/Enter/Space로 tier 전환이 가능하다.
+
+**Given** PersonaBar의 색상 조합이
+**When** light/dark 모두에서 대비 검사를 실행하면
+**Then** WCAG 2.1 AA 대비(4.5:1 본문, 3:1 대형 텍스트)를 만족한다 (`ci:contrast` 통과).
+
+**Evidence:** `jest-axe` 또는 `@axe-core/playwright` 자동 audit + 키보드 탐색 RTL 시뮬레이션.
+
+### AC-PER-07: 국제화 — ko/en (REQ-V3-PER-007)
+
+**Given** `messages/ko.json`에 `persona.tier.employee`, `persona.tier.ra`, `persona.tier.admin`, `persona.tierLocked` 키가 정의되어 있으면
+**When** 한국어 로켈로 PersonaBar가 렌더링되면
+**Then** tier 이름이 "전사 직원 / RA 담당자 / 관리자"로 표시된다.
+
+**Given** `messages/en.json`에 동일한 키가 정의되어 있으면
+**When** 영어 로켈로 렌더링되면
+**Then** "Employee / RA / Admin"으로 표시된다.
+
+**Evidence:** RTL — next-intl mock으로 키 lookup 검증.
+
+### AC-PER-08: 비회귀 — 기존 라우트/컴포넌트 보존 (REQ-V3-PER-008)
+
+**Given** 기존 `app/(app)/` flat 라우트 25+ 디렉토리(admin, audit, chat, consult, dashboard, history, impact, inbox, knowledge, settings, triage 등)가
+**When** 본 SPEC 변경 후에도
+**Then** 동일한 경로에서 동일한 RBAC 게이트로 동작한다 — 라우트 이동/이름 변경/그룹화 없음.
+
+**Given** 기존 `frontend-shell.test.ts`와 SPEC-REGULA-* / SPEC-V3-* 테스트가
+**When** `pnpm test` full suite를 실행하면
+**Then** 모두 통과한다 — Sidebar 수정이 additive이고 기존 `show*` / `NAV_ITEMS` / `userRole` prop을 제거하지 않음.
+
+**Evidence:** `pnpm test` full 실행 (L-009) + `pnpm lint` (lint:hex, L-008). diff에서 `app/(app)/` 라우트 디렉토리 이동/이름 변경 부재 단언.
+
+---
+
+## §2 Edge Cases
+
+### Edge Case 1: 역할이 3-tier에 고르게 분포하지 않는 경우 (qa-lead, auditor)
+
+**Given** `qa-lead` 역할(hierarchy 2.5) 사용자가
+**When** PersonaBar가 렌더링되면
+**Then** RA tier 버튼이 활성화된다 (`personaTier('qa-lead') === 'ra'`). Admin 버튼은 비활성화. — `qa-lead`가 Admin이 아님을 단언 (research.md §2.3 주의).
+
+**Given** `auditor` 역할(hierarchy 0.5) 사용자가
+**When** PersonaBar가 렌더링되면
+**Then** Employee tier 버튼이 활성화된다 (`personaTier('auditor') === 'employee'`). 기존 write-block(`withPermission`)은 유지되어 audit 엔드포인트 외 쓰기 차단.
+
+### Edge Case 2: Persona 전환 새로고침 영속
+
+**Given** `ra-member` 사용자가 RA에서 Employee tier로 전환 후
+**When** 브라우저를 완전히 닫고 다시 열어 `/`에 진입하면
+**Then** `regula-persona=employee` 쿠키가 읽혀 Employee tier로 렌더링된다 — 단, `ra-member` 역할이 Employee tier를 유효 범위로 포함하므로 폴백 없이 적용.
+
+**Given** 쿠키 만료(기본 30일) 후
+**When** 사용자가 진입하면
+**Then** 쿠키가 사라져 역할 기반 기본 tier(`ra`)로 폴백.
+
+### Edge Case 3: 타 tier 라우트 딥링크 — RBAC 유지
+
+**Given** Employee tier(`viewer`) 사용자가 PersonaBar로 Employee를 선택한 상태에서
+**When** 주소창에 `/consult` (RA 전용)를 직접 입력하면
+**Then** 서버 RBAC 게이트가 `consult.session.view`(`minRole: ra-member`)으로 거부하여 `/?error=access_denied`로 리다이렉트. PersonaBar 전환 상태는 RBAC를 우회하지 않는다 (REQ-V3-PER-004).
+
+**Given** 반대로 RA tier 사용자가 `/admin/users`를 직접 입력하면
+**When** 서버가 `auditLogs.view` / `rbac.manage`(`minRole: admin`) 게이트를 실행하면
+**Then** 거부된다.
+
+### Edge Case 4: 쿠키 변조 — 권한 상승 시도
+
+**Given** `viewer` 역할 사용자가 브라우저 DevTools로 `regula-persona=admin`을 수동 설정하고
+**When** `/admin` 라우트로 진입하면
+**Then** 서버가 쿠키를 무시하고 `session.user.role === 'viewer'`로 RBAC 판정하여 거부. 사용자는 PersonaBar에서 Admin 버튼이 여전히 disabled로 표시됨 (SSR이 쿠키를 검증 후 폴백).
+
+### Edge Case 5: 모바일 collapse
+
+**Given** 좁은 화면(모바일)에서
+**When** PersonaBar가 렌더링되면
+**Then** 3개 버튼이 아이콘 전용(텍스트 숨김) 또는 햄버거 메뉴로 collapse되어도 tier 전환 기능이 유지된다.
+
+### Edge Case 6: 다크 모드 렌더링
+
+**Given** 사용자가 다크 모드를 활성화하면
+**When** PersonaBar가 렌더링되면
+**Then** tier 버튼 활성/비활성 색상이 다크 모드에서도 WCAG AA 대비를 유지한다 (`ci:contrast` 통과).
+
+### Edge Case 7: 세션 만료 후 전환 시도
+
+**Given** 세션이 만료된 상태에서(로그아웃 후)
+**When** 사용자가 PersonaBar 버튼을 클릭하면
+**Then** 로그인 페이지로 리다이렉트된다 — PersonaBar는 인증된 사용자만 접근 가능 (`layout.tsx`의 `auth()`가 세션을 확인).
+
+### Edge Case 8: locale 전환 중 tier 영속
+
+**Given** 한국어 로켈에서 RA tier를 선택한 사용자가
+**When** 영어로 locale을 전환하면(`regula-locale` 쿠키 변경)
+**Then** tier 선택(`regula-persona`)은 독립적으로 유지되어 RA tier가 그대로 적용되고, tier 라벨만 "RA 담당자" → "RA"로 변경.
+
+---
+
+## §3 Quality Gate Criteria
+
+### Definition of Done (DoD)
+
+**SPEC-V3-PERSONA-001은 다음 조건을 모두 충족할 때 "완료"로 간주한다:**
+
+1. **기능 완료:**
+   - [ ] 8개 AC (AC-PER-01 ~ AC-PER-08)가 모두 통과한다
+   - [ ] PersonaBar 3-tier 전환이 동작한다 (활성/비활성 분기)
+   - [ ] tier별 Sidebar 필터가 동작한다 (비파괴 additive)
+   - [ ] tier별 랜딩 분기가 동작한다 (기존 ROLE_ENTRIES 위에 tier 분기)
+   - [ ] 서버 사이드 RBAC가 PersonaBar와 무관하게 동작한다 (보안 불변량)
+
+2. **i18n:**
+   - [ ] `messages/ko.json`에 `persona.*` 키가 정의되었다
+   - [ ] `messages/en.json`에 동일 키가 정의되었다
+   - [ ] 컴포넌트 내 하드코딩 문자열이 없다
+
+3. **접근성:**
+   - [ ] PersonaBar가 ARIA tablist/tab 패턴을 준수한다
+   - [ ] 키보드 전용 탐색이 가능하다
+   - [ ] `ci:contrast` 게이트가 통과한다 (WCAG 2.1 AA, light/dark)
+   - [ ] 모바일 collapse가 동작한다
+
+4. **비회귀 (항심 게이트):**
+   - [ ] 기존 `app/(app)/` flat 라우트가 변경되지 않았다 (이동/이름 변경/그룹화 없음)
+   - [ ] 기존 `NAV_ITEMS` 순서(REQ-FND-019)가 유지된다
+   - [ ] `frontend-shell.test.ts`가 통과한다
+   - [ ] 기존 SPEC-REGULA-* / SPEC-V3-* 테스트가 전체 통과한다
+   - [ ] Sidebar 수정이 additive하다 (`show*` / `NAV_ITEMS` / `userRole` prop 제거 없음)
+
+5. **보안:**
+   - [ ] 쿠키 변조 시 서버 RBAC가 거부한다 (AC-PER-05 단언)
+   - [ ] PersonaBar가 실제 권한을 변경하지 않는다 (view-only)
+   - [ ] 쿠키 tier가 역할 범위를 벗어나면 폴백
+
+6. **성능:**
+   - [ ] PersonaBar 초기 렌더링 < 500ms
+   - [ ] tier 전환 시 페이지 리로드 없음
+   - [ ] hydration mismatch 없음
+
+7. **테스트:**
+   - [ ] 단위 테스트 커버리지 85% 이상 (`components/shell/__tests__/`, `lib/auth/__tests__/persona.test.ts`)
+   - [ ] 8개 edge case 시나리오 테스트 포함
+   - [ ] 6종 역할 × 3 tier 매트릭스 단언 (특히 qa-lead=RA, auditor=Employee)
+
+### 테스트 전략
+
+**단위 테스트 (Vitest + RTL):**
+- `lib/auth/__tests__/persona.test.ts` — `personaTier(role)` 6종 역할 매핑 + `isValidTierForRole` 분기
+- `components/shell/__tests__/PersonaBar.test.tsx` — 렌더링/전환/비활성 분기
+- `components/shell/__tests__/Sidebar.tier.test.tsx` — tier prop별 NAV 필터 (기존 `__tests__/Sidebar.test.tsx`와 별개, 비회귀)
+- `app/(app)/__tests__/page.tier.test.tsx` — tier별 랜딩 분기
+
+**보안 테스트 (핵심):**
+- 쿠키 변조 시나리오 (`regula-persona=admin` in `viewer` 세션) → RBAC 거부 단언
+- 딥링크 시나리오 (Employee → `/inbox` 직접 진입) → redirect 단언
+
+**비회귀 테스트:**
+- `pnpm test` full suite 통과 (L-009)
+- `pnpm lint` (lint:hex) 통과 (L-008)
+- `frontend-shell.test.ts` 통과
+
+**Mock 패턴** (`components/consult/__tests__/` 직검 기반):
+- `vi.mock('next-intl')` — `useTranslations`
+- `vi.mock('@/lib/auth')` — 역할별 `auth()` 반환
+- `vi.mock('next/headers')` — `cookies()` mock
+
+**접근성 테스트:**
+- `jest-axe` 자동 audit
+- 키보드 탐색 RTL 시뮬레이션
+
+---
+
+**생성일:** 2026-07-06
+**버전:** 0.1.0
+**상태:** planned
+**총 AC 개수:** 8개 (AC-PER-01 ~ AC-PER-08)
+**총 Edge Cases:** 8개

--- a/.moai/specs/SPEC-V3-PERSONA-001/plan.md
+++ b/.moai/specs/SPEC-V3-PERSONA-001/plan.md
@@ -1,0 +1,527 @@
+# SPEC-V3-PERSONA-001 — Implementation Plan
+
+---
+**SPEC ID:** SPEC-V3-PERSONA-001
+**Version:** 0.1.0
+**Status:** planned
+**Phase:** D
+**Created:** 2026-07-06
+---
+
+## §1 Overview
+
+v3 Phase D **3-Tier PersonaBar** 구현 계획. 전사 직원(Employee) / RA 담당자(RA) / 관리자(Admin) 3-tier 페르소나 전환 레이어를 기존 shell에 **incremental**하게 추가한다. 마스터 플랜의 풀 라우트 재구성(`(employee)|(ra)|admin`)은 **거부**하고, 점진적 composition 접근을 취한다 (research.md §6-A3).
+
+**핵심 목표:**
+- `<PersonaBar />` 컴포넌트 — 3-tier 전환 (view-only)
+- `lib/auth/persona.ts` — tier 파생 순수 함수 + 쿠키 유틸
+- Sidebar persona-aware 확장 (additive, 비파괴)
+- 홈 페이지 tier별 랜딩 분기
+- i18n + WCAG 2.1 AA 접근성
+- 기존 라우트/RBAC/테스트 비회귀 보장
+
+**TDD 기본:** quality.yaml `development_mode: tdd`에 따라 RED-GREEN-REFACTOR. brownfieldEnhancement: 기존 Sidebar(482L) / layout(150L) / page(248L) 사전 독해 (Pre-RED).
+
+---
+
+## §2 Implementation Milestones
+
+### Milestone 1: persona.ts — Tier 파생 유틸 + 테스트 (Priority: High)
+
+**목표:** `lib/auth/persona.ts` 순수 함수 + `regula-persona` 쿠키 유틸
+
+**작업 항목:**
+1. `lib/auth/persona.ts` 신규:
+   - `type Tier = 'employee' | 'ra' | 'admin'`
+   - `personaTier(role: Role): Tier` — verified mapping (research.md §2.3):
+     - `viewer`, `auditor` → `'employee'`
+     - `ra-member`, `qa-lead`, `ra-lead` → `'ra'`
+     - `admin` → `'admin'`
+   - `isValidTierForRole(role: Role, tier: Tier): boolean` — 전환 권한 검증
+   - `PERSONA_COOKIE = 'regula-persona'`
+   - `readPersonaCookie(cookieStore): Tier | null` — `cookies()`에서 읽기
+   - `writePersonaCookie(tier: Tier)` — `document.cookie` 설정 (path=/, sameSite=lax, 30일)
+2. 단위 테스트 `lib/auth/__tests__/persona.test.ts`:
+   - `personaTier` 6종 역할 매핑 단언 (특히 `qa-lead`→RA, `auditor`→Employee)
+   - `isValidTierForRole` 분기 (viewer+admin=false, admin+employee=true 등)
+   - 쿠키 읽기/쓰기 mock
+
+**산출물:**
+- `lib/auth/persona.ts`
+- `lib/auth/__tests__/persona.test.ts`
+
+**완료 기준:**
+- [ ] `personaTier` 6종 역할 매핑이 research.md §2.3과 정확히 일치
+- [ ] `isValidTierForRole`이 권한 상승 시도를 거부
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- `@/lib/auth/rbac` (`Role`)
+
+### Milestone 2: PersonaBar 컴포넌트 + i18n (Priority: High)
+
+**목표:** 3-tier 전환 UI 컴포넌트 + i18n 키
+
+**작업 항목:**
+1. `components/shell/PersonaBar.tsx` 신규 ('use client'):
+   - props: `currentTier: Tier`, `role: Role`, `onTierChange: (tier: Tier) => void`
+   - 3개 버튼(Employee/RA/Admin)을 `role="tablist"`/`role="tab"` ARIA 패턴
+   - `isValidTierForRole(role, tier)`로 버튼 활성/비활성 결정
+   - 비활성 버튼: `disabled` + `aria-disabled` + 툴팁(i18n `persona.tierLocked`)
+   - 활성 버튼: `aria-selected="true"`
+   - 키보드: Tab 이동, Enter/Space 선택
+2. i18n 키 추가:
+   - `messages/ko.json`: `persona.tier.employee`="전사 직원", `persona.tier.ra`="RA 담당자", `persona.tier.admin`="관리자", `persona.tierLocked`="권한이 없는 tier입니다"
+   - `messages/en.json`: 동일 키 (Employee / RA / Admin)
+3. 단위 테스트 `components/shell/__tests__/PersonaBar.test.tsx`:
+   - 6종 역할별 활성/비활성 버튼 단언
+   - 전환 클릭 → `onTierChange` 콜백 호출
+   - 비활성 버튼 클릭 무시
+   - ARIA 속성 단언
+   - 키보드 탐색
+
+**산출물:**
+- `components/shell/PersonaBar.tsx`
+- `messages/ko.json`, `messages/en.json` 확장
+- `components/shell/__tests__/PersonaBar.test.tsx`
+
+**완료 기준:**
+- [ ] AC-PER-01 (3-tier 렌더링) 통과
+- [ ] AC-PER-06 (접근성 ARIA) 통과
+- [ ] AC-PER-07 (i18n ko/en) 통과
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- Milestone 1 (`personaTier`, `isValidTierForRole`)
+- `next-intl`
+- Radix UI `Tabs` (선택) 또는 네이티브 button + ARIA
+
+### Milestone 3: Sidebar persona-aware 확장 (Priority: High)
+
+**목표:** Sidebar에 `tier` prop 추가, tier별 NAV 필터 (비파괴 additive)
+
+> **H3 — 비파괴 확장 (run-phase 주의):** Sidebar는 이미 `userRole` prop으로 NAV를 필터 중이다 (line 79). 새 `tier` prop은 **additive**. 기존 `show*` props, `NAV_ITEMS`, `userRole`을 **삭제하지 않는다**. 제거 시 SPEC-REGULA-* / SPEC-V3-* 테스트가 깨진다.
+
+**작업 항목:**
+1. `components/shell/Sidebar.tsx` 수정 (additive):
+   - `SidebarProps`에 `tier?: Tier` 추가 (선택 prop — undefined 시 기존 동작 유지)
+   - tier 정의 시, tier별 우선 NAV 섹션 렌더링 (Employee: Ask/MyQuestions/Products/Guides, RA: Inbox/Consult/Impact/Knowledge, Admin: Users/Corpus/Audit/Settings)
+   - 기존 `NAV_ITEMS`(홈/새상담/히스토리/설정)는 tier 무관 항상 노출
+   - 기존 `show*` props는 그대로 유지 (tier 필터와 병렬 동작)
+   - tier에 속하지 않은 항목은 숨김 또는 비활성 배지 (UX는 run-phase 확정, OQ-1)
+2. 단위 테스트 `components/shell/__tests__/Sidebar.tier.test.tsx` (기존 테스트 파일과 별개):
+   - `tier="employee"` / `tier="ra"` / `tier="admin"` 각각 NAV 필터링 단언
+   - `tier` undefined 시 기존 동작 유지 (비회귀)
+   - 기존 `show*` props가 tier와 함께 동작
+
+**산출물:**
+- `components/shell/Sidebar.tsx` (수정, additive)
+- `components/shell/__tests__/Sidebar.tier.test.tsx`
+
+**완료 기준:**
+- [ ] AC-PER-04 (tier별 Sidebar 필터) 통과
+- [ ] 기존 `frontend-shell.test.ts` 통과 (비회귀)
+- [ ] 기존 `show*` / `NAV_ITEMS` / `userRole` prop 제거 없음 (코드 검사)
+
+**의존성:**
+- Milestone 1 (`Tier` 타입)
+- 기존 `Sidebar.tsx` (482L, 비파괴 확장)
+
+### Milestone 4: layout + page — 서버 사이드 tier 주입 + 랜딩 분기 (Priority: High)
+
+**목표:** `layout.tsx`에서 tier 파생 → PersonaBar + Sidebar 전달, `page.tsx` tier별 랜딩 분기
+
+**작업 항목:**
+1. `app/(app)/layout.tsx` 수정:
+   - `auth()` 후 `personaTier(userRole)`로 tier 파생
+   - `readPersonaCookie(cookieStore)`로 쿠키 읽기 — 단, `isValidTierForRole(userRole, cookieTier)` 검증 후 폴백 (변조 방지)
+   - `<PersonaBar currentTier={...} role={userRole} onTierChange={...} />` 배치 (Topbar 내 또는 독립 행 — OQ-2)
+   - `<Sidebar tier={tier} ...기존 props />` 전달
+2. `app/(app)/page.tsx` 수정:
+   - 기존 `ROLE_ENTRIES` 위에 tier 분기 추가
+   - `tier === 'employee'` → Employee 진입점 (Ask, Impact placeholder, Products)
+   - `tier === 'ra'` → RA 진입점 (Inbox, Consult, Triage)
+   - `tier === 'admin'` → Admin 진입점 (Users, Corpus, Audit)
+3. 단위 테스트:
+   - `app/(app)/__tests__/layout.tier.test.tsx` — tier 파생 + 쿠키 폴백 + 변조 거부
+   - `app/(app)/__tests__/page.tier.test.tsx` — tier별 랜딩 섹션 렌더링
+
+**산출물:**
+- `app/(app)/layout.tsx` (수정)
+- `app/(app)/page.tsx` (수정)
+- 단위 테스트 2종
+
+**완료 기준:**
+- [ ] AC-PER-02 (전환 동작) 통과
+- [ ] AC-PER-03 (tier별 랜딩 분기) 통과
+- [ ] AC-PER-05 (서버 사이드 RBAC 불변) 통과 — 보안 핵심
+- [ ] 단위 테스트 통과
+
+**의존성:**
+- Milestone 1 (`personaTier`, `readPersonaCookie`, `isValidTierForRole`)
+- Milestone 2 (`PersonaBar`)
+- Milestone 3 (`Sidebar` tier prop)
+
+### Milestone 5: 접근성 + 다크 모드 + 보안 E2E (Priority: High)
+
+**목표:** WCAG 2.1 AA + 다크 모드 + 쿠키 변조 보안 E2E
+
+**작업 항목:**
+1. PersonaBar ARIA 점검 (M2에서 구현, M5에서 audit):
+   - `jest-axe` 자동 접근성 audit
+   - 키보드 탐색: Tab/Shift+Tab/Enter/Space
+2. 다크 모드 렌더링 검증:
+   - PersonaBar 활성/비활성 색상 light/dark 대비
+   - `ci:contrast` 게이트 통과
+3. 보안 E2E (Playwright):
+   - `viewer` + `regula-persona=admin` 쿠키 변조 → `/admin` 접근 → 거부 단언
+   - Employee tier → `/inbox` 딥링크 → redirect 단언
+   - RA tier → `/admin/users` 딥링크 → redirect 단언
+4. 모바일 collapse 테스트 (viewport 375px)
+5. locale 전환 중 tier 영속 테스트
+
+**산출물:**
+- 접근성 audit 결과
+- E2E 테스트 시나리오 3종 (보안 핵심)
+- 다크 모드 / 모바일 테스트
+
+**완료 기준:**
+- [ ] AC-PER-05 (서버 사이드 RBAC 불변) E2E 통과 — 보안 불변량
+- [ ] AC-PER-06 (접근성) 통과
+- [ ] Edge Case 1-8 모두 테스트 커버
+
+**의존성:**
+- Milestone 4
+
+### Milestone 6: 비회귀 full suite + 통합 (Priority: High)
+
+**목표:** 기존 라우트/컴포넌트/테스트 비회귀 보장
+
+**작업 항목:**
+1. `pnpm test` full suite 실행 (L-009):
+   - 특히 `frontend-shell.test.ts`, SPEC-REGULA-* / SPEC-V3-* 테스트 통과
+2. `pnpm lint` (lint:hex) 실행 (L-008)
+3. diff에서 기존 `app/(app)/` 라우트 디렉토리 이동/이름 변경 부재 확인
+4. Sidebar 수정이 additive임을 코드 검사 (`show*` / `NAV_ITEMS` / `userRole` prop 제거 없음)
+5. 통합 시나리오:
+   - 6종 역할 × 3 tier 매트릭스 (PersonaBar + Sidebar + landing)
+   - tier 전환 → 쿠키 설정 → 새로고침 → tier 복원
+   - locale 전환 중 tier 독립성
+
+**산출물:**
+- 비회귀 테스트 결과
+- 통합 시나리오 결과
+
+**완료 기준:**
+- [ ] AC-PER-08 (비회귀) 통과
+- [ ] `pnpm test` full 통과
+- [ ] `pnpm lint` 통과
+- [ ] 기존 라우트 변경 부재 (diff 검사)
+
+**의존성:**
+- Milestone 5
+
+---
+
+## §3 New and Modified Files
+
+### 신규 파일 (New Files)
+
+**persona 유틸:**
+```
+lib/auth/
+├── persona.ts                              # M1: tier 파생 + 쿠키 유틸
+└── __tests__/
+    └── persona.test.ts                     # M1: 6종 역할 매핑
+```
+
+**PersonaBar 컴포넌트:**
+```
+components/shell/
+├── PersonaBar.tsx                          # M2: 3-tier 전환 UI
+└── __tests__/
+    ├── PersonaBar.test.tsx                 # M2: 렌더링/전환/ARIA
+    └── Sidebar.tier.test.tsx               # M3: tier prop별 NAV 필터
+```
+
+**layout/page 테스트:**
+```
+app/(app)/
+└── __tests__/
+    ├── layout.tier.test.tsx                # M4: tier 파생 + 쿠키 폴백
+    └── page.tier.test.tsx                  # M4: tier별 랜딩
+```
+
+### 수정 파일 (Modified Files)
+
+**additive 수정:**
+```
+components/shell/Sidebar.tsx                # M3: tier prop 추가 (비파괴, 기존 props 유지)
+app/(app)/layout.tsx                        # M4: personaTier 파생 + PersonaBar/Sidebar 전달
+app/(app)/page.tsx                          # M4: tier별 랜딩 분기 (ROLE_ENTRIES 위)
+```
+
+**i18n:**
+```
+messages/ko.json                            # M2: persona.* 키 추가
+messages/en.json                            # M2: 동일
+```
+
+### 수정 금지 / Out of Scope (변경 시 머지 불가)
+
+- `app/(app)/` 기존 flat 라우트 디렉토리(admin, audit, chat, consult, dashboard, history, impact, inbox, knowledge, settings, triage 등 25+) — 이동/이름 변경/그룹화 금지
+- `lib/auth/rbac.ts` — `Role` union, `ROLE_HIERARCHY`, `hasRole` 변경 금지
+- `lib/auth/permissions.ts` — `PERMISSION_MAP` 변경 금지
+- `lib/db/schema.ts` — frozen
+- 백엔드 API 라우트 — frozen
+- 기존 SPEC-REGULA-* / SPEC-V3-* 컴포넌트 — 비회귀
+
+---
+
+## §4 Technical Approach
+
+### 아키텍처 패턴
+
+**서버 사이드 tier 파생 + 클라이언트 전환 (기존 layout 패턴 준용):**
+```
+app/(app)/layout.tsx (server)
+    ↓ auth() → session.user.role
+    ↓ personaTier(role) → Tier (verified derivation)
+    ↓ readPersonaCookie(cookies()) → 쿠키 tier (검증 후 폴백)
+    ↓ isValidTierForRole(role, cookieTier) → 변조 방지
+    ↓ <PersonaBar currentTier={tier} role={role} onTierChange={...} />
+    ↓ <Sidebar tier={tier} ...기존 show* props />
+    ↓ <main>{children}</main>
+
+app/(app)/page.tsx (server)
+    ↓ auth() → role → personaTier(role) → Tier
+    ↓ tier 분기: employee / ra / admin 랜딩 섹션
+    ↓ 기존 ROLE_ENTRIES 재사용
+```
+
+**상태 관리:**
+- tier 상태: `regula-persona` 쿠키 (서버 사이드 읽기, SSR 일관성)
+- 전환: PersonaBar 클릭 → 쿠키 설정 → 클라이언트 재렌더링 (페이지 리로드 없음)
+- 전역 상태(Zustand/Jotai) 불필요 — 과잉 추상화 방지 (Charter [지양-5]).
+
+### Tier composition diagram
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ Role (rbac.ts)                                                  │
+│ admin(4) > ra-lead(3) > qa-lead(2.5) > ra-member(2) >           │
+│ viewer(1) > auditor(0.5)                                        │
+└──────────────────┬─────────────────────────────────────────────┘
+                   │ personaTier(role) — pure function
+                   ▼
+┌────────────────────────────────────────────────────────────────┐
+│ Tier (persona.ts)                                               │
+│ ┌──────────┬─────────────────┬────────┐                         │
+│ │ employee │ ra              │ admin  │                         │
+│ │ viewer,  │ ra-member,      │ admin  │                         │
+│ │ auditor  │ qa-lead,        │        │                         │
+│ │          │ ra-lead         │        │                         │
+│ └──────────┴─────────────────┴────────┘                         │
+└──────────────────┬─────────────────────────────────────────────┘
+                   │ PersonaBar view-only switch
+                   ▼
+┌────────────────────────────────────────────────────────────────┐
+│ View Layer (PersonaBar + Sidebar + landing)                     │
+│ • Sidebar NAV 필터 (tier별 우선 항목)                            │
+│ • page.tsx 랜딩 분기                                             │
+│ • 단, 서버 RBAC는 실제 role 기준 (tier 무관)                     │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### 왜 incremental인가 (마스터 플랜 거부 근거)
+
+| 항목 | 마스터 플랜 (route reorg) | 본 SPEC (incremental) |
+|---|---|---|
+| 라우트 디렉토리 | 25+ 이동 (3 그룹) | 0 변경 |
+| `<Link href>` 참조 | 50+ 갱신 | 0 갱신 |
+| E2E 테스트 | 10+ 깨짐 | 0 깨짐 |
+| RBAC 게이트 | 모두 재작업 | 0 변경 |
+| 회귀 위험 | HIGH | LOW (additive) |
+| Charter 가치 전달 | 80% (전체 완성 시) | 80% (shell 인프라) |
+| 일정 | 큼 | 작음 |
+
+→ 6-8인 내부 팀에 incremental이 적합. route reorg는 SPEC-V3-ROUTE-REORG-001로 이월.
+
+### 데이터 흐름
+
+**정상 플로우 (전환):**
+```
+PersonaBar 클릭 (RA tier 선택)
+    ↓
+onTierChange('ra')
+    ↓
+writePersonaCookie('ra') → document.cookie = 'regula-persona=ra; ...'
+    ↓
+클라이언트 재렌더링 (Sidebar tier prop 갱신)
+    ↓
+페이지 리로드 없이 NAV 필터 변경
+```
+
+**새로고침 플로우 (영속):**
+```
+layout.tsx (SSR)
+    ↓ auth() → role
+    ↓ personaTier(role) → 기본 tier
+    ↓ readPersonaCookie(cookies()) → 쿠키 tier
+    ↓ isValidTierForRole(role, 쿠키 tier)?
+    │   YES → 쿠키 tier 사용
+    │   NO  → 기본 tier 폴백 (변조 방지)
+    ↓ <PersonaBar currentTier={...} /> + <Sidebar tier={...} />
+```
+
+---
+
+## §5 Testing Strategy
+
+### 단위 테스트 (Vitest + RTL)
+
+**목표 커버리지:** 85% 이상
+
+**Mock 패턴:**
+```ts
+vi.mock('next-intl', () => ({ useTranslations: () => (key) => key }));
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }));
+vi.mock('next/headers', () => ({ cookies: vi.fn() }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+```
+
+**테스트 대상:** §3 신규 파일 목록 참조.
+
+### 보안 테스트 (핵심 — 머지 게이트)
+
+**쿠키 변조 시나리오:**
+1. `viewer` 역할 + `regula-persona=admin` 쿠키 → `/admin` 접근 → 거부
+2. `viewer` + `regula-persona=ra` → `/inbox` 접근 → 거부
+3. 쿠키 삭제 → 역할 기본 tier로 폴백
+
+→ AC-PER-05 단언. 실패 시 머지 불가 (보안 불변량).
+
+### 접근성 테스트
+
+- `jest-axe` 자동 audit
+- 키보드 탐색 RTL 시뮬레이션
+- `ci:contrast` CI 게이트 통과 (light/dark)
+
+### 비회귀 테스트
+
+- `pnpm test` full suite 통과 (L-009) — 특히 `frontend-shell.test.ts`, SPEC-REGULA-* / SPEC-V3-*
+- `pnpm lint` (lint:hex) full 실행 (L-008)
+- diff에서 라우트 디렉토리 이동/이름 변경 부재 확인
+
+---
+
+## §6 Risk Mitigation
+
+### 위험 1: 기존 라우트/RBAC 회귀 (마스터 플랜 route reorg)
+
+**완화:**
+- incremental 접근 채택 (route reorg 거부, research.md §6-A3)
+- 기존 flat 라우트 보존, Sidebar additive 확장
+- AC-PER-08 + M6 비회귀 게이트 강제
+
+**검증:** M6 `pnpm test` full + diff 검사.
+
+### 위험 2: PersonaBar 전환으로 RBAC 우회 (보안)
+
+**완화:**
+- tier는 view-only (REQ-V3-PER-004)
+- 서버는 매 요청마다 `session.user.role`로 RBAC 판정 (쿠키 신뢰 X)
+- AC-PER-05 쿠키 변조 시나리오로 보안 불변량 강제
+
+**검증:** M5 보안 E2E (쿠키 변조 3종).
+
+### 위험 3: hydration mismatch (SSR vs 클라이언트 tier)
+
+**완화:**
+- 쿠키 사용 (localStorage X) — layout.tsx가 SSR 시 읽음 (research.md §6-A4)
+- `regula-locale` 패턴 준용 (layout.tsx:118 입증)
+- M4 layout 테스트에서 hydration 일관성 단언
+
+**검증:** M4 `layout.tier.test.tsx` SSR 단언.
+
+### 위험 4: Sidebar 기존 테스트 깨짐 (show* prop 제거)
+
+**완화:**
+- `tier` prop은 **선택**(optional) — undefined 시 기존 동작 유지
+- 기존 `show*` / `NAV_ITEMS` / `userRole` prop 제거 금지 (H3)
+- M3 `Sidebar.tier.test.tsx`를 기존 테스트와 별개 파일로 작성
+
+**검증:** M6 `frontend-shell.test.ts` 통과.
+
+### 위험 5: Employee Impact 접근 (A2 tension)
+
+**완화:**
+- v1은 Employee tier의 Impact 진입점을 placeholder("RA 문의" CTA)로 표시
+- 페이지 게이트 완화(`impact.view` ra-member → viewer)는 SPEC-V3-EMPLOYEE-IMPACT-001로 이월
+- 본 SPEC은 게이트 변경 없음
+
+**검증:** M4 page 테스트에서 Employee Impact placeholder 단언.
+
+### 위험 6: qa-lead / auditor tier 매핑 혼동
+
+**완화:**
+- research.md §2.3 명시: qa-lead=RA, auditor=Employee
+- M1 `persona.test.ts`에서 6종 역할 매핑 단언 (특히 qa-lead≠Admin, auditor≠RA)
+- AC-PER-01 Edge Case 1 단언
+
+**검증:** M1 단위 테스트.
+
+---
+
+## §7 Dependencies Mapping
+
+### 내부 의존성
+
+| 의존 대상 | 용도 | Milestone |
+|---|---|---|
+| `@/lib/auth` (`auth()`) | 서버 사이드 역할 읽기 | M4 |
+| `@/lib/auth/rbac` (`Role`, `ROLE_HIERARCHY`) | tier 파생 입력 | M1 |
+| `components/shell/Sidebar.tsx` (기존 482L) | tier prop additive 확장 | M3 |
+| `components/shell/Topbar.tsx` | PersonaBar 배치 | M4 |
+| `next-intl` | i18n | M2 |
+| Tailwind v4 `@theme` | 디자인 토큰 | M2 |
+| 기존 `app/(app)/page.tsx` `ROLE_ENTRIES` | tier 랜딩 분기 재사용 | M4 |
+
+### 외부 의존성
+
+| 의존 대상 | 용도 | 버전 |
+|---|---|---|
+| Radix UI `Tabs` (선택) | 접근성 tier 전환 | 기존 사용 버전 |
+| `jest-axe` / `@axe-core/playwright` | 접근성 audit | 기존 설정 |
+
+### 외부 의존성이 아닌 것 (NOT Imported)
+
+- `/api/persona` — 백엔드 API 없음 (tier는 클라이언트 derivation)
+- localStorage / Zustand / Jotai — SSR 불가 / 과잉 추상화
+- ESIG / impersonation 백엔드 — future SPEC
+
+### 상위 SPEC 의존성 (depends_on)
+
+- **SPEC-V3-UI-001** (parent) — consult UI 패턴(TanStack Query provider, design tokens, i18n 네임스페이스) 참조. PersonaBar는 동일 패턴 준용.
+- **SPEC-V3-CONSULT-001** — consult 라우트가 RA tier NAV에 포함됨 (비회귀 대상).
+- **SPEC-V3-INBOX-001** — inbox 라우트가 RA tier NAV에 포함됨.
+- **SPEC-V3-IMPACT-UI-001** — impact 라우트가 RA tier NAV에 포함됨. Employee tier는 placeholder (A2).
+
+---
+
+## §8 Open Questions (Run-Phase Resolution)
+
+| ID | Question | Default | Owner |
+|---|---|---|---|
+| OQ-1 | tier 불일치 UX(숨김 vs 비활성 배지) | 비활성 + 툴팁 | run phase: UX 확정 |
+| OQ-2 | PersonaBar 배치(Topbar 내장 vs 독립 행) | Topbar 우측 | run phase: 레이아웃 확정 |
+| OQ-3 | Employee Impact 진입점(placeholder vs 숨김) | placeholder "RA 문의" | run phase: UX 확정 (A2 정렬) |
+| OQ-4 | `phase: D` 라벨 roadmap 교차 검증 | orchestrator 지시 따름 | plan-auditor |
+
+---
+
+**생성일:** 2026-07-06
+**버전:** 0.1.0
+**상태:** planned
+**총 Milestones:** 6개
+**예상 완료:** Phase D 종료 시점

--- a/.moai/specs/SPEC-V3-PERSONA-001/research.md
+++ b/.moai/specs/SPEC-V3-PERSONA-001/research.md
@@ -1,0 +1,246 @@
+# SPEC-V3-PERSONA-001 — Research (Codebase Analysis)
+
+---
+**SPEC ID:** SPEC-V3-PERSONA-001
+**Version:** 0.1.0
+**Status:** planned
+**Phase:** D
+**Created:** 2026-07-06
+**Author:** manager-spec
+**Method:** L-013 direct code inspection (no self-report, no matrix-only reasoning)
+---
+
+## §1 Research Scope
+
+Plan-phase deep codebase analysis to ground the **3-tier PersonaBar** SPEC in verified facts. v3 master plan (`docs/proposals/v3-architecture-revamp-plan-2026-07-02.md` §5.1 Phase D-2) assigns "3-tier PersonaBar + components/ 재작성" to a new SPEC. The master plan originally named this `SPEC-V3-UI-001`, but that ID is already taken (M6 RA Power Chat consult UI, completed). This SPEC uses `SPEC-V3-PERSONA-001` to avoid ID collision (research.md §7-A1).
+
+Every persona definition, RBAC tier, route, and Sidebar prop referenced in `spec.md` is traceable to a line in this document.
+
+**Out of scope:** backend changes, DB migration, schema, audit log changes, RBAC enum additions. Tier is a **client-side composition** over the existing `permissions.ts` / `rbac.ts` (read-only derivation).
+
+---
+
+## §2 Verified Role & Tier Foundation
+
+### 2.1 Role union (verified — `lib/auth/rbac.ts:14`)
+
+```ts
+export type Role = 'admin' | 'qa-lead' | 'ra-lead' | 'ra-member' | 'viewer' | 'auditor';
+```
+
+**NOTE:** The v3 docs (`docs/v3/05_claude_code_playbook.md`, `docs/v3/README.md`) describe "Employee" as a persona. The codebase has **no `employee` role**. The Employee persona maps to the `viewer` role (least-privileged operational role). `auditor` (external read-only inspector) is operationally equivalent to Employee tier for navigation purposes but is gated differently on audit endpoints (`PERMISSIONS[*].additionalRoles`).
+
+### 2.2 Role hierarchy ladder (verified — `lib/auth/rbac.ts:16-26`)
+
+```ts
+export const ROLE_HIERARCHY: Record<Role, number> = {
+  admin: 4,
+  'ra-lead': 3,
+  'qa-lead': 2.5,
+  'ra-member': 2,
+  viewer: 1,
+  auditor: 0.5,
+};
+```
+
+`hasRole(userRole, required)` returns `ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[required]` (rbac.ts:32-34).
+
+### 2.3 Tier mapping (derived, VERIFIED derivation)
+
+The 3-tier persona model composes over the 6-role ladder as follows. This is the **single source of truth** for `personaTier(role)`:
+
+| Persona Tier | Roles included | Hierarchy range | Charter mapping |
+|---|---|---|---|
+| `employee` | `viewer`, `auditor` | 0.5 – 1 | 전사 직원 셀프서비스 (Ask, MyQuestions, Products, Guides, Impact) |
+| `ra` | `ra-member`, `qa-lead`, `ra-lead` | 2 – 3 | RA 워크벤치 (Inbox, Consult, Triage, Authoring, Knowledge) |
+| `admin` | `admin` | 4 | Admin 감시 (users, corpus, audit logs, settings) |
+
+**NOTE:** `qa-lead` (2.5) maps to RA tier, NOT admin. `qa-lead` performs member-level RA work by default (rbac.ts:19-20 comment: "QA lead can perform member-level work by default"). Signature-only elevation uses `PERMISSIONS[*].additionalRoles` (rbac.ts:20-21).
+
+**NOTE:** `auditor` (0.5) maps to Employee tier for navigation/landing purposes, but remains blocked from all non-audit write endpoints by the `withPermission` write-block (rbac.ts:11-13 comment). The PersonaBar switch does NOT bypass this — server-side RBAC stays authoritative (REQ-V3-PER-004).
+
+### 2.4 Why tier = client-side composition, not a new role enum
+
+Adding a `tier` field to the DB / session / `Role` union would require:
+- migration (`lib/db/schema.ts`)
+- session extension (`lib/auth`)
+- `withPermission` rewrite
+- backfill for all existing users
+
+That is a **backend change**, explicitly out of scope for this UI-only SPEC. Instead, `lib/auth/persona.ts` exports a pure function `personaTier(role: Role): 'employee' | 'ra' | 'admin'` that derives the tier from the existing role at render time. This is read-only, non-breaking, and reversible.
+
+---
+
+## §3 Current Navigation Architecture (verified)
+
+### 3.1 Sidebar (`components/shell/Sidebar.tsx`, 482 lines)
+
+**NAV_ITEMS (lines 24-29, verified):**
+```ts
+const NAV_ITEMS: NavItem[] = [
+  { label: '홈', href: '/', minRole: 'viewer' },
+  { label: '새 상담', href: '/chat', testId: 'nav-chat', minRole: 'viewer' },
+  { label: '히스토리', href: '/history', minRole: 'viewer' },
+  { label: '설정', href: '/settings', minRole: 'viewer' },
+];
+```
+
+**~13 `show*` props (lines 33-81, verified):** `showExpertReview`, `showPredicate`, `showKnowledgeGap`, `showClassify`, `showTraceability`, `showStandards`, `showChangeControl`, `showLabeling`, `showClinicalInvestigation`, `showGovernance`, `showQualityHeatmap`, `showTeamKnowledge`, `showAuthoring`, `showEvidence`, `showInbox`, `showConsult`. Each has an `// @MX:NOTE` or SPEC comment documenting its permission gate.
+
+**`userRole` prop (line 79, verified):** Added 2026-06-29 ("사이드바 3계층: NAV_ITEMS를 userRole로 필터"). This is the **existing** persona-awareness hook — Sidebar already filters `NAV_ITEMS` by role. The new PersonaBar extends this same pattern.
+
+### 3.2 Layout (`app/(app)/layout.tsx`, 150 lines)
+
+Server component. Calls `auth()` (dynamic import, line 61), reads `session.user.role`, computes all 16 `show*` flags via `hasRole(userRole, '<minRole>')` (lines 66-100), and passes them to `<Sidebar>` (lines 122-141). Also reads `regula-locale` cookie for i18n (line 118).
+
+**This is the proven pattern for server-side RBAC composition.** PersonaBar tier detection MUST follow the same `auth()` + `hasRole` approach in the layout, then pass `tier` as a prop to the client PersonaBar.
+
+### 3.3 Home page (`app/(app)/page.tsx`, 248 lines)
+
+**Already has role-based branching** (lines 18-40, verified): `ROLE_ENTRIES: Record<Role, RoleEntry[]>` maps each role to different entry points (e.g., `ra-lead` → "RA 전략 시작" → `/chat`; `admin` → admin console; `viewer` → employee entry). This is the **persona landing foundation** — the new SPEC extends it with a tier-level branch (employee/ra/admin), reusing the existing `ROLE_ENTRIES` data.
+
+### 3.4 Permissions map (`lib/auth/permissions.ts`, 597 lines)
+
+`PERMISSION_MAP` (lines ~190-580) defines ~60 permissions, each with `minRole`, `scope`, `resourceType`, optional `additionalRoles`. Key tier-relevant gates (verified):
+
+| Permission | minRole | Tier implication |
+|---|---|---|
+| `dashboard.view` | `ra-member` | RA tier landing gate |
+| `dashboard.team` | `ra-lead` | RA Lead only |
+| `auditLogs.view` | `admin` | Admin tier only |
+| `sources.ingest` | `admin` | Admin tier only |
+| `rbac.manage` | `admin` | Admin tier only |
+| `consult.session.view` | `ra-member` | RA tier consult gate |
+| `inbox.view` | `ra-member` | RA tier inbox gate |
+| `impact.view` | `ra-member` | RA tier (employee impact self-check uses `impact.self_check` at `viewer`) |
+| `impact.self_check` | `viewer` | Employee tier — impact wizard backend reachable, but page gate is stricter (`ra-member` per SPEC-V3-IMPACT-UI-001 REQ-IMP-UI-001) |
+
+**NOTE — gate inversion:** `impact.self_check` (`minRole: viewer`) is reachable by Employee tier via the API, but the impact **page** gate (`impact.view`, `minRole: ra-member`) blocks Employee tier from the wizard UI. This is a known tension: the v3 master plan wants Employee to self-check impact (docs/v3/README.md §1.1 "Employee Impact 위저드"), but the current page gate blocks them. This SPEC does NOT change that gate (out of scope — backend/RBAC change). Employee Impact self-check is deferred to a follow-up SPEC that relaxes the page gate (see §6-A2).
+
+---
+
+## §4 Route Inventory (verified — flat, NOT route-grouped)
+
+`app/(app)/` contains these flat routes (verified via `ls`):
+
+```
+admin/  audit/  calendar/  chat/  consult/  dashboard/  expert-review/
+export/  governance/  history/  impact/  inbox/  knowledge/  knowledge-gap/
+library/  predicate/  projects/  quality/  settings/  standards/
+templates/  traceability/  triage/  updates/  workflows/  onboarding/
+```
+
+**Critical observation:** Routes are FLAT (single route group `(app)/`). The v3 master plan proposes `app/((employee)|(ra)|admin)/` route-group reorg (docs/v3/05_claude_code_playbook.md:39-50). This would require:
+- Moving 25+ route directories into 3 route groups
+- Updating every `<Link href>` (cross-route links break on rename)
+- Updating E2E tests (`frontend-shell.test.ts` order assertions)
+- Updating RBAC gates (currently per-route, not per-group)
+- Risk of breaking working, tested, RBAC-gated features (consult, inbox, impact, triage all post-merge)
+
+**This is a massive regression surface.** For a 6-8 person internal team (Charter scope), the incremental approach (PersonaBar + persona-aware Sidebar + persona landing branch, KEEP existing routes) delivers 80% of the value at 5% of the risk. Route reorg is deferred to a separate SPEC (§6-A3).
+
+---
+
+## §5 v3 Persona Definitions (verified — docs/v3/)
+
+### 5.1 Source documents
+
+- `docs/v3/README.md` §1 "3-tier Persona 아키텍처" (line 22): "상단에 페르소나 스위치 (`PersonaBar`) · 3-tier: **Employee · RA · Admin** · 각각 별도 사이드바 IA. 페르소나별 화면 접근권한은 서버에서 강제."
+- `docs/v3/05_claude_code_playbook.md` table (lines 39-50): persona → screen → route mapping
+- `docs/v3/reference/data.jsx` (line 437, `personas`): 9 persona profiles (Employee 5, RA 3, Admin 1)
+- `docs/proposals/v3-architecture-revamp-plan-2026-07-02.md` §5.1 Phase D-2: master plan assignment
+
+### 5.2 Persona screen inventory (verified)
+
+**Employee (5 screens, 26 users — docs/v3/README.md §1.1):**
+1. Ask — `/ask` (new route, master plan) or reuse `/chat`
+2. MyQuestions — `/my-questions` (new) or reuse `/history`
+3. Products — `/products` (new) or reuse `/library`
+4. Guides — `/guides` (new)
+5. Impact — `/impact` (exists, but page gate blocks employee tier — §3.4)
+
+**RA (6 screens):**
+1. Inbox — `/inbox` (exists, SPEC-V3-INBOX-001)
+2. Consult — `/consult` (exists, SPEC-V3-CONSULT-001)
+3. Submissions — `/submissions` (new)
+4. Registry — `/registry` (new)
+5. Radar — `/radar` (new)
+6. Knowledge — `/knowledge` (exists) / `/knowledge-gap` (exists)
+
+**Admin (12 screens, 5 categories):**
+- Overview, Users, Corpus, Radar Sources, Logs, Settings, Personas, Usability, Backlog (per docs/v3/05_claude_code_playbook.md:50)
+
+### 5.3 Scope discipline for this SPEC
+
+This SPEC does NOT build all 23 persona screens. Those are separate SPECs per screen. This SPEC delivers the **shell-level infrastructure** that all persona screens will plug into:
+- `<PersonaBar />` component (3-tier switch)
+- `lib/auth/persona.ts` (tier derivation util)
+- Persona-aware Sidebar composition (filter existing NAV by tier)
+- Persona landing branch (`app/(app)/page.tsx` tier branch)
+
+Individual screens (Ask, MyQuestions, Registry, Radar, Admin 12) are **out of scope** and belong to follow-up SPECs.
+
+---
+
+## §6 Ambiguities & Risks (must surface in spec.md)
+
+### A1. SPEC ID collision with SPEC-V3-UI-001 — RESOLVED
+
+Master plan assigns Phase D-2 to "SPEC-V3-UI-001". But `SPEC-V3-UI-001` already exists (M6 RA Power Chat consult UI, completed — see `.moai/specs/SPEC-V3-UI-001/`). Creating a second SPEC with the same ID would collide in `.moai/specs/` directory and break `/moai run SPEC-V3-UI-001` routing.
+
+**Resolution:** This SPEC uses `SPEC-V3-PERSONA-001`. `parent_spec: SPEC-V3-UI-001` (since PersonaBar is the shell-level extension of the v3 UI work).
+
+### A2. Employee Impact access — KNOWN TENSION (deferred)
+
+docs/v3/README.md §1.1 lists "Impact Check" as an Employee screen. But the impact **page** gate (`impact.view`, `minRole: ra-member`, SPEC-V3-IMPACT-UI-001 REQ-IMP-UI-001) blocks Employee tier. The API (`impact.self_check`, `minRole: viewer`) is reachable, but the page is not.
+
+**Resolution:** This SPEC does NOT change the impact page gate (out of scope — RBAC change). Employee tier PersonaBar will show an "Impact" entry, but clicking it will hit the existing `ra-member` gate and redirect to `/?error=access_denied`. A follow-up SPEC (e.g., SPEC-V3-EMPLOYEE-IMPACT-001) will relax the page gate for Employee-tier impact self-check. This SPEC's Sidebar lists Impact for Employee tier as a **placeholder** (greyed or "RA 문의" CTA), deferring the gate change.
+
+### A3. Route reorg vs incremental — PUSH BACK ON MASTER PLAN (documented in spec.md §Risk)
+
+Master plan proposes full `((employee)|(ra)|admin)` route reorg. This research identifies **5 concrete regression risks** (§4). Charter-aligned recommendation: **incremental composition** (PersonaBar + tier-aware Sidebar + landing branch, KEEP existing flat routes). Route-group migration is deferred to SPEC-V3-ROUTE-REORG-001 (future).
+
+**Quantified push-back:**
+- Master plan route reorg: touches 25+ route dirs, ~50+ `<Link>` references, 10+ E2E tests, all RBAC gates. Regression surface: HIGH.
+- Incremental approach: 3 new files (PersonaBar.tsx, persona.ts, page.tsx branch), 2 modified files (Sidebar.tsx additive, layout.tsx). Regression surface: LOW (additive only, existing routes untouched).
+
+**Decision:** Incremental. Documented in spec.md §8 Exclusions and plan.md §6 Risk Mitigation.
+
+### A4. Persona-switch state persistence — DECISION NEEDED
+
+Should the persona switch persist across page refreshes?
+
+**Options:**
+- (a) **Cookie** (`regula-persona`, like `regula-locale`) — server-readable, survives refresh, works with SSR. Default-recommended.
+- (b) **URL query** (`/?persona=ra`) — shareable links, but pollutes URL and breaks if user navigates away.
+- (c) **localStorage** — client-only, breaks SSR (layout can't read it during render → hydration mismatch).
+- (d) **No persistence** — reset to role-derived default on every page load. Simplest, but loses user preference.
+
+**Resolution:** Default to (a) cookie `regula-persona`, mirroring the existing `regula-locale` pattern (layout.tsx:118 reads `regula-locale` cookie). Server-side readable for SSR consistency. The switch is **view-only** — it does NOT change the user's actual role or permissions (REQ-V3-PER-004). RBAC stays server-side authoritative.
+
+### A5. "View-as" admin impersonation — DEFERRED (optional REQ)
+
+Master plan mentions admin "감시" (monitoring) which could include view-as-persona for admins to see what an employee sees. This is a powerful admin feature but adds:
+- Complex state (admin's real role vs. viewed tier)
+- Security review (impersonation must not grant actual permissions)
+- UX complexity (exit impersonation flow)
+
+**Resolution:** Defer to future SPEC. This SPEC includes REQ-V3-PER-009 as an **optional/deferred** requirement (EARS "Where possible" pattern) so the architecture doesn't preclude it, but no implementation in v1.
+
+---
+
+## §7 Plan-auditor Focus Areas
+
+1. **Tier derivation is read-only** — `personaTier(role)` is a pure function over existing `Role`. Spec MUST NOT propose adding `tier` to DB, session, or `Role` union.
+2. **RBAC stays server-side** — PersonaBar switch is view-only. spec MUST state that `withPermission` / `hasRole` gates are unaffected (REQ-V3-PER-004).
+3. **Non-regression on existing routes** — spec MUST list existing flat routes as out-of-scope for renaming/moving (REQ-V3-PER-008).
+4. **Incremental over full reorg** — plan.md §6 MUST document the push-back on master plan's route reorg with quantified regression surface (§4 of this research).
+5. **SPEC ID collision avoided** — ID is `SPEC-V3-PERSONA-001`, NOT `SPEC-V3-UI-001` (which exists).
+6. **qa-lead tier mapping** — `qa-lead` (2.5) maps to RA tier, NOT admin. Spec MUST NOT place qa-lead in admin tier.
+7. **auditor tier mapping** — `auditor` (0.5) maps to Employee tier for navigation. Spec MUST NOT block auditor from the Employee persona view, but MUST preserve the existing write-block.
+8. **Cookie persistence decision** — spec MUST state the `regula-persona` cookie decision (A4) and justify it over localStorage (SSR consistency).
+
+---
+
+**Generated:** 2026-07-06
+**Inspection basis:** `lib/auth/rbac.ts` (lines 1-35), `lib/auth/permissions.ts` (lines 13-62, 190-280), `components/shell/Sidebar.tsx` (lines 1-120), `app/(app)/layout.tsx` (full 150L), `app/(app)/page.tsx` (lines 1-40), `app/(app)/` route listing, `docs/v3/README.md`, `docs/v3/05_claude_code_playbook.md`, `docs/proposals/v3-architecture-revamp-plan-2026-07-02.md` §5.1, existing `.moai/specs/SPEC-V3-IMPACT-UI-001/` (4-file template).

--- a/.moai/specs/SPEC-V3-PERSONA-001/spec.md
+++ b/.moai/specs/SPEC-V3-PERSONA-001/spec.md
@@ -1,0 +1,286 @@
+---
+id: SPEC-V3-PERSONA-001
+version: 0.1.0
+status: planned
+phase: D
+priority: High
+created: 2026-07-06
+updated: 2026-07-06
+author: manager-spec
+issue_number: TBD
+depends_on:
+  - SPEC-V3-IMPACT-UI-001
+  - SPEC-V3-CONSULT-001
+  - SPEC-V3-INBOX-001
+blocks: []
+parent_spec: SPEC-V3-UI-001
+lifecycle_level: spec-anchored
+labels:
+  - component/frontend
+  - component/shell
+  - domain/persona
+  - type/v3-new
+---
+
+# SPEC-V3-PERSONA-001 — 3-Tier PersonaBar (v3 Phase D)
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-07-06 | manager-spec | 초기 작성. v3 Phase D-2 3-tier PersonaBar + persona-aware Sidebar + persona landing branch. research.md 직검 기반 (L-013). REQ 10종 (8 functional + 2 optional/deferred). 마스터 플랜 route reorg → incremental push-back (§6-A3). SPEC ID collision 회피 (UI-001 → PERSONA-001, §6-A1). |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+v3 마스터 플랜(`docs/proposals/v3-architecture-revamp-plan-2026-07-02.md` §5.1 Phase D-2)은 3-tier 페르소나 아키텍처(Employee · RA · Admin)를 Regula의 핵심 shell 레벨 전환으로 지정했다. `docs/v3/README.md` §1 "3-tier Persona 아키텍처"에 따라 상단에 `<PersonaBar />` 배치, 각 페르소나는 별도 사이드바 IA를 가진다.
+
+현재 코드베이스는 role-gated 사이드바(`components/shell/Sidebar.tsx`, 482L)와 서버 사이드 RBAC flag 산출(`app/(app)/layout.tsx`, 150L)을 이미 갖추고 있다. 본 SPEC은 이 위에 **3-tier 페르소나 전환 레이어**를 추가한다 — 단, 기존 라우트와 RBAC를 보존하는 **점진적(incremental)** 방식으로 (research.md §4, §6-A3).
+
+> **PUSH-BACK on master plan:** 마스터 플랜은 `app/((employee)|(ra)|admin)/` 풀 라우트 재구성을 제안하지만, 본 SPEC은 이를 **거부**하고 incremental 접근을 취한다. 이유: 25+ 라우트 디렉토리 이동, 50+ `<Link>` 참조 갱신, 10+ E2E 테스트 깨짐, 모든 RBAC 게이트 재작업 = 높은 회귀 위험. 6-8인 내부 팀(Charter)에 점진적 가치 전달이 적합. 라우트 재구성은 별도 SPEC-V3-ROUTE-REORG-001로 이월 (research.md §6-A3).
+
+### 1.2 핵심 가치
+
+- **페르소나 중심 전환:** 사용자가 자신의 역할에 해당하는 tier(Employee/RA/Admin)로 진입해 맞춤형 IA를 본다.
+- **기존 투자 보존:** consult, inbox, impact, triage 등 완성된 v3 컴포넌트/라우트를 **재작성 없이** persona-aware 레이어로 감싼다.
+- **서버 사이드 RBAC 불변:** PersonaBar 전환은 **뷰 전용**(view-only). `withPermission` / `hasRole` 서버 게이트는 그대로 동작한다 (Charter [정직성] — 권한 우회 금지).
+- **점진적 가치 전달:** PersonaBar + Sidebar 필터 + 랜딩 분기만으로 23개 페르소나 화면이 plug-in 할 수 있는 shell 인프라 완성.
+
+### 1.3 페르소나 정의 (verified — research.md §2.3)
+
+> **역할 래더 (verified, `lib/auth/rbac.ts:16-26`):** admin=4 > ra-lead=3 > qa-lead=2.5 > ra-member=2 > viewer=1 > auditor=0.5. `employee` 역할은 존재하지 않는다. Employee 페르소나 = `viewer`(+`auditor`) 역할 매핑.
+
+| 페르소나 Tier | 포함 역할 | Hierarchy | 대상 사용자 |
+|---|---|---|---|
+| Employee | `viewer`, `auditor` | 0.5 – 1 | 전사 직원 (26명, docs/v3/README.md §1.1) — 셀프서비스 Q&A |
+| RA | `ra-member`, `qa-lead`, `ra-lead` | 2 – 3 | RA 담당자 — 워크벤치 (Inbox, Consult, Authoring) |
+| Admin | `admin` | 4 | 관리자 — 감시 (users, corpus, audit, settings) |
+
+> **qa-lead 매핑 주의:** `qa-lead` (2.5)는 RA tier이다 (rbac.ts:19-20 comment: "QA lead can perform member-level work by default"). Admin tier가 아님.
+> **auditor 매핑 주의:** `auditor` (0.5)는 Employee tier이다 (탐색 목적). 단 기존 write-block(`withPermission`)은 그대로 유지된다 — PersonaBar가 이를 우회하지 않는다 (REQ-V3-PER-004).
+
+### 1.4 비목표 (Charter 정렬)
+
+- 23개 페르소나 화면(Ask, MyQuestions, Registry, Radar, Admin 12종 등) 개별 구현 X — 본 SPEC은 **shell 인프라**만. 개별 화면은 별도 SPEC.
+- 라우트 그룹 재구성(`(employee)/(ra)/admin`) X — incremental 접근, 기존 flat 라우트 보존 (research.md §6-A3).
+- 백엔드 변경 X — migration, schema, RBAC enum, audit 로그 변경 없음. Tier는 순수 클라이언트 derivation.
+- ESIG, 실시간 알림, admin impersonation(view-as) X — future SPEC (REQ-V3-PER-009로 명시만).
+
+---
+
+## §2 Scope
+
+### 2.1 In Scope
+
+1. `components/shell/PersonaBar.tsx` 신규 — 3-tier 전환 컴포넌트 (Employee/RA/Admin).
+2. `lib/auth/persona.ts` 신규 — `personaTier(role)` 순수 함수 + `regula-persona` 쿠키 읽기/쓰기 유틸.
+3. `components/shell/Sidebar.tsx` 수정(additive) — `tier` prop 추가, tier 기반 NAV 필터(기존 `show*`/`NAV_ITEMS`/`userRole` 비파괴 확장).
+4. `app/(app)/layout.tsx` 수정 — `auth()` → `personaTier(role)` → `<PersonaBar tier={...}>` + `<Sidebar tier={...}>` 전달.
+5. `app/(app)/page.tsx` 수정 — tier-level 랜딩 분기 (기존 `ROLE_ENTRIES` 위에 tier 분기 추가).
+6. `messages/ko.json` / `messages/en.json` — `persona` 키 신규 추가.
+7. `components/shell/__tests__/` — Vitest + RTL 단위 테스트.
+
+### 2.2 Out of Scope (Exclusions)
+
+- 백엔드 4계층 로직, 마이그레이션, RBAC enum 추가 — frozen.
+- 23개 페르소나 화면(Ask, MyQuestions, Products, Guides, Submissions, Registry, Radar, Admin 12종) — 별도 SPEC.
+- 라우트 그룹 재구성(`(employee)|(ra)|admin`) — SPEC-V3-ROUTE-REORG-001로 이월 (research.md §6-A3).
+- Employee Impact self-check 페이지 게이트 완화(`impact.view` 현재 `ra-member`) — SPEC-V3-EMPLOYEE-IMPACT-001로 이월 (research.md §6-A2).
+- Admin view-as / impersonation 플로우 — future SPEC (REQ-V3-PER-009 optional).
+- SearchPalette(`/` command palette) — v1은 PersonaBar + Sidebar만. SearchPalette는 future SPEC.
+
+---
+
+## §3 Functional Requirements (EARS)
+
+> **Verified basis:** 모든 REQ는 research.md §2-§3에 직검 검증된 `Role` union, `ROLE_HIERARCHY`, `PERMISSION_MAP`, Sidebar props, layout 패턴에 근거한다. Tier는 클라이언트 사이드 순수 derivation이다 (`lib/auth/persona.ts`의 `personaTier(role)`).
+
+### REQ-V3-PER-001: PersonaBar 3-Tier 전환 컴포넌트
+
+**WHEN** 인증된 사용자가 앱 셸에 진입하면, **THE SYSTEM SHALL** 상단(Topbar 또는 그 하위)에 3개 tier(Employee / RA / Admin) 전환 버튼을 가진 `<PersonaBar />`를 렌더링한다.
+
+**THE SYSTEM SHALL** 사용자의 현재 역할에서 파생된 기본 tier를 `personaTier(role)`로 산출하여 활성 버튼으로 표시한다 (verified derivation — research.md §2.3).
+
+**WHILE** 사용자의 역할이 `viewer` 또는 `auditor`일 때, **THE SYSTEM SHALL** Employee tier 버튼만 활성화하고 RA/Admin 버튼은 비활성화(disabled)한다 — 권한 없는 tier로 전환 시도 차단.
+
+**WHILE** 사용자의 역할이 `ra-member`, `qa-lead`, 또는 `ra-lead`일 때, **THE SYSTEM SHALL** Employee와 RA tier 버튼을 활성화하고 Admin 버튼은 비활성화한다.
+
+**WHERE** 사용자의 역할이 `admin`일 때, **THE SYSTEM SHALL** 세 tier 모두 활성화한다.
+
+### REQ-V3-PER-002: Persona 인지 Sidebar 필터
+
+**WHEN** PersonaBar의 활성 tier가 변경되면, **THE SYSTEM SHALL** `<Sidebar />`가 해당 tier에 맞게 네비게이션 항목을 필터링하여 표시한다.
+
+**THE SYSTEM SHALL** 기존 `NAV_ITEMS`(홈/새상담/히스토리/설정)와 `show*` props를 **비파괴적으로** 확장하여, tier가 `employee`일 때는 Employee 대상 항목(Ask, MyQuestions, Products, Guides)을, `ra`일 때는 RA 대상 항목(Inbox, Consult, Impact, Knowledge)을, `admin`일 때는 Admin 대상 항목(Users, Corpus, Audit, Settings)을 우선 노출한다.
+
+**IF** 항목이 해당 tier에 속하지 않으면, **THE SYSTEM SHALL** 해당 항목을 숨기거나(기본) 또는 비활성화된 "RA 전용" 배지로 표시한다 (UX 확정은 run-phase).
+
+> **H3 — 비파괴 확장 (run-phase 주의):** 기존 `show*` props와 `userRole` prop은 **삭제하지 않는다**. Sidebar는 이미 `userRole`로 NAV를 필터 중이다 (line 79). 새 `tier` prop은 **additive**하며, 기존 로직을 대체하지 않는다. run-phase에서 `show*` props 제거 시 기존 SPEC-REGULA-* / SPEC-V3-* 테스트가 깨진다.
+
+> **H4 — NAV_ITEMS 고정 + tier filter precedence (plan-auditor H1/H2 개정, 2026-07-06):** 4개 핵심 `NAV_ITEMS`(홈/새상담/히스토리/설정)은 REQ-FND-019가 정한 고정 순서로 primary `<nav>`에 **tier 값과 무관하게 항상** 렌더링된다 (`tests/unit/frontend-shell.test.ts`의 `navLinks.length === 4` / `toEqual(['/', '/chat', '/history', '/settings'])` 단언 준수). tier별 항목은 **별도 `<nav>` 블록**에 기존 `show*` 조건부 패턴과 동일 방식으로 additive 렌더링한다. `tier` prop이 설정된 경우 tier filter가 `show*` props에 **AND 결합**으로 우선 적용된다 (예: admin이 Employee tier 전환 시 `showInbox=true`여도 Inbox는 미노출). `tier`가 `undefined`인 경우 기존 `show*`-only 동작을 보존한다 (비회귀).
+
+### REQ-V3-PER-003: Persona 랜딩 페이지 분기
+
+**WHEN** 사용자가 `/` (home) 경로로 진입하면, **THE SYSTEM SHALL** `auth()`로 역할을 읽고 `personaTier(role)`로 tier를 파생하여 tier별 랜딩 섹션을 렌더링한다.
+
+**THE SYSTEM SHALL** 기존 `ROLE_ENTRIES`(`app/(app)/page.tsx`)를 재사용하여 tier 분기를 추가한다 — Employee tier는 Ask/Impact/Products 진입점, RA tier는 Inbox/Consult/Triage 진입점, Admin tier는 Users/Corpus/Audit 진입점.
+
+**WHERE** `regula-persona` 쿠키가 존재하면, **THE SYSTEM SHALL** 쿠키 값을 우선 적용하여 사용자가 마지막으로 선택한 tier로 랜딩한다 (단, 쿠키 tier가 역할에서 파생된 tier보다 권한이 높으면 거부하고 역할 기반 tier로 폴백 — REQ-V3-PER-004 준수).
+
+### REQ-V3-PER-004: 서버 사이드 RBAC 불변 (보안 핵심)
+
+**THE SYSTEM SHALL** PersonaBar 전환이 사용자의 실제 권한을 변경하지 않도록 보장한다 — 전환은 **뷰 전용**(view-only)이며, 모든 서버 사이드 `withPermission` / `hasRole` 게이트는 사용자의 **실제 역할**(`session.user.role`)을 기준으로 동작한다.
+
+**IF** Employee tier 사용자가 RA 전용 라우트(`/inbox`, `/consult` 등)로 직접 진입하면, **THE SYSTEM SHALL** 기존 RBAC 게이트가 그대로 동작하여 `/?error=access_denied`로 리다이렉트한다 — PersonaBar 전환 상태와 무관.
+
+> **H1 — 권한 우회 금지 (Charter [정직성]):** PersonaBar는 사용자가 볼 수 있는 IA를 바꿀 뿐, 실제 권한을 부여하지 않는다. 예: `viewer` 역할 사용자가 PersonaBar로 "RA"를 선택해도 `/inbox` 접근 시 서버 게이트가 거부한다. 이는 보안 불변량이며 테스트로 강제된다.
+
+### REQ-V3-PER-005: Persona 전환 상태 영속 (Cookie)
+
+**WHEN** 사용자가 PersonaBar에서 다른 tier를 선택하면, **THE SYSTEM SHALL** `regula-persona` 쿠키에 해당 tier 값을 저장한다.
+
+**THE SYSTEM SHALL** 쿠키를 서버 사이드에서 읽을 수 있도록 설정한다 (`httpOnly: false`, `path: '/'`, `sameSite: 'lax'`) — `layout.tsx`가 SSR 시 읽어 hydration mismatch를 방지 (research.md §6-A4 — localStorage 사용 시 SSR 불가).
+
+**THE SYSTEM SHALL** 쿠키의 tier 값이 사용자 역할에서 파생 가능한 tier 범위를 벗어나면(예: `viewer` 역할인데 쿠키가 `admin`), 쿠키를 무시하고 역할 기반 기본 tier로 폴백한다 (REQ-V3-PER-004 보강).
+
+> **A4 결정 (research.md):** localStorage가 아닌 cookie를 사용하는 이유 — `layout.tsx`(server component)가 SSR 시 읽을 수 있어야 hydration mismatch가 발생하지 않는다. localStorage는 클라이언트 전용이므로 SSR 시 빈 상태 렌더링 → 클라이언트 hydration 후 전환 → 깜빡임 발생. `regula-locale` 쿠키(layout.tsx:118)가 동일 패턴으로 입증되었다.
+
+### REQ-V3-PER-006: 접근성 (WCAG 2.1 AA)
+
+**WHEN** PersonaBar가 렌더링되면, **THE SYSTEM SHALL** 3개 tier 버튼을 `role="tablist"` / `role="tab"` ARIA 패턴으로 구현하고 `aria-selected` 상태를 활성 tier에 표시한다.
+
+**THE SYSTEM SHALL** 키보드 사용자가 Tab으로 버튼 사이를 이동하고 Enter/Space로 tier를 선택할 수 있게 한다.
+
+**THE SYSTEM SHALL** PersonaBar의 모든 색상 조합이 light/dark 모두에서 WCAG 2.1 AA 대비를 만족한다 (`ci:contrast` 게이트).
+
+### REQ-V3-PER-007: 국제화 (i18n)
+
+**THE SYSTEM SHALL** 모든 PersonaBar 가시 문자열(tier 이름, 툴팁, 비활성화 사유 등)을 `next-intl`의 `persona.*` 네임스페이스 키로 관리한다 (`messages/ko.json` + `messages/en.json`).
+
+**THE SYSTEM SHALL** tier 이름을 로켈별로 표시한다 — ko: "전사 직원 / RA 담당자 / 관리자", en: "Employee / RA / Admin".
+
+### REQ-V3-PER-008: 비회귀 (기존 라우트 보존)
+
+**THE SYSTEM SHALL** 기존 `app/(app)/` flat 라우트 구조(admin, audit, chat, consult, dashboard, history, impact, inbox, knowledge, settings, triage 등 25+ 디렉토리)를 변경하지 않는다 — 라우트 이동/이름 변경/그룹화 금지.
+
+**THE SYSTEM SHALL** 기존 `NAV_ITEMS` 순서(REQ-FND-019 계약)와 `frontend-shell.test.ts` 단언을 깨뜨리지 않는다 — Sidebar 수정은 **additive**(`tier` prop 추가)이며 기존 prop 제거 없음.
+
+**THE SYSTEM SHALL** 기존 SPEC-REGULA-* 및 SPEC-V3-*(INBOX/TRIAGE/IMPACT/CONSULT/UI) 컴포넌트/라우트에 영향을 주지 않는다.
+
+### REQ-V3-PER-009: Admin View-as (OPTIONAL / DEFERRED)
+
+**WHERE** 기능 플래그 `FEATURE_FLAGS.PERSONA_VIEW_AS`가 활성화되면, **THE SYSTEM SHALL** `admin` 역할 사용자가 다른 tier의 IA를 미리보기 할 수 있는 "view-as" 모드를 제공한다 (선택적).
+
+> **v1 비구현:** 본 REQ는 아키텍처가 이를 배제하지 않도록 명시만 해둔다. 구현은 future SPEC (research.md §6-A5). View-as는 **뷰 전용**이며 실제 권한 부여 없음 (REQ-V3-PER-004 준수).
+
+### REQ-V3-PER-010: SearchPalette (OPTIONAL / DEFERRED)
+
+**WHERE** 기능 플래그 `FEATURE_FLAGS.SEARCH_PALETTE`가 활성화되면, **THE SYSTEM SHALL** `/` 키 또는 Cmd+K로 여는 전역 검색 팔레트를 제공하여 tier 무관 모든 라우트로 점프할 수 있게 한다 (선택적).
+
+> **v1 비구현:** master plan이 언급한 SearchPalette, ModalHost, ToastHost는 v1 범위 밖. 본 SPEC은 PersonaBar + Sidebar + landing만. SearchPalette는 future SPEC.
+
+---
+
+## §4 Non-Functional Requirements
+
+### REQ-V3-PER-NFR-001: 성능
+
+**THE SYSTEM SHALL** PersonaBar 초기 렌더링을 500ms 이내에 완료한다 (서버 사이드 tier 파생 + 클라이언트 hydration).
+
+**THE SYSTEM SHALL** tier 전환 시 전체 페이지 리로드 없이 클라이언트 사이드에서 Sidebar/landing을 재렌더링한다 (쿠키만 갱신, navigation 없음).
+
+### REQ-V3-PER-NFR-002: 보안
+
+**THE SYSTEM SHALL** `regula-persona` 쿠키 값을 신뢰하지 않고, 매 요청마다 `session.user.role`에서 tier를 재파생하여 쿠키 값을 검증한다 (쿠키 변조 방지 — REQ-V3-PER-004 강제).
+
+**THE SYSTEM SHALL** 쿠키에 `httpOnly: false`를 사용하되(클라이언트 읽기 필요), tier 권한 상승은 서버가 거부한다.
+
+### REQ-V3-PER-NFR-003: 유지보수성
+
+**THE SYSTEM SHALL** `lib/auth/persona.ts`를 단일 책임 순수 함수로 유지한다 — `personaTier(role): Tier`, `isValidTierForRole(role, tier): boolean`, 쿠키 유틸. 부작용 없음.
+
+**THE SYSTEM SHALL** PersonaBar 컴포넌트를 presentation-only로 유지하고, tier 상태 관리는 `layout.tsx`가 서버 사이드에서 주입.
+
+### REQ-V3-PER-NFR-004: 비회귀
+
+**THE SYSTEM SHALL** 기존 `pnpm test` full suite (특히 `frontend-shell.test.ts`, SPEC-REGULA-* / SPEC-V3-* 테스트)가 모두 통과한다 — Sidebar 수정은 additive, 라우트 변경 없음.
+
+---
+
+## §5 Data Model
+
+본 SPEC은 DB 스키마를 정의하지 않는다 (Tier는 클라이언트 사이드 derivation). 다음 타입만 사용한다:
+
+```ts
+// lib/auth/persona.ts
+type Tier = 'employee' | 'ra' | 'admin';
+
+// Pure derivation from existing Role (no DB/session changes)
+export function personaTier(role: Role): Tier;
+export function isValidTierForRole(role: Role, tier: Tier): boolean;
+
+// Cookie utils (mirrors regula-locale pattern)
+export const PERSONA_COOKIE = 'regula-persona';
+export function readPersonaCookie(cookieStore: ReadonlyRequestCookies): Tier | null;
+export function writePersonaCookie(tier: Tier): void;
+```
+
+---
+
+## §6 API Contract
+
+본 SPEC은 API를 정의하지 않는다. PersonaBar는 순수 클라이언트 사이드 상태(cookie)이며, 백엔드 API 호출 없음.
+
+---
+
+## §7 Dependencies
+
+### 7.1 Internal
+- `@/lib/auth` (`auth()`, `session.user.role`) — 서버 사이드 역할 읽기.
+- `@/lib/auth/rbac` (`Role`, `ROLE_HIERARCHY`, `hasRole`) — tier 파생 입력.
+- `components/shell/Sidebar.tsx` — `tier` prop additive 확장.
+- `components/shell/Topbar.tsx` — PersonaBar 배치 위치.
+- `next-intl` — i18n.
+- Tailwind v4 `@theme` — design tokens.
+
+### 7.2 External
+- Radix UI `Tabs` primitive — 접근성 있는 tier 전환 (선택).
+
+### 7.3 NOT Imported
+- `/api/persona` — 백엔드 API 없음 (tier는 클라이언트 derivation).
+- localStorage / Zustand — SSR 불가 / 과잉 추상화 (research.md §6-A4).
+
+---
+
+## §8 Exclusions (What NOT to Build)
+
+[HARD] 본 SPEC의 제외 항목:
+
+1. **23개 페르소나 화면(Ask, MyQuestions, Products, Guides, Submissions, Registry, Radar, Admin 12종)** — 개별 화면은 별도 SPEC. 본 SPEC은 shell 인프라만.
+2. **라우트 그룹 재구성(`(employee)|(ra)|admin`)** — SPEC-V3-ROUTE-REORG-001로 이월. 기존 flat 라우트 보존 (research.md §6-A3). 마스터 플랜의 풀 재구성 제안을 **거부**하고 incremental 접근 채택.
+3. **백엔드 변경(migration, schema, RBAC enum, audit)** — Tier는 순수 클라이언트 derivation.
+4. **Employee Impact self-check 페이지 게이트 완화** — 현재 `impact.view`(`minRole: ra-member`)가 Employee tier 차단. 완화는 SPEC-V3-EMPLOYEE-IMPACT-001로 이월 (research.md §6-A2).
+5. **Admin view-as / impersonation** — future SPEC (REQ-V3-PER-009로 명시만).
+6. **SearchPalette / ModalHost / ToastHost** — future SPEC (REQ-V3-PER-010으로 명시만).
+
+---
+
+## §9 Open Questions (Run-Phase Resolution)
+
+| ID | Question | Default | Plan-auditor focus |
+|---|---|---|---|
+| OQ-1 | tier 불일치 시 UX(숨김 vs 비활성 배지) 확정 | 비활성 + 툴팁 | 접근성 / 혼란 방지 |
+| OQ-2 | PersonaBar 배치 위치(Topbar 내장 vs 독립 행) | Topbar 우측 | 레이아웃 일관성 |
+| OQ-3 | Employee tier의 Impact 진입점 처리(placeholder vs 숨김) | placeholder "RA 문의" CTA | A2 정렬 |
+| OQ-4 | `phase: D` 라벨 roadmap 교차 검증 | orchestrator 지시 따름 | — |
+
+---
+
+**생성일:** 2026-07-06
+**버전:** 0.1.0
+**상태:** planned
+**총 REQ:** 10 functional (8 mandatory + 2 optional/deferred) + 4 NFR
+**다음 단계:** plan.md 구현 계획 수립 → acceptance.md 검증 시나리오 → plan-auditor 감사


### PR DESCRIPTION
## 개요
Phase D 첫 SPEC — v3 마스터 계획의 3-tier PersonaBar (Employee/RA/Admin) plan 산출물. **점진적 접근** 채택 (전체 route reorg는 회귀 위험으로 SPEC-V3-ROUTE-REORG-001 이월).

## 산출물 (1336줄, .moai/specs/SPEC-V3-PERSONA-001/)
| 파일 | 줄 | 내용 |
|---|---|---|
| research.md | 246 | codebase 분석(Sidebar 482L/layout/permissions) + 3-persona 매핑 + tier→role + 마스터 vs incremental 트레이드오프 |
| spec.md | 284 | 10 functional REQ + 4 NFR (EARS). ID 충돌 회피(UI-001→PERSONA-001) |
| acceptance.md | 279 | 8 AC + 8 edge cases + DoD |
| plan.md | 527 | 6 milestones + §3 files + §4 아키텍처 + §7 deps |

## 핵심 설계 결정 3종
1. **점진적 접근** — 마스터 plan의 `app/((employee)|(ra)|admin)` 전체 route reorg는 25+ route 이동/50+ Link/10+ E2E 깨짐 = HIGH 회귀. additive tier prop + PersonaBar로 80% 가치. Charter 6-8인 팀 부합.
2. **cookie persistence** (`regula-persona`) — localStorage 아닌 cookie (SSR 안전, `regula-locale` 패턴 준용). 단 쿠키 값 신뢰 안 함 → 매 요청 `isValidTierForRole(role, cookie.tier)` 검증.
3. **tier→role 매핑** — Employee(viewer/auditor) / RA(ra-member/qa-lead/ra-lead) / Admin(admin). 클라이언트 순수 derivation, 백엔드 비파괴.

## plan-auditor 결과: PASS-WITH-CONDITIONS (Critical 0)
- ✅ **H1/H2 해결** (본 PR): REQ-V3-PER-002에 H4 조항 추가 — NAV_ITEMS 4개 고정(frontend-shell.test.ts 비회귀) + tier filter AND 결합(admin→Employee 전환 시 show* 무시).
- ✅ **M2 검증**: `ci:contrast` + `@axe-core/playwright` package.json 존재 확인.
- ⏭️ **M1/M3/Minor**: run phase에서 해결 (Topbar.tsx §3 정리, NFR-002 httpOnly 명시, edge case AC 매핑 등).

## 강점 (auditor)
- 허구 0: 모든 Role/hierarchy/permission/route/SPEC-ID 코드베이스 검증 (rbac.ts, permissions.ts, Sidebar.tsx, layout.tsx, docs/v3/)
- RBAC bypass 중립화: server-side session.user.role 불변, tier는 view-only
- qa-lead=RA / auditor=Employee 엣지 명시

## 다음 단계
annotation 승인 후 → `/moai run SPEC-V3-PERSONA-001` (M1 PersonaBar + tier detection → M6 non-regression E2E)

Refs SPEC-V3-PERSONA-001

🗿 MoAI <email@mo.ai.kr>