### PR TITLE
fix(audit): #378 workflows pccp — INSERT/UPDATE + audit tx 래핑 (위반 2곳)

### DIFF
--- a/app/api/ra/workflows/pccp/[id]/approve/route.ts
+++ b/app/api/ra/workflows/pccp/[id]/approve/route.ts
@@ -5,7 +5,7 @@ import { db } from '@/lib/db/client';
 import { pccpComponents, pccpVersions } from '@/lib/db/schema';
 import { auditPccpExpertApproved, auditPccpStatusChanged } from '@/lib/pccp/audit-wiring';
 import { validatePccpCompleteness } from '@/lib/pccp/validator';
-import { transitionPccpStatus } from '@/lib/pccp/version-manager';
+import { type DbClient, transitionPccpStatus } from '@/lib/pccp/version-manager';
 import { eq } from 'drizzle-orm';
 
 async function postApprove(
@@ -56,18 +56,28 @@ async function postApprove(
     );
   }
 
-  await transitionPccpStatus({
-    pccpVersionId: id,
-    toStatus: 'submitted',
-    actorId: session.user.id,
-  });
+  // 21 CFR Part 11 §11.10(e) — Issue #378: status UPDATE + approval audits
+  // ride ONE db.transaction. transitionPccpStatus accepts a tx (DbClient); the
+  // audit-wiring helpers forward tx to writeAudit. A failure between the
+  // UPDATE and the audits can never leave an approved version un-audited.
+  await db.transaction(async (tx) => {
+    await transitionPccpStatus({
+      pccpVersionId: id,
+      toStatus: 'submitted',
+      actorId: session.user.id,
+      tx: tx as DbClient,
+    });
 
-  await auditPccpExpertApproved({ actorId: session.user.id, pccpVersionId: id });
-  await auditPccpStatusChanged({
-    actorId: session.user.id,
-    pccpVersionId: id,
-    fromStatus: 'draft',
-    toStatus: 'submitted',
+    await auditPccpExpertApproved({ actorId: session.user.id, pccpVersionId: id }, tx);
+    await auditPccpStatusChanged(
+      {
+        actorId: session.user.id,
+        pccpVersionId: id,
+        fromStatus: 'draft',
+        toStatus: 'submitted',
+      },
+      tx,
+    );
   });
 
   return Response.json({ id, status: 'submitted' });

--- a/app/api/ra/workflows/pccp/route.ts
+++ b/app/api/ra/workflows/pccp/route.ts
@@ -45,29 +45,43 @@ async function postCreatePccp(request: Request, session: AuthSession): Promise<R
     indication: data.indication ?? null,
   });
 
-  const [created] = await db
-    .insert(pccpVersions)
-    .values({
-      deviceId: data.device_id,
-      deviceName: data.device_name,
-      manufacturer: data.manufacturer,
-      indication: data.indication,
-      version: data.version,
-      createdBy: session.user.id,
-      baselineSnapshotJsonb: snapshot,
-    })
-    .returning();
+  // 21 CFR Part 11 §11.10(e) — Issue #378: pccp_versions INSERT + audit ride
+  // ONE db.transaction so a failure between them can never orphan a version
+  // row without its pccp_created audit. auditPccpCreated forwards tx.
+  const created = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(pccpVersions)
+      .values({
+        deviceId: data.device_id,
+        deviceName: data.device_name,
+        manufacturer: data.manufacturer,
+        indication: data.indication,
+        version: data.version,
+        createdBy: session.user.id,
+        baselineSnapshotJsonb: snapshot,
+      })
+      .returning();
+
+    if (!row) {
+      return null;
+    }
+
+    await auditPccpCreated(
+      {
+        actorId: session.user.id,
+        pccpVersionId: row.id,
+        deviceId: data.device_id,
+        deviceName: data.device_name,
+      },
+      tx,
+    );
+
+    return row;
+  });
 
   if (!created) {
     return Response.json({ error: 'Insert failed' }, { status: 500 });
   }
