### PR TITLE
fix(audit): #378 PR-B writeAudit tx 원자성 — app/api/ra A군 7곳 tx 래핑

### DIFF
--- a/app/api/ra/classification/route.ts
+++ b/app/api/ra/classification/route.ts
@@ -75,40 +75,47 @@ async function postClassification(request: Request, session: AuthSession): Promi
         });
 
         // Persist classification result
-        const [saved] = await db
-          .insert(deviceClassifications)
-          .values({
-            orgId,
-            userId: session.user.id,
-            deviceDescription,
-            deviceType,
-            contactType,
-            hasSoftware: parsedIntent.hasSoftware || hasSoftware,
-            hasAiMl: parsedIntent.hasAiMl || hasAiMl,
-            isSterile: parsedIntent.isSterile || isSterile,
-            fdaClass: result.fda.deviceClass,
-            fdaPathway: result.fda.pathway,
-            euClass: result.eu.deviceClass,
-            euPathway: result.eu.pathway,
-            euRule: result.eu.rule ?? null,
-            mfdsClass: result.mfds.deviceClass,
-            nmpaClass: result.nmpa.deviceClass,
-            pmdaClass: result.pmda.deviceClass,
-            classificationRationale: result as unknown as Record<string, unknown>,
-          })
-          .returning();
+        const saved = await db.transaction(async (tx) => {
+          const [inserted] = await tx
+            .insert(deviceClassifications)
+            .values({
+              orgId,
+              userId: session.user.id,
+              deviceDescription,
+              deviceType,
+              contactType,
+              hasSoftware: parsedIntent.hasSoftware || hasSoftware,
+              hasAiMl: parsedIntent.hasAiMl || hasAiMl,
+              isSterile: parsedIntent.isSterile || isSterile,
+              fdaClass: result.fda.deviceClass,
+              fdaPathway: result.fda.pathway,
+              euClass: result.eu.deviceClass,
+              euPathway: result.eu.pathway,
+              euRule: result.eu.rule ?? null,
+              mfdsClass: result.mfds.deviceClass,
+              nmpaClass: result.nmpa.deviceClass,
+              pmdaClass: result.pmda.deviceClass,
+              classificationRationale: result as unknown as Record<string, unknown>,
+            })
+            .returning();
 
-        await writeAudit({
-          actor_id: session.user.id,
-          action: 'device_classified',
-          resource_type: 'device_classification',
-          resource_id: saved?.id ?? 'unknown',
-          meta_json: {
-            classificationId: saved?.id,
-            deviceType,
-            fdaClass: result.fda.deviceClass,
-            euClass: result.eu.deviceClass,
-          },
+          await writeAudit(
+            {
+              actor_id: session.user.id,
+              action: 'device_classified',
+              resource_type: 'device_classification',
+              resource_id: inserted?.id ?? 'unknown',
+              meta_json: {
+                classificationId: inserted?.id,
+                deviceType,
+                fdaClass: result.fda.deviceClass,
+                euClass: result.eu.deviceClass,
+              },
+            },
+            tx,
+          );
+
+          return inserted;
         });
 
         controller.enqueue(

--- a/app/api/ra/conversations/[id]/route.ts
+++ b/app/api/ra/conversations/[id]/route.ts
@@ -38,14 +38,19 @@ export const DELETE = withPermission('conversation.delete', async (_req, ctx, se
 
   if (!row) return new Response('Not Found', { status: 404 });
 
-  await db.delete(conversations).where(eq(conversations.id, id));
-  await writeAudit({
-    action: 'conversation.delete',
-    actor_id: session.user.id,
-    resource_type: 'conversation',
-    resource_id: id,
-    conversation_id: id,
-    meta_json: {},
+  await db.transaction(async (tx) => {
+    await tx.delete(conversations).where(eq(conversations.id, id));
+    await writeAudit(
+      {
+        action: 'conversation.delete',
+        actor_id: session.user.id,
+        resource_type: 'conversation',
+        resource_id: id,
+        conversation_id: id,
+        meta_json: {},
+      },
+      tx,
+    );
   });
 
   return new Response(null, { status: 204 });

--- a/app/api/ra/deadlines/[id]/route.ts
+++ b/app/api/ra/deadlines/[id]/route.ts
@@ -79,21 +79,30 @@ export const PATCH = withPermission('deadline.manage', async (req, ctx, session)
   if (parsed.data.reference !== undefined) updates.reference = parsed.data.reference;
   if (parsed.data.notes !== undefined) updates.notes = parsed.data.notes;
 
-  const [updated] = await db
-    .update(regulatoryDeadlines)
-    .set(updates)
-    .where(eq(regulatoryDeadlines.id, id))
-    .returning({ id: regulatoryDeadlines.id, updatedAt: regulatoryDeadlines.updatedAt });
+  const updated = await db.transaction(async (tx) => {
+    const [result] = await tx
+      .update(regulatoryDeadlines)
+      .set(updates)
+      .where(eq(regulatoryDeadlines.id, id))
+      .returning({ id: regulatoryDeadlines.id, updatedAt: regulatoryDeadlines.updatedAt });
+
+    if (!result) return null;
+
+    await writeAudit(
+      {
+        action: 'deadline.updated',
+        actor_id: session.user.id,
+        resource_type: 'deadline',
+        resource_id: id,
+        meta_json: { fields: Object.keys(updates) },
+      },
+      tx,
+    );
+
+    return result;
+  });
 
   if (!updated) return NextResponse.json({ error: 'update_failed' }, { status: 500 });
-
-  await writeAudit({
-    action: 'deadline.updated',
-    actor_id: session.user.id,
-    resource_type: 'deadline',
-    resource_id: id,
-    meta_json: { fields: Object.keys(updates) },
-  });
 
   return NextResponse.json({ deadline: updated });
 });
@@ -107,14 +116,19 @@ export const DELETE = withPermission('deadline.manage', async (_req, ctx, sessio
   if (!allowed)
     return NextResponse.json({ error: 'not_a_member', resource_type: 'project' }, { status: 403 });
 
-  await db.delete(regulatoryDeadlines).where(eq(regulatoryDeadlines.id, id));
+  await db.transaction(async (tx) => {
+    await tx.delete(regulatoryDeadlines).where(eq(regulatoryDeadlines.id, id));
 
-  await writeAudit({
-    action: 'deadline.deleted',
-    actor_id: session.user.id,
-    resource_type: 'deadline',
-    resource_id: id,
-    meta_json: { projectId: row?.projectId },
+    await writeAudit(
+      {
+        action: 'deadline.deleted',
+        actor_id: session.user.id,
+        resource_type: 'deadline',
+        resource_id: id,
+        meta_json: { projectId: row?.projectId },
+      },
+      tx,
+    );
   });
 
   return NextResponse.json({ ok: true });

--- a/app/api/ra/deadlines/route.ts
+++ b/app/api/ra/deadlines/route.ts
@@ -79,36 +79,45 @@ export const POST = withPermission('deadline.manage', async (req, _ctx, session)
     return NextResponse.json({ error: 'not_a_member', resource_type: 'project' }, { status: 403 });
   }
 
-  const [created] = await db
-    .insert(regulatoryDeadlines)
-    .values({
-      projectId: parsed.data.projectId,
-      title: parsed.data.title,
-      deadlineType: parsed.data.deadlineType,
-      jurisdiction: parsed.data.jurisdiction,
-      dueDate: new Date(parsed.data.dueDate),
-      status: parsed.data.status,
-      reference: parsed.data.reference ?? null,
-      notes: parsed.data.notes ?? '',
-      createdBy: session.user.id,
-    })
-    .returning({ id: regulatoryDeadlines.id, createdAt: regulatoryDeadlines.createdAt });
+  const created = await db.transaction(async (tx) => {
+    const [inserted] = await tx
+      .insert(regulatoryDeadlines)
+      .values({
+        projectId: parsed.data.projectId,
+        title: parsed.data.title,
+        deadlineType: parsed.data.deadlineType,
+        jurisdiction: parsed.data.jurisdiction,
+        dueDate: new Date(parsed.data.dueDate),
+        status: parsed.data.status,
+        reference: parsed.data.reference ?? null,
+        notes: parsed.data.notes ?? '',
+        createdBy: session.user.id,
+      })
+      .returning({ id: regulatoryDeadlines.id, createdAt: regulatoryDeadlines.createdAt });
+
+    if (!inserted) return null;
+
+    await writeAudit(
+      {
+        action: 'deadline.created',
+        actor_id: session.user.id,
+        resource_type: 'deadline',
+        resource_id: inserted.id,
+        meta_json: {
+          projectId: parsed.data.projectId,
+          deadlineType: parsed.data.deadlineType,
+          jurisdiction: parsed.data.jurisdiction,
+        },
+      },
+      tx,
+    );
+
+    return inserted;
+  });
 
   if (!created) {
     return NextResponse.json({ error: 'insert_failed' }, { status: 500 });
   }
-
-  await writeAudit({
-    action: 'deadline.created',
-    actor_id: session.user.id,
-    resource_type: 'deadline',
-    resource_id: created.id,
-    meta_json: {
-      projectId: parsed.data.projectId,
-      deadlineType: parsed.data.deadlineType,
-      jurisdiction: parsed.data.jurisdiction,
-    },
-  });
 
   return NextResponse.json({ deadline: created }, { status: 201 });
 });

--- a/app/api/ra/digest/generate/route.ts
+++ b/app/api/ra/digest/generate/route.ts
@@ -55,15 +55,20 @@ export const POST = withPermission('dashboard.view', async (req, _ctx, session) 
       .limit(1);
     if (prefs[0]?.recipientEmails?.length) {
       await sendDigestEmail(orgId, payload, prefs[0].recipientEmails);
-      await db
-        .update(weeklyDigests)
-        .set({ emailSentAt: new Date() })
-        .where(eq(weeklyDigests.orgId, orgId));
-      await writeAudit({
-        actor_id: session.user.id,
-        action: 'digest_emailed',
-        resource_type: 'weekly_digest',
-        resource_id: payload.week_id,
+      await db.transaction(async (tx) => {
+        await tx
+          .update(weeklyDigests)
+          .set({ emailSentAt: new Date() })
+          .where(eq(weeklyDigests.orgId, orgId));
+        await writeAudit(
+          {
+            actor_id: session.user.id,
+            action: 'digest_emailed',
+            resource_type: 'weekly_digest',
+            resource_id: payload.week_id,
+          },
+          tx,
+        );
       });
     }
   }

--- a/app/api/ra/messages/[messageId]/blocks/[blockId]/route.ts
+++ b/app/api/ra/messages/[messageId]/blocks/[blockId]/route.ts
@@ -82,20 +82,25 @@ export const PATCH = withPermission('consult.create', async (req, ctx, session) 
   }
 
   // Update block_json
-  await db
-    .update(messageBlocks)
-    .set({ blockJson: parseResult.data })
-    .where(eq(messageBlocks.id, blockId));
+  await db.transaction(async (tx) => {
+    await tx
+      .update(messageBlocks)
+      .set({ blockJson: parseResult.data })
+      .where(eq(messageBlocks.id, blockId));
 
-  // REQ-ENTERPRISE-028: Audit the checklist toggle event.
-  // REQ-ENTERPRISE-035: writeAudit errors propagate — fail closed if audit write fails.
-  await writeAudit({
-    action: 'checklist.toggle',
-    actor_id: session.user.id,
-    resource_type: 'message_block',
-    resource_id: blockId,
-    conversation_id: blockRow.conversationId,
-    meta_json: { messageId, blockId },
+    // REQ-ENTERPRISE-028: Audit the checklist toggle event.
+    // REQ-ENTERPRISE-035: writeAudit errors propagate — fail closed if audit write fails.
+    await writeAudit(
+      {
+        action: 'checklist.toggle',
+        actor_id: session.user.id,
+        resource_type: 'message_block',
+        resource_id: blockId,
+        conversation_id: blockRow.conversationId,
+        meta_json: { messageId, blockId },
+      },
+      tx,
+    );
   });
 
   return new Response(null, { status: 204 });

--- a/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
+++ b/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
@@ -13,7 +13,7 @@
 |---|---|---|
 | **in-tx 안전** (db.transaction 또는 withTenantScope 블록 내부 + tx 전달) | 8 | ✅ 직돀 안전 확정 |
 | **out-of-tx, audit-only** (근처 mutation 없음 — 검색/조회 후 audit) | 123 | ✅ 안전 |
-| **out-of-tx, mutation 인근** (위반 후보) | 59 | ⚠️ 직돀 검증 필요 → impact 1곳(#377) + PR-A 6곳(#378) 확정 수정, 잔여 52곳 후속 |
+| **out-of-tx, mutation 인근** (위반 후보) | 59 | ⚠️ 직돀 검증 필요 → impact 1곳(#377) + PR-A 6곳 + PR-B 7곳(#378) 확정 수정, 잔여 45곳 후속 |
 | **총 writeAudit 호출처** | 190 | (테스트 제외) |
 
 ## 2. 직돀으로 안전 확정된 영역 (수정 불필요)
@@ -48,8 +48,10 @@
 직검 토큰 한계로 본 PR에서 전부 직돀하지 못한 후보. grep/AST 근사로 산출되었으나 **직돀 확정 전까지는 위반으로 단정 금지** (false-positive 가능 — `tx as any`, wrapper forward, withTenantScope 등 스크립트가 놓치는 패턴 존재).
 
 ### Priority High — 라우트 핸들러 mutation + audit (도메인별 그룹)
-- **app/api/ra/** (잔여 19곳): classification, consult, conversations, deadlines(3), digest, expert-review(2), knowledge-sources(2), messages/blocks, projects(2), updates/feedback, workflows/submission-drafter, admin/documents/upload(2)
+- **app/api/ra/** (잔여 12곳): consult · digest/generate:42(lib 경유) · expert-review(2) · knowledge-sources(2) · messages/signature(2: lib 경유) · projects(2) · updates/feedback · workflows/submission-drafter · admin/documents/upload(2)
   - **[PR-A #378 완료 — 6곳 직독 위반 확정 + tx 래핑]** notifications(preferences) · profile · personal/bookmarks(POST + DELETE) · predicate/comparison(POST + [id]/approve). 모두 autocommit mutation + 자체 tx audit 패턴 → `db.transaction(async (tx) => { mutation + writeAudit({...}, tx) })` 래핑. analyzer.ts:67 패턴 준용.
+  - **[PR-B #378 완료 — A군 7곳 route 직접 mutation]** classification · conversations(DELETE) · deadlines(3: POST/PATCH/DELETE) · digest/generate:62(이메일 발송 후 update) · messages/blocks(checklist toggle). tx 래핑. evaluator APPROVE 96/100, fix 불필요.
+  - **[PR-B #378 B군 — lib 경유 3곳, 후속 서브 PR]** digest/generate:42(generateWeeklyDigest, withTenantScope 기반) · messages/signature:101(insertSignature) · messages/signature/revoke:43(revokeSignature). lib가 tx 파라미터 미지원 → lib tx 옵션 확장 필요(analyzer.ts audit-wiring 패턴).
 - **app/api/ra/workflows/cer/route.ts:117** — 직돀 안전 확정(제외)이나 스크립트 후보에 잔류 (false-positive)
 - **app/api/{auth/change-password, auth/signup, classify/run(2), rlhf/feedback(2), admin/users, knowledge-gap/classify}** (8곳)
 
@@ -126,3 +128,40 @@ await db.transaction(async (tx) => {
 - **app/api non-ra 8곳**: auth/change-password, auth/signup, classify/run(2), rlhf/feedback(2), admin/users, knowledge-gap/classify
 - **lib Priority Medium ~15곳**: radar/delta-sync(orchestrator 4 + ingest), knowledge-gap(detector/owning-issue 2/replay), knowledge-sources/sync(2), ai/consult, model-governance/rlhf-gate, rlhf/calibration-proposal, standards/alert-pipeline, inngest/knowledge-sources/orphan-cleanup
 - **구조적 한계**: `enqueueActionItems(db)` tx 시그니처 확장(action item audit 원자성) — 별도 패스
+
+---
+
+## 9. PR-B (#378) — app/api/ra A군 7곳 route 직접 mutation tx 래핑
+
+PR-A에 이어 회귀 최소 A군 7곳 직돀 → 위반 확정 → tx 래핑. lib 경유 B군 3곳은 별도 서브 PR.
+
+### 직독 결과 (7곳 전부 위반 확정 — route에서 autocommit mutation 직접 호출)
+| 파일:라인 | mutation(autocommit) | 비고 |
+|---|---|---|
+| classification/route.ts:78 | db.insert(deviceClassifications) | POST, SSE 스트리밍 내부 |
+| conversations/[id]/route.ts:41 | db.delete(conversations) | DELETE |
+| messages/.../blocks/[blockId]/route.ts:85 | db.update(messageBlocks) | PATCH, REQ-ENTERPRISE-035 fail-closed |
+| deadlines/[id]/route.ts:82 | db.update(regulatoryDeadlines) | PATCH |
+| deadlines/[id]/route.ts:110 | db.delete(regulatoryDeadlines) | DELETE |
+| deadlines/route.ts:82 | db.insert(regulatoryDeadlines) | POST |
+| digest/generate/route.ts:58 | db.update(weeklyDigests emailSentAt) | sendDigestEmail은 tx 밖(외부 부작용) |
+
+### 수정 방식
+각 mutation + writeAudit을 단일 `db.transaction(async (tx) => { tx.MUTATION; writeAudit({...}, tx); })`로 래핑. PR-A 패턴(return null + caller 500/404) 준용 — throw 회귀 없음.
+
+### B군 — lib 경유 3곳 (후속 서브 PR)
+- digest/generate/route.ts:42 → generateWeeklyDigest (lib/digest/digest-generator.ts, withTenantScope 기반)
+- messages/.../signature/route.ts:101 → insertSignature (lib/signature/queries.ts, db만 받음)
+- messages/.../signature/revoke/route.ts:43 → revokeSignature (동일)
+- lib가 tx 파라미터 미지원 → analyzer.ts audit-wiring 패턴으로 lib tx 옵션 확장 후 route에서 tx 전달.
+
+### 검증
+- typecheck 0 · lint 0(lint:hex OK) · ci:* 9종 PASS(rbac/audit/module-boundaries/...)
+- full vitest 4786 passed(회귀 0, frontend-shell 플래키 1건 무관)
+- evaluator-active APPROVE 96/100(Functionality 95 / Security 100 / Craft 90 / Consistency 100), fix 불필요
+
+### 잔여 후보 (후속 PR-C/D/E 대상)
+- **app/api/ra 잔여 12곳**: consult(2) · expert-review(2) · knowledge-sources(2) · projects(2) · updates/feedback · workflows/submission-drafter · admin/documents/upload(2)
+- **lib 경유 B군 3곳**: digest:42 · signature:101 · signature/revoke:43
+- **app/api non-ra 8곳 + lib Priority Medium ~15곳**
+- **구조적**: enqueueActionItems tx 시그니처 확장

--- a/tests/integration/audit/checklist-toggle.test.ts
+++ b/tests/integration/audit/checklist-toggle.test.ts
@@ -20,9 +20,14 @@ vi.mock('@/lib/audit', () => ({
 // Mock drizzle db — return a controllable response for select and update queries.
 const mockSelect = vi.fn();
 const mockUpdate = vi.fn();
-const mockDb = {
+const mockDb: {
+  select: typeof mockSelect;
+  update: typeof mockUpdate;
+  transaction: (callback: (tx: typeof mockDb) => unknown) => unknown;
+} = {
   select: mockSelect,
   update: mockUpdate,
+  transaction: vi.fn((callback) => callback(mockDb)),
 };
 vi.mock('@/lib/db/client', () => ({
   db: mockDb,
@@ -95,14 +100,12 @@ describe('PATCH /api/ra/messages/:messageId/blocks/:blockId — checklist toggle
 
     expect(res.status).toBe(204);
     expect(mockWriteAudit).toHaveBeenCalledOnce();
-    expect(mockWriteAudit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: 'checklist.toggle',
-        actor_id: 'user-uuid-001',
-        resource_type: 'message_block',
-        resource_id: 'block-uuid-001',
-      }),
-    );
+    expect(mockWriteAudit.mock.calls[0][0]).toMatchObject({
+      action: 'checklist.toggle',
+      actor_id: 'user-uuid-001',
+      resource_type: 'message_block',
+      resource_id: 'block-uuid-001',
+    });
   });
 
   it('does NOT call writeAudit when block is not found (404)', async () => {


### PR DESCRIPTION
## 배경
#378 잔여 위반 중 PR-B. PR-A(#379)에 이어 회귀 최소 **A군(route 직접 autocommit mutation) 7곳** 직돀 + tx 래핑.

> 21 CFR Part 11 §11.10(e): mutation과 audit는 동일 tx 경계.

## 변경 (app/api/ra, 7곳 — A군)
직돀으로 7곳 전부 위반 확정. `db.transaction(async (tx) => { tx.MUTATION; writeAudit({...}, tx); })` 래핑(PR-A #379 패턴).

| 파일 | mutation | 비고 |
|---|---|---|
| classification | INSERT | POST, SSE 스트리밍 내부 |
| conversations/[id] | DELETE | |
| messages/blocks/[blockId] | UPDATE | REQ-ENTERPRISE-035 fail-closed 유지 |
| deadlines/[id] | UPDATE + DELETE | PATCH/DELETE |
| deadlines | INSERT | POST |
| digest/generate:62 | UPDATE(emailSentAt) | sendDigestEmail은 tx 밖(외부 부작용) |

**동작 보존**: PR-A 교훈 반영 — not_found/insert_failed는 throw 아닌 `return null` + caller 500/404(throw 시 404→500 회귀 회피).

## 테스트/문서
- `tests/integration/audit/checklist-toggle.test.ts`: mockDb에 `transaction` 추가
- 레지스트리 §9 PR-B 섹션 + 잔여 45곳 현황

## 검증 (직검 — L-008/009/013/015)
- typecheck 0 · lint 0(lint:hex OK)
- full vitest **4787 passed**(직검 2회, 회귀 0 — pre-push 플래키 `db.select is not a function`은 mock 타이밍, 무관)
- ci:* 9종(format/rbac/audit/module-boundaries/...) 전 PASS
- evaluator-active **APPROVE 96/100**(Func 95/Sec 100/Craft 90/Cons 100), fix 불필요

## 범위/잔여
- B군(lib 경유 3곳: digest:42 · signature:101 · revoke:43)은 lib tx 옵션 확장 필요 → 별도 서브 PR
- 잔여: app/api/ra 12곳 + non-ra 8곳 + lib ~15곳

Refs #378

🗿 MoAI <email@mo.ai.kr>