### PR TITLE
test(shell): #384 frontend-shell REQ-FND-012 플래키 해소 — import → source-match

### DIFF
--- a/tests/unit/frontend-shell.test.ts
+++ b/tests/unit/frontend-shell.test.ts
@@ -155,12 +155,16 @@ describe('app/layout.tsx — REQ-FND-011, 012, 015, 056', () => {
     expect(source).toMatch(/lang=\{locale\}/);
   });
 
-  it('REQ-FND-012, 056: root metadata sets robots index/follow false', async () => {
-    const mod = await import('../../app/layout');
-    const meta = mod.metadata as { robots?: { index?: boolean; follow?: boolean } };
-    expect(meta.robots?.index).toBe(false);
-    expect(meta.robots?.follow).toBe(false);
-  }, 15_000);
+  it('REQ-FND-012, 056: root metadata sets robots index/follow false', () => {
+    // metadata is a STATIC literal (app/layout.tsx: robots: { index: false, follow: false }).
+    // Source-matched instead of `await import(layout)` because importing the root
+    // layout pulls the heavy app-shell module graph (fonts/providers/observability),
+    // which intermittently exceeded the test timeout under full-suite collect load.
+    // Eliminating the import removes the timeout failure mode entirely (Issue #384).
+    const source = readText('app/layout.tsx');
+    expect(source).toMatch(/robots:\s*\{[^}]*index:\s*false/);
+    expect(source).toMatch(/robots:\s*\{[^}]*follow:\s*false/);
+  });
 
   it('REQ-FND-015: imports next/font/google fonts', async () => {
     const source = readText('app/layout.tsx');


### PR DESCRIPTION
## #384 — frontend-shell 플래키 근본 해소

`frontend-shell.test.ts` REQ-FND-012(root metadata robots)가 full-suite collect 과부하(~320s) 시 \`await import(app/layout)\` heavy 모듈 그래프 로드가 15s testTimeout 초과로 간헐 실패. 단독 19/19 green.

### 근본 fix (test-only, 1파일 +10/-6)
metadata가 정적 리터럴(\`robots: { index: false, follow: false }\`, layout.tsx:51)이므로 REQ-FND-011/015처럼 \`readText\` source-match로 전환. **heavy module import 자체 제거 → 타임아웃 failure mode 원천 불가**(동기 regex 매칭).

\`\`\`diff
- it('...', async () => {
-   const mod = await import('../../app/layout');   // heavy: fonts/providers/observability
-   const meta = mod.metadata as {...};
-   expect(meta.robots?.index).toBe(false);
- }, 15_000);
+ it('...', () => {
+   const source = readText('app/layout.tsx');       // instant, no import
+   expect(source).toMatch(/robots:\s*\{[^}]*index:\s*false/);
+   expect(source).toMatch(/robots:\s*\{[^}]*follow:\s*false/);
+ });
\`\`\`

### 검증
- 단독 19/19 + full vitest **4787 passed 0 failed**(frontend-shell 1767ms, REQ-FND-012 타임아웃 0)
- typecheck 0 · lint 0 · ci:format 0
- **★ 정상 push 성공(pre-push full test 통과)** — #384 해소로 Husky pre-push가 더 이상 본 플래키로 차단 안 함

### 효과
- Husky pre-push(pnpm test) 간헐 차단 해소 → 향후 PR push가 \`--no-verify\` 없이 가능
- #384 플래키 단일 회귀 경로 제거 (DX/CI 안정성)

Fixes #384

🗿 MoAI <email@mo.ai.kr>