### PR TITLE
fix(impact): #366 writeAudit tx 원자성 — analyzer tx 래핑 + 전사 감사 레지스트리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@
 
 > Placeholder for post-1.0.0 development.
 
+### #366 — writeAudit 트랜잭션 원자성 감사 (Part 11 §11.10(e))
+
+- **이슈 #366** — 21 CFR Part 11 §11.10(e): mutation과 audit이 동일 트랜잭션 경계를 공유해야 감사 추적이 orphan 되지 않음. 전사 writeAudit 호출처 190곳 정밀 직검 감사 (madge 신규 도입 0, 사용자 합의).
+- **직검 분류**: in-tx 안전 8곳(ask/consult/cer routes + promote) · withTenantScope 안전 10곳(knowledge-promo/project-memory, #50/#51 fix) · audit-only 123곳 · 위반 후보 59곳.
+- **본 PR 확정 수정** (이슈 명시 impact 도메인):
+  - `lib/domains/impact/analyzer.ts`: assessment INSERT + `auditAssessmentCreated` + `auditCriticalDetected`를 per-iteration `db.transaction`으로 래핑, tx 전달 → mutation/audit 원자성 확보.
+  - `lib/domains/impact/audit-wiring.ts`: 3함수에 `tx?: AuditDbHandle` 매개변수 추가 (writeAudit tx forward). 기존 호출자 호환(선택적).
+- **레지스트리 문서**: `docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md` — 미검증 위반 후보 58곳(app/api/ra/* 25 · radar/delta-sync · knowledge-gap · 기타) 도메인별 등록, 후속 PR 분할 계획.
+- **구조적 한계**: `enqueueActionItems(db: Database)`가 tx 미지원 → action item audit은 별도 경계 (후속 패스에서 시그니처 확장 후 해결).
+- **RLS 잔여 도메인**: 이슈 명시(cyberdevice/model-gov/traceability)는 #239에서 전부 wiring 완료 (`PENDING_DOMAINS=[]`). 진짜 잔여 #317(sources/source_sections)은 별도 이슈.
+- **게이트 직검**: typecheck 0 / lint(biome+lint:hex) 내 파일 clean (12 pre-existing warnings) / full test 4,786 passed + 1 사전존재 flaky(frontend-shell 단독 19/19 통과, 본 작업 무관) / impact 도메인 38 passed / ci:audit PASS.
+
 ### SPEC-REGULA-VALIDATION-002 — Validation 정식 연동 (consumers 기반 Model-Gov/Traceability/Source-Gov/Release 통합)
 
 - **Validation 정식 연동** — VALIDATION-001 fallback/stub을 M0 consumer wrappers(#370) 기반 정식 연동으로 전환. thin glue (Charter [지양-5]), 비파괴(VALIDATION-001 시그니처 불변, migration 0).

--- a/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
+++ b/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
@@ -1,0 +1,96 @@
+# writeAudit 트랜잭션 원자성 감사 레지스트리
+
+- **이슈**: [#366](https://github.com/holee9/ra-med-bot/issues/366) — [Mid-check #9] writeAudit tx AST 감사 + RLS 잔여 도메인 점검 (Part 11 §11.10(e))
+- **날짜**: 2026-07-08
+- **규제 기준**: 21 CFR Part 11 §11.10(e) — 감사 추적 기록은 해당 데이터 변경과 동일한 트랜잭션 경계 내에서 원자적으로 기록되어야 함
+- **방법론**: 정밀 직검 (사용자 합의, madge/dependency-cruiser 신규 도입 0). AST 근사(괄호 매칭) 스크립트로 후보 산출 → orchestrator 직돀으로 확정/기각.
+
+## 1. 요약
+
+`writeAudit(params, tx?)` (lib/audit.ts:551)는 **AUDIT-CHAIN M1 (PR #356)** 이후 tx 미전달 시 자체 `db.transaction`으로 래핑. 따라서 **audit INSERT 자체의 원자성 + hash chain 무결성은 보장**됨. 본 감사의 진짜 대상 = **mutation(INSERT/UPDATE/DELETE)이 별도 tx에서 커밋된 후 writeAudit이 자체 tx로 실행**되어 mutation은 남고 audit만 누락되는 시나리오.
+
+| 분류 | 수 | 상태 |
+|---|---|---|
+| **in-tx 안전** (db.transaction 또는 withTenantScope 블록 내부 + tx 전달) | 8 | ✅ 직돀 안전 확정 |
+| **out-of-tx, audit-only** (근처 mutation 없음 — 검색/조회 후 audit) | 123 | ✅ 안전 |
+| **out-of-tx, mutation 인근** (위반 후보) | 59 | ⚠️ 직돀 검증 필요 → 본 PR 1곳 확정 수정, 잔여 후속 이슈 |
+| **총 writeAudit 호출처** | 190 | (테스트 제외) |
+
+## 2. 직돀으로 안전 확정된 영역 (수정 불필요)
+
+### in-tx 안전 (8곳) — mutation과 같은 tx
+- `app/api/ask/route.ts:90,114,166` — `db.transaction(async (tx) =>` 내부, `writeAudit({...}, tx as any)` 전달 (SPEC-V3-INBOX-001 / TRIAGE)
+- `app/api/consult/sessions/route.ts:57` · `[sessionId]/route.ts:89` · `[sessionId]/turns/route.ts:103` — `db.transaction` 내부 + tx 전달 (SPEC-V3-CONSULT-001). 주석 "INSERT turn + writeAudit (fast, atomic)"
+- `app/api/ra/workflows/cer/route.ts:117` — `cer_persisted` audit이 workflow_runs INSERT와 동일 `db.transaction` (SPEC-REGULA-CER-001). 주석 "SAME db.transaction — 21 CFR Part 11 atomicity"
+- `lib/domains/inbox/promote.ts:163` — `db.transaction` 내부 + tx (SPEC-V3-INBOX-001 H-3, #321 fix)
+
+### withTenantScope 안전 (이슈 후보에서 제외) — #239 RLS wiring으로 tx 래핑
+- `lib/knowledge-promo/promote.ts:93,125,183` — `withTenantScope(orgId, async (tx) =>` 내부 (SPEC-REGULA-KNOWLEDGE-PROMO, #50 C-3 fix). 주석 "wraps mutation + writeAudit in ONE db.transaction"
+- `lib/project-memory/manager.ts:119,145,202,225,254,275,334` (7곳) — `withTenantScope` 내부 (SPEC-REGULA-PROJECT-MEMORY, #51 fix). 주석 "writeAudit in ONE withTenantScope tx"
+
+### audit-only (mutation 없음, 자체 tx로 충분)
+`lib/export/audit-logger.ts` (export는 mutation 아님, 행위 기록) · `lib/cer/audit.ts` `auditCerCreated` (의도적 two-row provenance — REQ-CER-036, autocommit INITIATED + cer_persisted in tx, #255 확정 설계) 외 123곳.
+
+## 3. 본 PR 확정 수정 (이슈 명시 impact 도메인)
+
+### `lib/domains/impact/analyzer.ts` — 위반 확정 → 수정 ✅
+- **위반**: `analyzeImpact(req, db: Database)`에서 `db.insert(regulatoryImpactAssessments)`가 autocommit, `auditAssessmentCreated`/`auditCriticalDetected`가 자체 tx → mutation 커밋 후 audit 실패 시 추적 누락
+- **수정**: assessment INSERT + `auditAssessmentCreated` + `auditCriticalDetected`를 per-iteration `db.transaction(async (tx) => { ... })`로 래핑, tx 전달. 21 CFR Part 11 §11.10(e) 원자성 확보.
+
+### `lib/domains/impact/audit-wiring.ts` — tx forward 지원 추가 ✅
+- 3함수(`auditAssessmentCreated`/`auditCriticalDetected`/`auditActionItemCreated`)에 `tx?: AuditDbHandle` 매개변수 추가, `writeAudit({...}, tx)` forward. 기존 호출자(자체 tx) 호환(선택적).
+
+### 구조적 한계 (별도 후속)
+- `enqueueActionItems(input, db: Database)`가 tx를 받지 않음 (Drizzle `PgTransaction`이 `Database` 타입 `$client` 요구 미충족). 따라서 action item INSERT + `auditActionItemCreated`는 별도 경계. **action item audit 원자성**은 후속 패스에서 `enqueueActionItems` 시그니처 확장 후 해결 예정.
+
+## 4. 미검증 위반 후보 (후속 이슈로 분할)
+
+직검 토큰 한계로 본 PR에서 전부 직돀하지 못한 후보. grep/AST 근사로 산출되었으나 **직돀 확정 전까지는 위반으로 단정 금지** (false-positive 가능 — `tx as any`, wrapper forward, withTenantScope 등 스크립트가 놓치는 패턴 존재).
+
+### Priority High — 라우트 핸들러 mutation + audit (도메인별 그룹)
+- **app/api/ra/** (25곳): classification, consult, conversations, deadlines(3), digest, expert-review(2), knowledge-sources(2), messages/blocks, notifications, personal/bookmarks(2), predicate/comparison(2), profile, projects(2), updates/feedback, workflows/submission-drafter, admin/documents/upload(2)
+- **app/api/ra/workflows/cer/route.ts:117** — 직돀 안전 확정(제외)이나 스크립트 후보에 잔류 (false-positive)
+- **app/api/{auth/change-password, auth/signup, classify/run(2), rlhf/feedback(2), admin/users, knowledge-gap/classify}** (8곳)
+
+### Priority Medium — lib 도메인
+- `lib/radar/delta-sync/orchestrator.ts` (5곳: 143,182,267,308) · `ingest.ts:134` — corpusSyncRuns 상태 업데이트 + audit
+- `lib/knowledge-gap/{detector:117, owning-issue:209/233, replay:303}` (4곳)
+- `lib/knowledge-sources/sync.ts:96,121` (2곳)
+- `lib/ai/consult.ts:658` · `lib/model-governance/rlhf-gate.ts:52` · `lib/rlhf/calibration-proposal.ts:95` · `lib/standards/alert-pipeline.ts:72` · `lib/inngest/knowledge-sources/orphan-cleanup.ts:114`
+
+## 5. 수정 방법론 (후속 패스 표준)
+
+```typescript
+// 위반 패턴 (autocommit mutation + 자체 tx audit)
+await db.insert(table).values({...});           // autocommit
+await writeAudit({...});                         // 자체 tx → orphan 위험
+
+// 수정 (동일 tx 래핑)
+await db.transaction(async (tx) => {
+  await tx.insert(table).values({...});
+  await writeAudit({...}, tx);                   // 같은 tx → atomic
+});
+```
+
+**예외 (수정 불필요)**:
+- audit-only (mutation 없음) — 검색/조회/읽기 후 audit
+- 의도적 two-row provenance (cer_created autocommit + cer_persisted in tx) — 설계적
+
+## 6. RLS 잔여 도메인 (이슈 항목, 이미 완료)
+
+이슈가 "RLS 잔여 도메인 점검: cyberdevice/model-governance/traceability"를 명시했으나, **#239에서 전부 wiring 완료** 확인:
+- `tests/unit/db/with-tenant-scope-coverage.test.ts`: `PENDING_DOMAINS = []`, 주석 "All 7 org-scoped domains are wired"
+- 진짜 RLS 잔여 = **#317** (sources/source_sections RLS)만 OPEN — 본 이슈 범위에서 제외 (별도 이슈).
+
+## 7. 방법론 한계 (AST 도구 도입 검토)
+
+본 감사는 grep + 괄호 매칭 AST 근사 + orchestrator 직돀으로 수행. 한계:
+- **wrapper 함수 호출자 추적**: `auditX(params, tx?)` wrapper가 tx를 forward하므로, wrapper 정의만 보면 A 패턴(자체 tx)으로 오탐. 호출자까지 추적해야 진실.
+- **멀티라인 tx 인자**: `tx as any`, `tx satisfies X`, trailing 콤마, 주석이 섞인 호출 블록에서 마지막 인자 추출 정확도 저하.
+- **withTenantScope 인식**: #239 RLS 래퍼가 `db.transaction`과 동등하나 별개 식별자 → 스크립트 보정 필요.
+
+후속 패스에서 **madge/dependency-cruiser 신규 도입**이 정규 감사 자동화에 유효할 수 있음 (본 PR은 사용자 합의로 직검 선택, 도입은 별도 인프라 이슈 권장).
+
+---
+
+**본 PR 완료 범위**: 이슈 명시 impact 도메인(analyzer.ts + audit-wiring.ts) 직돀 위반 확정 + 수정. 잔여 58곳은 본 레지스트리에 등록 후 도메인별 후속 PR로 분할 진행 권장.

--- a/lib/domains/impact/analyzer.ts
+++ b/lib/domains/impact/analyzer.ts
@@ -60,42 +60,64 @@ export async function analyzeImpact(req: AnalysisRequest, db: Database): Promise
   let criticalCount = 0;
 
   for (const result of scanResults) {
-    const [inserted] = await db
-      .insert(regulatoryImpactAssessments)
-      .values({
-        regulatoryUpdateId: req.regulatory_update_id,
-        projectId: result.project_id,
-        impactLevel: result.impact_level,
-        affectedSections: result.affected_sections,
-        analysisSummary: result.analysis_summary,
-        confidence: String(result.confidence),
-        createdBy: req.actor_id,
-      })
-      .onConflictDoNothing()
-      .returning({ id: regulatoryImpactAssessments.id });
+    // 21 CFR Part 11 §11.10(e) — Issue #366: the assessment INSERT and the
+    // audit rows that record it ride the SAME db.transaction so a transient
+    // failure between them rolls back both. The audit trail can never be
+    // orphaned relative to the data it describes.
+    const inserted = await db.transaction(async (tx) => {
+      const [row] = await tx
+        .insert(regulatoryImpactAssessments)
+        .values({
+          regulatoryUpdateId: req.regulatory_update_id,
+          projectId: result.project_id,
+          impactLevel: result.impact_level,
+          affectedSections: result.affected_sections,
+          analysisSummary: result.analysis_summary,
+          confidence: String(result.confidence),
+          createdBy: req.actor_id,
+        })
+        .onConflictDoNothing()
+        .returning({ id: regulatoryImpactAssessments.id });
+
+      if (!row) return null; // already existed — skip
+
+      await auditAssessmentCreated(
+        {
+          actor_id: req.actor_id,
+          assessment_id: row.id,
+          project_id: result.project_id,
+          regulatory_update_id: req.regulatory_update_id,
+          impact_level: result.impact_level,
+        },
+        tx,
+      );
+
+      if (result.impact_level === 'critical') {
+        await auditCriticalDetected(
+          {
+            actor_id: req.actor_id,
+            assessment_id: row.id,
+            project_id: result.project_id,
+            regulatory_update_id: req.regulatory_update_id,
+          },
+          tx,
+        );
+      }
+
+      return row;
+    });
 
     if (!inserted) continue; // already existed — skip
 
     assessmentsCreated++;
+    const isCritical = result.impact_level === 'critical';
+    if (isCritical) criticalCount++;
 
-    await auditAssessmentCreated({
-      actor_id: req.actor_id,
-      assessment_id: inserted.id,
-      project_id: result.project_id,
-      regulatory_update_id: req.regulatory_update_id,
-      impact_level: result.impact_level,
-    });
-
-    if (result.impact_level === 'critical') {
-      criticalCount++;
-      await auditCriticalDetected({
-        actor_id: req.actor_id,
-        assessment_id: inserted.id,
-        project_id: result.project_id,
-        regulatory_update_id: req.regulatory_update_id,
-      });
-    }
-
+    // Action items are persisted by enqueueActionItems, which owns its own
+    // inserts via the global `db` and does not accept a tx handle (Drizzle
+    // PgTransaction is not assignable to the Database type it expects). Their
+    // audit rows therefore ride a separate boundary — a structural limitation
+    // recorded in the #366 audit registry for a follow-up pass.
     await enqueueActionItems(
       {
         assessment_id: inserted.id,

--- a/lib/domains/impact/audit-wiring.ts
+++ b/lib/domains/impact/audit-wiring.ts
@@ -1,60 +1,83 @@
 // SPEC-REGULA-IMPACT-001 — audit logging helpers for impact analysis events.
+// @MX:NOTE [AUTO] Issue #366 — these helpers now forward an optional `tx` so the
+// @MX:SPEC audit INSERT rides the same transaction as the mutation it records
+// (21 CFR Part 11 §11.10(e)). Callers that wrap mutation + audit in one
+// `db.transaction` (see analyzer.ts) pass the `tx` here so a transient failure
+// between the two rolls back both — the audit row can never be orphaned.
 
-import { writeAudit } from '@/lib/audit';
+import { type AuditDbHandle, writeAudit } from '@/lib/audit';
 import type { ImpactLevel } from './types';
 
-export async function auditAssessmentCreated(params: {
-  actor_id: string;
-  assessment_id: string;
-  project_id: string;
-  regulatory_update_id: string;
-  impact_level: ImpactLevel;
-}): Promise<void> {
-  await writeAudit({
-    actor_id: params.actor_id,
-    action: 'impact.assessment_created',
-    resource_type: 'impact_assessment',
-    resource_id: params.assessment_id,
-    meta_json: {
-      project_id: params.project_id,
-      regulatory_update_id: params.regulatory_update_id,
-      impact_level: params.impact_level,
+export async function auditAssessmentCreated(
+  params: {
+    actor_id: string;
+    assessment_id: string;
+    project_id: string;
+    regulatory_update_id: string;
+    impact_level: ImpactLevel;
+  },
+  tx?: AuditDbHandle,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.actor_id,
+      action: 'impact.assessment_created',
+      resource_type: 'impact_assessment',
+      resource_id: params.assessment_id,
+      meta_json: {
+        project_id: params.project_id,
+        regulatory_update_id: params.regulatory_update_id,
+        impact_level: params.impact_level,
+      },
     },
-  });
+    tx,
+  );
 }
 
-export async function auditCriticalDetected(params: {
-  actor_id: string;
-  assessment_id: string;
-  project_id: string;
-  regulatory_update_id: string;
-}): Promise<void> {
-  await writeAudit({
-    actor_id: params.actor_id,
-    action: 'impact.critical_detected',
-    resource_type: 'impact_assessment',
-    resource_id: params.assessment_id,
-    meta_json: {
-      project_id: params.project_id,
-      regulatory_update_id: params.regulatory_update_id,
+export async function auditCriticalDetected(
+  params: {
+    actor_id: string;
+    assessment_id: string;
+    project_id: string;
+    regulatory_update_id: string;
+  },
+  tx?: AuditDbHandle,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.actor_id,
+      action: 'impact.critical_detected',
+      resource_type: 'impact_assessment',
+      resource_id: params.assessment_id,
+      meta_json: {
+        project_id: params.project_id,
+        regulatory_update_id: params.regulatory_update_id,
+      },
     },
-  });
+    tx,
+  );
 }
 
-export async function auditActionItemCreated(params: {
-  actor_id: string;
-  action_item_id: string;
-  assessment_id: string;
-  project_id: string;
-}): Promise<void> {
-  await writeAudit({
-    actor_id: params.actor_id,
-    action: 'impact.action_item_created',
-    resource_type: 'impact_action_item',
-    resource_id: params.action_item_id,
-    meta_json: {
-      assessment_id: params.assessment_id,
-      project_id: params.project_id,
+export async function auditActionItemCreated(
+  params: {
+    actor_id: string;
+    action_item_id: string;
+    assessment_id: string;
+    project_id: string;
+  },
+  tx?: AuditDbHandle,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.actor_id,
+      action: 'impact.action_item_created',
+      resource_type: 'impact_action_item',
+      resource_id: params.action_item_id,
+      meta_json: {
+        assessment_id: params.assessment_id,
+        project_id: params.project_id,
+      },
     },
-  });
+    tx,
+  );
 }


### PR DESCRIPTION
## 요약

이슈 #366 — writeAudit 트랜잭션 원자성 감사 (Part 11 §11.10(e)). 전사 writeAudit 190 호출처 정밀 직검 감사 + 이슈 명시 impact 도메인 위반 확정 수정 + 미검증 58곳 레지스트리 문서화.

## 이슈 전제 직검 정정 (L-013/014)

| 항목 | 이슈 전제 | 실제 직검 |
|---|---|---|
| writeAudit 호출수 | "54곳" | **190곳** |
| lib/impact 경로 | `lib/impact` | **`lib/domains/impact`** (lib/impact는 빈 디렉토리) |
| RLS 잔여 도메인 | "cyberdevice/model-gov/traceability 점검" | **#239에서 전부 wiring 완료** (`PENDING_DOMAINS=[]`) |
| AST 도구 | "madge 선행 도입" | 미설치 → **정밀 직검**으로 대체 (사용자 합의) |

## 직검 분류 (190 호출처)

- **in-tx 안전 8곳**: ask/consult/cer routes + promote (`db.transaction`/`withTenantScope` + tx 전달)
- **withTenantScope 안전 10곳**: knowledge-promo/project-memory (#50/#51 fix)
- **audit-only 123곳**: mutation 없음 (검색/조회 후 audit)
- **위반 후보 59곳**: mutation 인근 + out-of-tx

## 본 PR 확정 수정 (이슈 명시 impact 도메인)

**`lib/domains/impact/analyzer.ts`** — 위반 확정 → 수정
- 이전: `db.insert(regulatoryImpactAssessments)` autocommit + `auditAssessmentCreated`/`auditCriticalDetected` 자체 tx → mutation 커밋 후 audit 실패 시 추적 누락
- 이후: assessment INSERT + audit 2종을 per-iteration `db.transaction(async (tx) => { ... })`로 래핑, tx 전달 → 21 CFR Part 11 §11.10(e) 원자성 확보

**`lib/domains/impact/audit-wiring.ts`** — tx forward 지원
- 3함수(`auditAssessmentCreated`/`auditCriticalDetected`/`auditActionItemCreated`)에 `tx?: AuditDbHandle` 매개변수 추가, `writeAudit({...}, tx)` forward. 기존 호출자 호환(선택적).

**`docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md`** — 감사 레지스트리
- 190 호출처 분류 + 미검증 위반 후보 58곳 도메인별 등록 (app/api/ra/* 25 · radar/delta-sync 5 · knowledge-gap 4 · 기타) + 후속 PR 분할 계획 + 수정 방법론

## 구조적 한계 (후속)

`enqueueActionItems(input, db: Database)`가 tx를 받지 않음 (Drizzle `PgTransaction`이 `Database` `$client` 미충족). 따라서 action item INSERT + `auditActionItemCreated`는 별도 경계. 후속 패스에서 시그니처 확장 후 해결.

## RLS 잔여 도메인 (이슈 항목)

이슈 명시 cyberdevice/model-governance/traceability는 **#239에서 전부 wiring 완료**. 진짜 잔여 #317(sources/source_sections)은 별도 이슈.

## 게이트 직검

- typecheck: EXIT 0
- lint(biome + lint:hex): 내 파일 clean (12 pre-existing warnings, 무관)
- full test: **4,786 passed** | 31 skipped | 1 사전존재 flaky(frontend-shell 단독 19/19 통과, 본 작업 무관)
- impact 도메인: 38 passed
- ci:audit: PASS

## 후속

- 미검증 위반 후보 58곳 도메인별 직검 + tx 래핑 (별도 이슈 분할)
- `enqueueActionItems` tx 지원 → action item audit 원자성

Refs #366 (전사 수정 미완료 — 본 PR은 impact 확정 위반 + 전사 감사 레지스트리).
