### PR TITLE
feat(validation): SPEC-REGULA-VALIDATION-002 M1~M4 — consumers 정식 연동 + release_id gate

### DIFF
--- a/app/api/validation/changes/route.ts
+++ b/app/api/validation/changes/route.ts
@@ -9,7 +9,14 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { z } from 'zod';
 
 const changesRequestSchema = z.object({
-  releaseId: z.string().min(1).max(128),
+  releaseId: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      /^v\d+\.\d+\.\d+(-rc\d+)?$/,
+      'Invalid release_id format. Expected ^v\\d+\\.\\d+\\.\\d+(-rc\\d+)?$',
+    ),
   previousRef: z.string().max(256).optional(),
 });
 

--- a/app/api/validation/iq/route.ts
+++ b/app/api/validation/iq/route.ts
@@ -11,7 +11,14 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { z } from 'zod';
 
 const iqRequestSchema = z.object({
-  releaseId: z.string().min(1).max(128),
+  releaseId: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      /^v\d+\.\d+\.\d+(-rc\d+)?$/,
+      'Invalid release_id format. Expected ^v\\d+\\.\\d+\\.\\d+(-rc\\d+)?$',
+    ),
 });
 
 // audit-check-ignore rationale: this route inserts validation_evidence rows;

--- a/app/api/validation/oq/route.ts
+++ b/app/api/validation/oq/route.ts
@@ -9,7 +9,14 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { z } from 'zod';
 
 const oqRequestSchema = z.object({
-  releaseId: z.string().min(1).max(128),
+  releaseId: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      /^v\d+\.\d+\.\d+(-rc\d+)?$/,
+      'Invalid release_id format. Expected ^v\\d+\\.\\d+\\.\\d+(-rc\\d+)?$',
+    ),
 });
 
 async function runCollectOq(releaseId: string): Promise<{ stdout: string; exitCode: number }> {

--- a/app/api/validation/pq/route.ts
+++ b/app/api/validation/pq/route.ts
@@ -9,7 +9,14 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { z } from 'zod';
 
 const pqRequestSchema = z.object({
-  releaseId: z.string().min(1).max(128),
+  releaseId: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      /^v\d+\.\d+\.\d+(-rc\d+)?$/,
+      'Invalid release_id format. Expected ^v\\d+\\.\\d+\\.\\d+(-rc\\d+)?$',
+    ),
 });
 
 async function runCollectPq(releaseId: string): Promise<{ stdout: string; exitCode: number }> {

--- a/app/api/validation/report/export/route.ts
+++ b/app/api/validation/report/export/route.ts
@@ -11,7 +11,14 @@ import { withPermission } from '@/lib/auth/with-permission';
 import { z } from 'zod';
 
 const exportRequestSchema = z.object({
-  releaseId: z.string().min(1).max(128),
+  releaseId: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      /^v\d+\.\d+\.\d+(-rc\d+)?$/,
+      'Invalid release_id format. Expected ^v\\d+\\.\\d+\\.\\d+(-rc\\d+)?$',
+    ),
 });
 
 async function runBuildReport(releaseId: string): Promise<{ stdout: string; exitCode: number }> {

--- a/app/api/validation/signoff/route.ts
+++ b/app/api/validation/signoff/route.ts
@@ -18,7 +18,14 @@ import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 const signoffRequestSchema = z.object({
-  releaseId: z.string().min(1).max(128),
+  releaseId: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      /^v\d+\.\d+\.\d+(-rc\d+)?$/,
+      'Invalid release_id format. Expected ^v\\d+\\.\\d+\\.\\d+(-rc\\d+)?$',
+    ),
   // Client-supplied checklist snapshot (id/title/met). Server re-evaluates from
   // DB state and ignores client met values — the client snapshot is recorded
   // in validation_signoff.checklist_state for audit, not for gate decisions.

--- a/scripts/validation/build-report.ts
+++ b/scripts/validation/build-report.ts
@@ -24,6 +24,12 @@ import {
   type ChecklistId,
   buildChecklist,
 } from '../../lib/validation/checklist.ts';
+import {
+  checkGitTagExists,
+  snapshotSourceGovernance,
+  snapshotTraceability,
+  validateReleaseIdFormat,
+} from '../../lib/validation/consumers/index.ts';
 import { evaluateRerunGate } from '../../lib/validation/rerun-gate.ts';
 
 interface BuildReportArgs {
@@ -143,15 +149,79 @@ function evidenceByType(rows: EvidenceRow[]) {
 }
 
 /**
+ * Release Scope Status section (AC-6, REQ-VAL2-007). Renders IQ/OQ/PQ evidence
+ * counts, the release_id, and git tag presence. #31-#34 referenced for static
+ * completeness (now CLOSED — scope is real, not stubbed).
+ */
+function renderReleaseScopeSection(
+  releaseId: string,
+  evidence: EvidenceRow[],
+  tagExists: boolean,
+): string {
+  const iq = evidence.filter((r) => r.qualificationType === 'iq').length;
+  const oq = evidence.filter((r) => r.qualificationType === 'oq').length;
+  const pq = evidence.filter((r) => r.qualificationType === 'pq').length;
+  const tagLine = tagExists
+    ? `git tag \`${releaseId}\` present locally.`
+    : `git tag \`${releaseId}\` not found locally (pre-release candidate?).`;
+  return `| metric | value |\n|---|---|\n| release_id | ${escapePipe(releaseId)} |\n| IQ evidence | ${iq} |\n| OQ evidence | ${oq} |\n| PQ evidence | ${pq} |\n| git tag | ${tagExists ? 'present' : 'absent'} |\n\n> ${tagLine}`;
+}
+
+/**
+ * Traceability Status section (AC-4, REQ-VAL2-005). Renders buildMatrix summary
+ * via consumer. EC-3: non-blocking on snapshot failure (records unavailable msg).
+ */
+async function renderTraceabilitySection(orgId: string): Promise<string> {
+  if (!orgId) return '[traceability snapshot unavailable: REGULA_ORG_ID not set]';
+  try {
+    const summary = await snapshotTraceability({ orgId });
+    return `| metric | value |\n|---|---|\n| totalRows | ${summary.totalRows} |\n| withGaps | ${summary.withGaps} |\n| stale | ${summary.stale} |`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Warning: traceability snapshot unavailable: ${msg}\n`);
+    return `[traceability snapshot unavailable: ${escapePipe(msg)}]`;
+  }
+}
+
+/**
+ * Source Governance Status section (AC-5, REQ-VAL2-006). Renders dashboard
+ * counts via consumer.
+ */
+async function renderSourceGovernanceSection(orgId: string): Promise<string> {
+  if (!orgId) return '[source-governance snapshot unavailable: REGULA_ORG_ID not set]';
+  try {
+    const dashboard = await snapshotSourceGovernance({ orgId });
+    const c = dashboard.counts;
+    return `| metric | value |\n|---|---|\n| approved | ${c.approved} |\n| pendingReview | ${c.pendingReview} |\n| stale | ${c.stale} |\n| superseded | ${c.superseded} |`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Warning: source-governance snapshot unavailable: ${msg}\n`);
+    return `[source-governance snapshot unavailable: ${escapePipe(msg)}]`;
+  }
+}
+
+/**
+ * Review Ops Status section (AC-7, REQ-VAL2-008). #36 Review-Ops not yet
+ * implemented — explicit "not implemented" + #36 reference. No fabricated data.
+ */
+function renderReviewOpsSection(): string {
+  return '> not implemented — SPEC-REGULA-REVIEW-OPS-001 (#36) is not yet complete. This section will report review-queue SLA and turnaround metrics once #36 lands. No review-ops numbers are fabricated here.';
+}
+
+/**
  * Assemble the 8-section Release Validation Report Markdown (AC-6).
  * Sections #6-#8 are stubs by design (R6 risk — #31-#34/#47/#48/#36 are not yet
  * complete; this report cites their pending state explicitly).
  */
 export async function buildReleaseReportMarkdown(releaseId: string): Promise<string> {
-  const [evidence, changes, rerunGate] = await Promise.all([
+  const orgId = process.env.REGULA_ORG_ID ?? '';
+  const [evidence, changes, rerunGate, tagCheck, traceSection, sourceSection] = await Promise.all([
     fetchEvidence(releaseId),
     fetchChanges(releaseId),
     evaluateRerunGate(releaseId),
+    Promise.resolve(checkGitTagExists(releaseId)),
+    renderTraceabilitySection(orgId),
+    renderSourceGovernanceSection(orgId),
   ]);
 
   const qual = evidenceByType(evidence);
@@ -207,20 +277,19 @@ ${
 
 ## Release Scope Status (#31-#34)
 
-> **Stub** — SPEC-REGULA-RELEASE-001 (#31-#34) not yet complete. This section
-> will list the release scope (features, subsystems, in this release) once
-> RELEASE-001 lands. Tracked as R6 risk in plan.md §4.
+${renderReleaseScopeSection(releaseId, evidence, tagCheck.exists)}
 
 ## Traceability Status (#47)
 
-> **Stub** — SPEC-REGULA-TRACEABILITY-001 (#47) not yet complete. This section
-> will summarize evidence-graph coverage for the release. Tracked as R6 risk.
+${traceSection}
 
-## Source Governance Status (#48) · Review Ops Status (#36)
+## Source Governance Status (#48)
 
-> **Stub** — SPEC-REGULA-SOURCE-GOVERNANCE-001 (#48) and
-> SPEC-REGULA-REVIEW-OPS-001 (#36) not yet complete. These sections will report
-> source-authority coverage and review SLA status once those SPECs land.
+${sourceSection}
+
+## Review Ops Status (#36)
+
+${renderReviewOpsSection()}
 
 ## Sign-off Checklist
 
@@ -246,6 +315,20 @@ export function writeReportFile(releaseId: string, markdown: string): string {
 
 async function main() {
   const { releaseId } = parseArgs(process.argv);
+  // M4: release_id format gate (REQ-VAL2-009).
+  const formatCheck = validateReleaseIdFormat(releaseId);
+  if (!formatCheck.valid) {
+    process.stderr.write(`ERROR: ${formatCheck.reason}\n`);
+    process.exit(1);
+  }
+  // M4: git tag warning (REQ-VAL2-010, non-blocking).
+  const tagCheck = checkGitTagExists(releaseId);
+  if (!tagCheck.exists) {
+    process.stderr.write(
+      `Warning: git tag ${releaseId} not found locally (pre-release candidate?)\n`,
+    );
+    if (tagCheck.warning) process.stderr.write(`${tagCheck.warning}\n`);
+  }
   const markdown = await buildReleaseReportMarkdown(releaseId);
   const fullPath = writeReportFile(releaseId, markdown);
   process.stdout.write(`${fullPath}\n`);

--- a/scripts/validation/classify-changes.ts
+++ b/scripts/validation/classify-changes.ts
@@ -25,10 +25,15 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
-import { and, eq, isNotNull } from 'drizzle-orm';
 import { db } from '../../lib/db/client.ts';
-import { changeControl, changeRequest } from '../../lib/db/schema.ts';
+import { changeControl } from '../../lib/db/schema.ts';
 import { CHANGE_AXES, type ChangeAxis, type ImpactLevel } from '../../lib/schemas/validation.ts';
+import {
+  checkGitTagExists,
+  fetchWindowScopedChangeRequests,
+  snapshotSourceGovernance,
+  validateReleaseIdFormat,
+} from '../../lib/validation/consumers/index.ts';
 
 interface ClassifyArgs {
   releaseId: string;
@@ -76,45 +81,124 @@ function countPathDiffs(previousRef: string | undefined, pathSpec: string): numb
 }
 
 /**
- * prompt/model axes — query model-governance changeRequest table.
- * High impact when an approved change exists in this release window.
- * research.md §1.3 boundary: change-workflow.ts owns the workflow itself.
+ * Resolve the release window [previousRef..HEAD] for window-scoped consumer queries.
+ * EC-5: when previousRef is missing or absent in git history, fall back to UNIX
+ * epoch (1970) so every existing change_request is conservatively in-window.
+ * SPEC-REGULA-VALIDATION-002 M1 (REQ-VAL2-001).
+ */
+function resolveWindow(previousRef?: string): {
+  windowStart: Date;
+  windowEnd: Date;
+  note: string;
+} {
+  const windowEnd = new Date();
+  if (!previousRef) {
+    return {
+      windowStart: new Date(0),
+      windowEnd,
+      note: 'previous_ref not provided, fallback to epoch',
+    };
+  }
+  const result = spawnSync('git', ['log', '-1', '--format=%cI', previousRef], {
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  });
+  const iso = result.status === 0 ? result.stdout.trim() : '';
+  if (!iso) {
+    return {
+      windowStart: new Date(0),
+      windowEnd,
+      note: `previous_ref ${previousRef} not found, fallback to epoch`,
+    };
+  }
+  return {
+    windowStart: new Date(iso),
+    windowEnd,
+    note: `window [${previousRef}..HEAD ${iso}]`,
+  };
+}
+
+/**
+ * Resolve the organization ID for window-scoped consumer queries.
+ * Charter [지양-5]: single-org assumption (not a multi-tenant SaaS). The script
+ * runs in a system/validation context where REGULA_ORG_ID is provided by env.
+ * SPEC-REGULA-VALIDATION-002 M1/M2.
+ */
+function resolveOrgId(): string {
+  const orgId = process.env.REGULA_ORG_ID;
+  if (!orgId) {
+    process.stderr.write(
+      'ERROR: REGULA_ORG_ID env var required for window-scoped consumer queries\n',
+    );
+    process.exit(1);
+  }
+  return orgId;
+}
+
+/**
+ * prompt/model axes — window-scoped model-governance change_request query via
+ * consumer (AC-1, AC-2, AC-10). REQ-VAL2-001/002.
+ *
+ * High impact when an approved change exists in the release window
+ * [previousRef..HEAD]. evalRunId/evalResultRef are recorded in residual_risk:
+ * change_control.evidence_ref is uuid-typed (schema.ts:3486 — reserved for
+ * validation_evidence.id loose ref per VALIDATION-001 design), while
+ * model-governance evalRunId is a free-form string — storing it in evidence_ref
+ * would require a column-type migration, which Charter [지양-5] 범위 통제 forbids.
+ * residual_risk carries the traceability instead.
  */
 async function classifyModelGovernanceAxis(
   _releaseId: string,
   axis: 'prompt' | 'model',
+  options?: {
+    orgId?: string;
+    windowStart?: Date;
+    windowEnd?: Date;
+    windowNote?: string;
+  },
 ): Promise<{ impactLevel: ImpactLevel; rerunRequired: boolean; residualRisk: string }> {
-  // Count approved change_request rows that touch this axis.
+  const orgId = options?.orgId ?? '';
+  const windowStart = options?.windowStart ?? new Date(0);
+  const windowEnd = options?.windowEnd ?? new Date();
+  const windowNote = options?.windowNote ?? 'window defaulted to epoch';
+
+  // Consumer 경유 window-scoped query (AC-1, AC-10).
+  const rows = await fetchWindowScopedChangeRequests({ orgId, windowStart, windowEnd });
   // prompt axis → promptId non-null; model axis → modelPinId non-null.
-  const column = axis === 'prompt' ? changeRequest.promptId : changeRequest.modelPinId;
-  const approved = await db
-    .select({ id: changeRequest.id })
-    .from(changeRequest)
-    .where(and(eq(changeRequest.approvalStatus, 'approved'), isNotNull(column)));
+  const relevant = rows.filter((r) => (axis === 'prompt' ? r.promptId : r.modelPinId) !== null);
+  const approved = relevant.filter((r) => r.approvalStatus === 'approved');
+  const pending = relevant.filter((r) => r.approvalStatus === 'pending_review');
 
   if (approved.length > 0) {
+    // evalRunId / evalResultRef → residual_risk (AC-2 traceability, schema 진실원).
+    const evalRunIds = approved.map((r) => r.evalRunId).filter((v): v is string => v !== null);
+    const evalResultRefs = approved
+      .map((r) => r.evalResultRef)
+      .filter((v): v is string => v !== null);
+    const evalNote =
+      evalRunIds.length > 0
+        ? ` — evalRunId=${evalRunIds.join(',')}${
+            evalResultRefs.length > 0 ? `, evalResultRef=${evalResultRefs.join(',')}` : ''
+          }`
+        : '';
     return {
       impactLevel: 'high',
       rerunRequired: true,
-      residualRisk: `${approved.length} approved ${axis} change(s) in change_request — OQ rerun mandatory`,
+      residualRisk: `${approved.length} approved ${axis} change(s) in ${windowNote}${evalNote} — OQ rerun mandatory`,
     };
   }
   // Pending review is medium (may resolve before sign-off).
-  const pending = await db
-    .select({ id: changeRequest.id })
-    .from(changeRequest)
-    .where(and(eq(changeRequest.approvalStatus, 'pending_review'), isNotNull(column)));
   if (pending.length > 0) {
     return {
       impactLevel: 'medium',
       rerunRequired: false,
-      residualRisk: `${pending.length} pending ${axis} change(s) — monitor before sign-off`,
+      residualRisk: `${pending.length} pending ${axis} change(s) in ${windowNote} — monitor before sign-off`,
     };
   }
   return {
     impactLevel: 'low',
     rerunRequired: false,
-    residualRisk: `No ${axis} change_request rows — no change detected`,
+    residualRisk: `No window-scoped ${axis} change_request rows in ${windowNote}`,
   };
 }
 
@@ -183,15 +267,66 @@ function classifyGitDiffAxis(
   };
 }
 
-/** source_policy — lib/source-governance/ or lib/ai/policy-keywords.ts */
+/**
+ * source_policy axis — git-diff heuristic + source-governance dashboard snapshot
+ * via consumer (AC-3, AC-10). REQ-VAL2-004.
+ *
+ * Conservative over-classification (plan.md §4 R3): git-diff >= 3 commits OR
+ * dashboard stale/superseded > 0 → high impact. residual_risk records both the
+ * git-diff count and the dashboard counts (cumulative snapshot at {timestamp}).
+ */
 async function classifySourcePolicyAxis(
   _releaseId: string,
   previousRef: string | undefined,
+  options?: { orgId?: string },
 ): Promise<{ impactLevel: ImpactLevel; rerunRequired: boolean; residualRisk: string }> {
-  return classifyGitDiffAxis('source_policy', previousRef, [
-    'lib/source-governance/',
-    'lib/ai/policy-keywords.ts',
-  ]);
+  const orgId = options?.orgId ?? '';
+  const pathSpecs = ['lib/source-governance/', 'lib/ai/policy-keywords.ts'];
+  const gitDiff = pathSpecs.reduce((sum, spec) => sum + countPathDiffs(previousRef, spec), 0);
+
+  // Consumer 경유 dashboard snapshot (AC-3, AC-10). Non-blocking on failure.
+  let counts: {
+    approved: number;
+    pendingReview: number;
+    stale: number;
+    superseded: number;
+  } | null = null;
+  let snapshotNote = 'snapshot unavailable';
+  try {
+    if (orgId) {
+      const dashboard = await snapshotSourceGovernance({ orgId });
+      counts = dashboard.counts;
+      snapshotNote = `snapshot at ${new Date().toISOString()}`;
+    }
+  } catch (err) {
+    snapshotNote = `snapshot failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+
+  const countsStr = counts
+    ? `dashboard=approved:${counts.approved},pending:${counts.pendingReview},stale:${counts.stale},superseded:${counts.superseded}`
+    : 'dashboard unavailable';
+  const base = `git_diff=${gitDiff} commit(s) under ${pathSpecs.join(', ')}; ${countsStr}; ${snapshotNote}`;
+
+  // Conservative: git-diff >= 3 OR stale/superseded > 0 → high (plan.md §4 R3).
+  if (gitDiff >= 3 || (counts !== null && (counts.stale > 0 || counts.superseded > 0))) {
+    return {
+      impactLevel: 'high',
+      rerunRequired: true,
+      residualRisk: `${base} — source-policy risk detected, rerun mandatory`,
+    };
+  }
+  if (gitDiff >= 1) {
+    return {
+      impactLevel: 'medium',
+      rerunRequired: false,
+      residualRisk: `${base} — monitor`,
+    };
+  }
+  return {
+    impactLevel: 'low',
+    rerunRequired: false,
+    residualRisk: base,
+  };
 }
 
 /** retrieval — lib/ai/retrievers/ + lib/ai/rerank */
@@ -260,7 +395,24 @@ async function upsertChangeControlRow(params: {
 
 async function main(): Promise<void> {
   const { releaseId, previousRef } = parseArgs(process.argv);
+  // M4: release_id format gate (REQ-VAL2-009).
+  const formatCheck = validateReleaseIdFormat(releaseId);
+  if (!formatCheck.valid) {
+    process.stderr.write(`ERROR: ${formatCheck.reason}\n`);
+    process.exit(1);
+  }
+  // M4: git tag warning (REQ-VAL2-010, non-blocking).
+  const tagCheck = checkGitTagExists(releaseId);
+  if (!tagCheck.exists) {
+    process.stderr.write(
+      `Warning: git tag ${releaseId} not found locally (pre-release candidate?)\n`,
+    );
+    if (tagCheck.warning) process.stderr.write(`${tagCheck.warning}\n`);
+  }
   const commitSha = getHeadCommitSha();
+  // SPEC-REGULA-VALIDATION-002 M1/M2: org + window context for consumer queries.
+  const orgId = resolveOrgId();
+  const window = resolveWindow(previousRef);
 
   const results: Array<{
     axis: ChangeAxis;
@@ -275,13 +427,18 @@ async function main(): Promise<void> {
     switch (axis) {
       case 'prompt':
       case 'model':
-        classification = await classifyModelGovernanceAxis(releaseId, axis);
+        classification = await classifyModelGovernanceAxis(releaseId, axis, {
+          orgId,
+          windowStart: window.windowStart,
+          windowEnd: window.windowEnd,
+          windowNote: window.note,
+        });
         break;
       case 'schema':
         classification = classifySchemaAxis(previousRef);
         break;
       case 'source_policy':
-        classification = await classifySourcePolicyAxis(releaseId, previousRef);
+        classification = await classifySourcePolicyAxis(releaseId, previousRef, { orgId });
         break;
       case 'retrieval':
         classification = await classifyRetrievalAxis(releaseId, previousRef);

--- a/scripts/validation/collect-iq.ts
+++ b/scripts/validation/collect-iq.ts
@@ -26,6 +26,10 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import * as path from 'node:path';
 import { parseEnv } from '../../lib/env.ts';
 import type { EvidenceResult } from '../../lib/schemas/validation.ts';
+import {
+  checkGitTagExists,
+  validateReleaseIdFormat,
+} from '../../lib/validation/consumers/release.ts';
 import { type EvidenceInput, insertEvidenceBundle } from '../../lib/validation/evidence-writer.ts';
 
 interface IqArgs {
@@ -259,6 +263,20 @@ function collectSecretEvidence(releaseId: string, commitSha: string): EvidenceIn
 
 async function main(): Promise<void> {
   const { releaseId } = parseArgs(process.argv);
+  // M4: release_id format gate (REQ-VAL2-009).
+  const formatCheck = validateReleaseIdFormat(releaseId);
+  if (!formatCheck.valid) {
+    process.stderr.write(`ERROR: ${formatCheck.reason}\n`);
+    process.exit(1);
+  }
+  // M4: git tag warning (REQ-VAL2-010, non-blocking).
+  const tagCheck = checkGitTagExists(releaseId);
+  if (!tagCheck.exists) {
+    process.stderr.write(
+      `Warning: git tag ${releaseId} not found locally (pre-release candidate?)\n`,
+    );
+    if (tagCheck.warning) process.stderr.write(`${tagCheck.warning}\n`);
+  }
   const commitSha = getHeadCommitSha();
 
   const bundle: EvidenceInput[] = [

--- a/scripts/validation/collect-oq.ts
+++ b/scripts/validation/collect-oq.ts
@@ -20,6 +20,10 @@
 
 import { spawnSync } from 'node:child_process';
 import type { EvidenceResult } from '../../lib/schemas/validation.ts';
+import {
+  checkGitTagExists,
+  validateReleaseIdFormat,
+} from '../../lib/validation/consumers/release.ts';
 import { type EvidenceInput, insertEvidenceBundle } from '../../lib/validation/evidence-writer.ts';
 
 interface OqArgs {
@@ -182,6 +186,20 @@ function collectAuditEvidence(
 
 async function main(): Promise<void> {
   const { releaseId } = parseArgs(process.argv);
+  // M4: release_id format gate (REQ-VAL2-009).
+  const formatCheck = validateReleaseIdFormat(releaseId);
+  if (!formatCheck.valid) {
+    process.stderr.write(`ERROR: ${formatCheck.reason}\n`);
+    process.exit(1);
+  }
+  // M4: git tag warning (REQ-VAL2-010, non-blocking).
+  const tagCheck = checkGitTagExists(releaseId);
+  if (!tagCheck.exists) {
+    process.stderr.write(
+      `Warning: git tag ${releaseId} not found locally (pre-release candidate?)\n`,
+    );
+    if (tagCheck.warning) process.stderr.write(`${tagCheck.warning}\n`);
+  }
   const commitSha = getHeadCommitSha();
   const ciRun = getLatestCiRun();
 

--- a/scripts/validation/collect-pq.ts
+++ b/scripts/validation/collect-pq.ts
@@ -22,6 +22,10 @@ import { existsSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { z } from 'zod';
 import type { EvidenceResult } from '../../lib/schemas/validation.ts';
+import {
+  checkGitTagExists,
+  validateReleaseIdFormat,
+} from '../../lib/validation/consumers/release.ts';
 import { type EvidenceInput, insertEvidenceBundle } from '../../lib/validation/evidence-writer.ts';
 
 interface PqArgs {
@@ -279,6 +283,20 @@ function parseEvalFile(
 
 async function main(): Promise<void> {
   const { releaseId } = parseArgs(process.argv);
+  // M4: release_id format gate (REQ-VAL2-009).
+  const formatCheck = validateReleaseIdFormat(releaseId);
+  if (!formatCheck.valid) {
+    process.stderr.write(`ERROR: ${formatCheck.reason}\n`);
+    process.exit(1);
+  }
+  // M4: git tag warning (REQ-VAL2-010, non-blocking).
+  const tagCheck = checkGitTagExists(releaseId);
+  if (!tagCheck.exists) {
+    process.stderr.write(
+      `Warning: git tag ${releaseId} not found locally (pre-release candidate?)\n`,
+    );
+    if (tagCheck.warning) process.stderr.write(`${tagCheck.warning}\n`);
+  }
   const commitSha = getHeadCommitSha();
   const ciRunId = getLatestCiRunId();
 

--- a/tests/unit/validation/build-report.test.ts
+++ b/tests/unit/validation/build-report.test.ts
@@ -45,12 +45,33 @@ vi.mock('@/lib/validation/rerun-gate', () => ({
   evaluateRerunGate: evaluateRerunGateMock,
 }));
 
+// M3: consumer snapshots mocked to real-shaped data (AC-4/5 real-data sections).
+const snapshotTraceabilityMock = vi.hoisted(() => vi.fn());
+const snapshotSourceGovernanceMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/validation/consumers/index', () => ({
+  snapshotTraceability: snapshotTraceabilityMock,
+  snapshotSourceGovernance: snapshotSourceGovernanceMock,
+  checkGitTagExists: vi.fn(() => ({ exists: true })),
+  validateReleaseIdFormat: vi.fn(() => ({ valid: true })),
+}));
+
 import { buildReleaseReportMarkdown } from '@/scripts/validation/build-report';
 
 describe('Release Validation Report builder (M5, AC-6)', () => {
   beforeEach(() => {
     selectFromWhereMock.mockReset();
     evaluateRerunGateMock.mockReset();
+    snapshotTraceabilityMock.mockReset();
+    snapshotSourceGovernanceMock.mockReset();
+    // M3: REGULA_ORG_ID required by render*Section (empty → snapshot unavailable).
+    process.env.REGULA_ORG_ID = '00000000-0000-0000-0000-000000000001';
+    // Default: realistic snapshots so AC-4/5 render real counts.
+    snapshotTraceabilityMock.mockResolvedValue({ totalRows: 5, withGaps: 2, stale: 1 });
+    snapshotSourceGovernanceMock.mockResolvedValue({
+      counts: { approved: 10, pendingReview: 3, stale: 1, superseded: 2 },
+      reviewDue: [],
+      staleCitationArtifacts: [],
+    });
   });
 
   it('AC-6: emits at least 8 "## " section headings', async () => {
@@ -160,5 +181,54 @@ describe('Release Validation Report builder (M5, AC-6)', () => {
     expect(md).toContain('oq:pass');
     expect(md).toContain('pq:pass');
     expect(md).toContain('unmet');
+  });
+
+  it('AC-4/5/6/7: real-data sections (no Stub), Review Ops not implemented + #36', async () => {
+    selectFromWhereMock.mockResolvedValueOnce([
+      {
+        qualificationType: 'iq',
+        testCommand: 'pnpm ci:typecheck',
+        commitSha: 'abc',
+        ciRunId: 1,
+        artifactPath: null,
+        result: 'pass',
+      },
+      {
+        qualificationType: 'oq',
+        testCommand: 'pnpm ci:test',
+        commitSha: 'abc',
+        ciRunId: 2,
+        artifactPath: null,
+        result: 'pass',
+      },
+      {
+        qualificationType: 'pq',
+        testCommand: 'pnpm test:e2e',
+        commitSha: 'abc',
+        ciRunId: 3,
+        artifactPath: null,
+        result: 'pass',
+      },
+    ]);
+    selectFromWhereMock.mockResolvedValueOnce([]);
+    evaluateRerunGateMock.mockResolvedValueOnce({ passed: true, failed: [] });
+
+    const md = await buildReleaseReportMarkdown('v0.1.0-rc1');
+    // AC-4: Traceability section — real snapshot counts.
+    expect(md).toContain('totalRows');
+    expect(md).toContain('withGaps');
+    expect(md).toContain('stale');
+    // AC-5: Source Governance section — dashboard counts.
+    expect(md).toContain('approved');
+    expect(md).toContain('superseded');
+    // AC-6: Release Scope section — IQ/OQ/PQ evidence labels.
+    expect(md).toContain('IQ evidence');
+    expect(md).toContain('OQ evidence');
+    expect(md).toContain('PQ evidence');
+    // AC-7: Review Ops section — "not implemented" + #36.
+    expect(md).toContain('not implemented');
+    expect(md).toContain('#36');
+    // DoD §8: "**Stub**" must not appear.
+    expect(md).not.toContain('**Stub**');
   });
 });


### PR DESCRIPTION
VALIDATION-001 fallback/stub을 M0 consumer wrappers(#370) 기반 정식 연동으로 전환합니다.

## 마일스톤
- **M1** (AC-1,2,10): `classify-changes` model-gov 축 → `fetchWindowScopedChangeRequests` consumer 경유 + previousRef 기반 window 쿼리. `evalRunId`/`evalResultRef` → `residual_risk`.
- **M2** (AC-3,10): source_policy 축 + `snapshotSourceGovernance` dashboard counts 병합(보수적 과분류: git-diff≥3 OR stale/superseded>0 → high).
- **M3** (AC-4,5,6,7,10): build-report 3 stub 섹션 → consumer 경유 실데이터 + Review Ops `not implemented` + `#36`.
- **M4** (AC-8,9,10): release_id regex + git tag gate — 5 scripts(`exit 1` + stderr warning non-blocking) + 6 API routes(Zod regex → 400).

## AC 검증 매트릭스
| AC | 검증 방법 | 상태 |
|----|-----------|------|
| AC-1 | consumer window query (`gte`/`lt`) + classify-changes 구현 | ✅ 구현 (integration follow-up) |
| AC-2 | `evalRunId` in `residual_risk` (evidence_ref uuid 스키마 진실원 → residual_risk) | ✅ 주석 문서화 |
| AC-3 | dashboard counts in `residual_risk` | ✅ 구현 (integration follow-up) |
| AC-4/5/6/7 | `build-report.test.ts` 단위 6/6 (totalRows/withGaps/stale, approved/superseded, IQ/OQ/PQ, not implemented/#36, `**Stub**` 0) | ✅ |
| AC-8 | `consumers/release.test.ts` (M0, regex 8 케이스) | ✅ |
| AC-9 | scripts stderr + exit 0 (구현) | ✅ (integration follow-up) |
| AC-10 | grep: consumer import ✓, `changeRequest`/`buildMatrix`/`getGovernanceDashboard` 직접 import 0 | ✅ |
| AC-11 | migration 0건, `releaseRegistry` schema 부재 | ✅ |

## 게이트 (orchestrator 직검, L-007/008/009/013/015)
- `typecheck` 0 / `lint`(biome+lint:hex) 0 / `ci:audit`·`ci:rbac`·`ci:migrations` 0
- `test` **4,786 passed** + 1 사전존재 flaky (`frontend-shell` REQ-FND-012, 단독 19/19 통과, 본 작업 무관)
- 회귀 0 (M0 베이스라인 4,785 → 4,786, +1 AC-4/5/6/7 신규)

## 설계 결정: AC-2 evidence_ref → residual_risk
`change_control.evidence_ref`는 `uuid` 타입(`schema.ts:3486`, validation_evidence.id loose ref — VALIDATION-001 설계). model-gov `evalRunId`는 free-form 문자열 → uuid 컬럼에 삽입 불가. evidence_ref text widening은 migration 필요 → Charter [지양-5] 범위 통제 위반. 따라서 `evalRunId`/`evalResultRef`는 `residual_risk`에 기록하여 AC-2 traceability 충족. 코드 주석에 투명 문서화.

## 비파괴 원칙
VALIDATION-001 API 시그니처 불변, 신규 DB 테이블 0, 신규 migration 0(AC-11). `classifyModelGovernanceAxis`/`classifySourcePolicyAxis`는 optional `options` 파라미터 추가(기존 2-arg 호출 호환).

Refs SPEC-REGULA-VALIDATION-002

🗿 MoAI <email@mo.ai.kr>