### PR TITLE
docs(spec): SPEC-REGULA-VALIDATION-002 plan 산출물 4종 — VALIDATION-001 정식 연동 (R2/R6/R7 해소)

### DIFF
--- a/.moai/specs/SPEC-REGULA-VALIDATION-002/acceptance.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-002/acceptance.md
@@ -1,0 +1,371 @@
+---
+artifact: acceptance
+spec_id: SPEC-REGULA-VALIDATION-002
+version: 0.1.0
+status: draft
+created: 2026-07-07
+updated: 2026-07-07
+author: manager-spec (plan-phase)
+---
+
+# Acceptance Criteria — SPEC-REGULA-VALIDATION-002
+
+본 문서는 binary-testable acceptance criteria와 Given-When-Then 시나리오, 그리고
+AC ↔ REQ ↔ evidence traceability matrix를 정의한다. 모든 AC는 관찰 가능한 증거
+(test output, DB row, Markdown grep, HTTP status, stderr 출력)로 검증된다
+(L-013 직검 원칙).
+
+---
+
+## §1 Acceptance Criteria (Binary-Testable)
+
+| AC# | Criterion | Verification Method | 관련 REQ |
+|-----|-----------|---------------------|----------|
+| AC-1 | `classify-changes.ts`의 model/prompt 축 쿼리가 `created_at` window 범위 조건을 포함한다 | grep `created_at` + `gte` (또는 `between`) in `lib/validation/consumers/model-governance.ts`; 단위 테스트: window 내/외 change_request 로우 분류 결과 직검 | REQ-VAL2-001 |
+| AC-2 | high-impact model/prompt change_control 행의 `evidence_ref` 컬럼에 `evalRunId` 값이 기록된다 | integration: change_request 1건 (evalRunId="run-abc") seed → classify-changes → `SELECT evidence_ref FROM change_control WHERE change_axis IN ('prompt','model') AND impact_level='high'` → `"run-abc"` 포함 | REQ-VAL2-002 |
+| AC-3 | source_policy 축 change_control 행의 `residual_risk` 텍스트에 dashboard counts 문자열이 포함된다 | integration: sources 3건 (1 approved, 1 pending, 1 superseded) seed → classify-changes → `SELECT residual_risk FROM change_control WHERE change_axis='source_policy'` → `approved:1` / `superseded:1` 포함 | REQ-VAL2-004 |
+| AC-4 | `build-report.ts` 출력 Markdown의 "Traceability Status" 섹션이 `totalRows` / `withGaps` / `stale` 숫자를 포함한다 | build-report 실행 → 출력 Markdown grep: `## Traceability Status` 섹션 하위에 `totalRows:` 또는 `total_rows:` 포함; `**Stub**` 부재 | REQ-VAL2-005 |
+| AC-5 | 출력 Markdown의 "Source Governance Status" 섹션이 `approved` / `pendingReview` / `stale` / `superseded` 숫자를 포함한다 | grep `## Source Governance Status` 섹션 하위에 `approved:` + `superseded:` 포함; `**Stub**` 부재 | REQ-VAL2-006 |
+| AC-6 | 출력 Markdown의 "Release Scope Status" 섹션이 IQ/OQ/PQ evidence count를 포함한다 | integration: evidence 6건 (IQ 2/OQ 2/PQ 2) seed → build-report → grep `## Release Scope Status` 하위에 `IQ:` 또는 `iq:` + count; `**Stub**` 부재 | REQ-VAL2-007 |
+| AC-7 | "Review Ops Status" 섹션이 `not implemented` 문자열과 `#36` 이슈 참조를 포함한다 | grep `## Review Ops Status` 하위에 `not implemented` + `#36`; `**Stub**` 텍스트는 허용되지 않으나 `not implemented`는 필수 | REQ-VAL2-008 |
+| AC-8 | release_id `v0.1.0`과 `v0.1.0-rc1`은 format 검증을 통과하고, `v0.1`, `invalid`, `0.1.0`, `v0.1.0.0`은 거부된다 | 단위 테스트: `validateReleaseIdFormat` 호출 결과 직검 (accept 2, reject 4) | REQ-VAL2-009 |
+| AC-9 | git tag가 로컬에 없는 release_id 호출 시 stderr에 warning이 출력되지만 exit code는 0이다 | integration: `git tag --list v99.99.99-rc1` 빈 출력 상태에서 build-report `v99.99.99-rc1` 실행 → stderr에 `Warning: git tag v99.99.99-rc1 not found` 포함; exit 0 | REQ-VAL2-010 |
+| AC-10 | `classify-changes.ts`와 `build-report.ts`가 `change_request` / `buildMatrix` / `getGovernanceDashboard`를 `lib/validation/consumers/`를 경유하여 소비한다 (직접 import 부재) | grep `from '../../lib/db/schema.ts'` + `changeRequest` in classify-changes.ts → 0 (consumer import로 대체); 동일하게 build-report.ts에서 `buildMatrix` / `getGovernanceDashboard` 직접 import 0 | REQ-VAL2-011 |
+| AC-11 | release_registry 데이터베이스 테이블이 신규 생성되지 않는다 | `ls migrations/` 에서 본 SPEC 관련 migration 파일 0건; schema.ts에 `releaseRegistry` 심볼 부재 (grep 검증) | REQ-VAL2-012 |
+
+---
+
+## §2 Given-When-Then 시나리오
+
+### AC-1: model/prompt window-scoped query
+
+```gherkin
+Scenario: window 내 change_request만 high-impact으로 분류된다
+  Given change_request 테이블에 2건의 approved 로우가 있다
+    # 로우 A: created_at=2026-06-01 (과거, window 외)
+    # 로우 B: created_at=2026-07-05 (window 내, 직전 release tag 이후)
+    And previous release tag "v0.1.0-rc0"가 2026-06-15에 생성되었다
+  When POST /api/validation/changes { release_id: "v0.1.0-rc1", previous_ref: "v0.1.0-rc0" } 호출한다
+  Then change_control 테이블에 change_axis='prompt' (또는 'model') 행 중
+    And impact_level='high'인 행의 residual_risk에 "window 내" change_request B만 카운트된다
+    And 로우 A는 무시된다 (residual_risk에 "0" 또는 미포함)
+```
+
+### AC-2: evidence_ref에 evalRunId 연결
+
+```gherkin
+Scenario: high-impact model change의 evidence_ref에 eval_run_id가 기록된다
+  Given change_request 테이블에 1건의 approved model 변경 로우가 있다
+    # evalRunId="eval-2026-007", evalResultRef="s3://bucket/eval-007.json"
+    And 현재 release_id="v0.1.0-rc1"이다
+  When classify-changes.ts 실행한다
+  Then change_control 행의 evidence_ref 컬럼에 "eval-2026-007" 문자열이 포함된다
+    And impact_level='high'이다
+    And rerun_required=true이다
+```
+
+### AC-3: source_policy dashboard snapshot
+
+```gherkin
+Scenario: source_policy 축이 dashboard counts를 residual_risk에 기록한다
+  Given sources 테이블에 3건의 로우가 있다
+    # 1건 approved, 1건 pending_review, 1건 superseded (superseded_by != null)
+  When classify-changes.ts 실행한다 (release_id="v0.1.0-rc1")
+  Then change_control 행의 residual_risk 텍스트에 다음이 모두 포함된다:
+    | 부분 문자열 |
+    | "approved:1" |
+    | "pending:1" (또는 pendingReview:1) |
+    | "superseded:1" |
+    | "snapshot at" (ISO timestamp) |
+```
+
+### AC-4: Traceability Status 섹션 실데이터
+
+```gherkin
+Scenario: report의 Traceability Status 섹션이 buildMatrix 결과를 렌더링한다
+  Given evidence_nodes 5건 + evidence_edges 3건이 seed 되어 있다
+    # deliverable 5건 중 2건은 derived_from edge 부재 (gap), 1건은 stale_flag 존재
+  When build-report.ts 실행한다 (release_id="v0.1.0-rc1")
+  Then 출력 Markdown의 "## Traceability Status" 섹션에 다음이 포함된다:
+    | 기대 문자열 |
+    | "totalRows" |
+    | "5" (또는 totalRows=5) |
+    | "withGaps" |
+    | "stale" |
+    And "**Stub**" 문자열이 해당 섹션에 등장하지 않는다
+```
+
+### AC-5: Source Governance Status 섹션 실데이터
+
+```gherkin
+Scenario: report의 Source Governance Status 섹션이 dashboard counts를 렌더링한다
+  Given sources 테이블에 approved 10건, pending_review 3건, superseded 2건이 있다
+  When build-report.ts 실행한다
+  Then "## Source Governance Status" 섹션에 다음이 포함된다:
+    | 기대 문자열 |
+    | "approved" |
+    | "10" |
+    | "pendingReview" (또는 "pending") |
+    | "superseded" |
+    | "2" |
+    And "**Stub**" 부재
+```
+
+### AC-6: Release Scope Status 섹션 실데이터
+
+```gherkin
+Scenario: report의 Release Scope Status 섹션이 evidence count를 렌더링한다
+  Given validation_evidence 테이블에 release_id="v0.1.0-rc1" evidence 6건이 있다
+    # IQ 2건, OQ 2건, PQ 2건
+  When build-report.ts 실행한다
+  Then "## Release Scope Status" 섹션에 다음이 포함된다:
+    | 기대 문자열 |
+    | "IQ" 또는 "iq" |
+    | "2" |
+    | "OQ" 또는 "oq" |
+    | "PQ" 또는 "pq" |
+    And "**Stub**" 부재
+    And release_id "v0.1.0-rc1" 표시
+```
+
+### AC-7: Review Ops stub 허구 데이터 부재
+
+```gherkin
+Scenario: Review Ops 섹션이 not implemented 사유를 명시한다
+  Given #36 Review-Ops SPEC이 OPEN 상태이다 (구현 없음)
+  When build-report.ts 실행한다
+  Then "## Review Ops Status" 섹션에 다음이 포함된다:
+    | 기대 문자열 |
+    | "not implemented" |
+    | "#36" |
+    And "SLA" 또는 "review queue" 등의 **구체적 숫자/상태**가 등장하지 않는다 (허구 방지)
+    And "Stub" 단어는 허용되나 "not implemented"가 우선
+```
+
+### AC-8: release_id regex 검증
+
+```gherkin
+Scenario: release_id 포맷이 정확히 검증된다
+  When 다음 release_id들을 validateReleaseIdFormat에 전달한다:
+    | 입력 | 기대 결과 |
+    | "v0.1.0" | valid: true |
+    | "v0.1.0-rc1" | valid: true |
+    | "v1.2.3-rc99" | valid: true |
+    | "v0.1" | valid: false |
+    | "0.1.0" | valid: false |
+    | "invalid" | valid: false |
+    | "v0.1.0.0" | valid: false |
+    | "v0.1.0-rc" | valid: false |
+  Then 각 입력이 기대 결과를 반환한다
+```
+
+### AC-9: git tag 부재 warning (non-blocking)
+
+```gherkin
+Scenario: git tag가 없는 release_id는 warning만 출력하고 계속 진행한다
+  Given 로컬 git 저장소에 "v99.99.99-rc1" tag가 존재하지 않는다
+    # `git tag --list v99.99.99-rc1` → 빈 출력
+  When build-report.ts "v99.99.99-rc1" 실행한다
+  Then stderr에 "Warning: git tag v99.99.99-rc1 not found"가 출력된다
+    And exit code는 0이다 (정상 완료)
+    And report Markdown 파일이 정상 생성된다
+```
+
+### AC-10: consumer 경유 소비 (single seam)
+
+```gherkin
+Scenario: classify-changes.ts와 build-report.ts가 consumers/ 경유로 소비한다
+  Given M0에서 lib/validation/consumers/ 가 생성되었다
+  When classify-changes.ts 코드를 검사한다 (grep)
+  Then 다음 직접 import가 부재한다:
+    | 금지된 import 패턴 |
+    | "from '../../lib/db/schema.ts'" 안의 changeRequest (consumers 경유로 대체) |
+  And "from '../../lib/validation/consumers/model-governance'" 가 존재한다
+  When build-report.ts 코드를 검사한다 (grep)
+  Then 다음이 부재한다:
+    | 금지된 import 패턴 |
+    | "from '@/lib/traceability/matrix'" 의 buildMatrix 직접 호출 |
+    | "from '@/lib/source-governance/dashboard'" 의 getGovernanceDashboard 직접 호출 |
+  And "from '@/lib/validation/consumers/traceability'" 가 존재한다
+  And "from '@/lib/validation/consumers/source-governance'" 가 존재한다
+```
+
+### AC-11: release_registry 테이블 부재
+
+```gherkin
+Scenario: 본 SPEC이 release_registry 테이블을 도입하지 않는다
+  When migrations/ 디렉토리를 검사한다
+  Then 본 SPEC 관련 migration 파일 (VALIDATION-002 또는 유사 명칭)이 0건이다
+  And lib/db/schema.ts에 "releaseRegistry" pgTable 선언이 부재한다 (grep)
+  And 단위/integration 테스트가 기존 VALIDATION-001 스키마만 사용한다
+```
+
+---
+
+## §3 Edge Cases
+
+### EC-1: change_request가 window 내 0건인 경우
+
+```gherkin
+Scenario: model/prompt 축에 window 내 change_request가 없다
+  Given change_request 테이블에 approved 로우가 있으나 모두 window 외이다
+  When classify-changes.ts 실행한다
+  Then model/prompt 축은 impact_level='low', rerun_required=false로 기록된다
+    And residual_risk에 "No window-scoped change_request rows" 포함
+```
+
+### EC-2: getGovernanceDashboard가 빈 결과를 반환하는 경우
+
+```gherkin
+Scenario: source-gov dashboard가 모든 count=0을 반환한다
+  Given sources 테이블이 비어 있다 (또는 org에 속한 source가 없다)
+  When classify-changes.ts 실행한다 (source_policy 축)
+  Then residual_risk에 "approved:0, pending:0, stale:0, superseded:0" 포함
+    And git-diff 카운트가 0이면 impact_level='low'
+```
+
+### EC-3: buildMatrix 호출이 실패하는 경우
+
+```gherkin
+Scenario: buildMatrix가 예외를 throw 한다
+  Given traceability 데이터베이스 연결이 끊겨 있다 (또는 쿼리 타임아웃)
+  When build-report.ts 실행한다
+  Then report는 traceability 섹션에 "[traceability snapshot unavailable: <error>]" 기록
+    And exit code 0 유지 (non-blocking, report 나머지 섹션은 정상)
+    And stderr에 경고 로깅
+```
+
+### EC-4: release_id가 regex를 통과하나 git tag가 있는 경우 (정상 flow)
+
+```gherkin
+Scenario: 정식 release tag로 build-report 실행
+  Given git tag "v0.1.0"이 존재한다
+  When build-report.ts "v0.1.0" 실행한다
+  Then stderr에 warning이 출력되지 않는다 (tag 존재)
+    And exit code 0
+    And report 정상 생성
+```
+
+### EC-5: previous_ref가 git history에 없는 경우
+
+```gherkin
+Scenario: classify-changes에 존재하지 않는 previous_ref 전달
+  Given previous_ref="v0.0.0-nonexistent" 를 인자로 전달
+  When classify-changes.ts 실행한다
+  Then window_start 계산 실패 → warning 출력 + window_start=UNIX epoch (1970) fallback
+    And 모든 change_request가 window 내로 간주됨 (보수적 과분류)
+    And residual_risk에 "previous_ref not found, fallback to epoch" 포함
+```
+
+### EC-6: #36이 향후 구현된 경우 (post-VALIDATION-002)
+
+```gherkin
+Scenario: #36 Review-Ops가 별도 SPEC으로 구현 완료
+  Given #36이 CLOSED 되었다
+  When 본 SPEC의 후속 (VALIDATION-003 또는 patch)에서 renderReviewOpsSection 교체
+  Then "not implemented" 사유 제거 → 실 review queue 데이터 렌더링
+  Note: 본 SPEC 자체는 #36 OPEN을 가정하므로 AC-7이 지배
+```
+
+---
+
+## §4 AC ↔ REQ ↔ Evidence Traceability Matrix
+
+| AC# | 관련 REQ | Evidence (검증 산출물) | 소유 milestone |
+|-----|---------|-----------------------|---------------|
+| AC-1 | REQ-VAL2-001 | consumers/model-governance.ts 단위 테스트 + window query grep | M0, M1 |
+| AC-2 | REQ-VAL2-002 | integration 테스트: change_control.evidence_ref DB query | M1 |
+| AC-3 | REQ-VAL2-004 | integration 테스트: change_control.residual_risk 문자열 직검 | M2 |
+| AC-4 | REQ-VAL2-005 | build-report 출력 Markdown grep (Traceability Status 섹션) | M3 |
+| AC-5 | REQ-VAL2-006 | build-report 출력 Markdown grep (Source Governance Status 섹션) | M3 |
+| AC-6 | REQ-VAL2-007 | build-report 출력 Markdown grep (Release Scope Status 섹션) | M3 |
+| AC-7 | REQ-VAL2-008 | build-report 출력 Markdown grep (Review Ops "not implemented" + "#36") | M3 |
+| AC-8 | REQ-VAL2-009 | validateReleaseIdFormat 단위 테스트 (8 케이스) | M0, M4 |
+| AC-9 | REQ-VAL2-010 | integration 테스트: stderr + exit code 직검 | M4 |
+| AC-10 | REQ-VAL2-011 | classify-changes.ts / build-report.ts grep (import 경로 검증) | M0, M1, M2, M3 |
+| AC-11 | REQ-VAL2-012 | migrations/ ls + schema.ts grep (releaseRegistry 부재) | 전체 |
+
+---
+
+## §5 Quality Gate Criteria (Definition of Done)
+
+본 SPEC은 다음 게이트를 모두 통과해야 completed로 전환된다:
+
+### 5.1 코드 품질 (TRUST 5)
+
+- **Tested**: 본 SPEC 관련 코드 (consumers/, classify-changes.ts 수정, build-report.ts
+  수정) 단위 + integration 테스트 커버리지 85% 이상
+- **Readable**: 모든 신규 함수에 영문 코멘트 (code_comments: en), @MX:NOTE/ANCHOR
+  태그 (fan_in >= 3 시)
+- **Unified**: biome 포맷 + ESLint 규칙 준수
+- **Secured**: read-only 소비 (SQL injection 불가 — Drizzle prepared statement);
+  git CLI 호출 인자 검증 (release_id regex 통과한 값만)
+- **Trackable**: 커밋 메시지에 `SPEC-REGULA-VALIDATION-002` + AC 번호 참조
+
+### 5.2 회귀 게이트 (L-009 원칙)
+
+- `pnpm test` 전체 스위트 green (기존 VALIDATION-001 테스트 포함)
+- 기존 단위 테스트 중 회귀 0건
+- classify-changes.ts / build-report.ts 시그니처 불변 (grep 비파괴 검증)
+
+### 5.3 CI 게이트 (L-015 원칙 — main 머지 전 로컬 직검)
+
+- `pnpm ci:typecheck` green
+- `pnpm ci:lint` (lint:hex 포함, L-008) green
+- `pnpm ci:format` green
+- `pnpm ci:migrations` green (신규 migration 0건이지만 기존 migration 적재 확인)
+- `pnpm ci:audit` green (본 SPEC이 audit에 영향 없음 — read-only)
+- `pnpm ci:rbac` green (validation RBAC 변경 없음)
+
+### 5.4 범위 통제 게이트
+
+- `lib/validation/consumers/` 외的新 인프라 부재 (새 테이블, 새 harness)
+- VALIDATION-001 public API 시그니처 불변
+- PDF export 미구현 (REQ-VAL-011 Optional 계승)
+- Review-Ops stub이 "not implemented" 유지 (#36 OPEN)
+
+### 5.5 허구 데이터 방지 (Charter [지양-2])
+
+- 모든 report 섹션이 실데이터 또는 명시적 "not implemented" 사유
+- 허구 숫자 / 가짜 상태 string 금지
+- self-report (단위 테스트 통과)에 의존하지 않고 실DB 직검 (L-013)
+
+---
+
+## §6 Test Scenarios Summary
+
+| 시나리오 | 유형 | 소유 AC | 자동화 |
+|---------|------|---------|--------|
+| change_request window 내/외 분류 | integration | AC-1, AC-2 | vitest + 실DB |
+| source_policy dashboard snapshot | integration | AC-3 | vitest + 실DB |
+| build-report 3 섹션 실데이터 | integration | AC-4, AC-5, AC-6 | vitest + Markdown grep |
+| Review Ops stub 유지 | 단위 | AC-7 | vitest + Markdown grep |
+| release_id regex 8 케이스 | 단위 | AC-8 | vitest (pure function) |
+| git tag 부재 warning | integration | AC-9 | child_process + stderr 캡처 |
+| consumer 경유 (single seam) | grep | AC-10 | grep 스크립트 (CI 통합) |
+| release_registry 부재 | grep | AC-11 | ls + grep 스크립트 |
+| change_request window 0건 | 단위 (edge) | EC-1 | vitest mock |
+| dashboard all-zero | 단위 (edge) | EC-2 | vitest mock |
+| buildMatrix 실패 | 단위 (edge) | EC-3 | vitest mock throw |
+| previous_ref 미존재 | integration (edge) | EC-5 | git + classify-changes |
+
+---
+
+## §7 Post-Implementation Review (Rule 3)
+
+구현 완료 후 다음을 점검한다:
+
+1. **잠재 이슈**:
+   - `buildMatrix` 호출 비용이 크면 report 빌드 지연 → 타임아웃 5초 설정
+   - change_request window query가 큰 org에서 느릴 수 있음 → 인덱스 확인
+   - git tag CLI 호출이 CI 환경에서 차단될 수 있음 → fallback 경로
+2. **추가 검증 권장**:
+   - 실제 rc1 빌드 시나리오로 end-to-end smoke test
+   - 대규모 change_request (100+ 로우) 환경에서 성능 프로파일링
+3. **알려진 한계**:
+   - source-gov snapshot이 cumulative (release 간 delta 불가) — post-v0.1 개선
+   - #36 Review-Ops stub 영구화 가능성 (해당 SPEC 진행 전까지)
+4. **후속 SPEC 제안**:
+   - **RELEASE-002**: release_registry 테이블 + release lifecycle SSoT
+   - **VALIDATION-003 (post-#36)**: Review-Ops 정식 연동
+   - **SOURCE-GOV-002 (post-v0.1)**: snapshot-at-release 테이블로 delta 지원

--- a/.moai/specs/SPEC-REGULA-VALIDATION-002/plan.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-002/plan.md
@@ -1,0 +1,371 @@
+---
+artifact: plan
+spec_id: SPEC-REGULA-VALIDATION-002
+version: 0.1.0
+status: draft
+created: 2026-07-07
+updated: 2026-07-07
+author: manager-spec (plan-phase)
+development_mode: tdd
+---
+
+# Implementation Plan — SPEC-REGULA-VALIDATION-002
+
+본 plan은 research.md의 자산 인벤토리를 소비하여 5개 milestone(M0~M4)로 구성된다.
+각 milestone은 priority 기반 순서를 가지며, 시간 추정은 moai-constitution Time
+Estimation 금지 원칙에 따라 phase ordering으로 표현한다.
+
+**범위 통제 원칙** (Charter [지양-5] + VALIDATION-001 §1.5 계승):
+- 신규 DB 테이블 금지 (release_registry 포함, REQ-VAL2-012)
+- 신규 테스트 harness 금지 (기존 vitest 패턴 준용)
+- 외부 라이브러리 도입 금지
+- VALIDATION-001 public 시그니처 불변 (비파괴)
+
+---
+
+## §1 Milestone 개요
+
+| Milestone | 이름 | Priority | Depends On | 산출물 |
+|-----------|------|----------|------------|--------|
+| M0 | Consumer Wrappers (Read-Only Integration Seam) | Critical (blocker) | — | `lib/validation/consumers/*.ts` 4 파일 + 단위 테스트 |
+| M1 | R2 — model/prompt 정식 연동 (window-scoped) | High | M0 | `classify-changes.ts` 수정 + eval_run 연계 |
+| M2 | R2 확장 — source_policy 정식 연동 | Medium | M0 | `classify-changes.ts` 수정 + dashboard snapshot |
+| M3 | R6 — report stub → 실데이터 | High | M0 | `build-report.ts` 3 섹션 실데이터 렌더링 |
+| M4 | R7 — release_id 정식화 (regex + git tag) | Medium | M0 | `lib/validation/consumers/release.ts` + API gate |
+
+> M1/M2/M3/M4는 M0 완료 후 병렬 착수 가능 (독립 파일). 단 PR 분리를 위해
+> 순차 진행을 권장한다.
+
+---
+
+## §2 Milestone 상세
+
+### M0 — Consumer Wrappers (Critical Blocker)
+
+**목표**: 4개 선행 SPEC의 read-only 소비를 단일 진입점(`lib/validation/consumers/`)으로
+라우팅하는 헬퍼 모듈을 신규 생성. 이후 milestone이 의존하는 기반.
+
+**태스크**:
+1. `lib/validation/consumers/model-governance.ts` 신규
+   - `fetchWindowScopedChangeRequests(params: { orgId, windowStart, windowEnd }): Promise<ChangeRequestRow[]>`
+   - `windowStart` = previous release tag date (git log -1 --format=%cI `<tag>`)
+   - `windowEnd` = 현재 release cutoff (기본 `new Date()`)
+   - 컬럼: `id`, `promptId`, `modelPinId`, `evalRunId`, `evalResultRef`,
+     `approvalStatus`, `approvedAt`, `createdAt`
+   - 명시적 `WHERE org_id = $1 AND created_at >= $2 AND created_at < $3`
+2. `lib/validation/consumers/traceability.ts` 신규
+   - `snapshotTraceability(params: { orgId, projectId? }): Promise<MatrixSummary>`
+   - 내부적으로 `buildMatrix(db, filters, deps)` 호출
+   - `MatrixSummary = { totalRows: number; withGaps: number; stale: number }`
+   - staleNodeIds 주입을 위해 `lib/traceability/stale-propagation.ts` 패턴 준용
+3. `lib/validation/consumers/source-governance.ts` 신규
+   - `snapshotSourceGovernance(params: { orgId }): Promise<GovernanceDashboard>`
+   - `getGovernanceDashboard` thin wrapper (변환 없음, 투명 전달)
+4. `lib/validation/consumers/release.ts` 신규
+   - `validateReleaseIdFormat(releaseId: string): { valid: boolean; reason?: string }`
+   - regex `^v\d+\.\d+\.\d+(-rc\d+)?$`
+   - `checkGitTagExists(releaseId: string): Promise<{ exists: boolean; warning?: string }>`
+   - `git tag --list <releaseId>` 호출 (child_process spawnSync)
+5. 단위 테스트 (TDD RED → GREEN):
+   - mock DB로 change_request window query 검증
+   - mock buildMatrix로 snapshot 검증
+   - mock getGovernanceDashboard로 snapshot 검증
+   - release_id regex accept/reject 케이스 (v0.1.0, v0.1.0-rc1, invalid-id, v0.1)
+   - git tag 존재/부재 케이스 (mock spawnSync)
+6. `index.ts` barrel export ( consumers/ 진입점)
+
+**Reuse**: `change_request` schema, `buildMatrix`, `getGovernanceDashboard`, git CLI
+
+**Gate (M0 → M1/M2/M3/M4)**:
+- `pnpm ci:typecheck` green
+- consumers/ 단위 테스트 N개 green (mock 기반)
+- 각 consumer 함수가 순수 함수 (side-effect 없음) 인증
+- `lib/validation/consumers/` 디렉토리에 4 파일 + index.ts 존재
+- AC-10 (consumer 경유) 기반 마련
+
+**Risks**:
+- `buildMatrix`의 `deps.staleNodeIds` 주입 패턴 학습 필요 → 기존
+  `app/api/traceability/route.ts` 호출 패턴 참조
+- git tag 호출이 샌드박스 환경에서 차단될 수 있음 → spawnSync fallback
+  (warning만, exit 0)
+
+---
+
+### M1 — R2 해소: model/prompt 정식 연동 (High)
+
+**목표**: `classify-changes.ts`의 model/prompt 축이 consumer 경유 + window-scoped로
+동작하도록 전환.
+
+**태스크**:
+1. `scripts/validation/classify-changes.ts` 수정:
+   - `classifyModelGovernanceAxis(releaseId, axis)`가
+     `fetchWindowScopedChangeRequests({ orgId, windowStart, windowEnd })` 호출
+   - `previousRef` 인자를 받아 windowStart 계산:
+     `git log -1 --format=%cI <previousRef>` → ISO timestamp
+   - `windowEnd` = `new Date()` (현재 release cutoff)
+2. `orgId` 결정 로직:
+   - 환경변수 `REGULA_ORG_ID` 또는 기본 org (시스템 검증 컨텍스트)
+   - 단일-org 가정 (Charter [지양-5] — SaaS 외판 아님)
+3. high-impact 시 `change_control.evidence_ref`에 `evalRunId` 기록:
+   - consumer가 반환한 `evalRunId` / `evalResultRef`를
+     `upsertChangeControlRow`의 `evidenceRef` 인자로 전달
+4. 단위 테스트 (TDD):
+   - window 내 change_request 1건 → high-impact 분류
+   - window 외 (과거) change_request → low-impact (무시)
+   - pending_review 1건 → medium-impact
+5. integration 테스트:
+   - 실DB에 change_request 2건 (window 내/외) seed → classify-changes 실행 →
+     change_control 행 2개의 impact_level 직검 (L-013)
+   - high-impact 행의 evidence_ref에 evalRunId 문자열 포함 확인
+
+**Reuse**: `lib/validation/consumers/model-governance.ts` (M0)
+
+**Gate (M1 완료 조건)**:
+- AC-1 (window-scoped query) 통과
+- AC-2 (evidence_ref에 evalRunId) 통과
+- 기존 VALIDATION-001 classify-changes 단위 테스트 회귀 없음
+- `pnpm ci:typecheck` green
+
+---
+
+### M2 — R2 확장: source_policy 정식 연동 (Medium)
+
+**목표**: source_policy 축을 git-diff + dashboard snapshot 결합으로 강화.
+
+**태스크**:
+1. `scripts/validation/classify-changes.ts` 수정:
+   - `classifySourcePolicyAxis(releaseId, previousRef)`가
+     `snapshotSourceGovernance({ orgId })` 호출
+   - 현재 git-diff 카운트와 dashboard counts를 모두 residual_risk에 기록
+2. residual_risk 문자열 포맷:
+   ```
+   git_diff={N} commit(s) under lib/source-governance/;
+   dashboard=approved:{a},pending:{p},stale:{s},superseded:{u}
+   ```
+3. impact rating 조정:
+   - git-diff >= 3 OR dashboard.stale > 0 OR dashboard.superseded > 0 →
+     high-impact (보수적 과분류, VALIDATION-001 R3 원칙 계승)
+   - 그 외 기존 임계값 유지
+4. 단위 테스트:
+   - git-diff 0 + dashboard counts 모두 0 → low
+   - git-diff 2 + dashboard.superseded 1 → high (superseded 우선)
+   - dashboard.stale > 0 → high
+5. integration 테스트:
+   - 실DB에 sources 행 3건 (approved/pending/superseded) seed → classify-changes
+     실행 → residual_risk 문자열에 counts 포함 직검
+
+**Reuse**: `lib/validation/consumers/source-governance.ts` (M0)
+
+**Gate (M2 완료 조건)**:
+- AC-3 (residual_risk에 dashboard counts) 통과
+- 기존 VALIDATION-001 source_policy 단위 테스트 회귀 없음
+
+**Risks**:
+- dashboard counts가 cumulative이므로 "release 기간 내 변경"을 직접 의미하지
+  않음 → residual_risk에 "snapshot at {timestamp}" 명시로 정확한 의미 기록
+
+---
+
+### M3 — R6 해소: report stub → 실데이터 (High)
+
+**목표**: `build-report.ts`의 3 stub 섹션을 실데이터 렌더링으로 교체.
+
+**태스크**:
+1. `scripts/validation/build-report.ts` 수정:
+   - 신규 함수 `renderReleaseScopeSection(releaseId, evidence)`:
+     IQ/OQ/PQ evidence count + git tag info + #31-34 정적 완료 상태
+   - 신규 함수 `renderTraceabilitySection(orgId)`:
+     `snapshotTraceability({ orgId })` 호출 → totalRows/withGaps/stale 표
+   - 신규 함수 `renderSourceGovernanceSection(orgId)`:
+     `snapshotSourceGovernance({ orgId })` 호출 → counts 표 + reviewDue 길이
+   - `renderReviewOpsSection()` (수정):
+     stub 유지 + "not implemented — #36 OPEN" 사유 명시
+2. `buildReleaseReportMarkdown` 수정:
+   - 3 stub 문자열 제거 → 새 렌더링 함수 호출로 교체
+   - `Promise.all([evidence, changes, rerunGate, traceSnapshot, sourceSnapshot])`
+     병렬 조회
+3. 단위 테스트:
+   - 각 render 함수가 non-stub Markdown 반환 (grep "Stub" → 0)
+   - traceability 섹션에 `totalRows: N` 포함
+   - source-gov 섹션에 `approved: N` 포함
+   - release scope 섹션에 `IQ: N OQ: N PQ: N` 포함
+   - review-ops 섹션에 `not implemented` + `#36` 포함
+4. integration 테스트:
+   - 실DB에 evidence 6건 (IQ 2/OQ 2/PQ 2) seed + trace/source 행 seed →
+     build-report 실행 → 출력 Markdown grep 직검
+
+**Reuse**: `lib/validation/consumers/{traceability,source-governance,release}.ts` (M0)
+
+**Gate (M3 완료 조건)**:
+- AC-4, AC-5, AC-6, AC-7 모두 통과
+- 생성된 report Markdown에서 "Stub" 단어 등장 0회 (review-ops는 "not implemented"
+  로 대체 — 둘은 다름)
+- 기존 VALIDATION-001 build-report 단위 테스트 회귀 없음
+
+**Risks**:
+- `buildMatrix` 호출 비용 (N+1 query) → 프로젝트 필터로 범위 제한 옵션
+- `getGovernanceDashboard` 호출이 드물게 지연 → 타임아웃 5초 설정 (non-blocking)
+
+---
+
+### M4 — R7 해소: release_id 정식화 (Medium)
+
+**목표**: release_id regex 검증 + git tag 교차 검증을 모든 validation API/script
+진입점에 적용.
+
+**태스크**:
+1. `lib/validation/consumers/release.ts` (M0에서 생성)의
+   `validateReleaseIdFormat` / `checkGitTagExists`를 다음 진입점에서 호출:
+   - `scripts/validation/collect-iq.ts` 진입부
+   - `scripts/validation/collect-oq.ts` 진입부
+   - `scripts/validation/collect-pq.ts` 진입부
+   - `scripts/validation/classify-changes.ts` 진입부
+   - `scripts/validation/build-report.ts` 진입부
+   - `app/api/validation/iq/route.ts` POST handler
+   - `app/api/validation/oq/route.ts`
+   - `app/api/validation/pq/route.ts`
+   - `app/api/validation/changes/route.ts`
+   - `app/api/validation/report/export/route.ts`
+   - `app/api/validation/signoff/route.ts`
+2. 거부 동작 (REQ-VAL2-009):
+   - regex 불일치 → HTTP 400 (API) 또는 exit 1 (script)
+   - 오류 메시지: `Invalid release_id format. Expected ^v\d+\.\d+\.\d+(-rc\d+)?$`
+3. warning 동작 (REQ-VAL2-010):
+   - git tag 부재 → stderr warning + 계속 진행 (exit 0 / HTTP 2xx)
+   - 메시지: `Warning: git tag <release_id> not found locally (pre-release candidate?)`
+4. 단위 테스트:
+   - `v0.1.0` accept, `v0.1.0-rc1` accept, `v0.1` reject, `invalid` reject,
+     `0.1.0` reject
+   - git tag 존재/부재 케이스
+5. integration 테스트:
+   - signoff API에 `release_id=invalid` → HTTP 400
+   - signoff API에 `release_id=v99.99.99-rc1` (존재하지 않는 tag) → HTTP 200
+     + stderr warning
+
+**Reuse**: `lib/validation/consumers/release.ts` (M0)
+
+**Gate (M4 완료 조건)**:
+- AC-8 (regex accept/reject) 통과
+- AC-9 (git tag warning non-blocking) 통과
+- 기존 VALIDATION-001 API route 단위 테스트 회귀 없음
+
+**Risks**:
+- release_id 관행이 이미 `v0.1.0-rc1`로 확립되었으나 일부 스크립트가 다른
+  포맷을 사용할 수 있음 → grep 사전 조사 (M0에서 수행)
+- 정식 release (rc 아님) 시나리오 → regex가 `v\d+\.\d+\.\d+` (rc 접미사 없음)
+  도 허용하도록 설계
+
+---
+
+## §3 Phase Gates
+
+| Gate | 위치 | 통과 조건 | 실패 시 |
+|------|------|-----------|---------|
+| Gate-A | M0 직후 | consumer wrapper 4 파일 + 단위 테스트 green + typecheck | M1~M4 착수 불가 |
+| Gate-B | M1~M4 각 milestone | 각 AC-1~AC-9 통과 + 기존 테스트 회귀 없음 | 다음 milestone 착수 보류 + plan 재검토 |
+| Gate-C | M4 완료 (SPEC 전체) | AC-1~AC-10 모두 통과 + `pnpm test` green + `pnpm ci:*` green | SPEC 완료 불가, plan-auditor 재검토 |
+
+---
+
+## §4 리스크 레지스터
+
+| ID | Risk | Probability | Impact | Mitigation | Owner |
+|----|------|-------------|--------|-----------|-------|
+| R1 | `buildMatrix` 시그니처 진화 (TRACEABILITY-001 v1.x) | 중 | 중 | consumer wrapper interface가 완충 (single seam); 추상화 비용 1회 | M0/M3 담당 |
+| R2 | source-gov dashboard counts cumulative only → release 간 delta 불가 | 높 | 중 | residual_risk에 "snapshot at {ts}" 명시; post-v0.1 snapshot-at-release 테이블 검토 | M2 담당 |
+| R3 | release_id regex가 RELEASE-001 실관행과 불일치 | 중 | 중 | M0에서 git tag 리스트 grep 사전 조사; regex 완화 옵션 (`v\d+\.\d+\.\d+(-rc\d+)?`) | M0/M4 담당 |
+| R4 | change_request 대량 누적 시 window 쿼리 지연 | 낮 | 낮 | `idx_change_request_org_status` + created_at range scan; 100k 행 이상 시 파티셔닝 검토 (post-v0.1) | M1 담당 |
+| R5 | #36 Review-Ops 장기 미구현 → stub 영구화 | 높 | 낮 | REQ-VAL2-008이 "not implemented" 사유 명시를 강제하여 허구 데이터 차단 | SPEC owner |
+| R6 | VALIDATION-001 코드 회귀 (비파괴 원칙 위반) | 낮 | 높 | 각 milestone에서 기존 VALIDATION-001 단위 테스트 full 실행 (L-009); 시그니처 불변 grep 검증 | 각 milestone 담당 |
+| R7 | git tag CLI 호출이 샌드박스/CI 환경에서 차단 | 중 | 낮 | spawnSync 실패 시 warning-only fallback (non-blocking); CI에서는 `actions/checkout --tags` 사전 확인 | M4 담당 |
+| R8 | consumer wrapper가 순환 의존성 유발 (consumers → A → consumers) | 낮 | 높 | consumers/ 는 lib/db, lib/traceability, lib/source-governance만 의존; 역방향 import 금지 (ESLint rule 추가 검토) | M0 담당 |
+
+---
+
+## §5 테스트 전략
+
+### 5.1 단위 테스트 (vitest)
+
+- consumer wrapper 4종 (mock DB / mock child_process)
+- classify-changes.ts 수정 분 (window query 로직, eval_run 연계)
+- build-report.ts render 함수들 (non-stub 검증)
+- release_id regex / git tag 검증
+
+### 5.2 Integration 테스트
+
+- change_request window 내/외 seed → classify-changes → change_control 직검
+- sources 행 seed → classify-changes source_policy → residual_risk 문자열 검증
+- evidence + trace + source 행 seed → build-report → Markdown grep
+- validation API에 release_id invalid → HTTP 400
+
+### 5.3 회귀 테스트 (L-009 원칙)
+
+- 각 milestone 완료 시 `pnpm test` **full 스위트** 실행 (타깃만 아님)
+- 기존 VALIDATION-001 테스트 (collect-iq/oq/pq, classify-changes, build-report,
+  rerun-gate) green 유지
+- 특히 classify-changes.ts / build-report.ts 시그니처 불변 grep 검증
+
+### 5.4 직접 검증 (L-007/L-013 원칙)
+
+- migration 신규 0건 → L-010 해당 없음
+- CI run ID / artifact는 실 GitHub Actions 출력과 교차 검증
+- dashboard counts는 실DB SELECT COUNT(*)로 직검 (self-report 금지)
+- 모든 게이트는 로컬 `pnpm ci:*` 직검 + CI green 병행 (L-015)
+
+### 5.5 수동 QA
+
+- release_id 포맷이 릴리즈 관행과 일치하는지 RA Lead 검토
+- source-gov snapshot 문자열 가독성 검토
+
+---
+
+## §6 범위 통제 원칙 (Scope Discipline)
+
+Charter [지양-5] + VALIDATION-001 §1.5 계승:
+
+1. **신규 DB 테이블 금지** — release_registry 포함 (REQ-VAL2-012)
+2. **신규 테스트 harness 금지** — 기존 vitest + CI 집계
+3. **신규 외부 라이브러리 금지** — Drizzle + child_process only
+4. **VALIDATION-001 API 시그니처 불변** — 비파괴 원칙
+5. **허구 데이터 금지** — Review-Ops stub은 "not implemented" 명시 (Charter [지양-2])
+6. **Traceability release-dim delta 금지** — snapshot 현재 시점 only (post-v0.1)
+7. **PDF export 금지** — Markdown only (REQ-VAL-011 Optional 계승)
+8. **다중 관할권 matrix 금지** — post-v0.1
+
+구현 중 scope creep 발견 시 §8 Exclusions로 이월하고 milestone을 재조정한다.
+
+---
+
+## §7 의존성 타임라인
+
+```
+VALIDATION-001 (main c154b43, MERGED) ────┐
+                                          ├─→ M0 (consumers) ─→ M1 (model-gov)
+MODEL-GOVERNANCE-001 (#71, CLOSED) ───────┤                    ├─→ M2 (source-gov)
+TRACEABILITY-001 (#47, CLOSED) ───────────┤                    ├─→ M3 (report)
+SOURCE-GOVERNANCE-001 (#48, CLOSED) ──────┤                    └─→ M4 (release_id)
+RELEASE-001 (#31, CLOSED) ────────────────┤
+REVIEW-OPS (#36, OPEN) ───────────────────┴─→ M3 (stub 유지, "not implemented")
+```
+
+모든 핵심 의존성이 CLOSED이므로 fallback 모드 불필요. 단 #36은 OPEN이므로
+해당 섹션만 stub 유지.
+
+---
+
+## §8 Definition of Done (SPEC 완료 조건)
+
+- [ ] AC-1~AC-10 모두 통과 (acceptance.md)
+- [ ] M0~M4 모든 milestone Gate 통과
+- [ ] `pnpm test` 전체 green (기존 VALIDATION-001 테스트 회귀 0)
+- [ ] `pnpm ci:typecheck`, `pnpm ci:lint`, `pnpm ci:format`, `pnpm ci:migrations` green
+- [ ] `pnpm ci:audit` green (VALIDATION-002가 audit에 영향 없음)
+- [ ] `lib/validation/consumers/` 디렉토리 4 파일 + index.ts 존재
+- [ ] `scripts/validation/build-report.ts` 출력 Markdown에서 "Stub" 0회 (review-ops
+  "not implemented"는 허용)
+- [ ] classify-changes.ts / build-report.ts의 직접 import 대신 consumers/ 경유
+  (grep 검증)
+- [ ] SPEC 문서 4종 (spec/plan/acceptance/research) 최신 상태
+- [ ] PR 본문에 QA evidence 섹션 (이슈 MoAI 교차검증 기준)
+- [ ] #36 Review-Ops가 OPEN인 동안 stub이 "not implemented" 사유 유지 (REQ-VAL2-008)
+- [ ] release_registry 테이블 도입 안 함 (REQ-VAL2-012, Exclusions §7)

--- a/.moai/specs/SPEC-REGULA-VALIDATION-002/research.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-002/research.md
@@ -1,0 +1,300 @@
+---
+artifact: research
+spec_id: SPEC-REGULA-VALIDATION-002
+version: 0.1.0
+status: draft
+created: 2026-07-07
+updated: 2026-07-07
+author: manager-spec (plan-phase)
+---
+
+# Research — SPEC-REGULA-VALIDATION-002 (Validation 정식 연동)
+
+본 research는 VALIDATION-001의 fallback/stub 지점을 정식 연동으로 전환하기 위해
+4개 선행 SPEC(#71 MODEL-GOVERNANCE, #47 TRACEABILITY, #48 SOURCE-GOVERNANCE, #31
+RELEASE)의 코드 자산을 인벤토리화하고, VALIDATION-001이 소비할 read-only API를
+식별한다. Charter [지양-5] (SaaS 외판 금지, over-engineering 금지)와 VALIDATION-001
+§1.5 CSV-Lite 원칙에 따라 모든 연동은 **thin glue layer**로만 수행한다.
+
+---
+
+## §1 범위 배경 (VALIDATION-001 fallback/stub 인벤토리)
+
+### 1.1 VALIDATION-001 산출물 (main `c154b43` 기준, PR #359 머지)
+
+| 코드 자산 | 라인 수 | 역할 | 정식 연동 대상 |
+|-----------|--------|------|---------------|
+| `scripts/validation/collect-iq.ts` | 308 | IQ evidence 수집 (env/deps/migrations/config/secret) | 본 SPEC 범위 외 (이미 self-contained) |
+| `scripts/validation/collect-oq.ts` | 228 | OQ evidence 수집 (CI run ID 매핑) | 본 SPEC 범위 외 |
+| `scripts/validation/collect-pq.ts` | 319 | PQ evidence 수집 (E2E + eval) | 본 SPEC 범위 외 |
+| `scripts/validation/classify-changes.ts` | 350 | 7축 change-control 분류 | **본 SPEC R2/M1 + source-gov/M2 대상** |
+| `scripts/validation/build-report.ts` | 261 | Release Validation Report Markdown 빌더 | **본 SPEC R6/M3 대상 (3 stub 섹션)** |
+| `lib/validation/rerun-gate.ts` | 129 | high-impact + rerun 부재 시 sign-off 차단 | 본 SPEC 범위 외 (이미 완결) |
+| `lib/validation/evidence-writer.ts` | 114 | evidence INSERT 헬퍼 | 본 SPEC 범위 외 |
+| `lib/validation/checklist.ts` | 89 | sign-off checklist 항목 정의 | 본 SPEC 범위 외 |
+| `app/api/validation/signoff/route.ts` | 216 | sign-off API (checklist gate + audit write) | 본 SPEC 범위 외 |
+
+### 1.2 정확한 fallback/stub 코드 위치 (본 SPEC 전환 대상)
+
+#### A. classify-changes.ts — model/prompt 축 (R2)
+
+**상태**: VALIDATION-001 plan.md는 R2를 "model-governance 미구현 → fallback
+허용"으로 기술했으나, **실제 구현(`c154b43`)은 이미 `change_request` 테이블을
+직접 조회**한다 (classify-changes.ts:83-119).
+
+```
+// classify-changes.ts:83-119 — 현재 구현 (이미 정식 연동의 기반)
+async function classifyModelGovernanceAxis(axis: 'prompt' | 'model') {
+  const column = axis === 'prompt' ? changeRequest.promptId : changeRequest.modelPinId;
+  const approved = await db.select({ id: changeRequest.id })
+    .from(changeRequest)
+    .where(and(eq(changeRequest.approvalStatus, 'approved'), isNotNull(column)));
+  // ... approved.length > 0 → high impact
+}
+```
+
+**R2 실제 gap** (정식 연동으로 보강해야 할 점):
+1. **Window scoping 부재**: `createdAt` 기준 `[previous_release_tag, current_cutoff]`
+   범위 필터가 없음 → 과거 release에서 승인된 change_request도 high로 분류됨.
+2. **org scoping 명시 부재**: RLS에 의존 (암묵적). consumer wrapper에서 명시해야
+   VALIDATION-002 도메인 경계가 명확해짐.
+3. **eval_run 연계 누락**: `change_request.evalRunId` / `evalResultRef`를
+   `change_control.evidence_ref`에 연결하지 않음 → rerun gate가 OQ evidence로만
+   평가함 (change_request 내부의 eval 게이트 결과 무시).
+
+#### B. classify-changes.ts — source_policy 축 (R2 확장)
+
+**상태**: 순수 git-diff heuristic (classify-changes.ts:186-195).
+
+```
+// classify-changes.ts:186-195
+async function classifySourcePolicyAxis(_releaseId, previousRef) {
+  return classifyGitDiffAxis('source_policy', previousRef, [
+    'lib/source-governance/', 'lib/ai/policy-keywords.ts',
+  ]);
+}
+```
+
+**Gap**: #48 SOURCE-GOVERNANCE의 `getGovernanceDashboard` API가 corpus 상태
+(approved/pendingReview/rejected/stale/superseded counts)를 노출하지만, 현재
+축 분류는 이를 소비하지 않음. "release 기간 내 source 권위도 변경"을
+평가하려면 dashboard snapshot 비교가 필요하다.
+
+#### C. build-report.ts — 3 stub 섹션 (R6)
+
+**정확한 위치**: `scripts/validation/build-report.ts:208-223`.
+
+```
+## Release Scope Status (#31-#34)
+> **Stub** — SPEC-REGULA-RELEASE-001 (#31-#34) not yet complete. ...
+
+## Traceability Status (#47)
+> **Stub** — SPEC-REGULA-TRACEABILITY-001 (#47) not yet complete. ...
+
+## Source Governance Status (#48) · Review Ops Status (#36)
+> **Stub** — ... not yet complete. ...
+```
+
+이제 #31/#47/#48은 모두 CLOSED/completed 상태이므로 stub을 실데이터로 교체해야
+한다. #36 (Review-Ops)은 여전히 OPEN이므로 stub을 유지하되 "not implemented"
+사유를 명시한다 (REQ-VAL2-008).
+
+#### D. release_id 포맷 (R7)
+
+**상태**: `validation_evidence.releaseId`는 `text()` (schema.ts:3451), FK 아님.
+RELEASE-001 (#31)은 release lifecycle 테이블을 정의하지 않는다 (아래 §2.4 참조).
+
+---
+
+## §2 선행 SPEC 코드 자산 인벤토리
+
+### 2.1 SPEC-REGULA-MODEL-GOVERNANCE-001 (#71, status: draft, code exists)
+
+> Issue #71은 CLOSED. SPEC 문서는 `draft`이나 코드는 lib/model-governance/에
+> 구현되어 있으며, VALIDATION-001이 이미 `change_request` 테이블을 소비 중.
+
+**코드 자산** (lib/model-governance/):
+
+| 파일 | 역할 | VALIDATION-002 소비 여부 |
+|------|------|--------------------------|
+| `change-workflow.ts` | change_request CRUD + 승인 워크플로우 | **소비 (간접)** — DB 직접 SELECT |
+| `registry.ts` | prompt registry 조회 | 소비 안 함 |
+| `model-pinning.ts` | model pin 관리 | 소비 안 함 |
+| `eval-gate.ts` | eval 게이트 실행 | 소비 안 함 (change_request.evalRunId로 간접) |
+| `rollback.ts` | 롤백 절차 | 소비 안 함 |
+| `audit.ts` | model-gov 감사 | 소비 안 함 |
+
+**소비 인터페이스** (VALIDATION-002가 읽을 데이터):
+- 테이블: `change_request` (schema.ts:2822-2845)
+- 컬럼: `id`, `orgId`, `promptId`, `modelPinId`, `evalRunId`, `evalStatus`,
+  `evalResultRef`, `approvalStatus`, `approvedAt`, `createdAt`
+- 인덱스: `idx_change_request_org`, `idx_change_request_org_status`
+
+**정식 연동 추가 쿼리** (M1):
+```sql
+-- window-scoped, org-scoped model/prompt approved change count
+SELECT id, eval_run_id, eval_result_ref, approved_at
+FROM change_request
+WHERE org_id = $1
+  AND approval_status = 'approved'
+  AND (prompt_id IS NOT NULL OR model_pin_id IS NOT NULL)
+  AND created_at >= $2  -- previous release tag date
+  AND created_at < $3   -- current release cutoff
+```
+
+### 2.2 SPEC-REGULA-TRACEABILITY-001 (#47, status: completed)
+
+**코드 자산** (lib/traceability/):
+
+| 파일 | 역할 | VALIDATION-002 소비 여부 |
+|------|------|--------------------------|
+| `matrix.ts` | `buildMatrix(db, filters, deps)` → MatrixResult | **소비 (M3)** |
+| `graph.ts` | node/edge CRUD + `findNodeByRef`, `isNodeStale` | 소비 안 함 |
+| `verify-edges.ts` | edge 무결성 검증 | 소비 안 함 |
+| `stale-propagation.ts` | stale 전파 | 소비 안 함 |
+| `client.ts` | 클라이언트 SDK | 소비 안 함 |
+
+**소비 인터페이스** (M3):
+```typescript
+// lib/traceability/matrix.ts:61
+export async function buildMatrix(
+  db: TraceabilityDb,
+  filters: MatrixFilters,  // { orgId, projectId?, ... }
+  deps: { staleNodeIds: Set<string>; ... }
+): Promise<MatrixResult>
+// MatrixResult.summary = { totalRows, withGaps, stale }
+```
+
+**경계 주의**: `buildMatrix`는 org/project 스코프이며 **release 차원이 없다**.
+VALIDATION-002는 sign-off 시점에 snapshot을 찍어 report에 기록하는 방식으로
+소비한다 (release 간 delta 비교는 post-v0.1).
+
+### 2.3 SPEC-REGULA-SOURCE-GOVERNANCE-001 (#48, status: draft, code exists)
+
+> Issue #48 CLOSED. 코드는 lib/source-governance/에 구현.
+
+**코드 자산** (lib/source-governance/):
+
+| 파일 | 역할 | VALIDATION-002 소비 여부 |
+|------|------|--------------------------|
+| `dashboard.ts` | `getGovernanceDashboard({orgId})` → counts + reviewDue + staleArtifacts | **소비 (M2 + M3)** |
+| `authority-model.ts` | 6-tier 권위도 모델 | 소비 안 함 |
+| `stale-check.ts` | `verifyGovernanceFreshness` | 소비 안 함 |
+| `review-workflow.ts` | source 검토 워크플로우 | 소비 안 함 |
+| `retrieval-gate.ts` | RAG 검색 게이트 | 소비 안 함 |
+
+**소비 인터페이스** (M2/M3):
+```typescript
+// lib/source-governance/dashboard.ts:40
+export async function getGovernanceDashboard(params: {
+  orgId: string;
+}): Promise<GovernanceDashboard>
+// counts: { approved, pendingReview, rejected, stale, superseded }
+// reviewDue: ReviewDueSource[]
+// staleCitationArtifacts: StaleCitationArtifact[]
+```
+
+**경계 주의**: dashboard counts는 **cumulative** (현재 시점 전체 corpus 상태).
+release 기간 내 delta를 구하려면 snapshot-at-release 테이블이 필요하나, 이는
+VALIDATION-002 범위를 넘는다 (Exclusions §7). M2에서는 "현재 시점 snapshot"을
+`change_control.residual_risk`에 문자열로 기록한다.
+
+### 2.4 SPEC-REGULA-RELEASE-001 (#31, status: completed)
+
+**상태**: umbrella SPEC. **release lifecycle 테이블을 정의하지 않음**.
+자식 SPEC 3종 (GATE-001 / HARDENING-001 / QUALITY-001) 모두 completed.
+
+**구현 코드**:
+
+| 자산 | 위치 | 역할 |
+|------|------|------|
+| `lib/release-gate/` | — | 디렉토리 없음 (게이트 로직은 lib/validation/rerun-gate.ts로 통합) |
+| release_id SSoT | 없음 | `validation_evidence.releaseId`는 text(), FK 아님 |
+| release 산출물 | `scripts/release-rc1/` | rc1 빌드 스크립트 (VALIDATION-001 plan.md에 참조) |
+
+**R7 gap 결론**: RELEASE-001이 release_id 생명주기를 관리하는 테이블을 갖지
+않으므로, VALIDATION-002는 **release_id regex + git tag 교차 검증**으로
+최소한의 정식화를 수행한다 (Charter [지양-5] 준수 — 신규 테이블 도입 금지).
+release_registry 테이블은 별도 후속 SPEC (RELEASE-002 권고)으로 이월한다
+(Exclusions §7).
+
+### 2.5 #36 Review-Ops (OPEN, 미구현)
+
+Issue #36은 OPEN 상태이며 lib/review-ops/ 디렉토리가 없다. VALIDATION-002는
+report의 Review Ops 섹션을 stub으로 유지하되 "not implemented" 사유를 명시한다
+(REQ-VAL2-008). 이는 허구 데이터 생성을 금지하는 Charter [지양-2] 준수 조치다.
+
+---
+
+## §3 Reuse Map (VALIDATION-002 소비 모델)
+
+```
+lib/validation/consumers/ (신규, 본 SPEC M0)
+├── model-governance.ts   ─→ change_request SELECT (window-scoped)
+├── traceability.ts        ─→ buildMatrix() snapshot
+├── source-governance.ts   ─→ getGovernanceDashboard() snapshot
+└── release.ts             ─→ release_id regex + git tag 교차 검증
+
+scripts/validation/classify-changes.ts (본 SPEC M1/M2)
+├── classifyModelGovernanceAxis()  ─→ consumers/model-governance.ts
+└── classifySourcePolicyAxis()     ─→ consumers/source-governance.ts (+ git diff)
+
+scripts/validation/build-report.ts (본 SPEC M3)
+├── renderTraceabilitySection()    ─→ consumers/traceability.ts
+├── renderSourceGovernanceSection() ─→ consumers/source-governance.ts
+├── renderReleaseScopeSection()    ─→ consumers/release.ts + evidence count
+└── renderReviewOpsSection()       ─→ stub 유지 (#36 OPEN)
+```
+
+**원칙** (Charter [지양-5]):
+- 모든 외부 SPEC 소비는 `lib/validation/consumers/` 단일 진입점으로 라우팅
+  (REQ-VAL2-011). 순환 의존성 방지 + SPEC 경계 명확화.
+- consumer wrapper는 read-only SELECT + 순수 함수 only. 신규 DB 테이블 금지.
+- 기존 VALIDATION-001 코드의 public 시그니처는 불변 (비파괴).
+
+---
+
+## §4 R 리스크별 해소 매트릭스 (VALIDATION-001 plan.md §4 기준)
+
+| VALIDATION-001 리스크 | 원 상태 | VALIDATION-002 해소 방식 | milestone |
+|----------------------|---------|--------------------------|-----------|
+| R2 (model-gov fallback) | 코드는 `change_request` 조회 중이나 window 없음 | window-scoped query + eval_run 연계 | M1 |
+| R2 확장 (source_policy) | 순수 git-diff heuristic | getGovernanceDashboard snapshot 결합 | M2 |
+| R6 (report stub) | 3 stub 섹션 (#31/47/48) | buildMatrix + getGovernanceDashboard 실데이터 주입 | M3 |
+| R7 (release_id) | regex 제안만, 관리 주체 없음 | regex + git tag 교차 검증 (release_registry는 RELEASE-002 이월) | M4 |
+
+---
+
+## §5 의존성 API 안정성 평가
+
+| 선행 SPEC | API 안정성 | 순환 의존 가능성 | 비고 |
+|-----------|-----------|------------------|------|
+| #71 MODEL-GOV | 높음 (이미 VALIDATION-001이 소비 중) | 없음 | consumer wrapper가 명시적 경계 |
+| #47 TRACEABILITY | 중간 (buildMatrix 시그니처 진화 가능) | 없음 | wrapper interface가 완충 |
+| #48 SOURCE-GOV | 중간 (dashboard counts 스키마 변경 시) | 없음 | wrapper interface가 완충 |
+| #31 RELEASE | 해당 없음 (테이블 없음) | 없음 | regex + git tag만 소비 |
+
+모든 소비는 read-only이므로 순환 의존성(VALIDATION-002 → 선행 SPEC →
+VALIDATION-002)은 발생하지 않는다.
+
+---
+
+## §6 테스트 고려 (L-013 직검 원칙)
+
+- 각 consumer wrapper는 mock DB로 단위 테스트 (VALIDATION-001 패턴 준용).
+- integration 테스트는 실DB에서 `change_request`, `evidence_nodes`,
+  `sources` 행을 seed → consumer 호출 → 반환값 직검.
+- AC 검증은 `pnpm test` 전체 스위트 + 수동 DB query (L-013).
+- `pnpm lint` (lint:hex 포함) full 실행 (L-008).
+- 마이그레이션 신규 0건 (본 SPEC은 스키마 변경 없음) → L-010 해당 없음.
+
+---
+
+## §7 References
+
+- VALIDATION-001 SPEC: `.moai/specs/SPEC-REGULA-VALIDATION-001/spec.md`
+- VALIDATION-001 plan.md §4 리스크 레지스터: line 189-195 (R2/R6/R7)
+- VALIDATION-001 plan.md §7 의존성 타임라인: line 243-259
+- PR #359 (VALIDATION-001 run-phase): main `c154b43`
+- PR #358 (VALIDATION-001 plan-phase): main `7c88a87`
+- Charter [지양-5] (SaaS 외판 금지): `~/.claude/projects/.../memory/product-charter.md`

--- a/.moai/specs/SPEC-REGULA-VALIDATION-002/spec.md
+++ b/.moai/specs/SPEC-REGULA-VALIDATION-002/spec.md
@@ -1,0 +1,264 @@
+---
+id: SPEC-REGULA-VALIDATION-002
+title: "Regula Validation 정식 연동 — Model-Gov / Traceability / Source-Gov / Release 통합"
+version: 0.1.0
+status: draft
+phase: system-validation
+priority: High
+created: 2026-07-07
+updated: 2026-07-07
+author: manager-spec (plan-phase)
+issue_number: null
+depends_on:
+  - SPEC-REGULA-VALIDATION-001
+related_specs:
+  - SPEC-REGULA-MODEL-GOVERNANCE-001
+  - SPEC-REGULA-TRACEABILITY-001
+  - SPEC-REGULA-SOURCE-GOVERNANCE-001
+  - SPEC-REGULA-RELEASE-001
+closes_issues: []
+verifies_specs: []
+lifecycle_level: spec-anchored
+labels:
+  - component/backend
+  - csv-lite
+  - iqqpq
+  - change-control
+  - integration
+revision_history:
+  - version: 0.1.0
+    date: 2026-07-07
+    author: manager-spec (plan-phase)
+    notes: "초안 작성. VALIDATION-001 R2/R6/R7 리스크 해소 — 4개 선행 SPEC(#71/#47/#48/#31 모두 CLOSED)의 자산을 정식 소비. thin glue layer 원칙 유지 (Charter [지양-5]). release_registry 테이블은 RELEASE-002로 이월 (Exclusions §7)."
+---
+
+# SPEC-REGULA-VALIDATION-002 — Regula Validation 정식 연동
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-07-07 | manager-spec (plan-phase) | 초안. VALIDATION-001 fallback/stub → 정식 연동 전환. 12 EARS REQ. M0~M4 milestone. |
+
+---
+
+## §1 Purpose (목적)
+
+### 1.1 배경 (Background)
+
+SPEC-REGULA-VALIDATION-001 (#49, PR #359 머지)은 Regula 자체 검증 패키지
+(IQ/OQ/PQ · 변경통제 · 릴리즈 증거)를 정의했으나, plan-phase 시점에 4개
+선행 의존성이 "진행중"이었다. 현재 이들 의존성은 **모두 CLOSED** 상태다:
+
+- **#71 SPEC-REGULA-MODEL-GOVERNANCE-001** — CLOSED (코드 구현 완료, SPEC 문서는 draft)
+- **#47 SPEC-REGULA-TRACEABILITY-001** — CLOSED (status: completed)
+- **#48 SPEC-REGULA-SOURCE-GOVERNANCE-001** — CLOSED (코드 구현 완료, SPEC 문서는 draft)
+- **#31 SPEC-REGULA-RELEASE-001** — CLOSED (status: completed, 단 release lifecycle 테이블은 없음)
+
+VALIDATION-001은 이들을 fallback/stub 모드로 소비했다 (plan.md §4 R2/R6/R7
+리스크). 본 SPEC-VALIDATION-002는 이제 이들을 **정식 연동**으로 전환하여
+검증 증거의 신뢰성을 높인다.
+
+### 1.2 규제 근거 (Regulatory Anchor)
+
+VALIDATION-001 §1.2를 그대로 계승한다:
+
+- **GAMP 5 / CSV** — IQ/OQ/PQ 단계별 검증 증거 체계.
+- **21 CFR Part 11 §11.10(i)** — 컴퓨터 시스템 검증 문서화.
+- **ISO 13485:2016 §4.1.6** — 소프트웨어 validation 및 변경통제.
+- **ISO 14971:2019** — 잔여 위험 기록.
+
+본 SPEC은 추가로 **검증 증거의 추적성(traceability)**과 **변경 통제의 정밀도**
+를 강화하여 위 규제 요구사항의 실질적 충족도를 높인다.
+
+### 1.3 본 SPEC의 범위 (In Scope)
+
+VALIDATION-001의 R2/R6/R7 리스크를 해소하는 4개 연동 영역:
+
+- **A. R2 해소 — model/prompt 축 정식 연동** (M1)
+  - `change_request` 조회를 window-scoped + org-scoped로 정밀화
+  - `evalRunId` / `evalResultRef`를 `change_control.evidence_ref`에 연결
+- **B. R2 확장 — source_policy 축 정식 연동** (M2)
+  - 순수 git-diff heuristic을 `getGovernanceDashboard` snapshot 결합으로 강화
+- **C. R6 해소 — report stub → 실데이터** (M3)
+  - Release Scope Status (#31-34): evidence count + git tag
+  - Traceability Status (#47): `buildMatrix` snapshot
+  - Source Governance Status (#48): `getGovernanceDashboard` snapshot
+  - Review Ops Status (#36): stub 유지 (OPEN, not implemented 사유 명시)
+- **D. R7 해소 — release_id 정식 체계** (M4)
+  - regex convention `^v\d+\.\d+\.\d+(-rc\d+)?$` 정의
+  - git tag 교차 검증 (non-blocking warning)
+
+### 1.4 Out of Scope (Non-Goals)
+
+- **release_registry 테이블 도입** — Charter [지양-5] 준수; RELEASE-002 후속
+  SPEC으로 이월 (Exclusions §7).
+- **Review-Ops (#36) 정식 연동** — #36이 OPEN 상태이므로 stub 유지.
+- **Traceability release-dim delta** — release 간 snapshot 비교 기능 (post-v0.1).
+- **Source-gov snapshot-at-release 테이블** — cumulative snapshot 문자열 기록으로
+  대체 (post-v0.1 테이블 도입 검토).
+- **PDF report** — VALIDATION-001 REQ-VAL-011 Optional (post-v0.1).
+- **다중 관할권 validation matrix** — post-v0.1.
+- **Real-time validation observability dashboard** — 별도 SPEC.
+
+### 1.5 CSV-Lite 원칙 (Charter [지양-5] 계승)
+
+VALIDATION-001 §1.5를 그대로 계승한다:
+
+- **금지**: 신규 테스트 harness — 기존 CI 집계 유지
+- **금지**: 신규 QMS 워크플로우 — model-gov / traceability / source-gov 재사용
+- **금지**: 신규 DB 테이블 (release_registry 포함) — read-only 소비 only
+- **금지**: 외부 라이브러리 도입 — 기존 Drizzle + git CLI only
+
+---
+
+## §2 Intended Use (제품 사용 범위 선언)
+
+VALIDATION-001 §2를 그대로 계승한다. 본 SPEC은 검증 증거의 **정밀도와 추적성**을
+강화할 뿐, 제품 사용 범위 자체를 변경하지 않는다.
+
+---
+
+## §3 Requirements (EARS Format)
+
+### 3.1 Requirements 매트릭스
+
+| ID | Pattern | EARS Statement | Priority |
+|----|---------|----------------|----------|
+| REQ-VAL2-001 | Event-Driven | **When** the change-control classifier runs for a release window, the system **shall** select `change_request` rows with `created_at` between the previous release tag date and the current release cutoff, rather than selecting all approved rows globally. | High |
+| REQ-VAL2-002 | Event-Driven | **When** a model or prompt `change_request` is classified as high-impact in a release window, the system **shall** record the `eval_run_id` and `eval_result_ref` from the `change_request` row into the corresponding `change_control.evidence_ref` field. | High |
+| REQ-VAL2-003 | Ubiquitous | The system **shall** scope all `change_request` consumer queries by `org_id` via explicit `WHERE org_id = $1`, independent of RLS enforcement, to keep the validation domain boundary auditable in code. | Medium |
+| REQ-VAL2-004 | Event-Driven | **When** the source_policy axis classifier runs, the system **shall** combine the git-diff heuristic with a `getGovernanceDashboard` snapshot, recording both signals in the `change_control.residual_risk` text. | Medium |
+| REQ-VAL2-005 | Event-Driven | **When** the release validation report is built, the system **shall** call `buildMatrix` from `lib/traceability/matrix.ts` and render the traceability summary (`totalRows`, `withGaps`, `stale`) in the Traceability Status section. | High |
+| REQ-VAL2-006 | Event-Driven | **When** the release validation report is built, the system **shall** call `getGovernanceDashboard` from `lib/source-governance/dashboard.ts` and render the source-governance counts table in the Source Governance Status section. | High |
+| REQ-VAL2-007 | Event-Driven | **When** the release validation report is built, the system **shall** render the Release Scope Status section from `validation_evidence` counts per qualification type plus git tag info, replacing the stub text. | High |
+| REQ-VAL2-008 | Unwanted | **If** the Review-Ops SPEC (#36) is not implemented, **then** the system **shall** keep the Review Ops section as an explicit "not implemented" stub with the issue reference, and **shall not** fabricate review-ops data. | High |
+| REQ-VAL2-009 | State-Driven | **While** a `release_id` is supplied to any validation API or script, the system **shall** validate it matches the regex `^v\d+\.\d+\.\d+(-rc\d+)?$` before processing. | High |
+| REQ-VAL2-010 | Event-Driven | **When** a `release_id` is validated, the system **shall** cross-check it against `git tag --list` and emit a non-blocking warning to stderr when the tag is absent from the local repository. | Medium |
+| REQ-VAL2-011 | Ubiquitous | The system **shall** route every read from the four dependency SPECs (`change_request`, `buildMatrix`, `getGovernanceDashboard`, git tags) through the `lib/validation/consumers/` wrapper module so that the integration seam is single-sourced. | High |
+| REQ-VAL2-012 | Unwanted | The system **shall not** introduce a `release_registry` database table in this SPEC; full release lifecycle ownership is deferred to a future RELEASE-002 SPEC. | High |
+
+### 3.2 경계: 선행 SPEC과의 분담 (Revised)
+
+| 소유권 | SPEC | 책임 | 본 SPEC의 소비 방식 |
+|--------|------|------|---------------------|
+| MODEL-GOVERNANCE (#71) | change_request CRUD + 승인 워크플로우 | read-only SELECT (window-scoped) |
+| TRACEABILITY (#47) | evidence graph + matrix builder | `buildMatrix` 1회 호출 (snapshot) |
+| SOURCE-GOVERNANCE (#48) | source authority + dashboard | `getGovernanceDashboard` 1회 호출 (snapshot) |
+| RELEASE (#31) | release 산출물 ( rc1 스크립트 등) | release_id regex + git tag 교차 검증 |
+| REVIEW-OPS (#36) | 전문가 검토 큐 (미구현) | stub 유지 + 사유 명시 |
+
+본 SPEC은 VALIDATION-001 §3.2 원칙을 계승하여 **중복 구현을 금지**하며,
+`lib/validation/consumers/`를 단일 진입점으로 하는 얇은 소비 계층이다.
+
+---
+
+## §4 Technical Approach (Sketch)
+
+> 상세는 `plan.md`와 `research.md` 참조. 본 절은 개요만.
+
+### 4.1 신규 모듈 (lib/validation/consumers/, 4 파일)
+
+```
+lib/validation/consumers/
+├── model-governance.ts   # window-scoped change_request SELECT
+├── traceability.ts        # buildMatrix snapshot wrapper
+├── source-governance.ts   # getGovernanceDashboard snapshot wrapper
+└── release.ts             # release_id regex + git tag cross-check
+```
+
+각 wrapper는:
+- read-only (SELECT 또는 git CLI 호출 only)
+- 순수 함수 (side-effect 없음, 호출 시점 상태 반환)
+- 단위 테스트 가능 (mock DB / mock child_process)
+
+### 4.2 기존 코드 수정 (비파괴)
+
+| 파일 | 수정 내용 | 비파괴 여부 |
+|------|-----------|------------|
+| `scripts/validation/classify-changes.ts` | `classifyModelGovernanceAxis` / `classifySourcePolicyAxis`가 consumer 경유 | 시그니처 불변 |
+| `scripts/validation/build-report.ts` | 3 stub 섹션 → 실데이터 렌더링 함수 호출 | Markdown 출력 확장만 |
+
+### 4.3 DB 변경
+
+**없음** (Charter [지양-5] 준수). 모든 연동은 기존 테이블 read-only 소비.
+
+### 4.4 API Endpoints 변경
+
+**없음**. 기존 VALIDATION-001 API route 시그니처 유지. 내부 로직만 consumer
+경유로 전환.
+
+---
+
+## §5 Acceptance Criteria (요약)
+
+> 상세는 `acceptance.md`. 요약:
+
+| AC# | Criterion (binary-testable) |
+|-----|-----|
+| AC-1 | `classify-changes.ts` 실행 시 change_request 조회가 `created_at` 범위 조건을 포함한다 (grep `created_at` + `gte`/`between`) |
+| AC-2 | high-impact model/prompt change_control 행의 `evidence_ref`에 eval_run_id가 기록된다 (DB query) |
+| AC-3 | source_policy 축의 `residual_risk`에 dashboard counts 문자열이 포함된다 |
+| AC-4 | build-report 출력 Markdown의 Traceability Status 섹션에 `totalRows`/`withGaps`/`stale` 숫자가 포함된다 (stub 문자열 부재) |
+| AC-5 | build-report 출력의 Source Governance Status 섹션에 `approved`/`pendingReview`/`stale`/`superseded` 숫자가 포함된다 |
+| AC-6 | build-report 출력의 Release Scope Status 섹션에 IQ/OQ/PQ evidence count가 포함된다 (stub 부재) |
+| AC-7 | Review Ops 섹션은 "not implemented" 사유와 #36 참조를 포함한다 (허구 데이터 부재) |
+| AC-8 | release_id `v0.1.0-rc1`은 accept, `invalid-id`는 reject (단위 테스트) |
+| AC-9 | git tag가 없는 release_id 호출 시 stderr에 warning이 출력된다 (exit 0 유지, non-blocking) |
+| AC-10 | 모든 외부 SPEC 소비가 `lib/validation/consumers/`를 경유한다 (grep 검증: classify-changes.ts/build-report.ts에 consumers/ import 존재, 직접 change_request/buildMatrix/getGovernanceDashboard import 부재) |
+
+---
+
+## §6 의존성 (Dependencies)
+
+### 6.1 선행 (Blocking)
+
+- `SPEC-REGULA-VALIDATION-001` (completed) — 본 SPEC이 consumer wrapper를 붙이는
+  기반 코드 (`classify-changes.ts`, `build-report.ts`)의 소유자.
+
+### 6.2 연계 (Integration, 모두 CLOSED)
+
+- `SPEC-REGULA-MODEL-GOVERNANCE-001` (#71, CLOSED) — `change_request` 테이블 SSoT.
+- `SPEC-REGULA-TRACEABILITY-001` (#47, CLOSED) — `buildMatrix` API SSoT.
+- `SPEC-REGULA-SOURCE-GOVERNANCE-001` (#48, CLOSED) — `getGovernanceDashboard` API SSoT.
+- `SPEC-REGULA-RELEASE-001` (#31, CLOSED) — release 산출물 + git tag 관행.
+
+### 6.3 후속 (Follow-up, 본 SPEC이 권고)
+
+- **RELEASE-002 (제안)** — release_registry 테이블 + release lifecycle 관리.
+  본 SPEC REQ-VAL2-012가 이를 Exclusions로 명시적으로 이월.
+
+### 6.4 기술 스택
+
+VALIDATION-001 §6.3을 동일하게 적용 (Next.js 15, Drizzle ORM, PostgreSQL, GitHub Actions CI).
+
+---
+
+## §7 Risks (요약, 상세 plan.md §4)
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Traceability `buildMatrix` 시그니처 진화 | consumer wrapper 재작성 | wrapper interface가 완충 (single seam) |
+| Source-gov dashboard counts cumulative only | release 간 delta 불가 | snapshot 문자열 기록 (post-v0.1 테이블 검토) |
+| release_id regex가 RELEASE-001 관행과 불일치 | 일부 release_id 거부 | git tag 기반 관행 매핑 + regex 완화 |
+| change_request 대량 누적 시 window 쿼리 성능 | classify-changes 지연 | `idx_change_request_org_status` + `created_at` range scan |
+| #36 Review-Ops 장기 미구현 | stub 영구화 | REQ-VAL2-008이 사유 명시를 강제 (허구 방지) |
+
+---
+
+## §8 Exclusions (What NOT to Build)
+
+> Charter [지양-5] 및 본 SPEC §1.4 원칙에 따른 제외 항목.
+
+- **배제**: `release_registry` 데이터베이스 테이블 — RELEASE-002로 이월
+  (REQ-VAL2-012).
+- **배제**: Review-Ops (#36) 정식 연동 — #36 OPEN 상태이므로 stub 유지
+  (REQ-VAL2-008).
+- **배제**: Traceability release-dim delta (release 간 snapshot 비교) — post-v0.1.
+- **배제**: Source-gov snapshot-at-release 테이블 — cumulative 문자열 기록으로 대체.
+- **배제**: PDF report export — VALIDATION-001 REQ-VAL-011 Optional 준수 (post-v0.1).
+- **배제**: 다중 관할권 validation matrix — post-v0.1.
+- **배제**: Real-time validation observability dashboard — 별도 SPEC.
+- **배제**: validation_evidence.releaseId에 FK 제약 추가 — release_registry
+  부재로 불가; RELEASE-002에서 검토.
+- **배제**: VALIDATION-001 public API 시그니처 변경 — 비파괴 원칙.


### PR DESCRIPTION
## 요약

VALIDATION-001 머지(c154b43, PR #359) 후 4개 선행 의존성(#71/#47/#48/#31)이 모두 CLOSED됨에 따라, VALIDATION-001의 fallback/stub(R2/R6/R7)을 **정식 연동**으로 전환하는 후속 SPEC의 plan-phase 산출물.

Follows #49 (VALIDATION-001 후속, 별도 이슈 생성 없음 — PR에서 후속 처리)

## 4종 산출물 (총 1,306줄)

| 파일 | 라인 | 내용 |
|------|------|------|
| research.md | 300 | 4개 선행 SPEC 자산 인벤토리 + VALIDATION-001 fallback 지점 정확한 매핑 |
| spec.md | 264 | 12 EARS REQ (REQ-VAL2-001~012), §3.2 경계 계승, §7 Exclusions 11종 |
| plan.md | 371 | 5 milestone (M0 consumers → M1~M4 병렬), R1~R8 리스크, 게이트 교훈 명시 |
| acceptance.md | 371 | 11 AC + 6 edge cases |

## Milestone (5종)

- **M0** Consumer Wrappers (Critical blocker): `lib/validation/consumers/` 4 파일 (model-gov/traceability/source-gov/release). 단일 연결점 (REQ-VAL2-011)
- **M1** R2 model/prompt 정식 연동: change_request window + eval_run 연계
- **M2** source_policy 정식 연동: getGovernanceDashboard snapshot 결합
- **M3** R6 report stub → 실데이터: build-report.ts 3 stub 섹션 실데이터 렌더링
- **M4** R7 release_id 정식화: regex + git tag 교차 검증

M1~M4는 M0 완료 후 병렬 착수 가능 (독립 파일).

## 핵심 설계 결정

- **thin glue layer 유지** (Charter [지양-5]): consumers/ 경유 단일 연결점
- **R2 정밀화**: 이미 change_request 조회 중 (window 갭만 해소)
- **R7 부분 해소**: regex + git tag 검증, release_registry는 **RELEASE-002 이월** (REQ-VAL2-012)
- **R6 #36 Review-Ops** (OPEN): "not implemented" 사유 강제 → 허구 데이터 차단 (Charter [지양-2])
- **비파괴**: VALIDATION-001 시그니처 불변

## annotation cycle 후보 결정 사항 (run phase 전 확인)

1. release_id regex — 정식(`v0.1.0`) + RC(`v0.1.0-rc1`) 모두 허용 확정
2. #36 Review-Ops stub 처리 — "not implemented" 명시 vs 섹션 생략
3. RELEASE-002 제안 이슈 — 본 PR에 포함 vs 별도
4. source-gov snapshot 저장 — residual_risk 문자열 vs 별도 jsonb 컬럼

## Follow-ups (권고)

- **RELEASE-002 제안 이슈**: release_registry 테이블 + release lifecycle SSoT (REQ-VAL2-012에서 이월)
- **#36 Review-Ops 연동**: #36 완료 시 stub → 정식 전환

@holee9