### PR TITLE
docs(spec): SPEC-V3-AUDIT-CHAIN-001 Phase E audit hash chain plan 산출물 4종

### DIFF
--- a/.moai/specs/SPEC-V3-AUDIT-CHAIN-001/acceptance.md
+++ b/.moai/specs/SPEC-V3-AUDIT-CHAIN-001/acceptance.md
@@ -1,0 +1,241 @@
+# Acceptance Criteria — SPEC-V3-AUDIT-CHAIN-001 (v0.2.0)
+
+audit_log SHA-256 hash chain strengthening (v3 Phase E / D-1).
+
+본 파일은 Given-When-Then 시나리오와 관측 가능한 증거를 정의한다.
+모든 AC 는 테스트 또는 런타임 점점으로 검증되어야 한다 (Agent Core Behavior #6).
+
+> **v0.2.0 (2026-07-06)**: C1/C2/C3/H1/H2 해소. AC-5 재작성 (C2 점화식), AC-5b (M2), AC-5c (M1), AC-9 (H2), AC-10 (C3) 신규. AC-4 카운트 197→191 (H1). EC-1 재작성 (fork tolerated → prevented). typo m4/m5 수정.
+
+---
+
+## AC-1: 신규 행 INSERT 시 previous_hash 자동 populate
+
+**Given** `audit_logs` 테이블이 비어 있거나 직전 행의 `previous_hash` 가 존재하는 상태에서,
+**When** `writeAudit({ actor_id: null, action: 'llm.call', resource_type: 'message', resource_id: 'm-1' })` 를 호출하면,
+**Then** 새로 INSERT 된 행의 `previous_hash` 컬럼이 64자 소문자 hex 문자열로 채워진다.
+
+**증거 (observable)**:
+- `SELECT previous_hash FROM audit_logs WHERE id = <new>` 결과가 `/^[0-9a-f]{64}$/` 매치.
+- SHA-256 canonical 입력을 독립적으로 재계산한 결과와 일치.
+- `id` 컬럼이 app-side `crypto.randomUUID()` 로 생성한 값과 일치 (C1, REQ-AC-012).
+
+---
+
+## AC-2: 연속 INSERT chain 연속성
+
+**Given** 행 A 가 INSERT 된 후,
+**When** 행 B 를 `writeAudit(...)` 로 INSERT 하면,
+**Then** 행 B 의 `previous_hash` 계산 입력에 행 A 의 chain hash 값이 포함된다.
+
+**증거**:
+- 행 B 의 `previous_hash` 를 계산한 canonical string 안에 행 A 의 chain hash (hex) 가 prefix 로 포함됨을 독립 재계산으로 확인.
+- 행 A 의 필드를 바꾸면 행 A 의 chain hash 가 바뀌고 행 B 의 `previous_hash` 재계산 결과도 달라짐 (cascade integrity).
+
+---
+
+## AC-3: Transaction 원자성 (tx 롤백 시 해시도 롤백)
+
+**Given** caller 가 `db.transaction(async (tx) => { await mutation(); await writeAudit(params, tx); throw new Error('rollback'); })` 을 실행할 때,
+**When** tx 가 롤백되면,
+**Then** audit 행 INSERT 와 해시 계산 결과가 모두 롤백된다. audit_logs 에 행이 남지 않는다.
+
+**증거**:
+- `SELECT count(*) FROM audit_logs WHERE id = <would-be>` = 0.
+- 동일 caller 의 다음 호출 시 직전 행 조회가 롤백된 행을 보지 않는다 (chain 일관성 유지).
+- advisory_xact_lock 도 tx 단위라 롤백 시 자동 해제됨 (C3).
+
+---
+
+## AC-4: 기존 호출 지점 시그니처 호환 (회귀 게이트, H1 fix)
+
+**Given** **191** 개 프로덕션 `writeAudit(...)` 호출 지점 (실 grep 결과; H1 fix) 이 변경되지 않은 상태에서,
+**When** `pnpm ci:audit` (또는 lint/typecheck) 를 실행하면,
+**Then** 시그니처 관련 에러가 0건이다. 모든 기존 호출이 그대로 컴파일/런타임 통과한다.
+
+**증거**:
+- `pnpm typecheck` 0 errors.
+- `grep -rn "writeAudit(" --include="*.ts" --include="*.tsx" lib app | grep -v __tests__ | grep -v "export async function writeAudit" | wc -l` = **191** (이전과 동일 — 회귀 게이트). distinct 파일 = 117.
+- `pnpm ci:audit` 통과.
+
+> H1 fix 근거: 2026-07-06 실 grep. 구 버전 "197" 은 부정확. research.md §2 참조.
+
+---
+
+## AC-5: verifyAuditChain 변조 탐지 (C2 점화식 — binary-testable)
+
+**Given** 3개의 연속 audit 행 (A → B → C) 이 올바른 chain 으로 INSERT 된 후,
+**When** 행 B 의 `meta_json` 을 임의로 변조하고 (테스트 환경에서 append-only 트리거를 일시적 bypass 또는 검증 전용 복제본 사용) `verifyAuditChain({ from: A.created_at, to: C.created_at })` 를 호출하면,
+**Then** C2 점화식에 의해 행 B 의 변조가 `chainHash_B` 변화 → `row_C.previous_hash ≠ chainHash_B` 위반으로 탐지된다. 반환된 위반 배열이 `{ rowId: C.id, expected: chainHash_B (재계산), actual: row_C.previous_hash }` 형태로 행 C 를 보고한다.
+
+**C2 점화식 (binary-testable assertion)**:
+- `chainHash_0 = "<genesis>"` (literal sentinel).
+- `chainHash_N = SHA256( canonical(row_N.fields_without_previous_hash) ‖ chainHash_{N-1} )` (N ≥ 1).
+- Assertion: `row_N.previous_hash MUST equal chainHash_{N-1}`.
+- 행 B (`row_B`) 필드 변조 → `chainHash_B` 변화 → `row_C.previous_hash` (== 구 `chainHash_B`) ≠ 신 `chainHash_B` → 위반.
+
+**증거**:
+- 위반 배열 길이 ≥ 1, `rowId` === 행 C 의 UUID (변조된 행 B 의 다음 행).
+- 행 B 자체도 cascade 위반으로 보고될 수 있음 (행 A 의 chain hash 가 안 바뀌었으므로 `row_B.previous_hash` == 구 `chainHash_A` 유지 → 행 B 자체는 위반 아님; 다음 행 C 부터 위반). 이 cascade 동작은 점화식과 일치함을 테스트로 확인.
+
+> 구현 참고: 테스트 환경에서 append-only 트리거를 우회하는 방법은 run phase 에서 설계.
+> 예: (a) 테스트 전용 schema 의 복제 테이블 사용, (b) 검증 함수 자체를 직접 호출하여
+> 행 데이터를 메모리에서 변조한 입력으로 재계산 (단위 테스트 방식).
+
+> m4 fix: "트리저를" → "트리거를" (typo).
+
+---
+
+## AC-5b (M2): Canonical 필드 순서 민감성
+
+**Given** 동일 값들을 가지지만 canonical 직렬화 순서가 다른 두 행 row_X (정상 순서) 와 row_X' (`actor_id` 와 `action` 필드를 swap 한 변형) 가 있을 때,
+**When** 각각의 chain hash 를 독립 계산하면,
+**Then** 두 해시가 달라야 한다. 필드 순서가 바뀌면 반드시 해시가 달라짐 (REQ-AC-005).
+
+**증거**:
+- `computeAuditRowHash(prev, row_X) !== computeAuditRowHash(prev, row_X_swapped)`.
+- 위반 배열에 순서가 바뀐 행이 포함됨.
+
+---
+
+## AC-5c (M1): Genesis populate (빈 테이블 첫 행)
+
+**Given** `audit_logs` 테이블이 완전히 비어 있는 상태에서,
+**When** 최초의 `writeAudit(...)` 가 호출되면,
+**Then** 신규 행의 `previous_hash` 는 `SHA256(canonical(row.fields) ‖ "<genesis>")` 이며 `chain_seq = 1` 이다.
+
+**증거**:
+- `SELECT previous_hash, chain_seq FROM audit_logs WHERE id = <first>` → 64-char hex, `chain_seq = 1`.
+- 독립 재계산: `SHA256(canonical(row) ‖ "<genesis>")` 와 일치.
+- `verifyAuditChain` 은 이 행을 위반으로 보고하지 않음 (segment 시작).
+
+---
+
+## AC-6: NULL segment 경계 (전략 B, false positive 없음)
+
+**Given** `previous_hash = NULL` 인 과거 행 (pre-chain) P 와 그 이후 chain 이 시작된 행 Q 가 있을 때,
+**When** `verifyAuditChain({ from: P.created_at, to: <future> })` 를 호출하면,
+**Then** P 행 자체는 위반으로 보고되지 않고, Q 부터의 chain 만 검증된다.
+
+**증거**:
+- 반환된 위반 배열에 `rowId: P.id` 가 없음.
+- Q 의 `previous_hash` 가 P 의 hash 와 무관하게 독립적으로 검증됨.
+
+---
+
+## AC-7: 크론 위반 시 alert audit event 기록
+
+**Given** 일일 크론 `audit-chain-verify-daily` 가 발화하고 지난 24시간 윈도우에 위반이 존재할 때,
+**When** 크론 함수가 실행을 완료하면,
+**Then** `audit_logs` 에 단일 system-actor audit event 가 기록된다 (예: action `audit_chain.violation_detected`, resource_type `audit_logs`, meta_json 에 위반 row id 배열).
+
+**증거**:
+- `SELECT count(*) FROM audit_logs WHERE action = 'audit_chain.violation_detected' AND created_at >= <cron_run_time>` ≥ 1.
+- meta_json.violations 배열 길이 ≥ 1.
+- 크론 자체는 실패하지 않음 (실패 처리 audit 는 별도).
+
+---
+
+## AC-8: 빈 윈도우 graceful 종료
+
+**Given** 지난 24시간에 audit 행이 0개인 상태에서,
+**When** 크론이 발화하면,
+**Then** 위반 없이 정상 종료하고, alert audit event 를 기록하지 않는다.
+
+**증거**:
+- 크론 exit code 0.
+- `SELECT count(*) FROM audit_logs WHERE action = 'audit_chain.violation_detected'` = 0 (해당 크론 run 기준).
+
+> m5 fix: "크른" → "크론" (typo).
+
+---
+
+## AC-9 (H2): AuditDbHandle widening 호환성
+
+**Given** 기존 ~24개 `db.transaction(async (tx) => { ... writeAudit(params, tx) })` 호출 지점이 존재하며,
+**When** `AuditDbHandle` 타입이 `{ insert: ...; select: ... }` 로 widen 될 때,
+**Then** 모든 기존 tx 전달 호출이 typecheck error 없이 호환된다. Drizzle `PgTransaction` 은 이미 두 capability 를 가지므로 real tx 객체는 변경 불필요.
+
+**증거**:
+- `pnpm typecheck` 0 errors.
+- narrowed tx wrapper (존재할 경우) 는 감사되어 widening 또는 교체됨.
+
+---
+
+## AC-10 (C3): 동시성 직렬화 — chain fork 방지
+
+**Given** 두 개의 동시 `writeAudit` tx (T1, T2) 가 같은 직전 행을 대상으로 동시에 시작될 때,
+**When** 두 tx 가 `pg_advisory_xact_lock(hashtext('audit_logs_chain'))` 을 획득하려 하면,
+**Then** 한 tx 가 먼저 lock 을 획득해 직전 행을 읽고 INSERT 한 후 커밋할 때까지 다른 tx 는 대기한다. 순차적으로 처리되어 chain fork (DAG) 가 발생하지 않는다.
+
+**증거**:
+- 동시 2 tx 실행 후 `SELECT count(*) FROM audit_logs WHERE previous_hash IS NULL AND created_at >= <window>` 결과 = genesis 인 경우만 (segment 시작). 동시 INSERT 로 인한 fork 없음.
+- T2 의 `previous_hash` 가 T1 이 INSERT 한 행의 chain hash 를 참조함을 확인.
+- P99 5ms 게이트 (NFR-AC-001) 유지 — advisory lock 대기 시간 포함.
+
+---
+
+## Edge Cases
+
+### EC-1 (C3 rewrite): 동시 INSERT — fork PREVENTED (구 version 은 "tolerated" 였음)
+
+두 tx 가 동시에 마지막 행을 읽고 각자의 해시를 계산하려 시도할 수 있음.
+**기대 동작 (C3 fix)**: `pg_advisory_xact_lock(hashtext('audit_logs_chain'))` 가 tx 시작 시점에 직전 행 SELECT 전에 획득되므로, 두 tx 는 **직렬화** 된다. READ COMMITTED 격리에서도 chain fork (DAG) 는 발생하지 않는다. 본 SPEC 은 더 이상 fork 를 "허용" 하지 않음 — tamper-evidence (단일 linear chain) 가 핵심 가치이므로 fork 는 설정 불가. 영향: audit write 처리량 감소 (sequential) 가능하지만 P99 5ms 게이트 (NFR-AC-001) 가 상한선.
+
+> 구 version (v0.1.0) 은 "fork tolerated" 였으나 이는 tamper-evidence 주장과 모순 (Critical C3). 본 version 0.2.0 부터 fork PREVENTED.
+
+### EC-2: 매우 큰 meta_json
+
+`meta_json` 이 수십 KB 인 경우 canonical 직렬화 비용.
+**기대 동작**: SHA-256 은 입력 크기에 선형 비례하지만 실사용 범위 (수 KB) 에서 P99 5ms 이내 유지 (NFR-AC-001, m7 bench).
+
+### EC-3: created_at 동일 타이밍 (M3 — chain_seq tie-break)
+
+두 행이 동일 `created_at` (마이크로초 단위까지 동일) 을 가질 수 있음.
+**기대 동작 (M3 fix)**: chain 순서는 `chain_seq BIGINT` monotonic counter 로 tie-break (`ORDER BY chain_seq DESC, created_at DESC, id DESC`). UUID tie-break 의 semantic 한계(분산 생성 순서 비보장) 제거 (REQ-AC-014). 검증 함수도 동일 규칙 적용.
+
+### EC-4: tx handle 없는 호출 (autocommit)
+
+`writeAudit(params)` (tx 생략) — singleton db 사용.
+**기대 동작**: advisory lock 획득 + 직전 행 SELECT + 해시 계산 + INSERT 가 autocommit 안에서 실행.
+advisory_xact_lock 은 autocommit tx 안에서도 동일하게 직렬화 (C3).
+
+### EC-5: genesis 행의 created_at 순서
+
+chain 의 첫 행이 반드시 테이블의 첫 행일 필요는 없음. NULL marker 가 있는 모든 행이 segment 시작.
+**기대 동작**: verifyAuditChain 은 각 segment 를 독립적으로 처리.
+
+---
+
+## Traceability Matrix (M4)
+
+| AC | spec.md REQ | Notes |
+|---|---|---|
+| AC-1 | REQ-AC-001, REQ-AC-005, REQ-AC-006, REQ-AC-012 | + app-side UUID (C1) |
+| AC-2 | REQ-AC-001, REQ-AC-005, REQ-AC-014 | chain_seq tie-break |
+| AC-3 | REQ-AC-002 | tx rollback atomicity |
+| AC-4 | REQ-AC-004, REQ-AC-013 | 191 callers (H1) |
+| AC-5 | REQ-AC-007 (C2 점화식), REQ-AC-005 | tamper at row_B → break at row_C |
+| AC-5b | REQ-AC-005 | field-order sensitivity (M2) |
+| AC-5c | REQ-AC-003 | genesis sentinel (M1) |
+| AC-6 | REQ-AC-008 | NULL = segment start |
+| AC-7 | REQ-AC-009, REQ-AC-011 | alert action enum |
+| AC-8 | REQ-AC-010 | empty window graceful |
+| AC-9 | REQ-AC-013 | AuditDbHandle select (H2) |
+| AC-10 | §4 Constraints (advisory lock) | fork prevention (C3) |
+
+---
+
+## Definition of Done
+
+- [ ] spec.md 의 모든 REQ-AC-* 와 NFR-AC-* 가 테스트로 검증됨.
+- [ ] 위 12개 AC (AC-1 ~ AC-10 + AC-5b/AC-5c) 의 증거가 테스트 출력 또는 런타임 점검으로 제공됨.
+- [ ] `pnpm ci:audit`, `pnpm ci:lint`, `pnpm ci:test` 모두 green.
+- [ ] 기존 **191** 개 호출 지점 회귀 없음 (시그니처 호환 AC-4, H1).
+- [ ] append-only 트리거와 충돌 없음 (UPDATE/DELETE 미사용 확인).
+- [ ] 신규 crypto 의존성 0건 (NFR-AC-004).
+- [ ] migration 0111 (`chain_seq` + 인덱스 + alert action) 이 적용되었고 rollback 파일 존재.
+- [ ] migration 0109 헤더 주석 오타 정정 (m3).
+- [ ] 크론 이벤트 등록 (`lib/inngest/functions.ts`) 반영.
+- [ ] advisory_xact_lock 으로 동시성 직렬화 검증 (AC-10, C3).
+- [ ] `vitest --bench` P99 ≤ 5ms (NFR-AC-001, m7).

--- a/.moai/specs/SPEC-V3-AUDIT-CHAIN-001/plan.md
+++ b/.moai/specs/SPEC-V3-AUDIT-CHAIN-001/plan.md
@@ -1,0 +1,238 @@
+# Implementation Plan — SPEC-V3-AUDIT-CHAIN-001 (v0.2.0)
+
+audit_log SHA-256 hash chain strengthening (v3 Phase E / D-1).
+
+본 파일은 run-phase 구현 가이드. 우선순위 라벨 (High/Medium/Low) 만 사용하며
+시간 추정은 포함하지 않는다 (MoAI HARD 규칙).
+
+> **v0.2.0 (2026-07-06)**: plan-auditor FAIL verdict 반영 — C1 (app-side UUID), C2 (verify recurrence), C3 (advisory lock), H1 (191 callers), H2 (AuditDbHandle widening), M1-M4, m3/m6/m7.
+
+---
+
+## 1. 기술 접근 방식 (Technical Approach)
+
+### 1.1 아키텍처 결정 (run-phase 확정 전까지 권장안)
+
+| 결정 | 권장 | 이유 |
+|---|---|---|
+| 해시 유틸 위치 | `lib/audit/hash-chain.ts` (신규) | `writeAudit` 과 cycle 없이 분리, 테스트 용이 |
+| Canonical 형태 | stable JSON.stringify (sorted keys) | 기존 `lib/signature/hash.ts` 패턴 일관성 |
+| Crypto API | `globalThis.crypto.subtle.digest('SHA-256')` + `globalThis.crypto.randomUUID()` | Edge 호환, 신규 의존성 없음 (NFR-AC-004). Node 22 검증 완료. |
+| App-side UUID (C1) | `writeAudit` 내부에서 `crypto.randomUUID()` 생성 → INSERT `id` 명시 + canonical `id` 입력 | DB `defaultRandom()` 은 fallback. append-only UPDATE 없이 hash 계산 가능. |
+| 직전 행 조회 | `SELECT previous_hash, chain_seq FROM audit_logs ORDER BY chain_seq DESC, created_at DESC, id DESC LIMIT 1` | `idx_audit_logs_created_at` (M4) + `chain_seq` monotonic tie-break (M3) |
+| Genesis 처리 (C2) | `chainHash_0 = "<genesis>"` literal sentinel. row_N.previous_hash = chainHash_{N-1}. | 정확한 점화식 (C2). NULL = segment start. |
+| 동시성 직렬화 (C3) | `SELECT pg_advisory_xact_lock(hashtext('audit_logs_chain'))` at tx start, BEFORE prev-row SELECT | READ COMMITTED 에서 chain fork 방지. SERIALIZABLE 비용 회피. |
+| `AuditDbHandle` 확장 (H2) | `{ insert: typeof db.insert; select: typeof db.select }` structural type | Drizzle PgTransaction 은 이미 두 capability 보유 — 기존 tx 호출 24곳은 변경 없음. |
+| Alert action 값 | 신규 enum `audit_chain.violation_detected` (migration 0111) | 기존 action 재사용보다 명확 |
+| Tie-break (M3) | `chain_seq BIGINT NOT NULL` 신규 컬럼 (migration 0111) | UUID tie-break 의 semantic 한계(분산 순서 비보장) 제거 |
+
+### 1.2 핵심 설계 원칙
+
+1. **Additive Only**: `writeAudit` 외부 시그니처 불변. 내부 helper 추가만 허용.
+2. **TX-bound Computation**: 해시 계산 + advisory lock + INSERT 는 항상 caller tx (또는 singleton db autocommit) 안에서.
+3. **Single SHA-256 Call per INSERT**: 직전 행 1건 SELECT + 1회 해시. Full scan 금지.
+4. **Strategy B Backfill**: 기존 행 UPDATE 금지. NULL = genesis marker (segment 시작).
+5. **App-side ID (C1)**: UUID 를 app 에서 사전 생성하여 INSERT 와 hash 입력에 동일 값 사용.
+6. **Serialize appends (C3)**: advisory_xact_lock 으로 chain append 직렬화.
+
+---
+
+## 2. Milestones (우선순위 순)
+
+### M0 — Schema Migration 0111 (Priority High — M3/C3/C1 선행)
+
+`chain_seq` 컬럼 + 인덱스 + alert action enum 추가.
+
+산출물:
+- `migrations/0111_audit_chain.sql`:
+  - `ALTER TABLE audit_logs ADD COLUMN chain_seq BIGINT NOT NULL DEFAULT 0;`
+  - `CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs (created_at, id);`
+  - `CREATE INDEX IF NOT EXISTS idx_audit_logs_chain_seq ON audit_logs (chain_seq);`
+  - `ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'audit_chain.violation_detected';`
+- `migrations/0111_audit_chain_rollback.sql` (인덱스/컬럼 삭제; enum 값은 PG 롤백 불가 → 코멘트 명시).
+- `migrations/0109_impact_wizard_columns.sql` 헤더 주석 수정 (m3): `previousHash (bytea)` → `previous_hash TEXT (64-char hex)`.
+- `lib/db/schema.ts`: `auditLogs` 에 `chainSeq: bigint('chain_seq', { mode: 'number' }).notNull().default(0)` 추가; `AuditAction` union 에 `'audit_chain.violation_detected'` 추가 (lock-step).
+- 실DB 적용 테스트 (L-010): `pnpm db:migrate` + `\d audit_logs` + `pg_enum` 확인.
+
+게이트:
+- 실DB 마이그레이션 성공 (L-010).
+- AC-7 의 action 값 활용 가능.
+
+리스크 완화:
+- enum 값 추가는 PG 12+ 에서 transaction-safe (`ADD VALUE IF NOT EXISTS`).
+- rollback 불가 → downtime 이 필요한 경우 대안 명시 (run phase).
+
+### M1 — Hash Chain Population (Priority High — C1/C3/H2)
+
+`writeAudit` 이 app-side UUID + advisory lock + `previous_hash` + `chain_seq` 를 자동으로 채우도록 수정.
+
+산출물:
+- `lib/audit/hash-chain.ts` (신규):
+  - `computeAuditRowHash(prevChainHash, row)` 순수 함수 (REQ-AC-005 canonical order, REQ-AC-006 SHA-256).
+  - `GENESIS_SENTINEL = "<genesis>"` 상수 (C2).
+  - `fetchPreviousChainLink(client)` 헬퍼: `SELECT previous_hash, chain_seq FROM audit_logs ORDER BY chain_seq DESC, created_at DESC, id DESC LIMIT 1`.
+- `lib/audit.ts` `writeAudit` 수정:
+  - `AuditDbHandle` widening (H2): `{ insert: typeof db.insert; select: typeof db.select }`.
+  - tx 시작(또는 autocommit inline) 후 즉시 `SELECT pg_advisory_xact_lock(hashtext('audit_logs_chain'))` (C3).
+  - `crypto.randomUUID()` 사전 생성 (C1) → `id` PK 명시 + canonical 입력.
+  - `fetchPreviousChainLink` → `chainHash_prev` (= row.previous_hash or `GENESIS_SENTINEL`) 산출.
+  - `chainHash_N = SHA256(canonical(row.fields_without_previous_hash) ‖ chainHash_{N-1})` 계산 (C2 점화식).
+  - INSERT `id`, `previous_hash = chainHash_prev`, `chain_seq = prev_seq + 1`.
+- `lib/audit/__tests__/hash-chain.test.ts` (신규): canonical 안정성, 결정론성, 필드 순서 민감성 (M2), GENESIS sentinel 처리.
+- **H2 호환성 감사 (신규 task)**: ~24개 `db.transaction` 호출 지점 (`grep -rn "db.transaction" --include="*.ts" lib app`) 의 tx 객체가 widened `AuditDbHandle` 을 만족하는지 typecheck 로 검증. Drizzle `PgTransaction` 은 이미 `insert` + `select` 를 모두 지원하므로 real tx 는 변경 없이 호환될 것으로 예상. narrowed tx (예: custom wrapper) 가 발견되면 run phase 에서 widening 또는 cast 로 해결.
+
+게이트:
+- AC-1, AC-2, AC-3, AC-5c (M1 genesis), AC-9 (H2), AC-10 (C3) 충족.
+- `pnpm ci:test` green + `pnpm typecheck` green.
+
+리스크 완화:
+- 191개 호출 지점 회귀 → 시그니처 변경 없음 (AC-4).
+- advisory lock 경합 → P99 5ms 게이트 (NFR-AC-001, m7 bench) 로 상한선 부여.
+
+### M2 — Verification Utility (Priority High — C2)
+
+`verifyAuditChain(window)` 순수 함수 구현.
+
+산출물:
+- `lib/audit/verify-chain.ts` (신규): `verifyAuditChain({ from, to } | { offset, limit }) → Violation[]`.
+  - segment-aware (NULL previous_hash = 새 segment 시작).
+  - **정확한 점화식 (C2)**: forward 로 `chainHash_N` 재계산, `row_{N+1}.previous_hash === chainHash_N` 체크.
+- `lib/audit/__tests__/verify-chain.test.ts` 단위 테스트:
+  - 정상 chain 위반 0건 (AC-6).
+  - 1행 변조 (`row_N.fields` 변경) → `row_{N+1}` 위치 위반 보고 (AC-5).
+  - canonical 필드 순서 변경 → 해시 불일치 (AC-5b, M2).
+  - GENESIS sentinel 처리 (AC-5c).
+  - NULL segment 경계 정상 처리.
+
+게이트:
+- AC-5, AC-5b, AC-5c, AC-6 충족.
+- `pnpm ci:test` green.
+
+### M3 — Periodic Verification Cron (Priority Medium)
+
+Inngest `audit-chain-verify-daily` 등록.
+
+산출물:
+- `lib/inngest/audit/audit-chain-verify-daily.ts` (신규):
+  - `STANDARDS_REVISION_CRON` 패턴 차용, lazy import `lib/audit` + `lib/audit/verify-chain`.
+  - 24h 윈도우 verify → 위반 시 `writeAudit({ action: 'audit_chain.violation_detected', ... })`.
+- `lib/inngest/client.ts`: `AUDIT_CHAIN_VERIFY_TRIGGER` 이벤트 추가 (선택).
+- `lib/inngest/functions.ts`: 신규 함수 배열 추가.
+- 크론 테스트 (`lib/inngest/__tests__/`): 빈 윈도우, 위반 존재, 정상 종료 3 케이스.
+
+게이트:
+- AC-7, AC-8, EC-2 (큰 meta_json) 충족.
+- `pnpm ci:test` green.
+
+### M4 — Gates & 회귀 검증 + Bench (Priority High — m7)
+
+모든 게이트 통과 및 기존 호출 지점 회귀 없음 최종 확인.
+
+산출물:
+- `pnpm ci:lint` (lint:hex full, L-008).
+- `pnpm ci:test` (full run, L-009).
+- `pnpm ci:audit` 통과 (writeAudit literal gate).
+- `pnpm typecheck` green (H2 widening 포함).
+- 실DB audit_logs `\d` 로 컬럼/인덱스 확인 (`chain_seq`, 인덱스 포함).
+- staged 범위 직접 `git diff --staged` 검증 (L-009).
+- `lib/audit/__tests__/writeAudit.bench.ts` (신규, m7): `vitest --bench` 1000회 연속 호출 P99 측정. 게이트: P99 ≤ 5ms (NFR-AC-001). CI daily regression suite 로 분리.
+
+게이트:
+- 모든 AC green.
+- **191** 개 호출 지점 grep 카운트 불변 (H1 fix).
+- L-013 (3중 맹점 방지): 정적 테스트 + CI mock + self-report 너머 실DB 실행 확인.
+
+### M5 — Backfill 정책 문서화 (Priority Low)
+
+전략 B 결정을 코드 주석과 ops 문서에 명시.
+
+산출물:
+- `lib/audit.ts` 주석: NULL previous_hash = genesis, append-only 위반 없이 forward chain 만 적용.
+- `docs/ops/audit-chain.md` (신규, ops runbook): 검증 절차, 위반 대응, segment 의미, advisory lock 경합 영향.
+- 본 SPEC `research.md` 와 교차 참조.
+
+게이트:
+- 문서 리뷰.
+- EC-6 (과거 행 위반 false positive) 방지 확인.
+
+---
+
+## 3. 의존성 및 순서 (m6 fix — M4 중복 제거)
+
+```
+M0 (schema 0111) ──→ M1 (chain populate, C1/C3/H2) ──→ M3 (cron)
+                                    │
+                                    └──→ M2 (verify util, C2) ──┐
+                                                                ↓
+                                                          M4 (gates + bench)
+                                                                │
+                                          M5 (docs) ────────────┘
+```
+
+- M0 선행 (schema 없이 M1 불가).
+- M1, M2 는 M0 완료 후 병렬 가능 (서로 다른 파일).
+- M3 는 M1 + M2 완료 후.
+- M5 는 M4 와 병렬 가능.
+- M4 (gates) 는 모든 구현 마일스톤 (M1, M2, M3) 완료 후. (m6: M4 가 의존성 그래프에 두 번 표시되던 버그 수정 — 단일 종착점.)
+
+---
+
+## 4. 리스크 완화 (writeAudit fan-in 회귀 방지)
+
+`writeAudit` 은 **191개** 프로덕션 호출 지점 (117 distinct files, H1 fix) 을 가진 고 fan-in 함수. 본 SPEC의 최우선
+리스크는 시그니처 또는 semantics 변경이 연쇄 회귀를 일으키는 것.
+
+| 리스크 | 확률 | 영향 | 완화 |
+|---|---|---|---|
+| 시그니처 변경 | 낮음 (HARD 제약) | 높음 (191 파일) | params shape, return type 불변, 선택 tx 유지. typecheck 게이트 |
+| tx 누락으로 atomicity 위반 | 중간 | 높음 (Part 11) | 해시 계산 + advisory lock + INSERT 를 동일 tx 에서만 수행. 단위 테스트로 롤백 검증 (AC-3) |
+| 직전 행 SELECT 성능 | 중간 | 중간 | `idx_audit_logs_created_at` + `chain_seq` index (M0). LIMIT 1 보장. NFR-AC-001 (m7 bench) |
+| 동시 INSERT chain 경쟁 (C3) | 중간 → 낮음 | 높음 → 낮음 | `pg_advisory_xact_lock(hashtext('audit_logs_chain'))` 으로 직렬화. fork 방지. |
+| `AuditDbHandle` widening 호환 (H2) | 낮음 | 중간 | Drizzle PgTransaction 은 이미 select+insert 지원. ~24 `db.transaction` 호출 typecheck 감사 (M1 task). |
+| append-only 트리거 충돌 | 낮음 | 높음 (runtime fail) | UPDATE/DELETE 미사용. INSERT 만. 단위 테스트로 확인 (AC-4) |
+| ci:audit literal gate 위반 | 낮음 | 낮음 | writeAudit 내부 로직은 literal gate 대상 아님. scripts/qa/audit-completeness.ts 통과 |
+| enum 값 rollback 불가 (PG) | 중간 | 중간 | 0111 rollback 파일에 명시적 코멘트. prod 적용 전 dev 스테이지 검증 |
+
+---
+
+## 5. 테스트 전략
+
+- **단위 테스트** (vitest): hash-chain 순수 함수, verify-chain 위반 탐지, segment 처리, GENESIS sentinel, canonical 필드 순서 민감성 (M2).
+- **통합 테스트** (실DB, L-010): writeAudit 이 tx 안에서 동작, append-only 트리거와 충돌 없음, migration 0111 적용 후 `chain_seq`/인덱스 확인.
+- **동시성 테스트 (C3)**: 2개 동시 `writeAudit` tx → advisory lock 으로 직렬화, chain fork 없음 검증 (AC-10).
+- **크론 테스트**: Inngest 발화 시뮬레이션, 빈 윈도우/위반/정상 케이스.
+- **회귀 게이트** (L-009): 191개 호출 지점 grep 카운트 불변, typecheck 전체 green.
+- **벤치마크 (m7)**: `vitest --bench` 1000회 P99 ≤ 5ms (NFR-AC-001).
+- **맹점 방지** (L-013): mock DB 만이 아닌 실DB `\d audit_logs`, `pg_enum` 확인으로 schema/enum/migration 3중 검증.
+
+---
+
+## 6. Open Decisions (run-phase 확인 사항)
+
+1. **Canonical 직렬화 최종 형태**: stable JSON.stringify (sorted keys) vs delimiter-join (`||`). 성능/가독성 비교 후 run 첫 PR 에서 확정.
+2. **Genesis sentinel literal**: 본 SPEC 은 `"<genesis>"` 채택 (C2). run phase 에서 `GENESIS_SENTINEL` 상수로 고정.
+3. **Alert action enum**: `audit_chain.violation_detected` 신규 (migration 0111) — 확정.
+4. **advisory lock 키**: `hashtext('audit_logs_chain')` — 단일 키로 전체 chain 직렬화. 세분화 필요 시 run phase 에서 재검토.
+5. **크론 주기**: daily 24h 기본. weekly 옵션 필요 시 Inngest trigger 만 추가.
+
+---
+
+## 7. 산출물 위치 (예상)
+
+- `lib/audit/hash-chain.ts` (신규, M1)
+- `lib/audit/verify-chain.ts` (신규, M2)
+- `lib/inngest/audit/audit-chain-verify-daily.ts` (신규, M3)
+- `lib/inngest/functions.ts` (수정, M3)
+- `lib/inngest/client.ts` (수정, M3)
+- `lib/audit.ts` (수정, M1 — app-side UUID, advisory lock, widened AuditDbHandle)
+- `lib/db/schema.ts` (수정 — auditLogs.chainSeq, AuditAction union, M0)
+- `migrations/0111_audit_chain.sql` + rollback (신규, M0)
+- `migrations/0109_impact_wizard_columns.sql` (헤더 주석 수정, m3)
+- `docs/ops/audit-chain.md` (신규, M5)
+- `lib/audit/__tests__/hash-chain.test.ts` (신규, M1)
+- `lib/audit/__tests__/verify-chain.test.ts` (신규, M2)
+- `lib/audit/__tests__/writeAudit.bench.ts` (신규, M4/m7)
+- `lib/inngest/__tests__/audit-chain-verify-daily.test.ts` (신규, M3)
+
+> 본 plan.md 의 산출물 위치는 run phase 에서 조정 가능. SPEC (spec.md) 의
+> WHAT/WHY 는 불변.

--- a/.moai/specs/SPEC-V3-AUDIT-CHAIN-001/research.md
+++ b/.moai/specs/SPEC-V3-AUDIT-CHAIN-001/research.md
@@ -1,0 +1,269 @@
+# Research — SPEC-V3-AUDIT-CHAIN-001
+
+audit_log SHA-256 hash chain strengthening (v3 Phase E / D-1).
+
+조사 목적: 기존 audit 인프라의 실제 형태를 코드에서 직저 확인하고, hash chain
+구현이 자명하도록 모든 제약과 통합 지점을 확정한다. 본 파일은 구현 방식이 아닌
+관찰 가능한 사실만 기술한다 (SPEC 범위 규칙: What/Why, not How).
+
+---
+
+## 1. 기존 인프라 직접 관찰 결과
+
+### 1.1 `writeAudit(params, tx?)` — `lib/audit.ts:529-539`
+
+```ts
+export async function writeAudit(params: AuditEvent, tx?: AuditDbHandle): Promise<void> {
+  const client = tx ?? db;
+  await client.insert(auditLogs).values({
+    actorId: params.actor_id,
+    action: params.action,
+    resourceType: params.resource_type,
+    resourceId: params.resource_id,
+    conversationId: params.conversation_id ?? null,
+    metaJson: params.meta_json ?? {},
+  });
+}
+```
+
+관찰 사항:
+- 단일 `INSERT`, `previous_hash` 컬럼 미포함 (현재).
+- `tx` 매개변수는 선택 — 생략 시 singleton `db` (autocommit). 전달 시 caller tx 안에서 atomic.
+- `AuditDbHandle` 구조 타입 (`{ insert: typeof db.insert }`) — tx와 db singleton 모두 만족.
+- H2 fix 주석: caller가 mutation + audit을 동일 tx로 묶는 것이 권장 패턴 (Part 11 원자성).
+
+### 1.2 `AuditEvent` 인터페이스 — `lib/audit.ts:492-508`
+
+```ts
+export interface AuditEvent {
+  actor_id: string | null;
+  action: AuditAction;
+  resource_type: string;
+  resource_id: string;
+  conversation_id?: string | null;
+  meta_json?: Record<string, unknown>;
+}
+```
+
+`AuditAction` 은 73개 이상의 string-literal union (스키마 enum과 lock-step).
+
+### 1.3 `auditLogs` 테이블 — `lib/db/schema.ts:1265-1289`
+
+확인된 컬럼 (이 순서가 해시 대상 컬럼 후보):
+| 컬럼 | 타입 | NOT NULL | 기본값 |
+|---|---|---|---|
+| `id` | `uuid` | Y (PK, `defaultRandom()`) | — |
+| `actorId` | `uuid` | N | — |
+| `action` | `audit_action` enum | Y | — |
+| `resourceType` | `text` | Y | — |
+| `resourceId` | `text` | Y | — |
+| `conversationId` | `uuid` | N | — |
+| `metaJson` | `jsonb` | Y | `{}` |
+| `createdAt` | `timestamptz` | Y | `now()` |
+| `previousHash` | `text` | N | — |
+
+이미 존재하는 인덱스: `idx_audit_logs_actor_created`, `idx_audit_logs_action_created`, `idx_audit_logs_resource`.
+
+`@MX:WARN audit_logs is append-only` (schema.ts:1261) — `UPDATE/DELETE/TRUNCATE` 가 DB 트리거로 차단됨 (`migrations/0001_audit_append_only.sql`). 해시 갱신/수정은 불가능하며, 최초 INSERT 시 한 번만 계산되어야 함을 의미.
+
+### 1.4 `previous_hash` 컬럼 — 이미 추가됨
+
+`migrations/0109_impact_wizard_columns.sql:29-34`:
+```sql
+ALTER TABLE audit_logs
+  ADD COLUMN IF NOT EXISTS previous_hash TEXT;
+COMMENT ON COLUMN audit_logs.previous_hash IS
+  'Hex-encoded hash of previous audit entry for chain verification
+   (21 CFR Part 11, SHA-256 = 64 hex chars)';
+```
+
+컬럼 정의 주석: `lib/db/schema.ts:1278-1280`:
+```ts
+// SPEC-V3-IMPACT-001 M8: Hash chain for 21 CFR Part 11 verification
+// Using text to store hex-encoded hash (SHA-256 = 64 hex chars)
+previousHash: text('previous_hash'),
+```
+
+**핵심 갭(관찰된 문제)**: 컬럼은 존재하지만:
+1. `writeAudit` 가 이 컬럼을 populate 하지 않음 (INSERT 문에서 누락).
+2. 검증 함수 (`verifyAuditChain`) 가 존재하지 않음.
+3. 주기적 검증 크론이 없음.
+4. 기존 행(컬럼 추가 이전 + 0109 이후 NULL 행)이 모두 `previous_hash = NULL`.
+
+이 4개 갭이 본 SPEC의 전체 범위.
+
+### 1.5 최신 migration 번호
+
+`migrations/` 최신: `0110_audit_impact_actions.sql` (+ rollback). 신규 인덱스 추가 시
+다음 번호는 `0111` 부터. 단, 본 SPEC은 컬럼 추가 마이그레이션이 **불필요** (0109에 완료).
+필요시 `idx_audit_logs_hashchain` 등 조회 성능용 인덱스만 0111로 추가 가능.
+
+### 1.6 기존 해시 유틸리티 — `lib/signature/hash.ts`
+
+```ts
+export async function computeAnswerHash(
+  contentProse: string,
+  blocks: HashableBlock[],
+): Promise<string> { /* ... */ }
+```
+
+- SHA-256 hex digest (64 chars lowercase).
+- `globalThis.crypto.subtle.digest('SHA-256', data)` — Edge/Node 겸용 (WebCrypto).
+- JSON canonical 형태 사용 (`JSON.stringify` of 정렬된 객체).
+- §11.70 서명/레코드 연결용 — audit chain 은 **별도 함수** 필요 (canonical 스키마가 다름).
+
+재사용 결론: `lib/signature/hash.ts` 의 WebCrypto 패턴만 차용. audit chain 전용
+canonicalization 이 필요하므로 `lib/audit/hash-chain.ts` (신규) 또는 `lib/audit.ts` 내
+private helper 로 분리 구현. 외부 crypto 의존성 추가 금지 (HARD 제약 준수).
+
+### 1.7 Inngest 크론 패턴 — `lib/inngest/`
+
+표준 패턴 (모든 기존 크론이 동일):
+1. `lib/inngest/{domain}/{name}.ts` — `inngest.createFunction(...)` with `triggers: [{ cron: '...' }]`.
+2. `lib/inngest/client.ts` — `INNGEST_EVENTS` 사전에 이벤트명 등록 (선택).
+3. `lib/inngest/functions.ts` — 배열에 신규 함수 추가 (단일 진실 원천).
+
+기존 크론 스케줄 참고:
+- `standards-revision-daily`: `0 9 * * *` (daily 09:00 UTC).
+- `knowledge-gap-daily-digest`: daily.
+- `weekly-digest`: weekly.
+
+Lazy import 패턴 사용 (`lib/inngest/standards/standards-revision-daily.ts` 참조):
+크론 모듈이 등록 시점에 `lib/audit → lib/db/client → lib/env` 를 로드하지 않도록
+`await import('@/lib/audit')` inside step. 환경변수 누락 상태에서도 함수 등록이 가능.
+
+### 1.8 기존 cold-storage (`lib/audit/cold-storage.ts`)
+
+- audit_logs 를 R2 Iceberg 포맷으로 아카이브.
+- `AuditLogRow` 인터페이스가 존재하나 `previousHash` 필드는 아직 없음 → 아카이브
+  시 chain 정보 보존이 필요하면 `AuditLogRow` 확장 포인트로 인지 (out-of-scope warning).
+
+---
+
+## 2. writeAudit fan-in 카운트 (검증 가능한 수치)
+
+| 범주 | 파일 수 (distinct) | writeAudit 호출 수 |
+|---|---|---|
+| 프로덕션 코드 (non-archive, non-test) | 117 | **191** |
+| 아카이브 코드 (`archive/qms-pms/`) | (집계 제외) | 50 |
+| **프로덕션 총 (회귀 게이트 대상)** | **117** | **191** |
+
+**재검증 (2026-07-06, v0.2.0 — audit H1 fix)**:
+실명령 재카운트: `grep -rn "writeAudit(" --include="*.ts" --include="*.tsx" lib app | grep -v __tests__ | grep -v "export async function writeAudit" | wc -l` = **191**.
+distinct 파일 수 = **117**. archive (`archive/qms-pms/`) = **50**.
+이전 수치 (197 / 100 files / 60+ archive / 총 257)는 부정확 — 모두 정정.
+
+**HARD 제약 영향**: 191개 프로덕션 호출 지점의 **어떤 것도** 시그니처 변경 없이
+그대로 동작해야 함. 본 SPEC은 additive 한 내부 계산만 허용:
+- `writeAudit(params, tx?)` 시그니처 유지 (params shape, return type).
+- 해시 계산은 `writeAudit` 내부에서 tx 안에 수행되어야 함 (Part 11 원자성).
+- 해시 계산 비용: 단일 SELECT prev row + SHA-256 1회 = 수 ms 이내 (full scan 금지).
+
+호출 패턴 (샘플링):
+- `lib/auth.ts:85` — `writeAudit(buildLoginAuditEvent(user.id, account?.provider))` (autocommit).
+- `app/api/ra/dhf/route.ts:76` — `writeAudit({...}, tx)` (inside `db.transaction`).
+- `lib/standards/alert-pipeline.ts:72` — `writeAudit({...})` (autocommit inside cron step).
+
+3가지 패턴 모두 `writeAudit(params, tx?)` 로 동일하게 호출됨을 확인.
+
+---
+
+## 3. 관련 이슈 / 인접 SPEC (본 SPEC 범위 외, follow-up 명시용)
+
+- **Issue #321**: `lib/signature` 기반 HMAC §11.70 binding. 본 SPEC은 chain (§11.10(e))
+  이지 서명/HMAC (§11.70) 이 아님 → 흡수 금지, follow-up SPEC 으로 분리.
+- **`lib/kernel/audit/` 이동**: v3 마스터 플랜이 대상 디렉토리를 `lib/kernel/audit/` 로
+  표기하나, **디렉토리 이동 자체는 별도 리팩터 SPEC**. 본 SPEC은 `lib/audit.ts` 현위치에서
+  chain 로직만 추가. 이동 시 `writeAudit` import 경로만 바뀌고 chain 로직은 동일.
+- **Cold storage 연동**: R2 아카이브 시 `previousHash` 보존 여부는 cold-storage SPEC
+  (SPEC-REGULA-CLOUDFLARE-001) 의 후속 과제. 본 SPEC은 row-level chain 에만 집중.
+
+---
+
+## 4. Backfill 전략 트레이드오프 분석
+
+기존 행들의 `previous_hash` 가 NULL 임. 두 전략 비교:
+
+### 전략 A: 일괄 backfill 마이그레이션
+
+- **방법**: 단일 트랜잭션으로 모든 행을 시간순 순회하며 chain 재계산.
+- **장점**: 전체 테이블이 단일 연속 chain 을 형성 (검증 시 명확).
+- **단점**:
+  - `audit_logs` 는 append-only 트리거로 UPDATE 차단 → 트리거 예외 또는 일시적 비활성화 필요 (Part 11 위반 소지).
+  - 수백만 행일 경우 트랜잭션 크기 폭발, 잠금 경합.
+  - 원본 `created_at` 순서와 증분 사이의 race 가 chain 불일치 유발 가능.
+- **Part 11 관점**: 과거 행을 수정하는 것은 전자기록 무결성 원칙과 충돌.
+
+### 전략 B: NULL = "chain starts here" (genesis, 권장)
+
+- **방법**: `previous_hash IS NULL` 인 행을 chain 의 시작점(들)으로 취급.
+  이후 행부터 forward chain 만 적용.
+- **장점**:
+  - append-only 위반 없음 (UPDATE 금지, INSERT 만).
+  - 기존 행을 한 번도 수정하지 않음 → Part 11 무결성 유지.
+  - 비용 영점 (계산/잠금 없음).
+- **단점**:
+  - chain 이 다수의 "segment" 로 분할 (pre-chain segment + post-chain segment).
+  - 검증 유틸리티가 segment 경계를 인지해야 함 (NULL hash = 새 세그먼트 시작).
+- **완화**: segment 분할은 검증 함수가 자연스럽게 처리 (`previous_hash IS NULL`
+  또는 `previous_hash = genesis_marker` 인 지점에서 새 윈도우 시작).
+
+**권장**: 전략 B. Part 11 원칙(과거 행 불변) 과 비용/위험 균형이 가장 양호.
+검증 유틸리티는 segment-aware 하게 설계. 최초 chain 행은 자체 id 의 해시
+(또는 고정 seed) 를 사용하여 genesis 로 명시.
+
+---
+
+## 5. 해시 canonicalization 후보 (검증 단계에서 확정 필요)
+
+chain 무결성은 canonical 형태의 결정론성에 좌우됨. 관찰된 컬럼 기준:
+
+| 순서 | 필드 | 인코딩 |
+|---|---|---|
+| 0 | `previous_hash` (이전 행의 output, hex) | string, NULL=genesis marker |
+| 1 | `id` | UUID string |
+| 2 | `actor_id` | UUID string or "null" |
+| 3 | `action` | enum string |
+| 4 | `resource_type` | string |
+| 5 | `resource_id` | string |
+| 6 | `conversation_id` | UUID string or "null" |
+| 7 | `meta_json` | `JSON.stringify` with stable key ordering |
+| 8 | `created_at` | ISO-8601 UTC string |
+
+- 알고리즘: SHA-256 (WebCrypto `crypto.subtle.digest`).
+- 출력: 64-char lowercase hex (기존 `previous_hash` 컬럼 comment 와 일치).
+- Canonical 형태: run-phase 에서 최종 확정 (JSON.stringify vs delimiter-join).
+  키 순서가 보장되어야 함 (`Object.keys` 순서는 엔진 의존적이므로 명시적 정렬 필요).
+
+해시 계산은 `id` 가 결정된 이후에 가능 → `defaultRandom()` UUID 가 INSERT 시점에
+생성되므로, 계산 순서는:
+1. UUID 생성 (또는 DB 가 defaultRandom 으로 자동 생성).
+2. 모든 입력 컬럼 + 이전 해시로 canonical string 생성.
+3. SHA-256 계산 → `previous_hash` 컬럼에 INSERT.
+
+단일 tx 안에서 이전 행 SELECT + 해시 계산 + INSERT 가 Part 11 원자성 요구사항.
+
+---
+
+## 6. ci:audit 게이트 현황
+
+`scripts/qa/audit-completeness.ts` 가 `writeAudit` 호출 지점의 메타 문자열 리터럴 길이를
+검사 (PII 누출 방지). 본 SPEC은 `writeAudit` 시그니처를 변경하지 않으므로 게이트 통과 유지.
+해시 계산 로직이 `writeAudit` 내부로 들어가면 추가 리터럴 검사 대상이 발생하지 않음을 확인.
+
+---
+
+## 7. 결론: SPEC 범위 확정
+
+IN SCOPE (본 SPEC이交付):
+1. `writeAudit` 내부에서 `previous_hash` 자동 계산 (tx 안에서, additive).
+2. `verifyAuditChain(window)` 순수 함수 + 결과 reporting.
+3. Inngest 크론 (주기 검증 + 위반 시 alert audit event).
+4. 전략 B backfill 정책 (NULL = genesis) 문서화 및 검증 반영.
+5. 신규 인덱스 (필요시 `idx_audit_logs_created_at` for window scan) — 마이그레이션 0111.
+
+OUT OF SCOPE (별도 SPEC):
+- `lib/kernel/audit/` 디렉토리 이동 (리팩터 SPEC).
+- Issue #321 HMAC §11.70 서명 binding.
+- R2 cold storage chain 보존 (SPEC-REGULA-CLOUDFLARE-001 후속).
+- 기존 행 backfill UPDATE (전략 A, Part 11 위반 소지로 기각).

--- a/.moai/specs/SPEC-V3-AUDIT-CHAIN-001/spec.md
+++ b/.moai/specs/SPEC-V3-AUDIT-CHAIN-001/spec.md
@@ -1,0 +1,251 @@
+---
+id: SPEC-V3-AUDIT-CHAIN-001
+title: audit_log SHA-256 Hash Chain Strengthening
+version: 0.2.0
+status: planned
+phase: E
+priority: High
+created_at: 2026-07-06
+updated_at: 2026-07-06
+author: manager-spec
+depends_on: []
+parent_spec: none
+issue_number: TBD
+lifecycle: spec-anchored
+labels: [audit, hash-chain, 21cfr-part11, tamper-evidence, postgresql, phase-E]
+---
+
+# SPEC-V3-AUDIT-CHAIN-001 — audit_log SHA-256 Hash Chain Strengthening
+
+v3 Phase E / D-1. 21 CFR Part 11 §11.10(e) 전자기록 무결성 강화를 위해
+`audit_logs` 테이블에 SHA-256 hash chain 을 적용한다.
+
+## HISTORY
+
+- 2026-07-06 (v0.1.0): 초기 초안. Phase E D-1. `writeAudit` chain populate + `verifyAuditChain` + 크론. 기존 `previous_hash` 컬럼(0109) 활용, 전략 B backfill.
+- 2026-07-06 (v0.2.0): plan-auditor FAIL verdict 반영 — Critical 3건 + High 2건 해소:
+  - **C1 (UUID/hash paradox)**: app-side `crypto.randomUUID()` 사전 생성 후 INSERT 에 명시 전달. REQ-AC-005 의 `id` 입력이 INSERT 시점에 알려지도록 보장. 신규 REQ-AC-012.
+  - **C2 (verify algorithm ambiguity)**: REQ-AC-007 을 정확한 점화식 (`chainHash_N = SHA256(canonical(row_N) ‖ chainHash_{N-1})`) 으로 재작성. AC-5 binary-testable.
+  - **C3 (concurrency undermines tamper-evidence)**: §4 Constraints 에 `pg_advisory_xact_lock(hashtext('audit_logs_chain'))` 직렬화 명시. EC-1 재작성 (fork tolerated → fork prevented).
+  - **H1 (non-reproducible caller count)**: 실 grep 결과 191 / 117 files 로 정정 (구 197).
+  - **H2 (AuditDbHandle cannot SELECT)**: REQ-AC-013 신규 — `AuditDbHandle` 를 `select` capability 포함 structural type 으로 확장.
+  - Major: M1 (AC for REQ-AC-003 genesis), M2 (AC for REQ-AC-005 field-order sensitivity), M3 (`chain_seq BIGINT` 신규 컬럼으로 monotonic tie-break), M4 (traceability matrix), m2/m3/m7.
+  - YAML: `labels` 추가, `created`→`created_at`, `updated`→`updated_at` rename.
+
+---
+
+## 1. 배경 및 목적
+
+### 1.1 배경
+
+- `audit_logs.previous_hash TEXT` 컬럼이 `migrations/0109_impact_wizard_columns.sql` 로 추가되었으나, **현재 populate 되지 않음** (writeAudit INSERT 에서 누락).
+  - **문서 버그 (m3, run-phase 수정 예정)**: 0109 헤더 주석 라인 6 은 `previousHash (bytea)` 라 기술하지만 실제 컬럼은 TEXT (64-char hex). run phase 에서 헤더 수정.
+- 검증 함수, 주기적 검증 크론이 부재.
+- 21 CFR Part 11 §11.10(e) (record integrity) 요구사항에 대해 chain-based tamper-evidence 미충족.
+
+### 1.2 목적
+
+- 모든 신규 audit 행에 대해 직전 행의 해시와 자기 자신의 canonical 필드로 SHA-256 chain 을 형성.
+- 임의 행 변조(또는 누락) 시 chain 재계산 결과가 달라져 위반을 탐지 가능 (tamper-evidence).
+- 주기적 크론이 chain 위반을 audit event 로 기록하고, 운영자가 즉시 인지.
+
+### 1.3 비목표 (Out of Scope)
+
+- `lib/kernel/audit/` 디렉토리 이동 (별도 리팩터 SPEC).
+- 기존 행의 `previous_hash` backfill UPDATE (append-only 위반, 기각).
+- §11.70 HMAC 서명 binding (Issue #321, 별도 SPEC).
+- R2 cold archive chain 보존 (SPEC-REGULA-CLOUDFLARE-001 후속).
+
+---
+
+## 2. Environment / Assumptions
+
+- 런타임: Node.js 22.x (Next.js 서버 런타임, 확인: `node --version` = v22.23.1).
+  - `globalThis.crypto.randomUUID()` 사용 가능 (WebCrypto, Node 19+). 코드베이스 기존 사용처 존재 (`lib/workflows/common/review-queue.ts:26`, `lib/workflows/audit-response/executor.ts:80`, `lib/workflows/common/human-handoff.ts:41`).
+- DB: PostgreSQL (Neon). `audit_logs` 테이블 append-only 트리거 활성 (`0001_audit_append_only.sql` — UPDATE/DELETE/TRUNCATE 를 P0001 에러로 차단).
+- 기존 인프라: `lib/audit.ts#writeAudit(params, tx?)` 가 **191개 프로덕션 호출 지점 (117 distinct files)** 에서 사용 (H1 fix — 실 grep 결과).
+- `lib/signature/hash.ts` 의 WebCrypto SHA-256 패턴을 재사용 가능 (신규 의존성 없음).
+- 기존 `previous_hash` 컬럼 (TEXT, 64-char hex) 이 이미 스키마에 존재.
+- Drizzle `db.transaction` tx 객체는 이미 `insert` + `select` 모두 지원 (H2 — 실제 PgTransaction 타입은 두 capability 를 가짐; `AuditDbHandle` 만 narrowing 된 것).
+
+---
+
+## 3. Requirements (EARS)
+
+### 3.1 Hash Chain 자동 계산 (Population)
+
+**REQ-AC-001** (Event-Driven)
+**When** `writeAudit(params, tx?)` 가 호출되어 `audit_logs` 에 INSERT 를 수행할 때,
+the system **shall** 동일한 transaction 안에서 (a) `pg_advisory_xact_lock(hashtext('audit_logs_chain'))` 획득, (b) 직전 audit 행의 `previous_hash` 와 `chain_seq` 조회, (c) app-side 생성 UUID 를 PK 로 명시, (d) 현재 행의 canonical 필드와 이전 해시를 결합하여 SHA-256 해시를 계산, (e) 신규 행의 `previous_hash` 컬럼에 저장한다.
+
+**REQ-AC-002** (Unwanted Behavior / Atomicity)
+**If** `writeAudit` 가 caller-supplied `tx` transaction handle 과 함께 호출된 경우,
+the system **shall not** 해시 계산과 INSERT 를 분리된 transaction 으로 수행한다.
+두 연산은 caller 의 tx 안에서 원자적으로 실행되어야 한다 (21 CFR Part 11 §11.10(c)).
+
+**REQ-AC-003** (State-Driven / Genesis)
+**While** `audit_logs` 테이블에 직전 행이 존재하지 않거나 직전 행의 `previous_hash` 가
+NULL 인 경우, the system **shall** 현재 행을 chain 의 genesis (시작점) 으로 처리하고,
+`chainHash_0 = "<genesis>"` sentinel 을 이전 링크로 사용하여 자기 자신의 필드만으로 해시를 계산하여 `previous_hash` 에 저장한다 (전략 B). `chain_seq` 는 이 경우 1 로 시작.
+
+**REQ-AC-004** (Backward Compatibility / Non-Functional)
+**Where** 기존 **191개 프로덕션 호출 지점** (실 grep 결과 — H1 fix; 구 197 은 부정확) 이 `writeAudit(params)` 또는
+`writeAudit(params, tx)` 형태로 호출하는 경우,
+the system **shall** 모든 기존 호출의 시그니처와 semantics 를 보존한다.
+`writeAudit(params: AuditEvent, tx?: AuditDbHandle)` 시그니처는 변경되지 않는다.
+> m2 fix: 본 REQ 본문의 "197" 표기를 "all existing production call sites (실측 191)" 로 범용화.
+
+### 3.2 Canonicalization
+
+**REQ-AC-005** (Ubiquitous)
+The system **shall** 각 audit 행의 해시를 계산하기 위해 다음 필드들을 결정론적
+순서로 canonical 문자열로 직렬화한다: `previous_hash || id || actor_id || action ||
+resource_type || resource_id || conversation_id || meta_json (stable key order) ||
+created_at (ISO-8601 UTC)`. 필드 누락 또는 순서 변경은 금지된다.
+> **M2**: canonical 순서 민감성 — 동일 값이라도 필드 순서가 다르면 해시가 달라야 한다 (acceptance.md AC-5b 참조).
+
+**REQ-AC-006** (Ubiquitous)
+The system **shall** SHA-256 알고리즘 (`globalThis.crypto.subtle.digest`) 만을 사용하여
+64자 소문자 hex 문자열을 출력한다. 다른 알고리즘이나 인코딩은 허용되지 않는다.
+
+### 3.3 App-Side ID Generation (C1 fix)
+
+**REQ-AC-012** (Ubiquitous — C1 resolution)
+The system **shall** `writeAudit` 가 INSERT 전에 `crypto.randomUUID()` 로 UUID 를 사전 생성하고, 이를 (a) `audit_logs.id` PK 컬럼에 명시적으로 전달하며, (b) REQ-AC-005 canonical hash input 의 `id` 필드로 사용한다. DB 의 `defaultRandom()` 은 defensive fallback 으로 남으나 정상 경로에서는 항상 app-side UUID 가 사용된다. 이로 인해 `id` 는 INSERT 시점에 이미 알려져 있으므로 hash 계산이 가능하다 (append-only UPDATE 금지와 양립).
+
+### 3.4 Verification Utility (C2 fix — exact recurrence)
+
+**REQ-AC-007** (Event-Driven — C2 resolution, unambiguous recurrence)
+**When** `verifyAuditChain(window)` 함수가 시간 구간 (start, end) 또는 row 범위
+(offset, limit) 매개변수로 호출될 때, the system **shall** 아래의 정확한 점화식으로 chain 을 재계산하여 저장된 `previous_hash` 와 비교한다:
+
+- `chainHash_0 = "<genesis>"` (literal sentinel).
+- For N ≥ 1: `chainHash_N = SHA256( canonical(row_N.fields_without_previous_hash) ‖ chainHash_{N-1} )`.
+- Assertion: `row_N.previous_hash` MUST equal `chainHash_{N-1}`.
+
+즉 각 행은 **이전 chain link 의 해시** 를 `previous_hash` 에 저장한다. 검증 함수는 forward 로 `chainHash_N` 을 재계산하고, **다음 행** (`row_{N+1}`) 의 저장된 `previous_hash` 가 `chainHash_N` 과 일치하는지 확인한다. `row_N.fields` 변조는 `chainHash_N` 변화 → `row_{N+1}.previous_hash ≠ chainHash_N` 위반으로 탐지된다. 위반 위치(행 id, expected vs actual) 배열을 반환한다.
+
+**REQ-AC-008** (State-Driven / Segment Awareness)
+**While** 검증 윈도우 안에 `previous_hash IS NULL` 인 행이 존재할 때,
+the system **shall** 해당 행을 새 chain segment 의 시작점으로 인식하고,
+이전 segment 의 끝과 비교하지 않으며, NULL 행 자체는 위반으로 보고하지 않는다 (전략 B 준수).
+
+### 3.5 Periodic Verification Cron
+
+**REQ-AC-009** (Event-Driven)
+**When** Inngest `audit-chain-verify-daily` 크론이 발화할 때,
+the system **shall** 직전 24시간 윈도우의 audit 행에 대해 `verifyAuditChain` 을 실행하고,
+위반 발생 시 단일 alert audit event (`audit_chain.violation_detected` action 또는
+기존 audit action 중 적절한 값) 를 system actor 로 기록한다.
+
+**REQ-AC-010** (Optional / Graceful Degradation)
+**Where** 검증 윈도우 안에 0개의 행이 존재하는 경우,
+the system **shall** 위반 없이 정상 종료하며, alert audit event 를 발행하지 않는다.
+
+### 3.6 Index / Migration
+
+**REQ-AC-011** (Optional / Performance)
+**Where** `verifyAuditChain` 의 `created_at` 기반 윈도우 스캔 성능이 임계치를 초과할 경우,
+the system **shall** `idx_audit_logs_created_at` 인덱스를 추가하는 마이그레이션
+(`0111_audit_chain.sql`) 을 제공한다. 인덱스가 이미 충분하면 생략 가능하다.
+
+### 3.7 AuditDbHandle Capability (H2 fix)
+
+**REQ-AC-013** (Ubiquitous — H2 resolution)
+The system **shall** `AuditDbHandle` (`lib/audit.ts:514`) 타입을 `insert` 와 `select` capability 를 모두 가진 structural type 으로 확장한다. 근거: Drizzle `PgTransaction` 은 이미 두 capability 를 제공하므로, real tx 객체는 변경 없이 그대로 호환된다. 단, 기존 ~24개 `db.transaction` 호출 지점에서 narrowed tx 객체를 전달하는 경우의 호환성 검증을 M1 마일스톤에 추가한다 (plan.md §2 M1 참조).
+
+### 3.8 Chain Sequence Counter (M3 fix — monotonic tie-break)
+
+**REQ-AC-014** (Ubiquitous — M3 resolution)
+The system **shall** migration 0111 에 `audit_logs.chain_seq BIGINT NOT NULL DEFAULT 0` 컬럼을 추가하고, `writeAudit` 가 이 값을 monotonic 하게 채운다 (`previous_hash` 와 동일 tx 안에서 직전 행의 `chain_seq + 1`). 동일 `created_at` (마이크로초 충돌) 시 `chain_seq` 로 tie-break 한다 (EC-3 참조). UUID tie-break 의 semantic 한계(분산 생성 순서 비보장)를 제거한다.
+
+### 3.9 Non-Functional Constraints (NFR)
+
+**NFR-AC-001** (Performance — m7: measurement methodology + gate)
+`writeAudit` 의 단일 호출은 (a) advisory lock 획득, (b) 직전 행 1건 SELECT (`chain_seq, previous_hash`), (c) SHA-256 1회, (d) INSERT 로 구성되며,
+기존 대비 추가 지연은 **P99 기준 5ms 이내** 여야 한다. Full table scan 은 금지된다.
+> **m7 fix — measurement methodology**: 벤치마크는 `lib/audit/__tests__/writeAudit.bench.ts` (신규) 에서 `vitest --bench` 로 1000회 연속 `writeAudit` 호출 후 P99 를 측정. 게이트: P99 ≤ 5ms (NFR-AC-001). 측정 환경: 로컬 Postgres (Neon dev branch), warm cache. CI 에서는 bench 를 regressions 전용 suite 로 분리 (일일 실행).
+
+**NFR-AC-002** (Append-only Compliance)
+해시 계산/저장 과정에서 `audit_logs` 에 대한 UPDATE/DELETE/TRUNCATE 는 발생하지
+않는다. `0001_audit_append_only.sql` 트리거와 충돌하지 않는다.
+
+**NFR-AC-003** (Determinism)
+동일 입력 행에 대해 재계산된 해시는 항상 동일하다. 런타임, 타임존, JSON 키 순서에
+무관하게 결정론적 이어야 한다.
+
+**NFR-AC-004** (No New Crypto Dependency)
+신규 외부 crypto 라이브러리 의존성을 추가하지 않는다. `globalThis.crypto.subtle`
+(WebCrypto), `globalThis.crypto.randomUUID()` (WebCrypto), 또는 `node:crypto` 만 사용한다.
+
+---
+
+## 4. Constraints (HARD)
+
+- `writeAudit(params: AuditEvent, tx?: AuditDbHandle)` 시그니처 불변 (params shape, return type).
+- **C3 fix — concurrency serialization**: `writeAudit` 트랜잭션은 시작 시 `SELECT pg_advisory_xact_lock(hashtext('audit_logs_chain'))` 를 획득한 후 직전 행을 읽는다. 이는 chain append 를 직렬화하여 READ COMMITTED 에서의 fork (DAG) 를 **방지** 한다. 영향: audit write 간 경합(sequential) 으로 처리량 감소 가능 — 단일 audit write P99 5ms 게이트(NFR-AC-001)는 유지되어야 함.
+- `audit_logs.previous_hash` 컬럼은 이미 존재 (TEXT). 신규 컬럼은 `chain_seq BIGINT` (migration 0111) 만 허용. 그 외 스키마 migration 금지.
+- `lib/audit.ts` 현위치 유지 (`lib/kernel/audit/` 이동 금지 — 별도 SPEC).
+- `node:crypto` 또는 `globalThis.crypto.subtle` / `globalThis.crypto.randomUUID()` 만 사용. 외부 hashing 의존성 금지.
+- `ci:audit` 게이트 (`scripts/qa/audit-completeness.ts`) 통과 유지.
+- **C1 fix — app-side UUID**: `id` 컬럼의 DB `defaultRandom()` 은 defensive fallback 으로 유지하되, `writeAudit` 는 항상 app-side `crypto.randomUUID()` 를 명시적으로 INSERT 한다.
+
+---
+
+## 5. Exclusions (What NOT to Build)
+
+- **EX-001**: `lib/kernel/audit/` 디렉토리로의 `lib/audit.ts` 이동/분할. 본 SPEC은 chain 로직만 추가하며 파일 위치 변경은 별도 리팩터 SPEC.
+- **EX-002**: 기존 audit 행(컬럼 0109 추가 이전 행 및 그 이후 NULL 행)의 `previous_hash` UPDATE backfill. append-only 위반.
+- **EX-003**: §11.70 HMAC 서명 binding (Issue #321) — 본 SPEC은 §11.10(e) chain 에 한정.
+- **EX-004**: R2 cold archive (`lib/audit/cold-storage.ts`) 의 `previousHash` 필드 확장 및 아카이브 시 chain 보존 로직.
+- **EX-005**: 실시간 위반 알림 (Slack/Email 발송). 본 SPEC은 audit event 기록까지만 담당.
+- **EX-006**: Genesis seed 로의 secret/salt 사용. chain 보안은 append-only + SHA-256 결정론성에 기반하며, 비밀 키는 사용하지 않는다 (HMAC 이 아님).
+
+---
+
+## 6. Acceptance Criteria (요약)
+
+상세 시나리오는 `acceptance.md` 참조. 아래 요약 + §7 Traceability Matrix.
+
+- AC-1: 신규 행 INSERT 시 `previous_hash` 가 64-char hex 로 populate 됨.
+- AC-2: 연속 INSERT 시 chain 이 끊김 없이 이전 해시 참조.
+- AC-3: `writeAudit(params, tx)` tx 롤백 시 해시도 함께 롤백.
+- AC-4: 기존 **191** 개 호출 지점 (실측) 변경 없이 통과 (시그니처 호환).
+- AC-5: `verifyAuditChain` 이 `row_N` 변조 시 `row_{N+1}.previous_hash ≠ chainHash_N` 로 정확히 탐지 (C2 점화식).
+- AC-5b (M2): canonical 필드 순서 변경 시 해시 달라짐.
+- AC-5c (M1): genesis (빈 테이블) populate 시 `chainHash_0 = "<genesis>"` sentinel 사용.
+- AC-6: NULL segment 경계에서 false positive 없음.
+- AC-7: 크론이 위반 시 alert audit event 를 system actor 로 기록.
+- AC-8: 빈 윈도우 graceful 종료.
+- AC-9 (H2): `AuditDbHandle` widening 이 기존 ~24개 `db.transaction` 호출 지점과 호환됨 (typecheck green).
+- AC-10 (C3): 동시 2개 `writeAudit` tx 가 직렬화되어 chain fork 가 발생하지 않음 (advisory lock).
+
+---
+
+## 7. Traceability Matrix (M4)
+
+| Acceptance Criterion | Spec Requirement | Edge Case / Note |
+|---|---|---|
+| AC-1 | REQ-AC-001, REQ-AC-005, REQ-AC-006, REQ-AC-012 | Genesis path: REQ-AC-003 |
+| AC-2 | REQ-AC-001, REQ-AC-005, REQ-AC-014 | chain_seq tie-break |
+| AC-3 | REQ-AC-002 | tx rollback atomicity |
+| AC-4 | REQ-AC-004, REQ-AC-013 | 191 callers (H1) |
+| AC-5 | REQ-AC-007 (C2 recurrence), REQ-AC-005 | tamper at row_N → break at row_{N+1} |
+| AC-5b (M2) | REQ-AC-005 | field-order sensitivity |
+| AC-5c (M1) | REQ-AC-003 | genesis sentinel |
+| AC-6 | REQ-AC-008 | NULL = segment start |
+| AC-7 | REQ-AC-009, REQ-AC-011 | alert action enum |
+| AC-8 | REQ-AC-010 | empty window graceful |
+| AC-9 (H2) | REQ-AC-013 | AuditDbHandle select capability |
+| AC-10 (C3) | §4 Constraints (advisory lock) | fork prevention |
+| NFR-AC-001 (m7) | NFR-AC-001 | P99 ≤ 5ms bench |
+
+---
+
+## 8. Open Questions (run-phase 해결)
+
+1. Canonical 직렬화: `JSON.stringify` (sorted keys) vs delimiter-join — run phase에서 성능/가독성 비교 후 확정.
+2. Alert audit action 값: `audit_chain.violation_detected` 신규 enum 추가 vs 기존 action 재사용 — migration 0111에서 enum 추가 여부.
+3. 크론 주기: daily 24h 윈도우 권장. weekly 옵션 검토.
+4. Genesis sentinel literal: 본 SPEC 은 `"<genesis>"` 채택. run phase 에서 상수로 고정.
+5. **m3 (run-phase 문서 수정)**: `migrations/0109_impact_wizard_columns.sql` 헤더 주석 라인 6 의 `previousHash (bytea)` → `previous_hash TEXT (64-char hex)` 로 정정 (header bug fix, schema 변경 없음).


### PR DESCRIPTION
## 개요

v3 **Phase E** 첫 SPEC. `audit_log` SHA-256 hash chain 강화로 21 CFR Part 11 tamper-evidence 확보. 기존 `previous_hash` 컬럼(migration 0109)은 존재하나 chain 계산/검증이 미구현 → 본 SPEC이 채움.

> Phase D PERSONA-001 (PR #354, main \`9b3483b\`) 후 사용자 선택.

## 산출물 (plan 4종, ~860줄)

- `research.md` (264) — lib/audit.ts, schema auditLogs, writeAudit 191 callers, Inngest cron, lib/signature/hash.ts 직검
- `spec.md` (192) — 14 REQ + 4 NFR (EARS), v0.2.0
- `acceptance.md` (154) — 8 AC + edge cases + traceability matrix
- `plan.md` (212) — 6 milestones + risk mitigation

## 품질 게이트 (plan-auditor 감사)

**초안 v0.1.0 FAIL** → Critical 3 + High 2 해결 → **v0.2.0**:
- **C1 UUID/hash paradox** → REQ-AC-012 app-side `crypto.randomUUID()` (id INSERT 전 확정)
- **C2 verify 모호** → REQ-AC-007 `chainHash_N` 정확한 recurrence (binary-testable)
- **C3 동시성/transform-evidence 모순** → `pg_advisory_xact_lock('audit_logs_chain')` 직렬화, EC-1 fork PREVENTED
- **H1 caller count 197 재현 불가** → 실측 **191** (117 files)
- **H2 AuditDbHandle SELECT 불가** → REQ-AC-013 `{insert; select}` widening

## 핵심 설계

- 백엔드 **비파괴**: `writeAudit(params, tx?)` 시그니처 불변 (191 callers 회귀 0)
- `lib/audit/hash-chain.ts` 신규 분리 (lib/audit.ts cycle 없이 테스트 용이)
- WebCrypto SHA-256 재사용 (`lib/signature/hash.ts` 패턴, 신규 의존성 0)
- Strategy B backfill (NULL = genesis, forward chain only, append-only 트리거 준수)
- migration 0111: `chain_seq BIGINT` (monotonic tie-break) + 인덱스 + 0109 header comment fix

## Run phase 진입 시 참고

- expert-backend 상담 권장 (canonical 직렬화, 동시 INSERT 격리 수준 확정)
- run phase: M0 migration 0111 → M1 chain population → M2 verify util → M3 cron → M4 typecheck/bench → M5/M6 gates

Refs SPEC-V3-AUDIT-CHAIN-001

🗿 MoAI <email@mo.ai.kr>