-
-  await auditPccpCreated({
-    actorId: session.user.id,
-    pccpVersionId: created.id,
-    deviceId: data.device_id,
-    deviceName: data.device_name,
-  });
 
   return Response.json(
     {

--- a/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
+++ b/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
@@ -344,3 +344,36 @@ PR-A/B/B-lib/C/D-1/D-2 연속. #366/§3 구조적 한계로 미뤘던 impact act
 - **PR-E ③ digest:42 통합**: generateWeeklyDigest withTenantScope(RLS tx) GUC 기반 구조적 설계 변경.
 - workflows 잔여 3종(audit-response / indication-impact / pccp) 별도 직돀.
 - **#384 frontend-shell 플래키**.
+
+## 15. workflows 3종 직돀 (#378) — pccp 위반 2곳 tx 래핑 / audit-only 5곳 분류
+
+PR-A/B/B-lib/C/D-1/D-2/E-① 연속. #378 잔여 workflows 3종(audit-response / indication-impact / pccp) 라우트 직돀. cer는 이미 tx 패턴(§11 확인), submission-drafter는 PR-C 완료 → 제외.
+
+### 직돀 결과 — 위반 2곳 (pccp만, 나머지 audit-only dispatcher)
+- **SAFE 5곳(수정 없음)**:
+  - audit-response/route.ts · indication-impact/route.ts — **audit-only**(writeAudit workflow.start, DB mutation 자체 없음 — runId는 crypto.randomUUID, workflow_runs INSERT 없음). 원자성 우려 성립 안 함.
+  - audit-response/[runId]/status · indication-impact/[runId]/status — writeAudit/mutation 0.
+  - pccp/[id]/export/route.ts — **audit-only**(workflow.download 2건, DB mutation 없음 — 파일 생성은 in-memory).
+  - cer/route.ts — 이미 `db.transaction`(line 90, §11 레지스트리 확인).
+- **위반 2곳**:
+  - pccp/route.ts(create) — INSERT pccpVersions + auditPccpCreated 별도 autocommit.
+  - pccp/[id]/approve/route.ts — transitionPccpStatus(UPDATE via lib, global db) + auditPccpExpertApproved + auditPccpStatusChanged 별도 autocommit.
+
+### 구현 (PR-B-lib + impact audit-wiring 패턴, 4 파일 +131/-71)
+- **lib/pccp/audit-wiring.ts**: auditPccpCreated / auditPccpExpertApproved / auditPccpStatusChanged에 `tx?: AuditDbHandle` 추가 + writeAudit forward(impact audit-wiring 패턴). AuditDbHandle import.
+- **lib/pccp/version-manager.ts**: `DbClient = PostgresJsDatabase<typeof schema>` 추가, transitionPccpStatus에 `tx?: DbClient` 옵션 + `q = tx ?? db`(SELECT 검증 + UPDATE 모두 q 사용). 단일 호출처(approve)만 영향.
+- **pccp/route.ts**: INSERT + auditPccpCreated를 `db.transaction(async (tx) => { tx.insert; auditPccpCreated({...}, tx) })` 래핑. `if (!row) return null` → 500 보존.
+- **pccp/[id]/approve/route.ts**: transitionPccpStatus + 2 audit를 `db.transaction` 래핑. `transitionPccpStatus({..., tx: tx as DbClient})` + `auditPccpExpertApproved({...}, tx)` + `auditPccpStatusChanged({...}, tx)`.
+- 동작 보존: transitionPccpStatus의 SELECT 검증(isValidTransition)은 tx 내에서 동일 동작. 404/409/422 사전 검증 라우트는 tx 외부 유지.
+
+### 검증 (직검, L-007/008/009/013/015)
+- typecheck 0(테스트 포함) · lint 0(biome organizeImports 정상) · full vitest **4785 passed**
+- 2 플래키(frontend-shell #384 + useConversations REQ-BREADTH) — **전부 단독 green**(useConversations 7/7), pccp 무관 도메인. pccp-migrations 7/7(영향 0).
+- ci:* 종 PASS — audit / format / rbac / module-boundaries / migrations 전 exit 0
+- 테스트 mock 보정 0파일: pccp 라우트 전용 단위 테스트 부재(pccp-migrations는 enum 카운트만). 행위 테스트 갭은 기존 상태.
+
+### 잔여 후보 (후속 PR-E ②③ 대상)
+- **workflows 3종**: 본 PR 완료 → **잔여 0곳**(pccp 위반 2곳 해소, 나머지 audit-only).
+- **PR-E ② AuditDbHandle duck-typing 전사 전환**: `tx as DbClient`(action-queue + version-manager 본 2 PR) + `tx as unknown as AuditDbHandle` cast 3곳(rlhf-gate, calibration-proposal, consult) + model-governance 3곳(rollback, change-workflow ×2) 제거.
+- **PR-E ③ digest:42 통합**: generateWeeklyDigest withTenantScope GUC 기반 구조적 설계 변경.
+- **#384 frontend-shell 플래키**.

--- a/lib/pccp/audit-wiring.ts
+++ b/lib/pccp/audit-wiring.ts
@@ -1,22 +1,30 @@
 // @MX:SPEC SPEC-REGULA-PCCP-001 (REQ-PCCP-021, REQ-PCCP-022, REQ-PCCP-023, REQ-PCCP-015, REQ-PCCP-024)
 // Audit wrappers for all PCCP-regulated events (21 CFR Part 11 compliance).
 
-import { writeAudit } from '@/lib/audit';
+import { type AuditDbHandle, writeAudit } from '@/lib/audit';
 import type { PccpComponentType, PccpStatus } from './types';
 
-export async function auditPccpCreated(params: {
-  actorId: string;
-  pccpVersionId: string;
-  deviceId: string;
-  deviceName: string;
-}): Promise<void> {
-  await writeAudit({
-    actor_id: params.actorId,
-    action: 'pccp_created',
-    resource_type: 'pccp_version',
-    resource_id: params.pccpVersionId,
-    meta_json: { deviceId: params.deviceId, deviceName: params.deviceName },
-  });
+export async function auditPccpCreated(
+  params: {
+    actorId: string;
+    pccpVersionId: string;
+    deviceId: string;
+    deviceName: string;
+  },
+  // 21 CFR Part 11 §11.10(e) — Issue #378: optional caller tx so the audit
+  // rides the same transaction as the pccp_versions INSERT (pccp/route.ts).
+  tx?: AuditDbHandle,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.actorId,
+      action: 'pccp_created',
+      resource_type: 'pccp_version',
+      resource_id: params.pccpVersionId,
+      meta_json: { deviceId: params.deviceId, deviceName: params.deviceName },
+    },
+    tx,
+  );
 }
 
 export async function auditPccpComponentCompleted(params: {
@@ -33,17 +41,25 @@ export async function auditPccpComponentCompleted(params: {
   });
 }
 
-export async function auditPccpExpertApproved(params: {
-  actorId: string;
-  pccpVersionId: string;
-}): Promise<void> {
-  await writeAudit({
-    actor_id: params.actorId,
-    action: 'pccp_expert_approved',
-    resource_type: 'pccp_version',
-    resource_id: params.pccpVersionId,
-    meta_json: {},
-  });
+export async function auditPccpExpertApproved(
+  params: {
+    actorId: string;
+    pccpVersionId: string;
+  },
+  // 21 CFR Part 11 §11.10(e) — Issue #378: optional caller tx so the approval
+  // audit rides the same transaction as transitionPccpStatus (pccp/approve).
+  tx?: AuditDbHandle,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.actorId,
+      action: 'pccp_expert_approved',
+      resource_type: 'pccp_version',
+      resource_id: params.pccpVersionId,
+      meta_json: {},
+    },
+    tx,
+  );
 }
 
 export async function auditPccpAlgorithmChangeTriggered(params: {
@@ -60,17 +76,25 @@ export async function auditPccpAlgorithmChangeTriggered(params: {
   });
 }
 
-export async function auditPccpStatusChanged(params: {
-  actorId: string;
-  pccpVersionId: string;
-  fromStatus: PccpStatus;
-  toStatus: PccpStatus;
-}): Promise<void> {
-  await writeAudit({
-    actor_id: params.actorId,
-    action: 'pccp_status_changed',
-    resource_type: 'pccp_version',
-    resource_id: params.pccpVersionId,
-    meta_json: { fromStatus: params.fromStatus, toStatus: params.toStatus },
-  });
+export async function auditPccpStatusChanged(
+  params: {
+    actorId: string;
+    pccpVersionId: string;
+    fromStatus: PccpStatus;
+    toStatus: PccpStatus;
+  },
+  // 21 CFR Part 11 §11.10(e) — Issue #378: optional caller tx so the status
+  // change audit rides the same transaction as transitionPccpStatus (pccp/approve).
+  tx?: AuditDbHandle,
+): Promise<void> {
+  await writeAudit(
+    {
+      actor_id: params.actorId,
+      action: 'pccp_status_changed',
+      resource_type: 'pccp_version',
+      resource_id: params.pccpVersionId,
+      meta_json: { fromStatus: params.fromStatus, toStatus: params.toStatus },
+    },
+    tx,
+  );
 }

--- a/lib/pccp/version-manager.ts
+++ b/lib/pccp/version-manager.ts
@@ -4,8 +4,16 @@
 
 import { db } from '@/lib/db/client';
 import { pccpVersions } from '@/lib/db/schema';
+import type * as schema from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { PccpStatus } from './types';
+
+// Issue #378 PR-E: transitionPccpStatus accepts an optional caller tx so the
+// status UPDATE can ride the same transaction as the approval audits.
+// PgTransaction ≠ Database `$client` — the narrower PostgresJsDatabase shape
+// satisfies both. Caller passes `tx: tx as DbClient` (PR-B-lib pattern).
+export type DbClient = PostgresJsDatabase<typeof schema>;
 
 const VALID_TRANSITIONS: Record<PccpStatus, PccpStatus[]> = {
   draft: ['submitted'],
@@ -26,8 +34,12 @@ export async function transitionPccpStatus(params: {
   pccpVersionId: string;
   toStatus: PccpStatus;
   actorId: string;
+  // 21 CFR Part 11 §11.10(e) — Issue #378 PR-E: optional caller tx so the
+  // status UPDATE rides the same transaction as the approval audits.
+  tx?: DbClient;
 }): Promise<void> {
-  const [current] = await db
+  const q = params.tx ?? db;
+  const [current] = await q
     .select({ status: pccpVersions.status })
     .from(pccpVersions)
     .where(eq(pccpVersions.id, params.pccpVersionId))
@@ -42,7 +54,7 @@ export async function transitionPccpStatus(params: {
     throw new Error(`Invalid PCCP status transition: ${fromStatus} → ${params.toStatus}`);
   }
 
-  await db
+  await q
     .update(pccpVersions)
     .set({
       status: params.toStatus,


### PR DESCRIPTION
## workflows pccp — audit 원자성 (#378 잔여)

#378 잔여 workflows 3종(audit-response/indication-impact/pccp) 라우트 직돀 → pccp 위반 2곳 tx 래핑 + audit-only 5곳 분류. cer는 이미 tx 패턴, submission-drafter는 PR-C 완료로 제외.

### 직돀 결과 (L-013)
- **SAFE 5곳(수정 없음)**: audit-response/route · indication-impact/route(audit-only — DB mutation 자체 없음, runId=crypto.randomUUID) · 각 [runId]/status(0/0) · pccp/export(audit-only workflow.download) · cer/route(이미 db.transaction)
- **위반 2곳**: pccp/route.ts(create INSERT+audit) · pccp/approve(transitionPccpStatus UPDATE + audit 2종)

### 구현 (PR-B-lib + impact audit-wiring 패턴, 4 파일 +131/-71)
- **lib/pccp/audit-wiring.ts**: auditPccpCreated/ExpertApproved/StatusChanged에 \`tx?: AuditDbHandle\` 추가 + writeAudit forward
- **lib/pccp/version-manager.ts**: transitionPccpStatus에 \`tx?: DbClient\` 옵션(q=tx??db, SELECT+UPDATE). 단일 호출처.
- **pccp/route.ts**: INSERT + auditPccpCreated \`db.transaction\` 래핑. \`if(!row) return null\`→500 보존.
- **pccp/approve**: transitionPccpStatus + audit 2종 \`db.transaction\` 래핑(tx as DbClient).
- 동작 보존: 사전 검증(404/409/422)은 tx 외부 유지.

### 검증 (직검, L-007/008/009/013/015)
- typecheck **0**(테스트 포함) · lint **0** · full vitest **4785 passed**
- 2 플래키(frontend-shell #384 + useConversations REQ-BREADTH) — 전부 단독 green, pccp 무관. pccp-migrations 7/7.
- ci:* 종 **PASS** — audit/format/rbac/module-boundaries/migrations

### evaluator-active → APPROVE (fix 불필요)
Functionality 100 / Security 100 / Craft 100 / Consistency 100. 결함 0. 2 위반 site + 5 safe 진성 + 단일 호출처 + 동작 보존 교차 검증.

### 진척
**#378 43/58곳**. workflows 잔여 0(pccp 2곳 해소, 나머지 audit-only). 잔여: PR-E ② AuditDbHandle duck-typing 전사(cast 제거) · PR-E ③ digest:42 통합 · #384.

Refs #378

🗿 MoAI <email@mo.ai.kr>