### PR TITLE
fix(audit): #378 PR-C writeAudit tx 원자성 — app/api/ra 복합 9곳 tx 래핑

### DIFF
--- a/app/api/ra/admin/documents/upload/route.ts
+++ b/app/api/ra/admin/documents/upload/route.ts
@@ -190,6 +190,12 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
   //    rows — SPEC REQ-003 requires a licensed source to exist before ingest.
   //    The title override (if any) updates the existing source row.
   // ---------------------------------------------------------------------
+  // 21 CFR Part 11 §11.10(e) — Issue #378: source_sections INSERT + the two
+  // upload audit rows ride the SAME db.transaction so a failure between them
+  // rolls back both. setPendingReviewOnIngest stays on a separate best-effort
+  // boundary (governance write may be unavailable; RLS isolates) — run AFTER
+  // the atomic persist+audit so its try/catch swallow cannot mask an audit
+  // failure.
   const result: UploadSuccess = await db.transaction(async (tx) => {
     // Attach sections to the pre-registered source (no new sources row).
     const sectionRows = chunks.map((c, idx) => ({
@@ -201,6 +207,37 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
     }));
 
     await tx.insert(sourceSections).values(sectionRows);
+
+    await writeAudit(
+      {
+        action: 'document.upload',
+        actor_id: session.user.id,
+        resource_type: 'source',
+        resource_id: existingSourceId,
+        meta_json: {
+          docClass,
+          mimeType,
+          sizeBytes: file.size,
+          sectionCount: sectionRows.length,
+          filenameExt: file.name.includes('.')
+            ? (file.name.split('.').pop()?.slice(0, 32) ?? null)
+            : null,
+          filenameLength: file.name.length,
+        },
+      },
+      tx,
+    );
+
+    await writeAudit(
+      {
+        action: 'document.chunk',
+        actor_id: session.user.id,
+        resource_type: 'source',
+        resource_id: existingSourceId,
+        meta_json: { sectionCount: sectionRows.length, docClass },
+      },
+      tx,
+    );
 
     return { sourceId: existingSourceId, sectionCount: sectionRows.length };
   });
@@ -220,35 +257,6 @@ export const POST = withPermission('sources.ingest', async (req, _ctx, session) 
   } catch {
     // Governance write unavailable — license gate still passed; RLS isolates.
   }
-
-  // ---------------------------------------------------------------------
-  // 6. Audit. Failures here propagate (lib/audit.ts contract — never
-  //    swallow the audit write).
-  // ---------------------------------------------------------------------
-  await writeAudit({
-    action: 'document.upload',
-    actor_id: session.user.id,
-    resource_type: 'source',
-    resource_id: result.sourceId,
-    meta_json: {
-      docClass,
-      mimeType,
-      sizeBytes: file.size,
-      sectionCount: result.sectionCount,
-      filenameExt: file.name.includes('.')
-        ? (file.name.split('.').pop()?.slice(0, 32) ?? null)
-        : null,
-      filenameLength: file.name.length,
-    },
-  });
-
-  await writeAudit({
-    action: 'document.chunk',
-    actor_id: session.user.id,
-    resource_type: 'source',
-    resource_id: result.sourceId,
-    meta_json: { sectionCount: result.sectionCount, docClass },
-  });
 
   return Response.json(result, { status: 201 });
 });

