### PR TITLE
fix(audit): #378 PR-A writeAudit tx 원자성 — 6곳 db.transaction 래핑

### DIFF
--- a/app/api/ra/notifications/preferences/route.ts
+++ b/app/api/ra/notifications/preferences/route.ts
@@ -85,13 +85,19 @@ export const PATCH = withPermission('profile.edit', async (req, _ctx, session) =
 
   const changedEvents = Object.keys(parsed.data.preferences).sort();
 
-  await db.update(users).set({ notificationPref: updated }).where(eq(users.id, session.user.id));
-  await writeAudit({
-    actor_id: session.user.id,
-    action: 'profile.update',
-    resource_type: 'notification_preferences',
-    resource_id: session.user.id,
-    meta_json: { changedEvents },
+  // 21 CFR Part 11 §11.10(e) — mutation + audit in same db.transaction (Issue #378)
+  await db.transaction(async (tx) => {
+    await tx.update(users).set({ notificationPref: updated }).where(eq(users.id, session.user.id));
+    await writeAudit(
+      {
+        actor_id: session.user.id,
+        action: 'profile.update',
+        resource_type: 'notification_preferences',
+        resource_id: session.user.id,
+        meta_json: { changedEvents },
+      },
+      tx,
+    );
   });
 
   return Response.json({ preferences: { ...DEFAULT_PREFS, ...updated } });

--- a/app/api/ra/personal/bookmarks/[id]/route.ts
+++ b/app/api/ra/personal/bookmarks/[id]/route.ts
@@ -62,22 +62,36 @@ export const PATCH = withPermission('personal.view', async (req, ctx, session) =
 // DELETE /api/ra/personal/bookmarks/[id]
 export const DELETE = withPermission('personal.view', async (_req, ctx, session) => {
   const { id } = await (ctx.params ?? Promise.resolve({ id: '' }));
-  const [deleted] = await db
-    .delete(personalBookmarks)
-    .where(and(eq(personalBookmarks.id, id), eq(personalBookmarks.userId, session.user.id)))
-    .returning({ id: personalBookmarks.id });
+
+  // 21 CFR Part 11 §11.10(e) — mutation + audit in same db.transaction (Issue #378)
+  const deleted = await db.transaction(async (tx) => {
+    const [removed] = await tx
+      .delete(personalBookmarks)
+      .where(and(eq(personalBookmarks.id, id), eq(personalBookmarks.userId, session.user.id)))
+      .returning({ id: personalBookmarks.id });
+
+    // Nothing matched (wrong id or not owned by this user) — skip audit and
+    // let the caller return 404. We must NOT throw here: unlike POST, DELETE has
+    // no try/catch, so a throw would surface as an unhandled 500 instead of 404.
+    if (!removed) return null;
+
+    await writeAudit(
+      {
+        action: 'personal_bookmark.deleted',
+        actor_id: session.user.id,
+        resource_type: 'personalBookmark',
+        resource_id: removed.id,
+        meta_json: {},
+      },
+      tx,
+    );
+
+    return removed;
+  });
 
   if (!deleted) {
     return NextResponse.json({ error: 'not_found' }, { status: 404 });
   }
-
-  await writeAudit({
-    action: 'personal_bookmark.deleted',
-    actor_id: session.user.id,
-    resource_type: 'personalBookmark',
-    resource_id: deleted.id,
-    meta_json: {},
-  });
 
   return NextResponse.json({ ok: true });
 });

--- a/app/api/ra/personal/bookmarks/route.ts
+++ b/app/api/ra/personal/bookmarks/route.ts
@@ -78,36 +78,48 @@ export const POST = withPermission('personal.view', async (req, _ctx, session) =
   const { messageId, blockId, title, customTitle, note, tags } = parsed.data;
 
   try {
-    const [created] = await db
-      .insert(personalBookmarks)
-      .values({
-        userId: session.user.id,
-        messageId,
-        blockId: blockId ?? null,
-        title,
-        customTitle: customTitle ?? null,
-        note: note ?? '',
-        tags: tags ?? [],
-      })
-      .returning({ id: personalBookmarks.id, createdAt: personalBookmarks.createdAt });
+    // 21 CFR Part 11 §11.10(e) — mutation + audit in same db.transaction (Issue #378)
+    const result = await db.transaction(async (tx) => {
+      const [created] = await tx
+        .insert(personalBookmarks)
+        .values({
+          userId: session.user.id,
+          messageId,
+          blockId: blockId ?? null,
+          title,
+          customTitle: customTitle ?? null,
+          note: note ?? '',
+          tags: tags ?? [],
+        })
+        .returning({ id: personalBookmarks.id, createdAt: personalBookmarks.createdAt });
 
-    if (!created) {
-      return NextResponse.json({ error: 'insert_failed' }, { status: 500 });
-    }
+      if (!created) {
+        throw new Error('insert_failed');
+      }
 
-    await writeAudit({
-      action: 'personal_bookmark.created',
-      actor_id: session.user.id,
-      resource_type: 'personalBookmark',
-      resource_id: created.id,
-      meta_json: { messageId, blockId: blockId ?? null, tagCount: tags?.length ?? 0 },
+      await writeAudit(
+        {
+          action: 'personal_bookmark.created',
+          actor_id: session.user.id,
+          resource_type: 'personalBookmark',
+          resource_id: created.id,
+          meta_json: { messageId, blockId: blockId ?? null, tagCount: tags?.length ?? 0 },
+        },
+        tx,
+      );
+
+      return created;
     });
 
-    return NextResponse.json({ bookmark: created }, { status: 201 });
+    return NextResponse.json({ bookmark: result }, { status: 201 });
   } catch (err: unknown) {
     // Unique-index violation: duplicate (user, message, block) bookmark → 409.
     if (err && typeof err === 'object' && 'code' in err && err.code === '23505') {
       return NextResponse.json({ error: 'duplicate_bookmark' }, { status: 409 });
+    }
+    // Transaction-layer error (insert_failed) → 500
+    if (err instanceof Error && err.message === 'insert_failed') {
+      return NextResponse.json({ error: 'insert_failed' }, { status: 500 });
     }
     throw err;
   }

--- a/app/api/ra/predicate/__tests__/comparison.test.ts
+++ b/app/api/ra/predicate/__tests__/comparison.test.ts
@@ -89,6 +89,24 @@ vi.mock('@/lib/db/client', () => {
     limit: vi.fn(async () => [{ id: 'wfr-001', userId: 'user-001', resultJson: storedState }]),
   });
 
+  // insert/update chains are shared by `db` and the `tx` handed to
+  // db.transaction (Issue #378 — routes wrap mutation + audit in one tx).
+  // Sharing keeps insertedValues/updateSet capture working for both paths.
+  const insertMock = vi.fn(() => ({
+    values: vi.fn((v: Record<string, unknown>) => {
+      insertedValues(v);
+      return { returning: insertReturning };
+    }),
+  }));
+  const updateMock = vi.fn(() => ({
+    set: vi.fn((v: Record<string, unknown>) => {
+      updateSet(v);
+      return {
+        where: vi.fn(() => ({ returning: updateReturning })),
+      };
+    }),
+  }));
+
   return {
     __setSelectMode: (m: 'department' | 'history' | 'state') => {
       selectMode = m;
@@ -104,20 +122,11 @@ vi.mock('@/lib/db/client', () => {
         if (selectMode === 'state') return stateChain();
         return departmentChain();
       }),
-      insert: vi.fn(() => ({
-        values: vi.fn((v: Record<string, unknown>) => {
-          insertedValues(v);
-          return { returning: insertReturning };
-        }),
-      })),
-      update: vi.fn(() => ({
-        set: vi.fn((v: Record<string, unknown>) => {
-          updateSet(v);
-          return {
-            where: vi.fn(() => ({ returning: updateReturning })),
-          };
-        }),
-      })),
+      insert: insertMock,
+      update: updateMock,
+      transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+        cb({ insert: insertMock, update: updateMock }),
+      ),
     },
   };
 });

--- a/app/api/ra/predicate/comparison/[id]/approve/route.ts
+++ b/app/api/ra/predicate/comparison/[id]/approve/route.ts
@@ -103,17 +103,23 @@ export const PUT = withPermission('workflow.execute', async (req, ctx, session) 
   cell.approved = cell.approved.slice();
   cell.approved[predicate_index] = true;
 
-  await db
-    .update(workflowRuns)
-    .set({ resultJson: comparison, updatedAt: new Date() })
-    .where(eq(workflowRuns.id, id))
-    .returning();
-  await writeAudit({
-    actor_id: session.user.id,
-    action: 'workflow.approve',
-    resource_type: 'predicate_comparison',
-    resource_id: id,
-    meta_json: { dimension, predicateIndex: predicate_index },
+  // 21 CFR Part 11 §11.10(e) — mutation + audit in same db.transaction (Issue #378)
+  await db.transaction(async (tx) => {
+    await tx
+      .update(workflowRuns)
+      .set({ resultJson: comparison, updatedAt: new Date() })
+      .where(eq(workflowRuns.id, id))
+      .returning();
+    await writeAudit(
+      {
+        actor_id: session.user.id,
+        action: 'workflow.approve',
+        resource_type: 'predicate_comparison',
+        resource_id: id,
+        meta_json: { dimension, predicateIndex: predicate_index },
+      },
+      tx,
+    );
   });
 
   return Response.json({ comparison });

--- a/app/api/ra/predicate/comparison/route.ts
+++ b/app/api/ra/predicate/comparison/route.ts
@@ -102,38 +102,49 @@ export const POST = withPermission('workflow.execute', async (req, _ctx, session
   // REQ-PRE-019 / REQ-PRE-024: persist the full comparison plus the selected
   // K-numbers in workflow_runs.resultJson so the session can be resumed.
   const orgId = session.user.organizationId ?? '';
-  const [created] = await db
-    .insert(workflowRuns)
-    .values({
-      userId: session.user.id,
-      organizationId: orgId,
-      workflowType: 'predicate_comparison',
-      // Comparison generation completes synchronously and needs no async review.
-      status: 'approved',
-      inputJson: {
-        subject_device_name,
-        subject_inputs,
-        selected_predicate_knumbers,
-      },
-      resultJson: {
-        ...comparison,
-        selected_predicate_knumbers,
-      },
-      reviewRequired: false,
-    })
-    .returning();
 
-  // REQ-PRE-017: audit every comparison generation.
-  await writeAudit({
-    action: 'predicate_comparison_generated',
-    actor_id: session.user.id,
-    resource_type: 'predicate_comparison',
-    resource_id: created?.id ?? 'unknown',
-    meta_json: {
-      predicate_k_numbers: selected_predicate_knumbers,
-      subject_device_name,
-    },
+  // 21 CFR Part 11 §11.10(e) — mutation + audit in same db.transaction (Issue #378)
+  const result = await db.transaction(async (tx) => {
+    const inserted = await tx
+      .insert(workflowRuns)
+      .values({
+        userId: session.user.id,
+        organizationId: orgId,
+        workflowType: 'predicate_comparison',
+        // Comparison generation completes synchronously and needs no async review.
+        status: 'approved',
+        inputJson: {
+          subject_device_name,
+          subject_inputs,
+          selected_predicate_knumbers,
+        },
+        resultJson: {
+          ...comparison,
+          selected_predicate_knumbers,
+        },
+        reviewRequired: false,
+      })
+      .returning();
+
+    // REQ-PRE-017: audit every comparison generation.
+    await writeAudit(
+      {
+        action: 'predicate_comparison_generated',
+        actor_id: session.user.id,
+        resource_type: 'predicate_comparison',
+        resource_id: inserted[0]?.id ?? 'unknown',
+        meta_json: {
+          predicate_k_numbers: selected_predicate_knumbers,
+          subject_device_name,
+        },
+      },
+      tx,
+    );
+
+    return inserted;
   });
+
+  const [created] = result;
 
   return Response.json({ workflow_run_id: created?.id, comparison });
 });

--- a/app/api/ra/profile/route.ts
+++ b/app/api/ra/profile/route.ts
@@ -81,19 +81,44 @@ export const PATCH = withPermission('profile.edit', async (req, _ctx, session) =
   if (department !== undefined) dbUpdates.department = department;
 
   if (Object.keys(dbUpdates).length > 0) {
-    // Update DB columns that changed
-    const rows = await db
-      .update(users)
-      .set(dbUpdates)
-      .where(eq(users.id, session.user.id))
-      .returning({
-        id: users.id,
-        email: users.email,
-        name: users.name,
-        role: users.role,
-        notificationPref: users.notificationPref,
-        department: users.department,
-      });
+    // 21 CFR Part 11 §11.10(e) — mutation + audit in same db.transaction (Issue #378)
+    const rows = await db.transaction(async (tx) => {
+      const updated = await tx
+        .update(users)
+        .set(dbUpdates)
+        .where(eq(users.id, session.user.id))
+        .returning({
+          id: users.id,
+          email: users.email,
+          name: users.name,
+          role: users.role,
+          notificationPref: users.notificationPref,
+          department: users.department,
+        });
+
+      // Only audit when the user row matched — preserves the original
+      // "404 (no match) → no audit row" semantics, while keeping a successful
+      // mutation + its audit atomic in one tx (Issue #378).
+      if (updated.length > 0) {
+        await writeAudit(
+          {
+            action: 'profile.update',
+            actor_id: session.user.id,
+            resource_type: 'user',
+            resource_id: session.user.id,
+            meta_json: {
+              ...(notificationPref !== undefined && { notificationPref: true }),
+              ...(theme !== undefined && { theme }),
+              ...(locale !== undefined && { locale }),
+              ...(department !== undefined && { department }),
+            },
+          },
+          tx,
+        );
+      }
+
+      return updated;
+    });
 
     profileRow = rows[0] ?? null;
   } else {
@@ -112,24 +137,28 @@ export const PATCH = withPermission('profile.edit', async (req, _ctx, session) =
       .limit(1);
 
     profileRow = rows[0] ?? null;
+
+    // Audit-only path (no DB mutation). Skip on 404 to match the original
+    // "no matching user → no audit row" behavior (Issue #378).
+    if (profileRow) {
+      await writeAudit({
+        action: 'profile.update',
+        actor_id: session.user.id,
+        resource_type: 'user',
+        resource_id: session.user.id,
+        meta_json: {
+          ...(notificationPref !== undefined && { notificationPref: true }),
+          ...(theme !== undefined && { theme }),
+          ...(locale !== undefined && { locale }),
+          ...(department !== undefined && { department }),
+        },
+      });
+    }
   }
 
   if (!profileRow) {
     return Response.json({ error: 'user_not_found' }, { status: 404 });
   }
-
-  await writeAudit({
-    action: 'profile.update',
-    actor_id: session.user.id,
-    resource_type: 'user',
-    resource_id: session.user.id,
-    meta_json: {
-      ...(notificationPref !== undefined && { notificationPref: true }),
-      ...(theme !== undefined && { theme }),
-      ...(locale !== undefined && { locale }),
-      ...(department !== undefined && { department }),
-    },
-  });
 
   // Echo theme/locale back in the response for client-side compatibility.
   return Response.json({

--- a/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
+++ b/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
@@ -13,7 +13,7 @@
 |---|---|---|
 | **in-tx 안전** (db.transaction 또는 withTenantScope 블록 내부 + tx 전달) | 8 | ✅ 직돀 안전 확정 |
 | **out-of-tx, audit-only** (근처 mutation 없음 — 검색/조회 후 audit) | 123 | ✅ 안전 |
-| **out-of-tx, mutation 인근** (위반 후보) | 59 | ⚠️ 직돀 검증 필요 → 본 PR 1곳 확정 수정, 잔여 후속 이슈 |
+| **out-of-tx, mutation 인근** (위반 후보) | 59 | ⚠️ 직돀 검증 필요 → impact 1곳(#377) + PR-A 6곳(#378) 확정 수정, 잔여 52곳 후속 |
 | **총 writeAudit 호출처** | 190 | (테스트 제외) |
 
 ## 2. 직돀으로 안전 확정된 영역 (수정 불필요)
@@ -48,7 +48,8 @@
 직검 토큰 한계로 본 PR에서 전부 직돀하지 못한 후보. grep/AST 근사로 산출되었으나 **직돀 확정 전까지는 위반으로 단정 금지** (false-positive 가능 — `tx as any`, wrapper forward, withTenantScope 등 스크립트가 놓치는 패턴 존재).
 
 ### Priority High — 라우트 핸들러 mutation + audit (도메인별 그룹)
-- **app/api/ra/** (25곳): classification, consult, conversations, deadlines(3), digest, expert-review(2), knowledge-sources(2), messages/blocks, notifications, personal/bookmarks(2), predicate/comparison(2), profile, projects(2), updates/feedback, workflows/submission-drafter, admin/documents/upload(2)
+- **app/api/ra/** (잔여 19곳): classification, consult, conversations, deadlines(3), digest, expert-review(2), knowledge-sources(2), messages/blocks, projects(2), updates/feedback, workflows/submission-drafter, admin/documents/upload(2)
+  - **[PR-A #378 완료 — 6곳 직독 위반 확정 + tx 래핑]** notifications(preferences) · profile · personal/bookmarks(POST + DELETE) · predicate/comparison(POST + [id]/approve). 모두 autocommit mutation + 자체 tx audit 패턴 → `db.transaction(async (tx) => { mutation + writeAudit({...}, tx) })` 래핑. analyzer.ts:67 패턴 준용.
 - **app/api/ra/workflows/cer/route.ts:117** — 직돀 안전 확정(제외)이나 스크립트 후보에 잔류 (false-positive)
 - **app/api/{auth/change-password, auth/signup, classify/run(2), rlhf/feedback(2), admin/users, knowledge-gap/classify}** (8곳)
 
@@ -93,4 +94,35 @@ await db.transaction(async (tx) => {
 
 ---
 
-**본 PR 완료 범위**: 이슈 명시 impact 도메인(analyzer.ts + audit-wiring.ts) 직돀 위반 확정 + 수정. 잔여 58곳은 본 레지스트리에 등록 후 도메인별 후속 PR로 분할 진행 권장.
+**본 PR 완료 범위**: 이슈 명시 impact 도메인(analyzer.ts + audit-wiring.ts) 직돀 위반 확정 + 수정. 잔여 후보는 본 레지스트리에 등록 후 도메인별 후속 PR로 분할 진행.
+
+---
+
+## 8. PR-A (#378) — 회귀 최소 도메인 6곳 직돀 확정 + tx 래핑
+
+58곳 잔여 후보 중 회귀가 가장 낮고 독립적인 도메인 그룹을 선정해 직돀 → 위반 확정 → 수정.
+
+### 직독 결과 (6곳 전부 위반 확정 — autocommit mutation + 자체 tx audit)
+
+| 파일:라인 | mutation(autocommit) | 비고 |
+|---|---|---|
+| `app/api/ra/notifications/preferences/route.ts:88` | `db.update(users)` | PATCH |
+| `app/api/ra/profile/route.ts:85` | `db.update(users)` | UPDATE 브랜치만; SELECT(else)는 audit-only 안전 |
+| `app/api/ra/personal/bookmarks/route.ts:81` | `db.insert(personalBookmarks)` | POST |
+| `app/api/ra/personal/bookmarks/[id]/route.ts:65` | `db.delete(personalBookmarks)` | DELETE — not_found는 throw 아닌 returning 기반 404 처리 |
+| `app/api/ra/predicate/comparison/route.ts:105` | `db.insert(workflowRuns)` | POST |
+| `app/api/ra/predicate/comparison/[id]/approve/route.ts:106` | `db.update(workflowRuns)` | PUT |
+
+### 수정 방식
+각 mutation + `writeAudit`을 단일 `db.transaction(async (tx) => { tx.MUTATION; writeAudit({...}, tx); })`로 래핑. analyzer.ts:67-103 패턴 준용.
+
+### 검증
+- typecheck 0 error · lint 0 error(lint:hex OK)
+- full vitest 4786 passed (comparison.test.ts mock에 `transaction` 추가 — db.transaction 인터페이스 반영)
+- ci:rbac · ci:audit · ci:module-boundaries · ci:format 포함 9개 ci:* 전 PASS
+
+### 잔여 후보 (후속 PR-B/C/D 대상)
+- **app/api/ra 잔여 19곳**: classification, consult(2), conversations, deadlines(3), digest, expert-review(2), knowledge-sources(2), messages/blocks, projects(2), updates/feedback, workflows/submission-drafter, admin/documents/upload(2)
+- **app/api non-ra 8곳**: auth/change-password, auth/signup, classify/run(2), rlhf/feedback(2), admin/users, knowledge-gap/classify
+- **lib Priority Medium ~15곳**: radar/delta-sync(orchestrator 4 + ingest), knowledge-gap(detector/owning-issue 2/replay), knowledge-sources/sync(2), ai/consult, model-governance/rlhf-gate, rlhf/calibration-proposal, standards/alert-pipeline, inngest/knowledge-sources/orphan-cleanup
+- **구조적 한계**: `enqueueActionItems(db)` tx 시그니처 확장(action item audit 원자성) — 별도 패스

--- a/tests/unit/api/profile-route.test.ts
+++ b/tests/unit/api/profile-route.test.ts
@@ -39,6 +39,13 @@ vi.mock('@/lib/db/client', () => ({
   db: {
     select: vi.fn(() => mockSelectChain),
     update: vi.fn(() => mockUpdateChain),
+    transaction: vi.fn((callback) => {
+      // Mock transaction: execute callback with a mock tx that has update method
+      const mockTx = {
+        update: vi.fn(() => mockUpdateChain),
+      };
+      return callback(mockTx);
+    }),
   },
 }));
 
@@ -216,6 +223,7 @@ describe('PATCH /api/ra/profile', () => {
     });
     await PATCH(req, {});
 
+    // writeAudit is called with params object and tx parameter
     expect(writeAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'profile.update',
@@ -223,6 +231,7 @@ describe('PATCH /api/ra/profile', () => {
         resource_type: 'user',
         resource_id: 'user-001',
       }),
+      expect.any(Object), // tx parameter
     );
   });
 


### PR DESCRIPTION
## 배경

#366(PR #377)에서 전사 writeAudit 190 호출처 감사 완료. 레지스트리에 미검증 위반 후보 58곳 등록. 본 PR은 **#378의 도메인 분할 중 PR-A** — 회귀 최소·독립 도메인 6곳 직돀 + tx 래핑.

> 21 CFR Part 11 §11.10(e): 감사 추적은 해당 데이터 변경과 **동일 트랜잭션 경계** 내에서 원자적 기록.

## 변경 (app/api/ra, 6곳 — 회귀 최소 도메인)

직독으로 6곳 전부 **위반 확정**(autocommit mutation + 자체 tx audit). `db.transaction(async (tx) => { tx.MUTATION; writeAudit({...}, tx); })` 래핑(analyzer.ts:67-103 패턴 준용).

| 파일 | mutation |
|---|---|
| notifications/preferences | `db.update(users)` |
| profile | `db.update(users)` — 404 경로 audit 스킵 원래 의미론 유지 + 원자성 확보 |
| personal/bookmarks (POST) | `db.insert` — insert_failed/duplicate(409) 분기 유지 |
| personal/bookmarks/[id] (DELETE) | `db.delete` — not_found returning 기반 404 (throw 회귀 fix) |
| predicate/comparison (POST) | `db.insert(workflowRuns)` |
| predicate/comparison/[id]/approve (PUT) | `db.update(workflowRuns)` |

## 테스트 / 문서
- `tests/unit/api/profile-route.test.ts`, `app/api/ra/predicate/__tests__/comparison.test.ts`: db.transaction mock 추가(인터페이스 변경 반영, 기존 캡처 단언 보존)
- 레지스트리 `docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md` §8 PR-A 섹션 + 잔여 52곳 현황 갱신

## 검증 (직검 — L-008/009/013/015)
- typecheck 0 error · lint 0 error(lint:hex OK)
- full vitest **4787 passed** (pre-push 포함)
- ci:\* 9종(format/rbac/audit/module-boundaries/migrations/tokens/i18n/glossary/contrast) 전 PASS
- evaluator-active 독립 리뷰 APPROVE (Functionality 85 / Security 95 / Craft 80 / Consistency 90) → profile 404-audit 의미론 복원 반영

## 범위 / 잔여
본 PR = #378 분할 중 **PR-A**(회귀 최소 6곳). 잔여 52곳은 후속 PR-B/C/D:
- app/api/ra 잔여 19곳(classification, consult, conversations, deadlines, digest, expert-review, knowledge-sources, messages/blocks, projects, updates/feedback, workflows/submission-drafter, admin/upload)
- app/api non-ra 8곳(auth, classify, rlhf, admin/users, knowledge-gap)
- lib Priority Medium ~15곳(radar/delta-sync, knowledge-gap, knowledge-sources, ai/consult, model-governance, rlhf, standards, inngest)
- 구조적 한계: enqueueActionItems tx 시그니처 확장(별도 패스)

Refs #378

🗿 MoAI <email@mo.ai.kr>