### PR TITLE
refactor(audit): #378 PR-E-② AuditDbHandle duck-typing 전사 — cast 10곳 + DbClient 4개 제거

### DIFF
--- a/app/api/ra/messages/[messageId]/signature/revoke/route.ts
+++ b/app/api/ra/messages/[messageId]/signature/revoke/route.ts
@@ -9,7 +9,7 @@ import { writeAudit } from '@/lib/audit';
 import { withPermission } from '@/lib/auth/with-permission';
 import { db } from '@/lib/db/client';
 import { getAuthorizedSignatureMessage } from '@/lib/signature/authorization';
-import { type DbClient, getActiveSignature, revokeSignature } from '@/lib/signature/queries';
+import { getActiveSignature, revokeSignature } from '@/lib/signature/queries';
 
 type RouteCtx = { params: Promise<{ messageId: string }> };
 
@@ -38,7 +38,7 @@ export const POST = withPermission('signature.sign', async (_req, ctx, session) 
 
   // 21 CFR Part 11 §11.10(e) — revoke UPDATE + audit in same db.transaction (Issue #378)
   const revoked = await db.transaction(async (tx) => {
-    const rev = await revokeSignature(existing.id, session.user.id, db, tx as DbClient);
+    const rev = await revokeSignature(existing.id, session.user.id, db, tx);
 
     // Append-only audit entry (REQ-ESIG-007)
     await writeAudit(

--- a/app/api/ra/messages/[messageId]/signature/route.ts
+++ b/app/api/ra/messages/[messageId]/signature/route.ts
@@ -10,7 +10,7 @@ import { db } from '@/lib/db/client';
 import { messageBlocks } from '@/lib/db/schema';
 import { getAuthorizedSignatureMessage } from '@/lib/signature/authorization';
 import { computeAnswerHash } from '@/lib/signature/hash';
-import { type DbClient, getActiveSignature, insertSignature } from '@/lib/signature/queries';
+import { getActiveSignature, insertSignature } from '@/lib/signature/queries';
 import { asc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
@@ -97,7 +97,7 @@ export const POST = withPermission('signature.sign', async (req, ctx, session) =
         recordHash,
       },
       db,
-      tx as DbClient,
+      tx,
     );
 
     // Append-only audit entry (fail-closed)

--- a/app/api/ra/workflows/pccp/[id]/approve/route.ts
+++ b/app/api/ra/workflows/pccp/[id]/approve/route.ts
@@ -57,7 +57,7 @@ async function postApprove(
   }
 
   // 21 CFR Part 11 §11.10(e) — Issue #378: status UPDATE + approval audits
-  // ride ONE db.transaction. transitionPccpStatus accepts a tx (DbClient); the
+  // ride ONE db.transaction. transitionPccpStatus accepts a tx (AuditDbHandle); the
   // audit-wiring helpers forward tx to writeAudit. A failure between the
   // UPDATE and the audits can never leave an approved version un-audited.
   await db.transaction(async (tx) => {

--- a/app/api/ra/workflows/pccp/[id]/approve/route.ts
+++ b/app/api/ra/workflows/pccp/[id]/approve/route.ts
@@ -5,7 +5,7 @@ import { db } from '@/lib/db/client';
 import { pccpComponents, pccpVersions } from '@/lib/db/schema';
 import { auditPccpExpertApproved, auditPccpStatusChanged } from '@/lib/pccp/audit-wiring';
 import { validatePccpCompleteness } from '@/lib/pccp/validator';
-import { type DbClient, transitionPccpStatus } from '@/lib/pccp/version-manager';
+import { transitionPccpStatus } from '@/lib/pccp/version-manager';
 import { eq } from 'drizzle-orm';
 
 async function postApprove(
@@ -65,7 +65,7 @@ async function postApprove(
       pccpVersionId: id,
       toStatus: 'submitted',
       actorId: session.user.id,
-      tx: tx as DbClient,
+      tx: tx,
     });
 
     await auditPccpExpertApproved({ actorId: session.user.id, pccpVersionId: id }, tx);

--- a/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
+++ b/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
@@ -389,7 +389,7 @@ PR-A/B/B-lib/C/D-1/D-2/E-①/workflows 연속. AuditDbHandle를 전사 표준 tx
 ### 구현 (13 파일 +37/-49, net 단순화)
 - **lib/audit.ts AuditDbHandle 확장**: `update` + `delete` 추가 → `{insert; select; update; delete; execute}`. (lib 도메인 함수들이 select/update/delete를 쓰므로 확장 필요. PgTransaction + db singleton 모두 호환.)
 - **`as unknown as AuditDbHandle` 6곳 제거**: rlhf-gate · calibration-proposal · consult(orgId 분기) · model-governance rollback · change-workflow ×2. withTenantScope callback(DrizzleClient) → AuditDbHandle 직접 할당. 미사용 import 정리.
-- **DbClient → AuditDbHandle 통일 (3 lib)**: action-queue · version-manager · signature/queries. `DbClient = PostgresJsDatabase<typeof schema>` 타입 정의 + PostgresJsDatabase/schema-namespace import 제거 → AuditDbHandle import로 대체. lib 함수 db/tx 파라미터 모두 AuditDbHandle.
+- **DbClient → AuditDbHandle 통일 (4 lib)**: action-queue · version-manager · signature/queries · signature/lock(isAnswerLocked). `DbClient = PostgresJsDatabase<typeof schema>` 타입 정의 + PostgresJsDatabase/schema-namespace import 제거 → AuditDbHandle import로 대체. lib 함수 db/tx 파라미터 모두 AuditDbHandle. (lock.ts는 evaluator completeness flag로 추가 — cast 없이 자체 DbClient 정의 사용하던 4번째.)
 - **`as DbClient` 4곳 제거**: analyzer.ts(enqueueActionItems) · pccp/approve(transitionPccpStatus) · signature route · revoke route. PgTransaction → AuditDbHandle 직접 할당. DbClient import 제거.
 
 ### 검증 (직검, L-007/008/009/013/015)

--- a/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
+++ b/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
@@ -377,3 +377,30 @@ PR-A/B/B-lib/C/D-1/D-2/E-① 연속. #378 잔여 workflows 3종(audit-response /
 - **PR-E ② AuditDbHandle duck-typing 전사 전환**: `tx as DbClient`(action-queue + version-manager 본 2 PR) + `tx as unknown as AuditDbHandle` cast 3곳(rlhf-gate, calibration-proposal, consult) + model-governance 3곳(rollback, change-workflow ×2) 제거.
 - **PR-E ③ digest:42 통합**: generateWeeklyDigest withTenantScope GUC 기반 구조적 설계 변경.
 - **#384 frontend-shell 플래키**.
+
+## 16. PR-E-② (#378) — AuditDbHandle duck-typing 전사 전환 (cast 10곳 제거)
+
+PR-A/B/B-lib/C/D-1/D-2/E-①/workflows 연속. AuditDbHandle를 전사 표준 tx 타입으로 승격 → `tx as DbClient` 4곳 + `tx as unknown as AuditDbHandle` 6곳 = **cast 10곳 전부 제거** + 병렬 `DbClient` 타입 3개(action-queue, version-manager, signature/queries) 제거.
+
+### 직돀 핵심 (feasibility 검증)
+- AuditDbHandle 주석이 "PgTransaction provides all three (insert/select/execute) with compatible signatures, ~24 db.transaction sites compatible WITHOUT change" 명시 → cast가 **과보호적(historical)**일 가능성.
+- **실험**: rlhf-gate 1곳 cast 제거 → typecheck EXIT 0 → DrizzleClient(withTenantScope callback)가 AuditDbHandle에 **직접 할당 가능** 확정. 전사 cast 제거 착수.
+
+### 구현 (13 파일 +37/-49, net 단순화)
+- **lib/audit.ts AuditDbHandle 확장**: `update` + `delete` 추가 → `{insert; select; update; delete; execute}`. (lib 도메인 함수들이 select/update/delete를 쓰므로 확장 필요. PgTransaction + db singleton 모두 호환.)
+- **`as unknown as AuditDbHandle` 6곳 제거**: rlhf-gate · calibration-proposal · consult(orgId 분기) · model-governance rollback · change-workflow ×2. withTenantScope callback(DrizzleClient) → AuditDbHandle 직접 할당. 미사용 import 정리.
+- **DbClient → AuditDbHandle 통일 (3 lib)**: action-queue · version-manager · signature/queries. `DbClient = PostgresJsDatabase<typeof schema>` 타입 정의 + PostgresJsDatabase/schema-namespace import 제거 → AuditDbHandle import로 대체. lib 함수 db/tx 파라미터 모두 AuditDbHandle.
+- **`as DbClient` 4곳 제거**: analyzer.ts(enqueueActionItems) · pccp/approve(transitionPccpStatus) · signature route · revoke route. PgTransaction → AuditDbHandle 직접 할당. DbClient import 제거.
+
+### 검증 (직검, L-007/008/009/013/015)
+- typecheck 0(테스트 포함, 2단계 검증: Sub-step A 6 cast → EXIT 0, Sub-step B 통일 → EXIT 0) · lint 0(12 기존 warning 무관, unused import 정리 완료)
+- full vitest **4787 passed 0 failed**(플래키 0 — #384 fix 유지). 타입 전사 통일 회귀 없음.
+- ci:* 종 PASS — audit / format / rbac / module-boundaries / migrations 전 exit 0
+
+### 효과
+- cast 10곳 + 병렬 타입 3개 제거 → 단일 AuditDbHandle duck-type로 tx 전달 통일. 향후 audit-atomicity PR cast 불필요.
+- net -12 LOC(단순화). Part 11 원자성 변경 없음(타입만).
+
+### 잔여 후보 (후속 PR-E ③ 대상)
+- **PR-E ③ digest:42 통합**: generateWeeklyDigest withTenantScope(RLS tx) GUC 기반 구조적 설계 변경 — 마지막 구조적 청크.
+- (참고) #384 플래키는 PR #388로 CLOSED.

--- a/lib/ai/consult.ts
+++ b/lib/ai/consult.ts
@@ -14,7 +14,7 @@ import { eq } from 'drizzle-orm';
 import type { Session } from 'next-auth';
 import type { ConsultRequest } from '../../types/consult';
 import type { SourceItem, StreamEvent, TraceEvent } from '../../types/streaming';
-import { type AuditDbHandle, writeAudit } from '../audit';
+import { writeAudit } from '../audit';
 import { db, withTenantScope } from '../db/client';
 import { conversations, messageBlocks, messages } from '../db/schema';
 import { captureKnowledgeGap, detectKnowledgeGap } from '../knowledge-gap/detector';
@@ -665,7 +665,7 @@ export async function* consult(
                 confidence_score: confidenceScore,
               },
             },
-            dbs as unknown as AuditDbHandle,
+            dbs,
           );
         });
       } else {

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -527,6 +527,14 @@ export interface AuditEvent {
 export type AuditDbHandle = {
   insert: (typeof db)['insert'];
   select: (typeof db)['select'];
+  // Issue #378 PR-E-②: widened to include `update` + `delete` so lib domain
+  // functions (transitionPccpStatus, signature queries, action-queue) accept the
+  // SAME duck-typed handle as writeAudit — eliminating the parallel `DbClient`
+  // type and the `tx as DbClient` / `tx as unknown as AuditDbHandle` casts.
+  // Drizzle PgTransaction + the db singleton both satisfy this shape with
+  // compatible signatures (AC-9), so all call sites are cast-free.
+  update: (typeof db)['update'];
+  delete: (typeof db)['delete'];
   execute: (typeof db)['execute'];
 };
 

--- a/lib/domains/impact/action-queue.ts
+++ b/lib/domains/impact/action-queue.ts
@@ -1,17 +1,8 @@
 // SPEC-REGULA-IMPACT-001 — persist impact action items from scan results.
 
+import type { AuditDbHandle } from '@/lib/audit';
 import { impactActionItems } from '@/lib/db/schema';
-import type * as schema from '@/lib/db/schema';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { AffectedSection, ImpactLevel } from './types';
-
-// Issue #378 PR-E: the impact analyzer wraps action-item INSERTs + their audit
-// rows in ONE db.transaction. PgTransaction is not assignable to the full
-// `Database` type (no `$client`), so we accept the narrower PostgresJsDatabase
-// shape that both the global `db` and a transaction `tx` satisfy. Callers pass
-// `tx as DbClient` (PR-B-lib pattern); AuditDbHandle duck-typing unification
-// (cast removal) is PR-E ②.
-export type DbClient = PostgresJsDatabase<typeof schema>;
 
 interface ActionItemInput {
   assessment_id: string;
@@ -28,11 +19,11 @@ interface ActionItemInput {
  */
 export async function enqueueActionItems(
   input: ActionItemInput,
-  db: DbClient,
+  db: AuditDbHandle,
   // 21 CFR Part 11 §11.10(e) — Issue #378 PR-E: optional caller tx so the
   // action-item INSERTs ride the same transaction as auditActionItemCreated.
   // Omit to keep the historical autocommit behavior (backward compatible).
-  tx?: DbClient,
+  tx?: AuditDbHandle,
 ): Promise<void> {
   const q = tx ?? db;
   if (input.sections.length === 0) {

--- a/lib/domains/impact/analyzer.ts
+++ b/lib/domains/impact/analyzer.ts
@@ -115,8 +115,8 @@ export async function analyzeImpact(req: AnalysisRequest, db: Database): Promise
 
     // 21 CFR Part 11 §11.10(e) — Issue #378 PR-E: action-item INSERTs + their
     // audit rows ride ONE db.transaction. enqueueActionItems now accepts a tx
-    // handle (PgTransaction ≠ Database `$client` resolved via the narrower
-    // DbClient shape — see action-queue.ts). The SELECT-back +
+    // handle (PR-E ② AuditDbHandle duck-type — PgTransaction & db both
+    // assignable without cast). The SELECT-back +
     // auditActionItemCreated use the same tx so a failure between INSERT and
     // audit can never orphan an action item without its audit row. (Action
     // items stay on a separate boundary from the assessment INSERT above — an

--- a/lib/domains/impact/analyzer.ts
+++ b/lib/domains/impact/analyzer.ts
@@ -11,7 +11,7 @@ import {
   regulatoryUpdates,
 } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
-import { type DbClient, enqueueActionItems } from './action-queue';
+import { enqueueActionItems } from './action-queue';
 import {
   auditActionItemCreated,
   auditAssessmentCreated,
@@ -131,7 +131,7 @@ export async function analyzeImpact(req: AnalysisRequest, db: Database): Promise
           summary: result.analysis_summary,
         },
         db,
-        tx as DbClient,
+        tx,
       );
 
       // Count created action items for reporting

--- a/lib/model-governance/change-workflow.ts
+++ b/lib/model-governance/change-workflow.ts
@@ -7,7 +7,7 @@
 //           (approve route, rollback, test fixtures).
 // @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (Issue 71, REQ-MODELGOV-004/005/012/013/014)
 
-import { type AuditDbHandle, writeAudit } from '@/lib/audit';
+import { writeAudit } from '@/lib/audit';
 import { withTenantScope } from '@/lib/db/client';
 import { approvedCombination, changeRequest } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
@@ -220,7 +220,7 @@ export async function approveChangeRequest(params: {
       approverId: params.approverId,
       combinationId: newCombo.id,
       evalResultRef,
-      tx: tx as unknown as AuditDbHandle,
+      tx,
     });
 
     return { combinationId: newCombo.id };
@@ -263,7 +263,7 @@ export async function recordEvalResult(params: {
       score: gate.score,
       threshold: gate.threshold,
       evalRunId: gate.evalRunId,
-      tx: tx as unknown as AuditDbHandle,
+      tx,
     });
 
     return gate;

--- a/lib/model-governance/rlhf-gate.ts
+++ b/lib/model-governance/rlhf-gate.ts
@@ -6,7 +6,7 @@
 //           deferred to a follow-up issue (see @MX:TODO below).
 
 import { createHash } from 'node:crypto';
-import { type AuditDbHandle, writeAudit } from '@/lib/audit';
+import { writeAudit } from '@/lib/audit';
 import { db, withTenantScope } from '@/lib/db/client';
 import { changeRequest } from '@/lib/db/schema';
 
@@ -62,7 +62,7 @@ export async function submitRlhfProposal(params: {
           proposal_text_hash: hashProposalText(params.proposalText),
         },
       },
-      dbs as unknown as AuditDbHandle,
+      dbs,
     );
 
     return { changeRequestId: row.id };

--- a/lib/model-governance/rollback.ts
+++ b/lib/model-governance/rollback.ts
@@ -6,7 +6,6 @@
 //           so the transition is a single transaction. fan_in >= 3 (route, test, audit).
 // @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (Issue 71, REQ-MODELGOV-006, AC-03)
 
-import type { AuditDbHandle } from '@/lib/audit';
 import { withTenantScope } from '@/lib/db/client';
 import { approvedCombination } from '@/lib/db/schema';
 import { and, desc, eq } from 'drizzle-orm';
@@ -101,7 +100,7 @@ export async function rollbackCombination(params: {
       resourceId: targetId,
       fromCombinationId: current.id,
       toCombinationId: targetId,
-      tx: tx as unknown as AuditDbHandle,
+      tx,
     });
 
     return { fromId: current.id, toId: targetId };

--- a/lib/pccp/version-manager.ts
+++ b/lib/pccp/version-manager.ts
@@ -2,18 +2,11 @@
 // PCCP version lifecycle: draft → submitted → cleared → superseded
 // AC-9: only one active version per device — enforced at DB level (partial UNIQUE INDEX).
 
+import type { AuditDbHandle } from '@/lib/audit';
 import { db } from '@/lib/db/client';
 import { pccpVersions } from '@/lib/db/schema';
-import type * as schema from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { PccpStatus } from './types';
-
-// Issue #378 PR-E: transitionPccpStatus accepts an optional caller tx so the
-// status UPDATE can ride the same transaction as the approval audits.
-// PgTransaction ≠ Database `$client` — the narrower PostgresJsDatabase shape
-// satisfies both. Caller passes `tx: tx as DbClient` (PR-B-lib pattern).
-export type DbClient = PostgresJsDatabase<typeof schema>;
 
 const VALID_TRANSITIONS: Record<PccpStatus, PccpStatus[]> = {
   draft: ['submitted'],
@@ -36,7 +29,7 @@ export async function transitionPccpStatus(params: {
   actorId: string;
   // 21 CFR Part 11 §11.10(e) — Issue #378 PR-E: optional caller tx so the
   // status UPDATE rides the same transaction as the approval audits.
-  tx?: DbClient;
+  tx?: AuditDbHandle;
 }): Promise<void> {
   const q = params.tx ?? db;
   const [current] = await q

--- a/lib/rlhf/calibration-proposal.ts
+++ b/lib/rlhf/calibration-proposal.ts
@@ -11,7 +11,7 @@
 // governance review + the #71 MODEL-GOVERNANCE change-control approve path,
 // never here. The detector output is a proposal, not an applied change.
 
-import { type AuditDbHandle, writeAudit } from '@/lib/audit';
+import { writeAudit } from '@/lib/audit';
 import { withTenantScope } from '@/lib/db/client';
 import { calibrationCandidates } from '@/lib/db/schema';
 import type { CalibrationCandidateInput } from './calibration-detector';
@@ -108,7 +108,7 @@ export async function proposeCalibrationCandidate(
           bucket_midpoint: input.bucketMidpoint,
         },
       },
-      tx as unknown as AuditDbHandle,
+      tx,
     );
 
     return row;

--- a/lib/signature/lock.ts
+++ b/lib/signature/lock.ts
@@ -3,13 +3,9 @@
 //            Locking gate for 21 CFR Part 11 §11.70 integrity enforcement.
 // @MX:SPEC SPEC-REGULA-ESIG-001 (REQ-ESIG-003)
 
+import type { AuditDbHandle } from '@/lib/audit';
 import { answerSignatures } from '@/lib/db/schema';
-import type * as schema from '@/lib/db/schema';
-import { isNull } from 'drizzle-orm';
-import { and, eq } from 'drizzle-orm';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-
-type DbClient = PostgresJsDatabase<typeof schema>;
+import { and, eq, isNull } from 'drizzle-orm';
 
 /**
  * Returns true when the given message has an active (non-revoked) electronic signature.
@@ -20,7 +16,7 @@ type DbClient = PostgresJsDatabase<typeof schema>;
  * @param messageId - UUID of the message (answer) to check
  * @param db - Drizzle DB client (injected for testability)
  */
-export async function isAnswerLocked(messageId: string, db: DbClient): Promise<boolean> {
+export async function isAnswerLocked(messageId: string, db: AuditDbHandle): Promise<boolean> {
   const rows = await db
     .select({ id: answerSignatures.id })
     .from(answerSignatures)

--- a/lib/signature/queries.ts
+++ b/lib/signature/queries.ts
@@ -1,12 +1,9 @@
 // @MX:NOTE [AUTO] Signature query helpers — DB access layer for answer_signatures table.
 // @MX:SPEC SPEC-REGULA-ESIG-001 (REQ-ESIG-001, REQ-ESIG-005)
 
+import type { AuditDbHandle } from '@/lib/audit';
 import { answerSignatures } from '@/lib/db/schema';
-import type * as schema from '@/lib/db/schema';
 import { and, eq, isNull } from 'drizzle-orm';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-
-export type DbClient = PostgresJsDatabase<typeof schema>;
 
 export interface SignatureRow {
   id: string;
@@ -35,7 +32,7 @@ export interface InsertSignatureData {
  */
 export async function getActiveSignature(
   messageId: string,
-  db: DbClient,
+  db: AuditDbHandle,
 ): Promise<SignatureRow | null> {
   const rows = await db
     .select()
@@ -50,11 +47,11 @@ export async function getActiveSignature(
  */
 export async function insertSignature(
   data: InsertSignatureData,
-  db: DbClient,
+  db: AuditDbHandle,
   // 21 CFR Part 11 §11.10(e) — optional caller tx so the signature INSERT can
   // ride the same transaction as the route's writeAudit (Issue #378).
   // Omit to keep the historical autocommit behavior (backward compatible).
-  tx?: DbClient,
+  tx?: AuditDbHandle,
 ): Promise<SignatureRow> {
   const q = tx ?? db;
   const rows = await q
@@ -79,10 +76,10 @@ export async function insertSignature(
 export async function revokeSignature(
   signatureId: string,
   revokedBy: string,
-  db: DbClient,
+  db: AuditDbHandle,
   // 21 CFR Part 11 §11.10(e) — optional caller tx so the revoke UPDATE can
   // ride the same transaction as the route's writeAudit (Issue #378).
-  tx?: DbClient,
+  tx?: AuditDbHandle,
 ): Promise<SignatureRow> {
   const q = tx ?? db;
   const rows = await q


### PR DESCRIPTION
## PR-E-② — AuditDbHandle duck-typing 전사 전환 (TYPE-ONLY)

AuditDbHandle를 전사 표준 tx 타입으로 승격. **cast 10곳 전부 제거** + 병렬 **DbClient 타입 4개 제거** → 단일 duck-type으로 tx 전달 통일. Part 11 원자성 변경 없음(타입만), net 단순화.

### 직돀 feasibility (cast가 과보호적이었음)
AuditDbHandle 주석이 "PgTransaction compatible WITHOUT change" 명시. 실험(rlhf-gate 1곳 cast 제거 → typecheck 0)으로 DrizzleClient/PgTransaction 모두 AuditDbHandle **직접 할당 가능** 확정 → cast는 historical 과보호.

### 구현 (15 파일, type-only)
- **lib/audit.ts**: AuditDbHandle 확장 \`{insert; select; update; delete; execute}\` (lib 도메인 함수들이 update/delete를 쓰므로)
- **\`as unknown as AuditDbHandle\` 6곳 제거**: rlhf-gate · calibration-proposal · consult · model-governance rollback · change-workflow ×2
- **DbClient → AuditDbHandle 통일 (4 lib)**: action-queue · version-manager · signature/queries · signature/lock (DbClient 타입 정의 + PostgresJsDatabase/schema import 제거)
- **\`as DbClient\` 4곳 제거**: analyzer · pccp/approve · signature route · revoke route

### 검증 (직검, L-007/008/009/013/015)
- typecheck **0**(테스트 포함, 2단계 검증) · lint **0** · full vitest **4787 passed 0 failed**(회귀 0, 플래키 0)
- ci:* 종 **PASS** — audit/format/rbac/module-boundaries/migrations
- DbClient 타입 정의 전부 제거 확인(grep — 잔존는 comment 내 역사적 언급만)

### evaluator-active → APPROVE (fix 불필요)
Functionality 100 / Security 100 / Craft 95 / Consistency 100. CRITICAL/HIGH 0. no-behavior-change + cast 완전 제거 + import 정리 검증. INFORMATIONAL: lock.ts 4번째 DbClient → 본 PR 보완 커밋으로 통일 완료.

### 진척
#378 잔여 구조적 청크 중 큰 것 완료. 잔여: **PR-E ③ digest:42 통합**(마지막 구조적 청크).

Refs #378

🗿 MoAI <email@mo.ai.kr>