--- a/app/api/ra/expert-review/[id]/route.ts
+++ b/app/api/ra/expert-review/[id]/route.ts
@@ -117,18 +117,27 @@ export const PATCH = async (req: Request, ctx: IdCtx): Promise<Response> => {
 
   // Guard with the appropriate permission
   const guarded = withPermission(requiredAction, async (_req2, _ctx2, session) => {
-    const [updated] = await db
-      .update(expertReviews)
-      .set(updateValues)
-      .where(eq(expertReviews.id, id))
-      .returning();
+    // 21 CFR Part 11 §11.10(e) — Issue #378: UPDATE + audit ride the same
+    // db.transaction so a failure between them rolls back both.
+    const updated = await db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(expertReviews)
+        .set(updateValues)
+        .where(eq(expertReviews.id, id))
+        .returning();
 
-    await writeAudit({
-      action: auditAction,
-      actor_id: session.user.id,
-      resource_type: 'expert_review',
-      resource_id: id,
-      meta_json: { from: currentStatus, to: targetStatus },
+      await writeAudit(
+        {
+          action: auditAction,
+          actor_id: session.user.id,
+          resource_type: 'expert_review',
+          resource_id: id,
+          meta_json: { from: currentStatus, to: targetStatus },
+        },
+        tx,
+      );
+
+      return row;
     });
 
     return Response.json(updated);

--- a/app/api/ra/expert-review/route.ts
+++ b/app/api/ra/expert-review/route.ts
@@ -34,31 +34,42 @@ export const POST = withPermission('expertReview.create', async (req, _ctx, sess
 
   const { conversationId, messageId, reason } = parsed.data;
 
-  const [record] = await db
-    .insert(expertReviews)
-    .values({
-      conversationId,
-      messageId,
-      requestedBy: session.user.id,
-      status: 'pending',
-      notes: reason,
-    })
-    .onConflictDoNothing()
-    .returning();
+  // 21 CFR Part 11 §11.10(e) — Issue #378: INSERT + audit ride the same
+  // db.transaction so a failure between them rolls back both.
+  const record = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(expertReviews)
+      .values({
+        conversationId,
+        messageId,
+        requestedBy: session.user.id,
+        status: 'pending',
+        notes: reason,
+      })
+      .onConflictDoNothing()
+      .returning();
+
+    if (!row) return null; // already existed — skip audit
+
+    await writeAudit(
+      {
+        action: 'expert_review.flag',
+        actor_id: session.user.id,
+        resource_type: 'message',
+        resource_id: messageId,
+        meta_json: { reason, trigger: 'manual' },
+      },
+      tx,
+    );
+
+    return row;
+  });
 
   // If conflict (duplicate), return 201 without re-writing audit
   if (!record) {
     // Idempotent — return empty body with 201
     return Response.json({ message: 'already_exists' }, { status: 201 });
   }
-
-  await writeAudit({
-    action: 'expert_review.flag',
-    actor_id: session.user.id,
-    resource_type: 'message',
-    resource_id: messageId,
-    meta_json: { reason, trigger: 'manual' },
-  });
 
   return Response.json(record, { status: 201 });
 });

--- a/app/api/ra/knowledge-sources/[id]/route.ts
+++ b/app/api/ra/knowledge-sources/[id]/route.ts
@@ -29,16 +29,21 @@ export const DELETE = withPermission('knowledgesources.manage', async (_req, ctx
     // IDOR guard: ensure source belongs to org
     await assertKnowledgeSourceInOrg(id, orgId);
 
-    // Delete knowledge source
-    await db.delete(knowledgeSources).where(eq(knowledgeSources.id, id));
+    // 21 CFR Part 11 §11.10(e) — Issue #378: DELETE + audit ride the same
+    // db.transaction so a failure between them rolls back both.
+    await db.transaction(async (tx) => {
+      await tx.delete(knowledgeSources).where(eq(knowledgeSources.id, id));
 
-    // Write audit log
-    await writeAudit({
-      actor_id: userId,
-      action: 'knowledge_source.deleted',
-      resource_type: 'knowledgeSource',
-      resource_id: id,
-      meta_json: {},
+      await writeAudit(
+        {
+          actor_id: userId,
+          action: 'knowledge_source.deleted',
+          resource_type: 'knowledgeSource',
+          resource_id: id,
+          meta_json: {},
+        },
+        tx,
+      );
     });
 
     return Response.json({ success: true });

--- a/app/api/ra/knowledge-sources/route.ts
+++ b/app/api/ra/knowledge-sources/route.ts
@@ -45,40 +45,50 @@ export const POST = withPermission('knowledgesources.manage', async (req, _ctx, 
       return Response.json({ error: 'invalid_git_url' }, { status: 400 });
     }
 
-    // Create knowledge source — syncStatus 'idle' (migration CHECK: idle/syncing/synced/failed)
-    const [source] = await db
-      .insert(knowledgeSources)
-      .values({
-        organizationId: orgId,
-        createdBy: userId,
-        gitUrl: git_url,
-        branch: branch || 'main',
-        sourceHost: parsed.host,
-        sourceOwner: parsed.owner,
-        sourceRepo: parsed.repo,
-        authTokenEncrypted: auth_token || null,
-        syncStatus: 'idle',
-      })
-      .returning();
+    // 21 CFR Part 11 §11.10(e) — Issue #378: INSERT + audit ride the same
+    // db.transaction so a failure between them rolls back both.
+    const source = await db.transaction(async (tx) => {
+      // Create knowledge source — syncStatus 'idle' (migration CHECK: idle/syncing/synced/failed)
+      const [row] = await tx
+        .insert(knowledgeSources)
+        .values({
+          organizationId: orgId,
+          createdBy: userId,
+          gitUrl: git_url,
+          branch: branch || 'main',
+          sourceHost: parsed.host,
+          sourceOwner: parsed.owner,
+          sourceRepo: parsed.repo,
+          authTokenEncrypted: auth_token || null,
+          syncStatus: 'idle',
+        })
+        .returning();
+
+      if (!row) return null;
+
+      await writeAudit(
+        {
+          actor_id: userId,
+          action: 'knowledge_source.created',
+          resource_type: 'knowledgeSource',
+          resource_id: row.id,
+          meta_json: {
+            git_url,
+            branch: branch || 'main',
+            host: parsed.host,
+            owner: parsed.owner,
+            repo: parsed.repo,
+          },
+        },
+        tx,
+      );
+
+      return row;
+    });
 
     if (!source) {
       return Response.json({ error: 'failed_to_create_source' }, { status: 500 });
     }
-
-    // Write audit log
-    await writeAudit({
-      actor_id: userId,
-      action: 'knowledge_source.created',
-      resource_type: 'knowledgeSource',
-      resource_id: source.id,
-      meta_json: {
-        git_url,
-        branch: branch || 'main',
-        host: parsed.host,
-        owner: parsed.owner,
-        repo: parsed.repo,
-      },
-    });
 
     return Response.json({ source }, { status: 201 });
   } catch (error) {

--- a/app/api/ra/projects/[id]/route.ts
+++ b/app/api/ra/projects/[id]/route.ts
@@ -62,25 +62,35 @@ export const PATCH = withPermission('project.manage', async (req, ctx, session) 
 
   if (!existing) return new Response('Not Found', { status: 404 });
 
-  const [updated] = await db
-    .update(projects)
-    .set({
-      ...(parsed.data.name !== undefined && { name: parsed.data.name }),
-      ...(parsed.data.deviceClass !== undefined && { deviceClass: parsed.data.deviceClass }),
-      ...(parsed.data.color !== undefined && { color: parsed.data.color }),
-      ...(parsed.data.status !== undefined && { status: parsed.data.status }),
-      ...(parsed.data.submissionDate !== undefined && {
-        submissionDate: parsed.data.submissionDate,
-      }),
-    })
-    .where(eq(projects.id, id))
-    .returning();
-  await writeAudit({
-    action: 'project.update',
-    actor_id: session.user.id,
-    resource_type: 'project',
-    resource_id: id,
-    meta_json: { fields: Object.keys(parsed.data).sort() },
+  // 21 CFR Part 11 §11.10(e) — Issue #378: UPDATE + audit ride the same
+  // db.transaction so a failure between them rolls back both.
+  const updated = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(projects)
+      .set({
+        ...(parsed.data.name !== undefined && { name: parsed.data.name }),
+        ...(parsed.data.deviceClass !== undefined && { deviceClass: parsed.data.deviceClass }),
+        ...(parsed.data.color !== undefined && { color: parsed.data.color }),
+        ...(parsed.data.status !== undefined && { status: parsed.data.status }),
+        ...(parsed.data.submissionDate !== undefined && {
+          submissionDate: parsed.data.submissionDate,
+        }),
+      })
+      .where(eq(projects.id, id))
+      .returning();
+
+    await writeAudit(
+      {
+        action: 'project.update',
+        actor_id: session.user.id,
+        resource_type: 'project',
+        resource_id: id,
+        meta_json: { fields: Object.keys(parsed.data).sort() },
+      },
+      tx,
+    );
+
+    return row;
   });
 
   return Response.json({ project: updated });

--- a/app/api/ra/projects/route.ts
+++ b/app/api/ra/projects/route.ts
@@ -55,26 +55,36 @@ export const POST = withPermission('project.create', async (req, _ctx, session) 
     return Response.json({ error: 'No organization context' }, { status: 400 });
   }
 
-  const [created] = await db
-    .insert(projects)
-    .values({
-      organizationId: orgId,
-      name: parsed.data.name,
-      deviceClass: parsed.data.deviceClass ?? null,
-      targetMarkets: parsed.data.targetMarkets ?? [],
-      color: parsed.data.color ?? null,
-      submissionDate: parsed.data.submissionDate ?? null,
-    })
-    .returning();
-  if (created) {
-    await writeAudit({
-      action: 'project.create',
-      actor_id: session.user.id,
-      resource_type: 'project',
-      resource_id: created.id,
-      meta_json: { organizationId: orgId },
-    });
-  }
+  // 21 CFR Part 11 §11.10(e) — Issue #378: INSERT + audit ride the same
+  // db.transaction so a failure between them rolls back both.
+  const created = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(projects)
+      .values({
+        organizationId: orgId,
+        name: parsed.data.name,
+        deviceClass: parsed.data.deviceClass ?? null,
+        targetMarkets: parsed.data.targetMarkets ?? [],
+        color: parsed.data.color ?? null,
+        submissionDate: parsed.data.submissionDate ?? null,
+      })
+      .returning();
+
+    if (!row) return null;
+
+    await writeAudit(
+      {
+        action: 'project.create',
+        actor_id: session.user.id,
+        resource_type: 'project',
+        resource_id: row.id,
+        meta_json: { organizationId: orgId },
+      },
+      tx,
+    );
+
+    return row;
+  });
 
   return Response.json({ project: created }, { status: 201 });
 });

--- a/app/api/ra/updates/[id]/feedback/route.ts
+++ b/app/api/ra/updates/[id]/feedback/route.ts
@@ -32,33 +32,40 @@ export const POST = withPermission('dashboard.view', async (req, ctx, session) =
     return Response.json({ error: 'No organization context' }, { status: 403 });
   }
 
-  // Upsert feedback into org_update_relevance
-  const existing = await db
-    .select({ id: orgUpdateRelevance.id })
-    .from(orgUpdateRelevance)
-    .where(and(eq(orgUpdateRelevance.orgId, orgId), eq(orgUpdateRelevance.updateId, id)))
-    .limit(1);
+  // 21 CFR Part 11 §11.10(e) — Issue #378: upsert + audit ride the same
+  // db.transaction so a failure between them rolls back both.
+  await db.transaction(async (tx) => {
+    // Upsert feedback into org_update_relevance
+    const existing = await tx
+      .select({ id: orgUpdateRelevance.id })
+      .from(orgUpdateRelevance)
+      .where(and(eq(orgUpdateRelevance.orgId, orgId), eq(orgUpdateRelevance.updateId, id)))
+      .limit(1);
 
-  if (existing.length > 0) {
-    await db
-      .update(orgUpdateRelevance)
-      .set({ feedback: parsed.data.feedback })
-      .where(and(eq(orgUpdateRelevance.orgId, orgId), eq(orgUpdateRelevance.updateId, id)));
-  } else {
-    await db.insert(orgUpdateRelevance).values({
-      orgId,
-      updateId: id,
-      impactScore: '0',
-      feedback: parsed.data.feedback,
-    });
-  }
+    if (existing.length > 0) {
+      await tx
+        .update(orgUpdateRelevance)
+        .set({ feedback: parsed.data.feedback })
+        .where(and(eq(orgUpdateRelevance.orgId, orgId), eq(orgUpdateRelevance.updateId, id)));
+    } else {
+      await tx.insert(orgUpdateRelevance).values({
+        orgId,
+        updateId: id,
+        impactScore: '0',
+        feedback: parsed.data.feedback,
+      });
+    }
 
-  await writeAudit({
-    actor_id: session.user.id,
-    action: 'message.feedback',
-    resource_type: 'regulatory_update',
-    resource_id: id,
-    meta_json: { feedbackType: parsed.data.feedback },
+    await writeAudit(
+      {
+        actor_id: session.user.id,
+        action: 'message.feedback',
+        resource_type: 'regulatory_update',
+        resource_id: id,
+        meta_json: { feedbackType: parsed.data.feedback },
+      },
+      tx,
+    );
   });
 
   return Response.json({ ok: true });

--- a/app/api/ra/workflows/submission-drafter/route.ts
+++ b/app/api/ra/workflows/submission-drafter/route.ts
@@ -34,32 +34,39 @@ async function postSubmissionDrafter(request: Request, session: AuthSession): Pr
   // @MX:SPEC SPEC-REGULA-RELEASE-HARDENING-001 (REQ-HARDEN-028)
   const isMock = true; // Beta scaffold: all steps are mock implementations
 
-  await db
-    .insert(workflowRuns)
-    .values({
-      id: runId,
-      userId: session.user.id,
-      organizationId,
-      projectId: data.project_id,
-      workflowType: 'submission_drafter',
-      status: 'queued',
-      inputJson: data,
-      resultJson: null,
-      stepProgress: null,
-      reviewRequired: true,
-    })
-    .returning();
+  // 21 CFR Part 11 §11.10(e) — Issue #378: INSERT + audit ride the same
+  // db.transaction so a failure between them rolls back both.
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(workflowRuns)
+      .values({
+        id: runId,
+        userId: session.user.id,
+        organizationId,
+        projectId: data.project_id,
+        workflowType: 'submission_drafter',
+        status: 'queued',
+        inputJson: data,
+        resultJson: null,
+        stepProgress: null,
+        reviewRequired: true,
+      })
+      .returning();
 
-  await writeAudit({
-    actor_id: session.user.id,
-    action: 'workflow.start',
-    resource_type: 'workflow',
-    resource_id: runId,
-    meta_json: {
-      workflowType: 'submission_drafter',
-      mock_data: isMock,
-      workflow_run_id: runId,
-    },
+    await writeAudit(
+      {
+        actor_id: session.user.id,
+        action: 'workflow.start',
+        resource_type: 'workflow',
+        resource_id: runId,
+        meta_json: {
+          workflowType: 'submission_drafter',
+          mock_data: isMock,
+          workflow_run_id: runId,
+        },
+      },
+      tx,
+    );
   });
 
   return Response.json(

--- a/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
+++ b/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
@@ -196,3 +196,43 @@ generateWeeklyDigest(lib/digest/digest-generator.ts)는 내부 `withTenantScope`
 - **app/api/ra 잔여 12곳**: consult(2) · expert-review(2) · knowledge-sources(2) · projects(2) · updates/feedback · workflows/submission-drafter · admin/documents/upload(2)
 - **app/api non-ra 8곳 + lib Priority Medium ~15곳**
 - **구조적**: enqueueActionItems tx 시그니처 + digest:42 withTenantScope 통합 + AuditDbHandle 전사 전환
+
+---
+
+## 11. PR-C (#378) — app/api/ra 복합 9 route / writeAudit 10곳 tx 래핑
+
+PR-A/B/B-lib 연속. app/api/ra 잔여 복합 라우트 직돀 + tx 래핑.
+
+### tx 래핑 (analyzer.ts:67-103 패턴, 9 route)
+| route | mutation | audit action |
+|---|---|---|
+| expert-review POST | INSERT expertReviews | expert_review.flag |
+| expert-review/[id] PATCH | UPDATE expertReviews | expert_review.assign / resolve |
+| knowledge-sources POST | INSERT knowledgeSources | knowledge_source.created |
+| knowledge-sources/[id] DELETE | DELETE knowledgeSources | knowledge_source.deleted |
+| projects POST | INSERT projects | project.create |
+| projects/[id] PATCH | UPDATE projects | project.update |
+| workflows/submission-drafter POST | INSERT workflowRuns | workflow.start |
+| updates/[id]/feedback POST | UPSERT orgUpdateRelevance | message.feedback |
+| admin/documents/upload POST | sourceSections INSERT + document.upload/chunk audit → 동일 tx 통합 | document.upload, document.chunk |
+
+각 라우트 `db.transaction(async (tx) => { tx.MUTATION; writeAudit({...}, tx); })` 래핑. 동작 보존(return null + caller 500/404, throw 회귀 없음). admin upload는 setPendingReviewOnIngest(별도 best-effort 경계, 에러 swallow)를 atomic persist+audit 이후로 정리.
+
+### 안전 분류 (수정 없음)
+- **consult/route.ts** (writeAudit:206,227): `audit-check-ignore` 주석 + E2E_TEST_MODE 전용. lib/ai/consult.ts(llm.call:274 / source.access:371 / expert_review.flag auto:604 / consult.expert_review_auto_flag:658)의 audit 원자성은 PR-D/E(lib 도메인)로 이월.
+- **admin upload :86** (corpus.ingestion_blocked): audit-only 거부 audit (mutation 없음).
+
+### 이슈 전제 정정 (L-013)
+- "admin/documents/upload(2)" → 실제 경로 `app/api/ra/admin/documents/upload/route.ts` (app/api/admin 아님)
+- workflows 나머지(audit-response / cer / indication-impact / pccp)는 PR-C 범위 밖 — cer는 이미 tx 패턴 직검 확인, 나머지 3종은 별도 직돀 필요(후속)
+
+### 검증
+- typecheck 0 · lint 0(lint:hex OK) · full vitest **4786 passed**(회귀 0, frontend-shell 플래키 1건 무관)
+- ci:* 9종 PASS(audit / rbac / format / migrations / tokens / i18n / glossary / contrast / module-boundaries)
+- 테스트 4종 db.transaction mock + writeAudit 2인자 단언 보정(expert-review 2종 / submission-drafter / docingest)
+
+### 잔여 후보 (후속 PR-D/E 대상)
+- **app/api/ra**: consult route 안전 분류 완료 → **잔여 0곳**(lib/ai/consult.ts audit 원자성은 lib 도메인)
+- **app/api non-ra 8곳**: auth/change-password, auth/signup, classify/run(2), rlhf/feedback(2), admin/users, knowledge-gap/classify
+- **lib Priority Medium ~15곳**: radar/delta-sync(orchestrator 4 + ingest), knowledge-gap(detector / owning-issue 2 / replay), knowledge-sources/sync(2), ai/consult(4곳), model-governance/rlhf-gate, rlhf/calibration-proposal, standards/alert-pipeline, inngest/knowledge-sources/orphan-cleanup
+- **구조적(PR-E)**: enqueueActionItems tx 시그니처 + AuditDbHandle duck-typing 전사 전환

--- a/tests/integration/api/expert-review-api.test.ts
+++ b/tests/integration/api/expert-review-api.test.ts
@@ -63,6 +63,11 @@ vi.mock('@/lib/db/client', () => ({
     insert: vi.fn(() => mockInsertChain),
     select: vi.fn(() => mockSelectChain),
     update: vi.fn(() => mockUpdateChain),
+    // Issue #378: route wraps INSERT/UPDATE + audit in db.transaction; the tx
+    // callback reuses the same mock chains so returning assertions still hold.
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb({ insert: vi.fn(() => mockInsertChain), update: vi.fn(() => mockUpdateChain) }),
+    ),
   },
 }));
 

--- a/tests/integration/docingest-e2e.test.ts
+++ b/tests/integration/docingest-e2e.test.ts
@@ -153,11 +153,14 @@ describe('Document Ingestion E2E (REQ-QUAL-015..019)', () => {
     expect(body.sectionCount).toBeGreaterThanOrEqual(1);
 
     expect(embedChunksMock).toHaveBeenCalledOnce();
+    // Issue #378: writeAudit now receives the tx handle as its 2nd arg.
     expect(writeAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'document.upload' }),
+      expect.anything(),
     );
     expect(writeAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'document.chunk' }),
+      expect.anything(),
     );
   });
 

