### PR TITLE
Mid-check #361 group 2: ci:audit lib wrapper 인식 + ci:module-boundaries cross-domain + allowlist

### DIFF
--- a/scripts/ci/module-boundaries.ts
+++ b/scripts/ci/module-boundaries.ts
@@ -5,6 +5,9 @@
  * Observability (engineering metrics) must remain separate from audit logs
  * (21 CFR Part 11 compliance).
  *
+ * Also checks for cross-domain dependencies within lib/domains/.
+ * Domains should not directly import from other domains (ARCH-003).
+ *
  * Exit 0 if no violations; exit 1 if any violations found.
  *
  * Usage: pnpm ci:module-boundaries
@@ -17,33 +20,100 @@ import { logger } from '../../lib/observability/logger.ts';
 const OBS_DIR = path.join(process.cwd(), 'lib', 'observability');
 const FORBIDDEN_PATTERNS = ['writeAudit', 'lib/audit'];
 
+const DOMAINS_DIR = path.join(process.cwd(), 'lib', 'domains');
+
+/**
+ * Intentional cross-domain dependencies (SPEC-approved reuse/wrapper).
+ * @MX:NOTE: These are direct cross-domain imports but are intentional architecture
+ * documented in SPEC. Add new entries ONLY with SPEC reference + justification.
+ */
+const ALLOWED_CROSS_DOMAIN: Record<string, readonly string[]> = {
+  // SPEC-V3-CONSULT-001: run-consult.ts reuses runTriage (RAG pipeline wrapper + H-3 citation)
+  consult: ['triage'],
+};
+
 function checkFile(filePath: string): string[] {
   const content = fs.readFileSync(filePath, 'utf-8');
   return FORBIDDEN_PATTERNS.filter((pattern) => content.includes(pattern));
 }
 
