### PR TITLE
docs(spec): SPEC-REGULA-VALIDATION-001 plan 산출물 4종 (IQ/OQ/PQ 검증 패키지)

### DIFF
--- a/.moai/specs/SPEC-REGULA-VALIDATION-001/acceptance.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-001/acceptance.md
@@ -1,0 +1,229 @@
+---
+artifact: acceptance
+spec_id: SPEC-REGULA-VALIDATION-001
+version: 1.1.0
+status: planned
+created: 2026-07-06
+updated: 2026-07-06
+author: manager-spec (plan-phase)
+---
+
+# Acceptance Criteria — SPEC-REGULA-VALIDATION-001
+
+본 문서는 binary-testable acceptance criteria와 Given-When-Then 시나리오, 그리고 AC ↔ REQ ↔ evidence traceability matrix를 정의한다. 모든 AC는 관찰 가능한 증거(test output, file 존재, DB row, HTTP status)로 검증된다.
+
+---
+
+## §1 Acceptance Criteria (Binary-Testable)
+
+| AC# | Criterion | Verification Method | 관련 REQ |
+|-----|-----------|---------------------|----------|
+| AC-1 | `docs/validation/intended-use.md` 파일이 존재하고 git history에 최소 1건 commit이 있다 | `test -f docs/validation/intended-use.md && git log --oneline docs/validation/intended-use.md` | REQ-VAL-001 |
+| AC-2 | 임의의 release_id에 대해 IQ evidence 레코드가 5개(env/deps/migrations/config/secret) 존재하며 각각 `commit_sha`, `test_command`, `result`가 non-null이다 | DB query: `SELECT qualification_type, commit_sha, test_command, result FROM validation_evidence WHERE release_id=? AND qualification_type='iq'` → 5행 | REQ-VAL-003, REQ-VAL-006 |
+| AC-3 | OQ evidence 레코드가 `ci_run_id` 필드를 포함하고, 해당 ID가 GitHub Actions ci.yml run과 일치한다 | DB query + `gh run view <ci_run_id> --json headSha,conclusion` 교차 검증 | REQ-VAL-004, REQ-VAL-006, REQ-VAL-014 |
+| AC-4 | PQ evidence 레코드가 `.github/workflows/e2e.yml` 시나리오 결과 N건과 `tests/eval/results/latest.json` eval 결과 1건을 링크한다 | DB query: `SELECT artifact_path FROM validation_evidence WHERE release_id=? AND qualification_type='pq'` → e2e artifact + eval JSON path 존재 | REQ-VAL-005, REQ-VAL-006 |
+| AC-5 | high-impact change_control 행이 존재하고 rerun evidence가 부재할 때, sign-off API 호출이 HTTP 409를 반환한다 | integration test: high-impact 행 INSERT → sign-off POST → 409 응답 + 실패 항목 목록 | REQ-VAL-008, REQ-VAL-013 |
+| AC-6 | Release Validation Report Markdown 파일에 #31-34, #47, #48, #36 상태 섹션이 각각 존재한다 | `grep -c "## " docs/validation/release-report-<id>.md` ≥ 8 (8개 섹션), 각 이슈 번호 grep | REQ-VAL-010 |
+| AC-7 | sign-off 성공 시 `audit_logs` 테이블에 action_type=`validation.signoff` 행 1건이 추가되고, `approver_id`, `signed_at`, `report_artifact_path`가 기록된다 | DB query before/after signoff + `lib/audit/verify-chain.ts` chain 연속성 통과 | REQ-VAL-012 |
+| AC-8 | checklist 미충족 상태에서 sign-off POST 호출 시 HTTP 409 + 실패한 checklist 항목 배열이 응답 body에 포함된다 | integration test: checklist 1개 false → sign-off → 409 + `{"failed":["iq:deps",...]}` | REQ-VAL-013 |
+
+---
+
+## §2 Given-When-Then 시나리오
+
+### AC-1: Intended Use 문서 존재
+
+```gherkin
+Scenario: intended-use.md가 존재하고 버전 관리된다
+  Given docs/validation/intended-use.md 파일이 작성되어 있다
+  When git에 commit한다
+  Then git log에 해당 파일의 commit 이력이 존재한다
+  And 파일 내용에 "Intended Use", "Prohibited Use", "Human Review Boundary" 섹션이 모두 있다
+```
+
+### AC-2: IQ Evidence Bundle 생성
+
+```gherkin
+Scenario: IQ bundle 실행 시 5개 evidence 레코드가 생성된다
+  Given release_id="v0.1.0-rc1"로 마이그레이션이 적용된 DB가 있다
+  When POST /api/validation/iq { release_id: "v0.1.0-rc1" } 호출한다
+  Then validation_evidence 테이블에 release_id="v0.1.0-rc1", qualification_type='iq'인 행이 5개 생성된다
+  And 각 행의 commit_sha, test_command, result 필드가 non-null이다
+  And 5개의 test_command는 각각 env/deps/migrations/config/secret 검증을 가리킨다
+```
+
+### AC-3: OQ CI Run 매핑
+
+```gherkin
+Scenario: OQ bundle이 CI run ID를 정확히 매핑한다
+  Given ci.yml의 최신 run이 databaseId=123456, conclusion=success, headSha=<release commit>이다
+  When POST /api/validation/oq { release_id: "v0.1.0-rc1" } 호출한다
+  Then validation_evidence에 ci_run_id=123456인 행이 3개(test/rbac/audit) 생성된다
+  And 각 행의 commit_sha가 <release commit>과 일치한다
+```
+
+```gherkin
+Scenario: CI artifact가 만료된 경우 result=skip으로 기록된다
+  Given ci_run_id=123456의 artifact가 만료되어 다운로드 불가하다
+  When POST /api/validation/oq 호출한다
+  Then 해당 evidence 행의 result='skip'이다
+  And metadata.reason 필드에 "artifact_expired"가 기록된다
+```
+
+### AC-4: PQ E2E + Eval 매핑
+
+```gherkin
+Scenario: PQ bundle이 E2E 시나리오와 eval 결과를 링크한다
+  Given e2e.yml의 최신 run이 5개 smoke 시나리오를 통과했다
+  And tests/eval/results/latest.json이 존재한다
+  When POST /api/validation/pq { release_id: "v0.1.0-rc1" } 호출한다
+  Then validation_evidence에 qualification_type='pq'인 행이 6개(5 E2E + 1 eval) 생성된다
+  And 각 행의 artifact_path가 유효한 경로를 가리킨다
+```
+
+### AC-5: High-Impact Rerun Gate
+
+```gherkin
+Scenario: high-impact change + rerun 부재 시 sign-off 차단
+  Given release_id="v0.1.0-rc1"의 change_control에 change_axis='model', impact_level='high', rerun_required=true 행이 있다
+  And validation_evidence에 rerun 증거가 없다
+  When POST /api/validation/signoff { release_id: "v0.1.0-rc1", checklist_state: {...} } 호출한다
+  Then HTTP 409가 반환된다
+  And 응답 body의 failed 배열에 "change_control:model:rerun_required"가 포함된다
+```
+
+```gherkin
+Scenario: high-impact change + rerun 완료 시 sign-off 진행 가능
+  Given 동일한 change_control 행이 있고
+  And rerun evidence가 qualification_type='oq'로 추가되어 있다
+  When sign-off POST 호출한다
+  Then checklist 통과 시 HTTP 200이 반환된다
+```
+
+### AC-6: Release Validation Report 섹션
+
+```gherkin
+Scenario: Report에 4개 이슈 그룹 상태 섹션이 존재한다
+  Given M1~M4가 완료되어 evidence와 change_control이 채워져 있다
+  When POST /api/validation/report/export { release_id: "v0.1.0-rc1" } 호출한다
+  Then docs/validation/release-report-v0.1.0-rc1.md 파일이 생성된다
+  And 파일에 다음 섹션이 존재한다:
+    | ## Intended Use |
+    | ## IQ Evidence |
+    | ## OQ Evidence |
+    | ## PQ Evidence |
+    | ## Change Control |
+    | ## Release Scope Status (#31-#34) |
+    | ## Traceability Status (#47) |
+    | ## Source Governance Status (#48) |
+    | ## Review Ops Status (#36) |
+    | ## Sign-off Checklist |
+```
+
+### AC-7: Sign-off Audit Log 기록
+
+```gherkin
+Scenario: sign-off 성공 시 audit_logs에 hash-chain 행 추가
+  Given 모든 checklist 항목이 충족되었다
+  When sign-off POST 호출이 성공한다 (HTTP 200)
+  Then audit_logs 테이블에 action_type='validation.signoff' 행이 1건 추가된다
+  And 해당 행의 metadata에 approver_id, release_id, report_artifact_path가 포함된다
+  And lib/audit/verify-chain.ts 실행 시 해당 행까지 chain 연속성이 유지된다
+```
+
+### AC-8: Checklist Gate
+
+```gherkin
+Scenario: checklist 미충족 시 409 반환
+  Given release_id="v0.1.0-rc1"의 checklist_state가 { iq: false, oq: true, pq: true, change_control: true } 이다
+  When sign-off POST 호출한다
+  Then HTTP 409가 반환된다
+  And 응답 body의 failed 배열에 "iq"가 포함된다
+  And audit_logs에 새 행이 추가되지 않는다
+```
+
+---
+
+## §3 Edge Cases (경계 케이스)
+
+| EC# | 시나리오 | 기대 동작 |
+|-----|---------|-----------|
+| EC-1 | release_id에 해당하는 evidence가 전혀 없는 상태에서 sign-off 시도 | HTTP 409 + failed: all checklist items |
+| EC-2 | approver가 `validation:approve` 권한이 없는 경우 | HTTP 403 |
+| EC-3 | writeAudit 호출 실패 (DB 연결 끊김) | HTTP 500 + signoff 취소 (부분 성공 금지) |
+| EC-4 | model-governance change-workflow가 비어있는 경우 (fallback 모드) | 7축 중 model/prompt 축은 git diff 휴리스틱으로 동작, metadata.fallback=true |
+| EC-5 | 동일 release_id에 대해 sign-off 중복 호출 | HTTP 409 + "already signed off" (validation_signoff unique 제약) |
+| EC-6 | TRACEABILITY-001(#47) 미완료 상태에서 report export | report의 traceability 섹션은 stub("Traceability SPEC pending")으로 채워짐 |
+| EC-7 | CI run이 아직 running 중인 상태에서 OQ 수집 | result='skip', metadata.reason='ci_running', 30분 후 재시도 권장 메시지 |
+| EC-8 | promptfoo eval 결과 JSON 스키마 불일치 | Zod 검증 실패 → result='skip', metadata.reason='eval_schema_mismatch' |
+
+---
+
+## §4 AC ↔ REQ ↔ Evidence Traceability Matrix
+
+| AC | REQ | Evidence Artifact | 검증 위치 |
+|----|-----|-------------------|-----------|
+| AC-1 | REQ-VAL-001 | `docs/validation/intended-use.md` + git log | 단위 테스트 + 수동 |
+| AC-2 | REQ-VAL-003, 006 | `validation_evidence` IQ 행 5개 | integration 테스트 |
+| AC-3 | REQ-VAL-004, 006, 014 | `validation_evidence` OQ 행 + `gh run view` 결과 | integration 테스트 |
+| AC-4 | REQ-VAL-005, 006 | `validation_evidence` PQ 행 + e2e/eval artifact path | integration 테스트 |
+| AC-5 | REQ-VAL-008, 013 | HTTP 409 응답 + failed 배열 | integration 테스트 |
+| AC-6 | REQ-VAL-010 | `docs/validation/release-report-<id>.md` 섹션 | 단위 테스트 (grep) |
+| AC-7 | REQ-VAL-012 | `audit_logs` 행 + `verify-chain.ts` 통과 | integration 테스트 |
+| AC-8 | REQ-VAL-013 | HTTP 409 + failed checklist | integration 테스트 |
+
+---
+
+## §5 Definition of Done (Quality Gate)
+
+SPEC 완료 선언을 위한 8개 품질 게이트:
+
+| Gate# | 항목 | 측정 방법 |
+|-------|------|-----------|
+| QG-1 | AC-1~AC-8 모두 통과 | 본 문서 §1 매트릭스 |
+| QG-2 | 단위 테스트 커버리지 ≥ 85% | `pnpm ci:test` coverage report |
+| QG-3 | lint/format green | `pnpm ci:lint && pnpm ci:format` |
+| QG-4 | typecheck green | `pnpm ci:typecheck` |
+| QG-5 | 마이그레이션 실DB 적용 성공 | `pnpm ci:migrations` + 로컬 Postgres |
+| QG-6 | RBAC 권한 검증 | `pnpm ci:rbac` (validation:run/approve/read 3권한) |
+| QG-7 | audit_logs hash chain 연속성 | `lib/audit/verify-chain.ts` sign-off 행 포함 통과 |
+| QG-8 | Charter [지양-5] 준수 | §8 Exclusions 항목 위반 0건 (수동 리뷰) |
+
+---
+
+## §6 수동 QA (Gate 4 도메인 UAT)
+
+이슈 #49 MoAI 교차검증 기준 Gate 4 (RA 도메인 UAT) 항목:
+
+- [ ] `intended-use.md`를 RA Lead가 검토하고 intended/prohibited/boundary가 실제 운영과 일치하는지 확인
+- [ ] criticality 분류를 RA Lead + QA Lead가 합의 (chat=critical, RAG=critical, workflow draft=critical, review=critical, submission package=critical, risk management=critical; support/ancillary 분류 명확화)
+- [ ] residual risk 서술 1건 이상 실 운영 시나리오로 검증
+- [ ] Release Validation Report를 RA Lead가 읽고 "이해 가능한 문서"인지 확인
+- [ ] sign-off 절차를 admin 계정으로 end-to-end 수행
+
+---
+
+## §7 비기능 요구사항 (NFR 검증)
+
+| NFR | 기준 | 측정 |
+|-----|------|------|
+| 성능 | IQ bundle 수집 ≤ 30초 | `time pnpm validation:collect:iq` |
+| 성능 | Report export ≤ 10초 | `time pnpm validation:report:build` |
+| 보안 | sign-off API는 admin 권한 필수 | RBAC 단위 테스트 |
+| 보안 | PII/PHI는 evidence 메타데이터에 저장 금지 | 단위 테스트 (PII 패턴 검증) |
+| 가용성 | writeAudit 실패 시 sign-off rollback | integration 테스트 |
+| 감사 | 모든 evidence 변경은 audit_logs 기록 | 단위 테스트 |
+
+---
+
+## §8 Charter 준수 검증
+
+| Charter 원칙 | 본 SPEC 적용 | 검증 |
+|--------------|-------------|------|
+| [핵심 가치] RA 전문가 시간 절약 | 자동 evidence 수집으로 수기 작업 제거 | AC-2, AC-3, AC-4 |
+| [주 사용자] RA Lead | sign-off 주체, report 독자 | AC-6, AC-7 |
+| [지양-1] over-engineering 금지 | aggregator/glue 설계, 신규 harness 금지 | §8 Exclusions |
+| [지양-2] 모방 아닌 적합 | CSV-lite 내부용 (외부 인증 아님) | §1.4 |
+| [지양-3] 수동→자동 역순 | 기존 CI/eval 먼저, 본 SPEC은 집계 | research.md §1 |
+| [지양-4] mock/fallback 명시 | model-gov fallback 모드 metadata.fallback=true | EC-4 |
+| [지양-5] 범위 이탈 방지 | §8 Exclusions + REQ-VAL-011 Optional | QG-8 |

--- a/.moai/specs/SPEC-REGULA-VALIDATION-001/plan.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-001/plan.md
@@ -1,0 +1,272 @@
+---
+artifact: plan
+spec_id: SPEC-REGULA-VALIDATION-001
+version: 1.1.0
+status: planned
+created: 2026-07-06
+updated: 2026-07-06
+author: manager-spec (plan-phase)
+development_mode: tdd
+---
+
+# Implementation Plan — SPEC-REGULA-VALIDATION-001
+
+본 plan은 research.md의 자산 인벤토리를 소비하여 6개 milestone(M0~M5)로 구성된다. 각 milestone은 priority 기반 순서를 가지며, 시간 추정은 Charter [지양-5]와 moai-constitution Time Estimation 금지 원칙에 따라 phase ordering으로 표현한다.
+
+---
+
+## §1 Milestone 개요
+
+| Milestone | 이름 | Priority | Depends On | 산출물 |
+|-----------|------|----------|------------|--------|
+| M0 | Evidence Schema & DB Migration | Critical (blocker) | — | migration 0NNN, Drizzle schema 3 테이블 |
+| M1 | IQ Bundle Generator | High | M0 | `scripts/validation/collect-iq.ts` + API route |
+| M2 | OQ Aggregator | High | M0 | `scripts/validation/collect-oq.ts` + API route |
+| M3 | PQ E2E+Eval Bundle | High | M0 | `scripts/validation/collect-pq.ts` + API route |
+| M4 | Change-Control Impact Assessment | High | M0 | `scripts/validation/classify-changes.ts` + rerun gate |
+| M5 | Release Validation Report + Sign-off | Critical | M1, M2, M3, M4 | `scripts/validation/build-report.ts` + sign-off API + audit_logs write |
+
+---
+
+## §2 Milestone 상세
+
+### M0 — Evidence Schema & DB Migration (Critical Blocker)
+
+**목표**: 3개 신규 테이블 스키마 확정 + 마이그레이션 파일 + Drizzle ORM 모델.
+
+**태스크**:
+1. `migrations/0NNN_validation_evidence.sql` 작성 (research.md §6 참조)
+2. `lib/db/schema.ts`에 `validationEvidence`, `changeControl`, `validationSignoff` 추가
+3. Zod 검증 스키마 (`qualification_type`, `result`, `change_axis`, `impact_level` enum)
+4. 단위 테스트: 테이블 생성 + enum 제약 + CHECK 제약 + index (TDD RED→GREEN)
+
+**Gate (M0 → M1)**:
+- `pnpm ci:migrations` 성공
+- 로컬 Postgres에서 `pnpm seed-test-db` 후 테이블 존재 확인
+- schema.ts Drizzle 타입 추론 성공
+
+**Risks**:
+- 기존 77+ migration과 충돌 → 최신 main 기준 번호 할당
+- enum CHECK 제약 vs Postgres native enum → 본 SPEC은 CHECK 제약 사용 (rollback 용이)
+
+---
+
+### M1 — IQ Bundle Generator (High)
+
+**목표**: IQ evidence 수집 스크립트 + API route. 5개 검증(env/deps/migrations/config/secret) 결과를 `validation_evidence`에 INSERT.
+
+**태스크**:
+1. `scripts/validation/collect-iq.ts` — 단일 진입점
+   - `pnpm install --frozen-lockfile` 결과 + `pnpm-lock.yaml` sha256
+   - `scripts/validate-runtime-env.ts` 호출 결과
+   - `pnpm ci:migrations` exit code
+   - `.env.example` vs 실제 env 키 diff
+2. `app/api/validation/iq/route.ts` — POST handler (RBAC: `validation:run`)
+3. 단위 테스트: 각 검증 항목별 pass/fail/skip 케이스 (TDD)
+4. integration 테스트: 실DB INSERT + commit_sha/ci_run_id 필드 검증
+
+**Reuse**: `scripts/validate-runtime-env.ts`, `scripts/ci/check-migrations.ts`, `lib/env.ts`
+
+**Gate (M1 완료 조건)**:
+- IQ bundle 실행 시 5개 evidence record 생성 (env/deps/migrations/config/secret)
+- 각 record에 `commit_sha`, `test_command`, `result` non-null
+- AC-2 충족
+
+---
+
+### M2 — OQ Aggregator (High)
+
+**목표**: CI unit/integration test 결과를 `validation_evidence`에 매핑.
+
+**태스크**:
+1. `scripts/validation/collect-oq.ts`:
+   - `gh run list --workflow=ci.yml --json databaseId,headSha,conclusion`로 CI run ID 획득
+   - `pnpm ci:test` (vitest), `pnpm ci:rbac`, `pnpm ci:audit` 결과 매핑
+   - artifact path: `gh run view <id> --json artifacts`에서 추출
+2. `app/api/validation/oq/route.ts` — POST handler
+3. 단위 테스트: CI run ID 매핑 정확도, artifact 만료 시 result=skip 처리
+4. integration 테스트: 실 CI run 결과로 OQ bundle 생성
+
+**Reuse**: `.github/workflows/ci.yml`, `scripts/qa/check-rbac.mjs`, `scripts/qa/audit-completeness.ts`, `tests/results/junit.xml` (있을 경우)
+
+**Gate (M2 완료 조건)**:
+- OQ bundle에 3개 test command 결과 포함
+- `ci_run_id`가 GitHub Actions databaseId와 일치
+- AC-3 충족
+
+---
+
+### M3 — PQ E2E + Eval Bundle (High)
+
+**목표**: E2E 시나리오 + promptfoo eval 결과를 `validation_evidence`에 매핑.
+
+**태스크**:
+1. `scripts/validation/collect-pq.ts`:
+   - `.github/workflows/e2e.yml`의 smoke + full suite 결과
+   - `tests/eval/results/latest.json` 파싱 (스키마 Zod 검증)
+   - 시나리오명 → artifact path 매핑 테이블
+2. `app/api/validation/pq/route.ts` — POST handler
+3. 단위 테스트: eval JSON 스키마 검증, E2E skip 시나리오 처리
+4. integration 테스트: 실 e2e.yml 결과 + eval 결과로 PQ bundle 생성
+
+**Reuse**: `.github/workflows/e2e.yml`, `tests/eval/promptfoo.config.yaml`, `scripts/run-eval.sh`
+
+**Gate (M3 완료 조건)**:
+- PQ bundle에 E2E 시나리오 결과 N건 + eval 결과 1건 포함
+- 각 시나리오에 artifact path 또는 skip 사유 존재
+- AC-4 충족
+
+---
+
+### M4 — Change-Control Impact Assessment (High)
+
+**목표**: 릴리즈별 7축(source_policy/prompt/model/schema/retrieval/export/review_workflow) impact 평가 + high-impact rerun gate.
+
+**태스크**:
+1. `scripts/validation/classify-changes.ts`:
+   - model/prompt 축: `lib/model-governance/change-workflow.ts` record 조회 (있을 경우)
+   - schema 축: `migrations/` diff (이전 release tag 기준)
+   - source_policy 축: `lib/source-governance/` 상태 (있을 경우) 또는 git diff 휴리스틱
+   - retrieval/export/review_workflow 축: git diff 휴리스틱 (경로 패턴 매칭)
+2. impact rating 로직: high = 사용자 가시 동작 변경 / 규제 근거 변경 / RBAC 변경; medium = 내부 로직; low = cosmetic
+3. `app/api/validation/impact-assessment/route.ts` — POST handler
+4. `lib/validation/rerun-gate.ts` — high-impact + rerun evidence 부재 시 차단
+5. 단위 테스트: 7축 각각 high/medium/low 분류 정확도
+6. integration 테스트: high-impact + rerun 부재 시 HTTP 409 (AC-5)
+
+**Reuse**: `lib/model-governance/change-workflow.ts`, `lib/source-governance/` (있을 경우), git diff
+
+**Fallback**: model-governance 미구현 시 git diff 휴리스틱만 동작 (단기 허용)
+
+**Gate (M4 완료 조건)**:
+- 7축 각각에 대해 impact_level + rerun_required + residual_risk 기록
+- high-impact + rerun 부재 시 sign-off 차단 로직 동작
+- AC-5 충족
+
+---
+
+### M5 — Release Validation Report + Sign-off (Critical)
+
+**목표**: Release Validation Report Markdown 빌더 + sign-off API + audit_logs hash-chain write.
+
+**태스크**:
+1. `scripts/validation/build-report.ts`:
+   - 섹션: Intended Use 요약, IQ/OQ/PQ evidence 표, Change-Control 7축 표, Release Scope Status (#31~#34), Traceability Status (#47), Source Governance Status (#48), Review Ops Status (#36), Sign-off Checklist
+   - Markdown 출력 → `docs/validation/release-report-<release_id>.md`
+2. `app/api/validation/report/export/route.ts` — POST handler
+3. `app/api/validation/signoff/route.ts` — POST handler:
+   - checklist_state 검증 (모든 항목 true)
+   - change-control rerun gate 재확인 (M4)
+   - `lib/audit.ts writeAudit(action_type: 'validation.signoff')` 호출 → audit_log_ref 저장
+4. `lib/validation/checklist.ts` — checklist 항목 정의 (IQ/OQ/PQ pass, change-control resolved, report exported)
+5. 단위 테스트: checklist 항목 누락 시 HTTP 409 (AC-8)
+6. integration 테스트: sign-off 성공 시 `audit_logs` 행 1건 추가, hash chain 연속성 유지 (AC-7)
+
+**Reuse**: `lib/audit.ts writeAudit` (hash chain), `scripts/release-rc1/` 패턴
+
+**Gate (M5 완료 / SPEC 완료 조건)**:
+- 모든 AC-1~AC-8 통과
+- `pnpm test` 전체 green
+- `docs/validation/intended-use.md` git history 존재
+- sign-off audit_logs 행 hash chain 검증 통과 (`lib/audit/verify-chain.ts`)
+
+---
+
+## §3 게이트 (Phase Gates)
+
+| Gate | 위치 | 통과 조건 | 실패 시 |
+|------|------|-----------|---------|
+| Gate-A | M0 직후 | migration + schema + 테이블 생성 테스트 green | M1~M5 착수 불가 |
+| Gate-B | M1~M4 각 milestone | AC-2, AC-3, AC-4, AC-5 각각 통과 | 다음 milestone 착수 보류 + plan 재검토 |
+| Gate-C | M5 완료 | AC-1~AC-8 모두 통과 + hash chain 검증 | SPEC 완료 불가, plan-auditor 재검토 |
+
+---
+
+## §4 리스크 레지스터 (상세)
+
+| ID | Risk | Probability | Impact | Mitigation | Owner |
+|----|------|-------------|--------|-----------|-------|
+| R1 | CI artifact 90일 만료 → evidence 누락 | 중 | 중 | artifact 만료 전 snapshot 수집; 만료 시 result=skip + 사유 | M2/M3 담당 |
+| R2 | model-governance change-workflow 미구현 | 중 | 높음 | M4 fallback 모드 (git diff 휴리스틱); #71 완료 후 정식 연동 | M4 담당 |
+| R3 | 7축 자동 분류 정확도 낮음 | 중 | 중 | high는 보수적 판정(과분류 허용); 사람이 residual_risk로 override | M4 담당 |
+| R4 | audit_logs chain 실패 → sign-off 불가 | 낮 | 높음 | writeAudit 실패 시 500 + retry 3회; SPEC-V3-AUDIT-CHAIN-001 verifyDaily 선행 | M5 담당 |
+| R5 | PDF export 범위 확장 요구 | 중 | 중 | REQ-VAL-011 Optional 고정; §8 Exclusions 명시 | SPEC owner |
+| R6 | TRACEABILITY-001(#47) 지연 → report 내 섹션 누락 | 중 | 낮음 | report에 stub 섹션 허용; #47 완료 후 보강 | M5 담당 |
+| R7 | release_id 체계 미정의 (RELEASE-001이 관리 안 함) | 중 | 중 | 본 SPEC에서 release_id 포맷 제안 (예: `v0.1.0-rc1`); RELEASE-001 sync | M0 담당 |
+
+---
+
+## §5 테스트 전략
+
+### 5.1 단위 테스트 (vitest)
+
+- 스키마 검증 (enum, CHECK, FK)
+- Evidence collector 함수 (각 검증 항목 pass/fail/skip)
+- 7축 분류 로직 (high/medium/low)
+- Checklist 항목 평가
+- Report builder 섹션별 출력
+
+### 5.2 Integration 테스트
+
+- 실DB 마이그레이션 + INSERT/SELECT
+- CI run ID 매핑 (`gh` CLI mock 또는 fixture)
+- API route happy/negative path (RBAC 거부, checklist 미충족 409)
+- audit_logs chain 연속성 (writeAudit 후 verify-chain 통과)
+
+### 5.3 E2E (제한적)
+
+- Validation workflow 시나리오: IQ 수집 → OQ → PQ → change-control → report → sign-off 전 주기
+- `tests/e2e/validation-signoff.spec.ts` (신규)
+
+### 5.4 수동 QA (Gate 4 도메인 UAT)
+
+- intended-use.md RA Lead 검토
+- criticality 분류 RA Lead + QA Lead 합의
+- residual risk 서술 검토
+
+---
+
+## §6 범위 통제 원칙 (Scope Discipline)
+
+Charter [지양-5] 준수:
+
+1. **신규 테스트 harness 금지** — 기존 CI 집계
+2. **신규 QMS 워크플로우 금지** — model-gov, source-gov 재사용
+3. **PDF 라이브러리 도입 금지** (M5에서는 Markdown only)
+4. **다중 관할권 matrix 금지** (post-v0.1)
+5. **real-time dashboard 금지** (별도 observability SPEC)
+
+구현 중 scope creep 발견 시 §8 Exclusions로 이월하고 milestone을 재조정한다.
+
+---
+
+## §7 의존성 타임라인
+
+```
+AUDIT-CHAIN-001 (PR #356, MERGED) ──┐
+                                     ├─→ M0 (schema) ─→ M5 (sign-off writes audit_logs)
+FOUNDATION-001 (기존) ───────────────┤
+                                     │
+RELEASE-001 (기존) ──────────────────┼─→ M5 (report links release scope)
+                                     │
+TRACEABILITY-001 (#47, 진행중) ──────┼─→ M5 (report section, stub 허용)
+                                     │
+MODEL-GOVERNANCE-001 (#71, 진행중) ──┼─→ M4 (change-control 7축 중 model/prompt, fallback 허용)
+                                     │
+SOURCE-GOVERNANCE-001 (#48) ─────────┼─→ M4 (change-control 7축 중 source_policy, fallback 허용)
+```
+
+Non-blocking 의존성은 fallback 모드로 동작하며, 완료 후 정식 연동 PR로 전환.
+
+---
+
+## §8 Definition of Done (SPEC 완료 조건)
+
+- [ ] AC-1~AC-8 모두 통과 (acceptance.md)
+- [ ] M0~M5 모든 milestone Gate 통과
+- [ ] `pnpm test` 전체 green
+- [ ] `pnpm ci:migrations`, `pnpm ci:typecheck`, `pnpm ci:lint`, `pnpm ci:format` green
+- [ ] `docs/validation/intended-use.md` git history 존재
+- [ ] sign-off audit_logs 행 hash chain 검증 (`lib/audit/verify-chain.ts`)
+- [ ] SPEC 문서 4종(spec/plan/acceptance/research) 최신 상태
+- [ ] PR 본문에 QA evidence 섹션 (이슈 #49 MoAI 교차검증 기준)

--- a/.moai/specs/SPEC-REGULA-VALIDATION-001/research.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-001/research.md
@@ -1,0 +1,246 @@
+---
+artifact: research
+spec_id: SPEC-REGULA-VALIDATION-001
+version: 1.1.0
+created: 2026-07-06
+updated: 2026-07-06
+author: manager-spec (plan-phase)
+purpose: "구현 착수 전 코드베이스 분석 — 재사용 가능 자산·통합 지점·자동화 범위 식별"
+---
+
+# Research — SPEC-REGULA-VALIDATION-001
+
+본 문서는 구현 착수 전(Plan phase) 코드베이스 정적 분석 결과를 기록한다. 목표는 (1) 재사용 가능 자산 식별, (2) 통합 지점 매핑, (3) 자동화 가능 영역과 수동 영역의 구분이다. Charter [지양-5]에 따라 신규 자산 생성을 최소화하고 기존 인프라를 집계하는 설계를 지향한다.
+
+---
+
+## §1 코드베이스 자산 인벤토리 (Reuse Map)
+
+### 1.1 CI/Quality Gate 인프라 (IQ/OQ/PQ evidence 소스)
+
+| 자산 | 경로 | 역할 | 검증 단계 |
+|------|------|------|-----------|
+| CI workflow | `.github/workflows/ci.yml` | typecheck/lint/format/test/rbac/audit/tokens gates | IQ(config) + OQ(unit) |
+| E2E workflow | `.github/workflows/e2e.yml` | Playwright smoke + full suite | PQ |
+| Security workflow | `.github/workflows/security.yml` | gitleaks/dependency scan | IQ(secret) |
+| Deploy workflow | `.github/workflows/deploy.yml` | Vercel preview/prod | IQ(deploy) |
+| Preflight | `scripts/preflight.sh` | 로컬 사전검증 (eval/e2e/load skip 플래그) | OQ/PQ 로컬 실행 |
+| Env validation | `scripts/validate-runtime-env.ts` | lib/env.ts Zod 검증 | IQ(env/secret) |
+| Migration check | `scripts/ci/check-migrations.ts` | `pnpm ci:migrations` | IQ(migration) |
+| RBAC check | `scripts/qa/check-rbac.mjs` | `pnpm ci:rbac` | OQ(rbac) |
+| Audit completeness | `scripts/qa/audit-completeness.ts` | `pnpm ci:audit` | OQ(audit) |
+| QA gate scripts | `scripts/qa/gate-{0..5}-*.ts` | QA 게이트 0~5 (qa-gate-roadmap.md SSoT) | Gate 5 = 운영 QA |
+| Eval | `tests/eval/promptfoo.config.yaml` + `pnpm eval:ci` | promptfoo eval 결과 (`tests/eval/results/latest.json`) | PQ(eval) |
+| Release scripts | `scripts/release-rc1/{merge-gate,pr-body-template,safe-merge}.sh` | RC1 릴리즈 게이트 | Report 연동 |
+
+**핵심 발견**: IQ/OQ/PQ evidence는 새 harness를 만들지 않고 위 결과를 집계하는 얇은 레코드 조립이다.
+
+### 1.2 Audit Chain Foundation (PR #356, 방금 머지)
+
+| 자산 | 경도 | 역할 |
+|------|------|------|
+| writeAudit (hash chain) | `lib/audit.ts:535+` | app-side `crypto.randomUUID()` 사전 생성 → INSERT 시 `previous_hash`, `chain_seq` 명시 전달 (REQ-AC-005) |
+| Hash compute | `lib/audit/hash-chain.ts` | `chainHash_N = SHA256(canonical(row_N) ‖ chainHash_{N-1})` 점화식 |
+| Verify | `lib/audit/verify-chain.ts` | chain 위반 탐지 (tamper-evidence) |
+| Daily cron | `lib/inngest/audit/audit-chain-verify-daily.ts` | 일일 chain 검증 (SPEC-V3-AUDIT-CHAIN-001 M3) |
+
+**활용 방식**: `validation_signoff` 테이블과 이중 저장하지 않고, sign-off 성공 시 `writeAudit` 1건 호출 (action_type: `validation.signoff`). `audit_logs` 행의 hash chain이 sign-off 무결성을 보장한다.
+
+### 1.3 Model Governance (변경통제 7축 중 model/prompt 소스)
+
+| 자산 | 경로 | 역할 |
+|------|------|------|
+| Registry | `lib/model-governance/registry.ts` | LLM 모델 registry, 메타데이터 |
+| Pinning | `lib/model-governance/model-pinning.ts` | release별 model pinning 기록 |
+| Change workflow | `lib/model-governance/change-workflow.ts` | model/prompt 변경 이력 |
+| Eval gate | `lib/model-governance/eval-gate.ts` | eval 통과 게이트 |
+| RLHF gate | `lib/model-governance/rlhf-gate.ts` | RLHF 피드백 게이트 |
+| Rollback | `lib/model-governance/rollback.ts` | 모델 롤백 절차 |
+| Combination | `lib/model-governance/combination-resolver.ts` | model+prompt 조합 |
+| Audit | `lib/model-governance/audit.ts`, `audit-metadata.ts` | model-gov 변경 audit 메타데이터 |
+
+**경계 (§3.2 spec.md 참조)**: `change-workflow.ts`가 model/prompt 변경 워크플로우 자체를 담당. 본 SPEC은 릴리즈 시점에 change-workflow 기록을 읽어 7축 중 `prompt`, `model` 축의 impact 평가에 소비한다. 중복 구현 금지.
+
+### 1.4 DB 스키마 (기존)
+
+| 자산 | 경로 | 내용 |
+|------|------|------|
+| 중앙 스키마 | `lib/db/schema.ts` | users, audit_logs, messages, workflow_runs 등 |
+| DocIngest 스키마 | `lib/db/schema-docingest.ts` | source_sections, citations 등 (traceability SPEC) |
+| Migrations | `migrations/*.sql` | 77+ 파일 (예: `0013_workflow_audit_actions.sql`, `0069_pms.sql`, `0077_model_governance.sql`, `0109_impact_wizard_columns.sql`) |
+
+**발견**: `audit_logs` 테이블이 이미 `previous_hash`, `chain_seq` 컬럼을 보유 (PR #356). 본 SPEC의 `validation_evidence`, `change_control`, `validation_signoff` 3개 신규 테이블은 신규 마이그레이션 1건으로 추가.
+
+### 1.5 기존 Validation/Evidence 코드 탐색 결과
+
+```
+grep -rn "validationEvidence\|releaseReport\|qualification" src/ app/ lib/  → 0 matches
+```
+
+**결론**: 현재 validation-specific 코드 부재. greenfield 구현이나 모든 빌딩 블록(audit, model-gov, CI, schema)은 존재. 따라서 본 SPEC의 구현은 **aggregator/glue** 코드가 중심이며, 신규 비즈니스 로직은 최소화.
+
+---
+
+## §2 통합 지점 (Integration Points)
+
+### 2.1 SPEC-REGULA-TRACEABILITY-001 (#47) 연동
+
+- Traceability SPEC은 source_sections/citations/messages/workflow_runs/expert_reviews/submission_packages/risk_items 간 evidence graph를 정의.
+- 본 SPEC의 `validation_evidence` 레코드는 traceability graph의 **추가 노드 타입**으로 연결 가능 (`derived_from` edge로 release 노드와 연결).
+- 단, 본 SPEC은 traceability graph 구현을 직접 하지 않고, TRACEABILITY-001이 완료된 후 노드 타입 확장을 후속 PR로 처리 (의존성 non-blocking).
+
+### 2.2 SPEC-REGULA-RELEASE-001 (#31) §2.1 연동
+
+- RELEASE-001 §2.1은 60개 OPEN 이슈를 5분류(in-scope/post-v0.1/Wave3/Wave5/QA-program)로 분류한 release 범위 SSoT.
+- 본 SPEC의 `release_id`는 RELEASE-001이 관리하는 release 식별자를 참조.
+- Release Validation Report의 "release scope status" 섹션은 RELEASE-001 §2.1의 5분류 상태를 집계.
+
+### 2.3 _shared/qa-gate-roadmap.md (QA SSoT)
+
+- QA Gate 0~5 중 본 SPEC은 Gate 5(운영 QA, #79)의 입력을 제공:
+  - `validation_evidence` 레코드 → Gate 5 synthetic check 기준
+  - `change_control` impact history → Gate 5 회귀 모니터링 대상 식별
+  - Release Validation Report → Gate 5 rollback 판단 근거
+
+### 2.4 CI run ID 매핑
+
+- GitHub Actions run ID는 `gh run list --workflow=ci.yml --json databaseId,headSha,conclusion`로 획득.
+- artifact path는 `gh run view <id> --log` 또는 actions API로 수집.
+- artifact 만료(기본 90일) 전에 validation bundle로 확정 저장해야 함 → M2/M3 설계에서 snapshot 시점 명시.
+
+---
+
+## §3 자동화 가능 vs 수동 영역 구분
+
+### 3.1 자동화 가능 (Auto-collect)
+
+| 항목 | 소스 | 자동화 방법 |
+|------|------|------------|
+| commit SHA | git | `git rev-parse HEAD` |
+| CI run ID | GitHub API | `gh run list --json` |
+| test result (pass/fail/skip) | vitest/junit | `tests/results/junit.xml` 파싱 |
+| artifact path | GitHub API | `gh run view --json artifacts` |
+| dependency hash | `pnpm-lock.yaml` | sha256 |
+| env/secret presence | `lib/env.ts` | Zod 검증 결과 |
+| migration status | `scripts/ci/check-migrations.ts` | exit code |
+| model change | `lib/model-governance/change-workflow.ts` | record 조회 |
+| prompt change | git diff + `lib/model-governance/registry.ts` | 휴리스틱 + registry |
+| schema change | `migrations/` diff | 파일 목록 비교 |
+| E2E result | `.github/workflows/e2e.yml` artifact | HTML report path |
+| eval result | `tests/eval/results/latest.json` | JSON 파싱 |
+
+### 3.2 수동 (Human-in-loop)
+
+| 항목 | 이유 | 담당 |
+|------|------|------|
+| `intended-use.md` 최초 작성 | 제품 사용 범위 선언은 전문가 판단 | RA Lead |
+| criticality 분류 (critical/support/ancillary) | 기능별 비즈니스 임팩트 판단 | RA Lead + QA Lead |
+| residual risk 서술 | 자동 분류 불가 | RA Lead |
+| exception note 서술 | 자동 분류 불가 | QA Lead |
+| final sign-off 승인 | 규제 책임 | Admin (validation:approve 권한) |
+
+---
+
+## §4 자동화 스크립트 설계 (구현 착수 시 참조)
+
+### 4.1 Evidence Collector (신규, 경량)
+
+```
+scripts/validation/
+  collect-iq.ts        # IQ bundle 생성 (env/deps/migrations/config/secret)
+  collect-oq.ts        # OQ bundle 생성 (CI test 결과 매핑)
+  collect-pq.ts        # PQ bundle 생성 (E2E + eval 매핑)
+  classify-changes.ts  # 7축 분류 (model-gov + git diff)
+  build-report.ts      # Markdown report 조립
+  export-pdf.ts        # (post-v0.1) PDF 변환
+```
+
+### 4.2 자동화 트리거
+
+- **수동**: `pnpm validation:collect --release=<id>` 명령
+- **CI 연동**: `release-rc1` workflow 내에서 release tag 시점에 자동 실행 (별도 workflow job)
+- **Inngest**: 주기적 evidence refresh (artifact 만료 전 갱신)
+
+---
+
+## §5 위험 분석 (구현 착수 전)
+
+### 5.1 기술적 위험
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| CI run ID ↔ 테스트 결과 매핑 정확도 | 중 | 중 | `gh run view --json` 결과를 저장 후 추출; 추출 실패 시 result=skip + 로깅 |
+| promptfoo eval 결과 스키마 변경 | 낮 | 중 | eval 결과 JSON 버전 핀; 스키마 검증 Zod 추가 |
+| model-governance change-workflow 미구현 상태 | 중 | 높음 | M0~M3는 model-gov 없이 동작하는 fallback 모드 설계 (git diff 휴리스틱만 사용) |
+| audit_logs chain 실패 | 낮 | 높음 | sign-off는 writeAudit 성공을 전제; 실패 시 500 + retry policy |
+
+### 5.2 범위 위험 (Scope creep)
+
+| Risk | Mitigation |
+|------|-----------|
+| "PDF도 만들어야 함" 확장 요구 | REQ-VAL-011을 Optional/Low로 고정; §8 Exclusions에 명시 |
+| "QMS 워크플로우 통합" 확장 요구 | §1.4 Out of Scope, §8 Exclusions에 명시 |
+| "real-time dashboard" 요구 | §8 Exclusions; observability는 별도 SPEC |
+| "다중 관할권 matrix" 요구 | §8 Exclusions; post-v0.1 |
+
+---
+
+## §6 마이그레이션 설계 (개요)
+
+신규 마이그레이션 1건 (`migrations/0NNN_validation_evidence.sql`, 번호는 착수 시점 최신 + 1):
+
+```sql
+-- validation_evidence: IQ/OQ/PQ 증거 레코드
+CREATE TABLE validation_evidence (
+  id UUID PRIMARY KEY,
+  release_id TEXT NOT NULL,
+  qualification_type TEXT NOT NULL CHECK (qualification_type IN ('iq','oq','pq')),
+  commit_sha TEXT NOT NULL,
+  ci_run_id BIGINT,
+  test_command TEXT NOT NULL,
+  artifact_path TEXT,
+  result TEXT NOT NULL CHECK (result IN ('pass','fail','skip')),
+  metadata JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- change_control: 7축 변경 영향 평가
+CREATE TABLE change_control (
+  id UUID PRIMARY KEY,
+  release_id TEXT NOT NULL,
+  change_axis TEXT NOT NULL CHECK (change_axis IN
+    ('source_policy','prompt','model','schema','retrieval','export','review_workflow')),
+  impact_level TEXT NOT NULL CHECK (impact_level IN ('low','medium','high')),
+  rerun_required BOOLEAN NOT NULL,
+  residual_risk TEXT NOT NULL,
+  exception_note TEXT,
+  evidence_ref UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- validation_signoff: 최종 승인
+CREATE TABLE validation_signoff (
+  id UUID PRIMARY KEY,
+  release_id TEXT NOT NULL UNIQUE,
+  checklist_state JSONB NOT NULL,
+  approver_id UUID NOT NULL REFERENCES users(id),
+  signed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  report_artifact_path TEXT NOT NULL,
+  audit_log_ref UUID
+);
+
+CREATE INDEX idx_validation_evidence_release ON validation_evidence(release_id);
+CREATE INDEX idx_change_control_release ON change_control(release_id);
+```
+
+charter RLS(Regula-Lite Single-tenant) 전제이므로 tenant_id는 생략. 모든 테이블은 append-only (update 미지원, 갱신 시 신규 INSERT). audit_logs chain 무결성을 해치지 않음.
+
+---
+
+## §7 결론 및 구현 착수 전제조건
+
+1. **재사용 전제 충족**: 모든 빌딩 블록(audit chain, model-gov, CI, DB)이 존재 → greenfield가 아닌 aggregator 구현.
+2. **의존성 전제**: SPEC-V3-AUDIT-CHAIN-001(PR #356) 머지 완료. TRACEABILITY-001(#47)은 non-blocking이나 report의 traceability 섹션은 TRACEABILITY-001 완료 전까지 stub 허용.
+3. **범위 원칙**: §1.5 CSV-lite, §8 Exclusions에 명시된 항목은 post-v0.1로 이월. 구현 중 scope creep 발생 시 plan.md의 milestone 재조정.
+4. **자동화 한계**: §3.2 수동 항목은 사람이 작성. 자동화 강요 금지.
+5. **plan.md의 milestone M0~M5가 본 research의 자산 인벤토리를 소비**.

--- a/.moai/specs/SPEC-REGULA-VALIDATION-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-001/spec.md
@@ -1,20 +1,42 @@
 ---
 id: SPEC-REGULA-VALIDATION-001
-version: 1.0.0
-status: draft
-phase: system
+title: "Regula 자체 검증 패키지 — IQ/OQ/PQ·변경통제·릴리즈 증거"
+version: 1.1.0
+status: planned
+phase: system-validation
 priority: High
 created: 2026-06-22
-updated: 2026-06-22
-author: manager-spec (batch-2026-06-22)
+updated: 2026-07-06
+author: manager-spec (plan-phase completion)
 issue_number: 49
 depends_on:
   - SPEC-REGULA-FOUNDATION-001
+  - SPEC-REGULA-RELEASE-001
+  - SPEC-REGULA-TRACEABILITY-001
+  - SPEC-V3-AUDIT-CHAIN-001
+related_specs:
+  - SPEC-REGULA-MODEL-GOVERNANCE-001
+  - SPEC-REGULA-SOURCE-GOVERNANCE-001
+  - SPEC-REGULA-REVIEW-OPS-001
+closes_issues: []
+verifies_specs:
   - SPEC-REGULA-RELEASE-001
 lifecycle_level: spec-anchored
 labels:
   - component/backend
   - component/infra
+  - csv-lite
+  - iqqpq
+  - change-control
+revision_history:
+  - version: 1.1.0
+    date: 2026-07-06
+    author: manager-spec (plan-phase)
+    notes: "plan-phase 완료. status draft→planned. depends_on 보강 (TRACEABILITY, AUDIT-CHAIN). EARS 구문 정비 (한영 혼용→영문 EARS). 4-doc 셋 완성 (research/plan/acceptance 추가). CSV-lite 원칙 명시 (§1.5). #71 MODEL-GOVERNANCE와의 경계 §3.2 명확화. audit-chain foundation (PR #356) 활용."
+  - version: 1.0.0
+    date: 2026-06-22
+    author: manager-spec (batch)
+    notes: "초기 작성. Issue #49 기반."
 ---
 
 # SPEC-REGULA-VALIDATION-001 — Regula 자체 검증 패키지 (IQ/OQ/PQ·변경통제·릴리즈 증거)
@@ -23,6 +45,7 @@ labels:
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 1.1.0 | 2026-07-06 | manager-spec (plan-phase) | plan-phase 완료. 4-doc 셋 완성. EARS 정비. AUDIT-CHAIN·TRACEABILITY 의존성 추가. CSV-lite 원칙·경계 명시. |
 | 1.0.0 | 2026-06-22 | manager-spec (batch) | 초기 작성. Issue #49 기반. |
 
 ---
@@ -31,114 +54,214 @@ labels:
 
 ### 1.1 배경 (Background)
 
-Regula가 RA 의사결정, 제출 초안, 위험관리, 검토 승인에 사용된다면 Regula 자체도 검증 가능한(validated) 업무 시스템이어야 한다. 기능 이슈들은 제품 기능을 완성하지만, 운영 관점에서는 릴리즈마다 무엇이 검증됐고 어떤 제한 조건으로 사용 가능한지를 증거로 남겨야 한다.
+Regula가 RA 의사결정, 제출 초안, 위험관리, 검토 승인에 사용된다면 Regula 자체도 검증 가능한(validated) 업무 시스템이어야 한다. #31~#46은 제품 기능을 완성하지만, 운영 관점에서는 **릴리즈마다 무엇이 검증됐고 어떤 제한 조건으로 사용 가능한지**를 증거로 남겨야 한다.
 
-본 SPEC은 내부용 CSV-lite 수준의 IQ/OQ/PQ(Installation/Operational/Performance Qualification) 기반 Regula system validation package를 정의한다. 이는 외부 인증 대행이나 FDA 제출용 소프트웨어 validation이 아니라, 내부 거버넌스를 위한 검증 증거 체계다.
+본 SPEC은 내부용 **CSV-lite** 수준의 IQ/OQ/PQ(Installation/Operational/Performance Qualification) 기반 Regula system validation package를 정의한다. 이는 외부 인증 대행이나 FDA 제출용 소프트웨어 validation이 아니라, 내부 거버넌스를 위한 검증 증거 체계다.
 
-검증 증거는 사람이 수기로 정리하는 것이 아니라 commit SHA, CI run, test command, artifact path를 자동 수집하여 신뢰 가능한 release validation report로 묶는다.
+검증 증거는 사람이 수기로 정리하는 것이 아니라 **commit SHA, CI run ID, test command, artifact path**를 자동 수집하여 신뢰 가능한 release validation report로 묶는다.
 
 변경통제(change control)는 source policy, prompt, model, schema, retrieval, export, review workflow 변경의 영향을 평가하고, high-impact change에는 validation rerun을 강제한다.
 
 ### 1.2 규제 근거 (Regulatory Anchor)
 
-- GAMP 5 / CSV (Computerized System Validation) — IQ/OQ/PQ 단계별 검증 증거 체계.
-- 21 CFR Part 11 — validation sign-off는 electronic record로 audit_logs에 기록되어야 한다.
-- ISO 13485 §4.1.6 — 소프트웨어 validation 및 변경통제 요구.
+- **GAMP 5 / CSV (Computerized System Validation)** — IQ/OQ/PQ 단계별 검증 증거 체계.
+- **21 CFR Part 11 §11.10(i)** — 컴퓨터 시스템 검증 문서화; **§11.50 / §11.70** — 전자기록 서명자·타임스탬프, e-signature binding (audit-chain foundation PR #356이 tamper-evidence 담당).
+- **ISO 13485:2016 §4.1.6** — 소프트웨어 validation 및 변경통제 요구.
+- **ISO 14971:2019** — 잔여 위험(residual risk) 기록 요구 (change control과 연계).
 
 ### 1.3 본 SPEC의 범위 (In Scope)
 
-- A. Intended Use & Validation Scope: intended/prohibited use, human review boundary 문서화, 기능별 validation criticality 분류
-- B. IQ/OQ/PQ Evidence: 환경/dependency/migration/config/secret 검증(IQ), core function requirement test(OQ), 대표 RA 시나리오 E2E evidence(PQ)
-- C. Change Control: 릴리즈별 변경 영향 평가, high-impact change validation rerun, exception/residual risk 기록
-- D. Release Validation Report: 릴리즈 결과 연결, traceability/source governance/review ops 상태 포함, final sign-off checklist
+- **A. Intended Use & Validation Scope**: intended/prohibited use, human review boundary 문서화, 기능별 validation criticality 분류
+- **B. IQ/OQ/PQ Evidence**:
+  - IQ — 환경/dependency/migration/config/secret presence 검증 번들 (기존 `scripts/validate-runtime-env.ts`, `pnpm ci:migrations`, `pnpm install --frozen-lockfile` 결과 집계)
+  - OQ — core function requirement test 결과 번들 (기존 `pnpm ci:test`, `pnpm ci:rbac`, `pnpm ci:audit` 집계)
+  - PQ — 대표 RA 시나리오 end-to-end evidence 번들 (기존 `.github/workflows/e2e.yml`, `tests/eval/promptfoo.config.yaml` 집계)
+- **C. Change Control**: 릴리즈별 변경 영향 평가 (7축: source_policy/prompt/model/schema/retrieval/export/review_workflow), high-impact → validation rerun, residual risk 기록
+- **D. Release Validation Report**: 릴리즈 결과 연결 (#31~#34), traceability (#47), source governance (#48), review ops (#36) 상태 포함, final sign-off checklist
 
-### 1.4 Out of Scope
+### 1.4 Out of Scope (Non-Goals)
 
-- 외부 인증기관 검증 대행
-- SOC 2 / ISO 27001 full certification
-- FDA 제출용 소프트웨어 validation 패키지
+- 외부 인증기관 검증 대행 (SOC 2 / ISO 27001 / FDA 510(k) software validation)
+- Full QMS (Quality Management System) 워크플로우 — 본 SPEC은 CSV-lite 내부 거버넌스 범위
+- `audit_logs` hash chain 자체 구현 (PR #356 SPEC-V3-AUDIT-CHAIN-001이 담당; 본 SPEC은 chain에 write하는 소비자)
+- LLM/prompt 변경관리 워크플로우 자체 (Issue #71 / SPEC-REGULA-MODEL-GOVERNANCE-001이 담당; 본 SPEC은 결과를 7축 중 하나로 집계)
+- 외부 e-QMS 양방향 동기화
 
----
+### 1.5 CSV-Lite 원칙 (Over-Engineering 방지)
 
-## §2 Requirements (EARS Format)
+Charter [지양-5]에 따라 본 SPEC은 다음을 금지한다:
 
-| ID | EARS Statement | Priority |
-|----|---------------|----------|
-| REQ-VALIDATION-001 | THE SYSTEM SHALL Regula의 intended use, prohibited use, human review boundary를 문서로 관리해야 한다 | High |
-| REQ-VALIDATION-002 | THE SYSTEM SHALL 각 기능(chat/RAG/workflow draft/review/submission package/risk management)에 validation criticality 등급을 분류해야 한다 | High |
-| REQ-VALIDATION-003 | WHEN IQ가 실행되면 THE SYSTEM SHALL 환경, dependency, migration, config, secret presence를 검증하고 결과를 기록해야 한다 | High |
-| REQ-VALIDATION-004 | WHEN OQ가 실행되면 THE SYSTEM SHALL core function requirement test 결과를 evidence bundle로 묶어야 한다 | High |
-| REQ-VALIDATION-005 | WHEN PQ가 실행되면 THE SYSTEM SHALL 대표 RA 시나리오의 end-to-end evidence를 묶어야 한다 | High |
-| REQ-VALIDATION-006 | THE SYSTEM SHALL 각 evidence에 commit SHA, CI run ID, test command, artifact path를 포함해야 한다 | High |
-| REQ-VALIDATION-007 | WHEN 릴리즈가 준비되면 THE SYSTEM SHALL source policy/prompt/model/schema/retrieval/export/review workflow 변경 영향 평가를 생성해야 한다 | High |
-| REQ-VALIDATION-008 | IF 변경이 high-impact로 분류되면 THEN THE SYSTEM SHALL validation rerun을 필수 조건으로 강제해야 한다 | High |
-| REQ-VALIDATION-009 | THE SYSTEM SHALL validation exception과 residual risk를 기록해야 한다 | Medium |
-| REQ-VALIDATION-010 | THE SYSTEM SHALL release validation report에 release/traceability/source governance/review ops 상태를 연결해야 한다 | High |
-| REQ-VALIDATION-011 | WHEN release validation report가 export되면 THE SYSTEM SHALL Markdown 및 PDF 형식으로 생성해야 한다 | Medium |
-| REQ-VALIDATION-012 | WHEN validation이 sign-off되면 THE SYSTEM SHALL 승인자, 타임스탬프를 audit_logs에 기록해야 한다 | High |
-| REQ-VALIDATION-013 | IF final sign-off checklist 항목이 미충족이면 THEN THE SYSTEM SHALL release sign-off를 차단해야 한다 | High |
-| REQ-VALIDATION-014 | THE SYSTEM SHALL CI/test/eval 결과를 validation report에 자동으로 링크해야 한다 | High |
+- **금지**: 새로운 테스트 harness/프레임워크 도입 — 기존 CI(`.github/workflows/ci.yml`, `e2e.yml`, `security.yml`) 결과를 집계
+- **금지**: 독자적 QMS 워크플로우 — 기존 `lib/model-governance/`, `lib/audit/` 재사용
+- **금지**: 수기 문서 작성 — 모든 evidence는 commit SHA + CI run ID로 자동 수집
+- **금지**: PDF 전용 외부 라이브러리 (Pandoc/PrinceXML) 도입 — Markdown 우선, PDF는 post-v0.1 후순위 (REQ-VAL-011 Optional)
 
 ---
 
-## §3 Acceptance Criteria
+## §2 Intended Use (제품 사용 범위 선언)
 
-| AC# | Criterion | Verification |
-|-----|-----------|-------------|
-| AC-01 | intended use / prohibited use 문서가 생성되고 버전 관리됨 | 문서 존재 + git history 확인 |
-| AC-02 | IQ/OQ/PQ evidence template과 자동 수집 스크립트가 동작함 | 스크립트 실행 후 evidence bundle 생성 확인 |
-| AC-03 | CI/test/eval 결과가 validation report에 링크됨 | report 내 CI run ID/artifact path 검증 |
-| AC-04 | prompt/model/source/schema 변경 시 impact assessment가 생성됨 | 변경 시뮬레이션 후 assessment 문서 자동 생성 |
-| AC-05 | release validation report가 Markdown 및 PDF로 export됨 | export 실행 후 두 형식 파일 생성 검증 |
-| AC-06 | validation sign-off가 audit_logs에 승인자/타임스탬프로 기록됨 | DB 조회: audit_logs sign-off row 확인 |
-| AC-07 | final sign-off checklist 미충족 시 release가 차단됨 | Integration: 미충족 상태에서 sign-off 시도 시 거부 |
+### 2.1 Intended Use (허용 사용)
+
+Regula는 다음 용도로 사용된다:
+
+1. RA 전문가의 의사결정 보조 (chat, RAG 기반 인용 응답)
+2. 규제 전략·제출 초안 작성 보조 (workflow drafts: 510(k), CER, PCCP)
+3. 위험관리 문서화 보조 (risk register, FMEA)
+4. 전문가 검토 워크벤치 (expert review, citation 추적)
+5. 제출 패키지 증거 묶음 (submission packaging)
+
+### 2.2 Prohibited Use (금지 사용)
+
+1. 자율 규제 의사결정 (human review 없는 최종 판단 금지)
+2. 의료 진단·치료 권고
+3. 환자 식별정보(PII/PHI) 처리 (SPEC-REGULA-PHI-REMOVAL-001 준수 전제)
+4. FDA/EMA 등 규제 당국 직접 제출 (사람의 최종 검토·승인 필수)
+
+### 2.3 Human Review Boundary
+
+- 모든 RA claim은 citation과 reviewer sign-off 없이 제출 불가
+- 자동 생성 draft는 human review 게이트 통과 후에만 export
+- 검토자 책임은 SPEC-REGULA-REVIEW-OPS-001 (#36)에 정의
 
 ---
 
-## §4 Technical Approach
+## §3 Requirements (EARS Format)
 
-### 4.1 파일 구조
+### 3.1 Requirements 매트릭스
 
-```
-src/
-  app/api/
-    validation/iq/route.ts
-    validation/oq/route.ts
-    validation/pq/route.ts
-    validation/impact-assessment/route.ts
-    validation/report/export/route.ts
-    validation/signoff/route.ts
-  lib/
-    validation/criticality.ts        # 기능별 criticality 분류
-    validation/evidence-collector.ts # commit SHA/CI run/artifact 수집
-    validation/change-control.ts     # 변경 영향 평가
-    validation/report-builder.ts     # Markdown/PDF report 생성
-  db/schema/
-    validation-evidence.ts
-    change-control.ts
-    validation-signoff.ts
-scripts/
-  collect-validation-evidence.ts     # CI 연동 자동 수집
-docs/validation/
-  intended-use.md
-```
+| ID | Pattern | EARS Statement | Priority |
+|----|---------|----------------|----------|
+| REQ-VAL-001 | Ubiquitous | The system **shall** maintain a version-controlled `intended-use.md` document declaring intended use, prohibited use, and human review boundary (§2). | High |
+| REQ-VAL-002 | Ubiquitous | The system **shall** classify each functional capability (chat, RAG, workflow draft, review, submission package, risk management) with a validation criticality tier (critical / support / ancillary). | High |
+| REQ-VAL-003 | Event-Driven | **When** a release is prepared, the system **shall** produce an IQ (Installation Qualification) evidence bundle aggregating environment, dependency, migration, config, and secret-presence verification results. | High |
+| REQ-VAL-004 | Event-Driven | **When** a release is prepared, the system **shall** produce an OQ (Operational Qualification) evidence bundle linking the `pnpm ci:test`, `pnpm ci:rbac`, and `pnpm ci:audit` CI run results. | High |
+| REQ-VAL-005 | Event-Driven | **When** a release is prepared, the system **shall** produce a PQ (Performance Qualification) evidence bundle linking the `.github/workflows/e2e.yml` scenario results and `tests/eval/promptfoo.config.yaml` eval output. | High |
+| REQ-VAL-006 | Ubiquitous | The system **shall** attach to every evidence record: `commit_sha`, `ci_run_id`, `test_command`, `artifact_path`, and `result` (pass/fail/skip). | High |
+| REQ-VAL-007 | Event-Driven | **When** a release is prepared, the system **shall** generate a change-impact assessment covering the 7 axes (source_policy, prompt, model, schema, retrieval, export, review_workflow). | High |
+| REQ-VAL-008 | Unwanted | **If** any change axis is classified `high-impact` and validation rerun evidence is absent, **then** the system **shall** block release sign-off. | High |
+| REQ-VAL-009 | Ubiquitous | The system **shall** record residual risk and validation exception notes for every high-impact change with explicit justification. | Medium |
+| REQ-VAL-010 | Ubiquitous | The system **shall** emit a Release Validation Report linking release scope (#31~#34), traceability status (#47 / SPEC-REGULA-TRACEABILITY-001), source governance status (#48), and review ops status (#36). | High |
+| REQ-VAL-011 | Optional | **Where** PDF export is requested, the system **shall** emit the Release Validation Report in both Markdown and PDF formats. | Low |
+| REQ-VAL-012 | Event-Driven | **When** a validation sign-off is recorded, the system **shall** write an entry to `audit_logs` (hash-chained per SPEC-V3-AUDIT-CHAIN-001) containing approver id, timestamp, and report artifact path. | High |
+| REQ-VAL-013 | Unwanted | **If** any final sign-off checklist item is unmet, **then** the system **shall** reject the sign-off request with HTTP 409 and surface the failed checklist items. | High |
+| REQ-VAL-014 | Ubiquitous | The system **shall** auto-link CI/test/eval results to the validation report by CI run ID and artifact path without manual transcription. | High |
 
-### 4.2 DB Schema
+### 3.2 경계: SPEC-REGULA-MODEL-GOVERNANCE-001 (#71)과의 분담
 
-- `validation_evidence`: id, qualification_type (enum: IQ/OQ/PQ), commit_sha, ci_run_id, test_command, artifact_path, result (enum: pass/fail/skip), created_at
-- `change_control`: id, release_id, change_axis (enum: source_policy/prompt/model/schema/retrieval/export/review_workflow), impact_level (enum: low/medium/high), rerun_required (boolean), residual_risk (text), exception_note (text, nullable), created_at
-- `validation_signoff`: id, release_id, checklist_state (jsonb), approver_id (FK), signed_at, report_artifact_path
-- `audit_logs` (기존): sign-off 이벤트 기록
+| 소유권 | SPEC | 책임 |
+|--------|------|------|
+| MODEL-GOVERNANCE (#71) | LLM model registry, prompt versioning, eval gate enforcement, rollback procedure 자체 |
+| VALIDATION (본 SPEC, #49) | 릴리즈 시점 impact assessment의 7축 중 하나로 MODEL-GOVERNANCE change record를 **소비** |
+| SOURCE-GOVERNANCE (#48) | source authority, version, effective date 관리 자체 |
+| VALIDATION (본 SPEC, #49) | 릴리즈 시점 source_policy 축의 변경여부 판단을 위해 SOURCE-GOVERNANCE 상태를 **참조** |
 
-### 4.3 API Endpoints
+본 SPEC은 중복 구현을 금지하며, 기존 change-tracking 시스템의 결과를 집계하는 얇은(aggregator) 계층이다.
 
-- `POST /api/validation/iq|oq|pq` — qualification 실행 및 evidence 수집
-- `POST /api/validation/impact-assessment` — 변경 영향 평가 생성
-- `POST /api/validation/report/export` — Markdown/PDF report export
-- `POST /api/validation/signoff` — final sign-off (checklist gate 적용)
+---
 
-### 4.4 의존성
+## §4 Technical Approach (Sketch)
 
-- 선행: SPEC-REGULA-FOUNDATION-001 (audit_logs, RBAC), SPEC-REGULA-RELEASE-001 (release scope SSoT)
-- 연계: #31~#34 Release, #47 Traceability, #48 Source Governance, #36 Review Ops
-- 기술: Next.js 15, Drizzle ORM, PostgreSQL, CI (GitHub Actions) 연동, promptfoo eval 결과 연결
+> 상세는 `plan.md`와 `research.md` 참조. 본 절은 개요만.
+
+### 4.1 증거 수집 재사용 맵 (Reuse Map)
+
+| Evidence | 재사용 자산 | 신규 구현 |
+|----------|------------|-----------|
+| IQ env | `scripts/validate-runtime-env.ts` | bundle record 조립 |
+| IQ deps | `pnpm install --frozen-lockfile` + `pnpm-lock.yaml` hash | lockfile hash 기록 |
+| IQ migrations | `pnpm ci:migrations` (`scripts/ci/check-migrations.ts`) | 결과 메타데이터 저장 |
+| IQ config/secret | `lib/env.ts` Zod 검증 + `.env.example` diff | 누락 키 목록 기록 |
+| OQ unit/integration | `pnpm ci:test` (vitest), `pnpm ci:rbac`, `pnpm ci:audit` | CI run ID 매핑 |
+| PQ E2E | `.github/workflows/e2e.yml` (smoke + full) | 시나리오별 artifact path |
+| PQ eval | `tests/eval/promptfoo.config.yaml`, `pnpm eval:ci` | eval 결과 JSON 링크 |
+| Change-control | `lib/model-governance/change-workflow.ts` + `git diff` classify | 7축 분류 + impact rating |
+| Sign-off | `lib/audit.ts writeAudit` (hash chain, PR #356) | sign-off action type 추가 |
+| Report | Markdown builder (신규, 경량) | PDF는 post-v0.1 |
+
+### 4.2 DB Schema (신규 3 테이블, 마이그레이션 1건)
+
+- `validation_evidence` (id, release_id, qualification_type enum[iq/oq/pq], commit_sha, ci_run_id, test_command, artifact_path, result enum[pass/fail/skip], metadata jsonb, created_at)
+- `change_control` (id, release_id, change_axis enum[7], impact_level enum[low/medium/high], rerun_required boolean, residual_risk text, exception_note text null, evidence_ref uuid null, created_at)
+- `validation_signoff` (id, release_id, checklist_state jsonb, approver_id fk users, signed_at, report_artifact_path, audit_log_ref uuid)
+
+`audit_logs`는 기존 테이블 재사용 (hash chain 포함).
+
+### 4.3 API Endpoints (최소 4종)
+
+- `POST /api/validation/iq|oq|pq` — qualification 실행 및 evidence upsert
+- `POST /api/validation/impact-assessment` — 변경 영향 평가 생성/갱신
+- `POST /api/validation/report/export` — Markdown (PDF optional) report 생성
+- `POST /api/validation/signoff` — final sign-off (checklist gate, audit_logs write)
+
+### 4.4 RBAC
+
+- `validation:run` — IQ/OQ/PQ 실행 (admin, qa_lead)
+- `validation:approve` — sign-off (admin only)
+- `validation:read` — report 열람 (admin, qa_lead, ra_lead)
+
+---
+
+## §5 Acceptance Criteria (요약)
+
+> 상세는 `acceptance.md`. 요약:
+
+| AC# | Criterion (binary-testable) |
+|-----|-----|
+| AC-1 | `docs/validation/intended-use.md` 존재 + git history 존재 |
+| AC-2 | 릴리즈별 IQ evidence bundle이 DB에 존재 (5 필드 모두 non-null) |
+| AC-3 | OQ evidence가 `ci_run_id`와 `pnpm ci:test` 결과 매핑 포함 |
+| AC-4 | PQ evidence가 e2e.yml 시나리오 결과 + promptfoo eval 결과 링크 |
+| AC-5 | high-impact change + rerun 미실시 상태에서 sign-off 시도 → HTTP 409 |
+| AC-6 | Release Validation Report에 #31-34/#47/#48/#36 상태 섹션 존재 |
+| AC-7 | sign-off 성공 시 `audit_logs` 행 1건 추가 (approver + timestamp + report path) |
+| AC-8 | checklist 미충족 상태에서 sign-off → 409 + 실패 항목 목록 반환 |
+
+---
+
+## §6 의존성 (Dependencies)
+
+### 6.1 선행 (Blocking)
+
+- `SPEC-REGULA-FOUNDATION-001` — `audit_logs` 테이블, RBAC 기반
+- `SPEC-REGULA-RELEASE-001` — release scope SSoT (§2.1) — 본 SPEC이 release_id를 참조
+- `SPEC-REGULA-TRACEABILITY-001` (#47) — evidence graph 노드/엣지 (validation evidence가 노드 타입 중 하나로 연결)
+- `SPEC-V3-AUDIT-CHAIN-001` (PR #356) — `audit_logs` hash chain (sign-off 무결성 기반)
+
+### 6.2 연계 (Non-blocking, 참조)
+
+- `SPEC-REGULA-MODEL-GOVERNANCE-001` (#71) — model/prompt change record (change-control 7축 중 model/prompt 소스)
+- `SPEC-REGULA-SOURCE-GOVERNANCE-001` (#48) — source authority/version (change-control 7축 중 source_policy 소스)
+- `SPEC-REGULA-REVIEW-OPS-001` (#36) — review SLA 상태 (Release Report에 참조)
+- `.moai/specs/_shared/qa-gate-roadmap.md` — QA 게이트 0~5 SSoT (본 SPEC은 Gate 5 운영 QA 입력)
+
+### 6.3 기술 스택
+
+- Next.js 15 (App Router), Drizzle ORM, PostgreSQL
+- CI: GitHub Actions (`.github/workflows/{ci,e2e,security,deploy}.yml`)
+- eval: promptfoo (`tests/eval/`)
+- audit: `lib/audit.ts` writeAudit (hash chain)
+
+---
+
+## §7 Risks (요약, 상세 plan.md §4)
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| CI run ID 매핑 실패 (artifact 만료) | OQ/PQ evidence 누락 | 만료 전 snapshot 시점에 즉시 수집; 만료 시 result=skip 기록 |
+| Change-control 7축 자동 분류 정확도 | 위분류 → rerun 누락 | `lib/model-governance/change-workflow.ts` 기록 우선, `git diff` 휴리스틱은 보조 |
+| PDF export 라이브러리 도입 범위 확장 | Charter [지양-5] 위반 | REQ-VAL-011을 Optional/Low로 강제, Markdown 우선 |
+| audit_logs chain 실패 시 sign-off 블록 | sign-off 불가 | SPEC-V3-AUDIT-CHAIN-001 verifyDaily가 선행; 본 SPEC은 write 실패 시 500 + retry |
+
+---
+
+## §8 Exclusions (What NOT to Build)
+
+> Charter [지양-5] 및 Issue #49 "내부용 CSV-lite" 원칙에 따른 제외 항목.
+
+- **배제**: 외부 QMS 시스템(SAP, Veeva Vault, MasterControl) 연동
+- **배제**: FDA 510(k) / CE / PMDA 공식 제출용 software validation 패키지
+- **배제**: SOC 2 Type II / ISO 27001 인증 증거
+- **배제**: 자체 PDF 렌더링 파이프라인 (Pandoc/PrinceXML/headless Chrome) — Markdown 우선, PDF는 post-v0.1 별도 SPEC
+- **배제**: Real-time validation dashboard (별도 observability SPEC)
+- **배제**: 다중 규제 관할권별 validation matrix (post-v0.1)
+- **배제**: 사전 승인된 validation template 자동 생성 (사람이 작성하는 intended-use.md가 SSoT)


### PR DESCRIPTION
## SPEC-REGULA-VALIDATION-001 — Regula 자체 검증 패키지 plan (Phase: system)

Issue #49. 내부용 CSV-lite IQ/OQ/PQ 검증 증거 aggregator + 변경통제 + 릴리즈 검증 리포트.

### 산출물 4종 (.moai/specs/SPEC-REGULA-VALIDATION-001/)
- **spec.md** v1.0.0 draft → **v1.1.0 planned** (14 EARS REQ-VAL-001~014, depends_on 확장 [FOUNDATION/RELEASE/TRACEABILITY], §3.2 #71 MODEL-GOVERNANCE 경계, §1.5 CSV-lite 원칙, §8 Exclusions)
- **research.md** (신규) — codebase 자산 인벤토리, audit-chain/model-gov 재사용 맵, auto vs manual 분리, migration 스케치
- **plan.md** (신규) — M0~M5 milestones + gates + risk register + test strategy + DoD
- **acceptance.md** (신규) — AC-1~AC-8 binary-testable + 8 GWT 시나리오 + 8 edge cases + traceability matrix + NFR + Charter compliance

### 핵심 설계 결정
1. 기존 CI/eval/model-gov 자산을 집계하는 **thin glue layer** (신규 harness 금지, Charter [지양-5])
2. sign-off는 PR #356 audit-chain `writeAudit` 소비 (중복 저장 금지)
3. #71 MODEL-GOVERNANCE와 경계 명확화 — 본 SPEC은 7축 impact assessment의 model/prompt를 change-workflow record에서 소비
4. PDF export는 REQ-VAL-011 Optional/Low로 고정 (post-v0.1 이월)

### Milestones
- M0 Evidence Schema & DB Migration (3 tables) — Critical
- M1 IQ Bundle Generator (env/deps/migrations/config/secret)
- M2 OQ Aggregator (CI run ID 매핑)
- M3 PQ E2E+Eval Bundle
- M4 Change-Control Impact Assessment (7축 + high-impact rerun gate)
- M5 Release Validation Report + Sign-off (Markdown builder + audit_logs hash-chain write) — Critical

### ⚠️ Annotation cycle 미해결 사항 (4) — run phase 전 사용자 결정 권장
1. **PDF export 시점**: M5 Markdown-only 고정, PDF post-v0.1 이월 확인
2. **release_id 포맷**: `v0.1.0-rc1` 제안 — RELEASE-001 sync 필요
3. **`validation:approve` 권한 주체**: admin 단일 vs QA Lead 분리
4. **high-impact rerun 범위**: 영향축만 rerun vs 전체 IQ/OQ/PQ rerun

### 선행 의존성
- ✅ SPEC-V3-AUDIT-CHAIN-001 (PR #356 머지됨) — sign-off audit 기반
- ✅ FOUNDATION / RELEASE 기존 구현
- non-blocking fallback: TRACEABILITY / SOURCE-GOVERNANCE / MODEL-GOVERNANCE

Refs #49

🗿 MoAI <email@mo.ai.kr>