--- a/tests/unit/api/expert-review-route.test.ts
+++ b/tests/unit/api/expert-review-route.test.ts
@@ -63,6 +63,11 @@ const mockDb = {
   insert: vi.fn(() => mockInsertChain),
   select: vi.fn(() => makeSelectChain(selectResults.shift() ?? [])),
   update: vi.fn(() => mockUpdateChain),
+  // Issue #378: route wraps INSERT/UPDATE + audit in db.transaction; tx reuses
+  // the same insert/update chains so assertions still hold.
+  transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb({ insert: vi.fn(() => mockInsertChain), update: vi.fn(() => mockUpdateChain) }),
+  ),
 };
 
 vi.mock('@/lib/db/client', () => ({ db: mockDb }));
@@ -183,6 +188,7 @@ describe('POST /api/ra/expert-review — create', () => {
         resource_type: 'message',
         resource_id: 'msg-001',
       }),
+      expect.anything(),
     );
   });
 });

--- a/tests/unit/api/workflows/submission-drafter.test.ts
+++ b/tests/unit/api/workflows/submission-drafter.test.ts
@@ -41,6 +41,11 @@ vi.mock('@/lib/auth/with-permission', () => ({
 vi.mock('@/lib/db/client', () => ({
   db: {
     insert: dbMocks.insert,
+    // Issue #378: route wraps INSERT + audit in db.transaction; tx reuses the
+    // same insert chain so the values assertion still holds.
+    transaction: vi.fn(async (cb: (tx: { insert: typeof dbMocks.insert }) => Promise<unknown>) =>
+      cb({ insert: dbMocks.insert }),
+    ),
     query: {
       workflowRuns: {
         findFirst: dbMocks.findFirst,


### PR DESCRIPTION
## 개요

#378 (writeAudit tx 원자성 — 21 CFR Part 11 §11.10(e)) PR-C. PR-A/B/B-lib(#379/#380/#381) 연속 작업으로 app/api/ra 잔여 복합 라우트 9곳의 mutation + writeAudit을 동일 `db.transaction`으로 래핑 — mutation 성공 후 audit 실패로 인한 orphan audit row를 원천 차단.

## 구현 (analyzer.ts:67-103 패턴, 동작 보존)

| route | mutation | audit action |
|---|---|---|
| expert-review POST | INSERT expertReviews | expert_review.flag |
| expert-review/[id] PATCH | UPDATE expertReviews | expert_review.assign / resolve |
| knowledge-sources POST | INSERT knowledgeSources | knowledge_source.created |
| knowledge-sources/[id] DELETE | DELETE knowledgeSources | knowledge_source.deleted |
| projects POST | INSERT projects | project.create |
| projects/[id] PATCH | UPDATE projects | project.update |
| workflows/submission-drafter POST | INSERT workflowRuns | workflow.start |
| updates/[id]/feedback POST | UPSERT orgUpdateRelevance | message.feedback |
| admin/documents/upload POST | sourceSections INSERT + document.upload/chunk audit → 동일 persist tx 통합 | document.upload, document.chunk |

- `db.transaction(async (tx) => { tx.MUTATION; writeAudit({...}, tx); })` 래핑
- return null + caller 500/404 (throw 회귀 없음, PR-A 교훈 반영)
- admin upload: `setPendingReviewOnIngest`는 별도 best-effort 경계(에러 swallow 의도적)로, atomic persist+audit 이후로 정리 — audit 실패를 mask하지 않도록

## 안전 분류 (수정 없음)

- **consult/route.ts** (writeAudit:206,227): `audit-check-ignore` 주석 + E2E_TEST_MODE 전용. lib/ai/consult.ts(llm.call / source.access / expert_review auto-flag)의 audit 원자성은 PR-D/E(lib 도메인)로 이월.
- **admin upload :86** (corpus.ingestion_blocked): audit-only 거부 audit (mutation 없음).

## 이슈 전제 정정 (L-013)

- "admin/documents/upload(2)" → 실제 경로 `app/api/ra/admin/documents/upload/route.ts` (`app/api/admin` 아님)
- workflows 나머지(audit-response / cer / indication-impact / pccp)는 PR-C 범위 밖 — cer는 이미 tx 패턴 직검 확인, 나머지 3종은 별도 직돀 필요(후속)

## 게이트 직검 (orchestrator, L-007/008/009/013/015)

- typecheck **0** / lint(biome + lint:hex) **0 errors** / full test **4786 passed** (회귀 0, frontend-shell REQ-FND-012 metadata timeout 1건은 사전존재 flaky — 단독 19/19 통과, 무관)
- ci:* **9종 PASS** (audit / rbac / format / migrations / tokens / i18n / glossary / contrast / module-boundaries)
- 테스트 4종 보정: db.transaction mock 체인 + writeAudit 2인자(tx) 단언 `expect.anything()` (expert-review-api / expert-review-route / submission-drafter / docingest-e2e)

## evaluator-active 독립 검토 → APPROVE

Functionality 95 / Security 100 / Craft 90 / Consistency 95. Critical/High/Medium/Low 전부 0 — fix 불필요. 모든 9 route가 analyzer.ts 참조 패턴과 일관, 행동 보존(status code / response body / error semantics), unsafe cast 없음.

## 진척

#378 전체 58곳 중 **25곳 완료** (impact 1 + PR-A 6 + PR-B 7 + PR-B-lib 2 + PR-C 9). **잔여 33곳** → PR-D/E.

Refs #378

🗿 MoAI <email@mo.ai.kr>