-function main(): void {
-  if (!fs.existsSync(OBS_DIR)) {
-    process.exit(0);
+/**
+ * Check for cross-domain dependencies in lib/domains/.
+ * Detects direct imports from one domain to another (e.g., domains/auth importing domains/inbox).
+ */
+function checkCrossDomainDependencies(): string[] {
+  const violations: string[] = [];
+
+  if (!fs.existsSync(DOMAINS_DIR)) {
+    return violations;
   }
 
-  const files = fs
-    .readdirSync(OBS_DIR)
-    .filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'))
-    .map((f) => path.join(OBS_DIR, f));
+  const domains = fs.readdirSync(DOMAINS_DIR).filter((f) => {
+    const fullPath = path.join(DOMAINS_DIR, f);
+    return fs.statSync(fullPath).isDirectory();
+  });
 
-  const violations: string[] = [];
-  for (const file of files) {
-    const found = checkFile(file);
-    if (found.length > 0) {
-      violations.push(`${path.basename(file)}: imports [${found.join(', ')}]`);
+  for (const domain of domains) {
+    const domainPath = path.join(DOMAINS_DIR, domain);
+    const files = fs
+      .readdirSync(domainPath)
+      .filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'))
+      .map((f) => path.join(domainPath, f));
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf-8');
+
+      // Check for imports from other domains
+      // Pattern: import ... from '@/lib/domains/{other_domain}'
+      const allowed = ALLOWED_CROSS_DOMAIN[domain] ?? [];
+      for (const otherDomain of domains) {
+        if (otherDomain === domain) continue; // Skip self
+        if (allowed.includes(otherDomain)) continue; // SPEC-approved reuse
+
+        // Check both quoted and unquoted import patterns
+        const patterns = [
+          new RegExp(`from\\s+['"]@/lib/domains/${otherDomain}`, 'g'),
+          new RegExp(`from\\s+['"]\\.\\.*/\\.\\.*/domains/${otherDomain}`, 'g'),
+        ];
+
+        for (const pattern of patterns) {
+          if (pattern.test(content)) {
+            const relative = path.relative(process.cwd(), file);
+            violations.push(`${relative}: imports from domain ${otherDomain}`);
+          }
+        }
+      }
     }
   }
 
-  const count = files.length;
-  if (violations.length > 0) {
-    logger.error(`Module boundaries check: ${count} files checked. VIOLATION:`);
-    for (const v of violations) {
+  return violations;
+}
+
+function main(): void {
+  const allViolations: string[] = [];
+
+  // Original check: observability → audit
+  if (fs.existsSync(OBS_DIR)) {
+    const files = fs
+      .readdirSync(OBS_DIR)
+      .filter((f) => f.endsWith('.ts') || f.endsWith('.tsx'))
+      .map((f) => path.join(OBS_DIR, f));
+
+    for (const file of files) {
+      const found = checkFile(file);
+      if (found.length > 0) {
+        allViolations.push(`${path.basename(file)}: imports [${found.join(', ')}]`);
+      }
+    }
+  }
+
+  // New check: cross-domain dependencies
+  const crossDomainViolations = checkCrossDomainDependencies();
+  allViolations.push(...crossDomainViolations);
+
+  if (allViolations.length > 0) {
+    logger.error('Module boundaries check: VIOLATIONS FOUND:');
+    for (const v of allViolations) {
       logger.error(`  - ${v}`);
     }
     process.exit(1);

--- a/scripts/qa/audit-completeness.ts
+++ b/scripts/qa/audit-completeness.ts
@@ -3,6 +3,7 @@
 //
 // Scans app/api/**/route.ts files for state-mutating HTTP handlers
 // (POST, PATCH, PUT, DELETE) and verifies each calls writeAudit().
+// Also scans lib/ files containing audit wrappers for PII leaks.
 // Also scans writeAudit() meta_json arguments for PII key patterns.
 //
 // Override: add `/* audit-check-ignore: <justification> */` on the same
@@ -155,6 +156,27 @@ function collectRouteFiles(dir: string, results: string[] = []): string[] {
 }
 
 /**
+ * Recursively collect all TypeScript files under lib/ that contain audit wrapper calls.
+ * This ensures lib/ domain audit wrappers are also checked for coverage.
+ */
+function collectLibAuditFiles(dir: string, results: string[] = []): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectLibAuditFiles(full, results);
+    } else if (entry.isFile() && (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx'))) {
+      // Only include files that actually use audit wrappers
+      const content = fs.readFileSync(full, 'utf-8');
+      if (hasAuditCall(content)) {
+        results.push(full);
+      }
+    }
+  }
+  return results;
+}
+
+/**
  * Run the full audit completeness check across all route files in apiDir.
  *
  * @param apiDir - Root directory to scan (default: app/api)
@@ -162,10 +184,12 @@ function collectRouteFiles(dir: string, results: string[] = []): string[] {
  */
 export async function runAuditCheck(
   apiDir: string,
+  libDir: string,
 ): Promise<{ violations: string[]; piiViolations: string[] }> {
   const violations: string[] = [];
   const piiViolations: string[] = [];
 
+  // Check route files (existing behavior - MUTABLE_METHODS only)
   const routeFiles = collectRouteFiles(apiDir);
 
   for (const filePath of routeFiles) {
@@ -175,6 +199,18 @@ export async function runAuditCheck(
     const coverageViolations = checkFileForAuditCoverage(content, relative);
     violations.push(...coverageViolations);
 
+    const pii = checkFileForPiiLeaks(content, relative);
+    piiViolations.push(...pii);
+  }
+
+  // Check lib/ files with audit wrappers (PII only - no MUTABLE_METHODS check)
+  const libFiles = collectLibAuditFiles(libDir);
+
+  for (const filePath of libFiles) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const relative = path.relative(process.cwd(), filePath);
+
+    // Only PII check for lib files (they already call audit wrappers)
     const pii = checkFileForPiiLeaks(content, relative);
     piiViolations.push(...pii);
   }
@@ -191,7 +227,8 @@ const isDirectRun =
 
 if (isDirectRun) {
   const apiDir = path.resolve(process.cwd(), 'app', 'api');
-  runAuditCheck(apiDir).then(({ violations, piiViolations }) => {
+  const libDir = path.resolve(process.cwd(), 'lib');
+  runAuditCheck(apiDir, libDir).then(({ violations, piiViolations }) => {
     const allViolations = [...violations, ...piiViolations];
 
     if (violations.length > 0) {


### PR DESCRIPTION
## #361 그룹 2/3 — CI 게이트 확장

### 변경
- `ci:audit` 확장: lib/ 도메인 audit wrapper 자동 검출(`collectLibAuditFiles`), 기존 route 검사 불변, `APPROVED_AUDIT_WRAPPER_NAMES` 14개 유지, `audit-check-ignore` 호환.
- `ci:module-boundaries` 확장: `lib/domains/` cross-domain 의존 검사 추가(정적 grep, madge 의존성 추가 없음).
- `ALLOWED_CROSS_DOMAIN` 예외: `consult→triage` (SPEC-V3-CONSULT-001 runTriage 래퍼). **orchestrator 직검 정정** — 에이전트가 예외 처리 누락해 CI exit 1 블로커 발생, allowlist로 해소.

### 게이트 직검 (orchestrator, L-007/L-013/L-015)
| 게이트 | 결과 |
|---|---|
| ci:audit | PASS (exit 0) |
| ci:module-boundaries | exit 0 (allowlist 적용 후) |
| typecheck | exit 0 |
| lint | exit 0 (12 warnings pre-existing) |

### 에이전트 산출물 직접 정정 (L-013)
- 에이전트가 consult→triage 위반을 "의도적 동작 증명"이라 했으나 실제 exit 1 CI 블로커 → orchestrator가 SPEC 문서화된 의도적 의존(consult/run-consult.ts = runTriage 래퍼)을 allowlist로 정정.

### 범위 외 (별도 이슈)
- 그룹 3 (QA gate workflow 통합 + CI 스크립트 thin 분리): 별도 follow-up 이슈로 이관 (gate-0 경로 정리 + 회귀 리스크).

Closes #361 (group 1 머지됨 PR #367 + group 2 본 PR; group 3 follow-up 별도)

🗿 MoAI <email@mo.ai.kr>