### PR TITLE
fix(audit): #378 PR-E-③ digest:42 통합 — audit를 lib withTenantScope tx 내부로

### DIFF
--- a/__tests__/lib/digest/digest-generator.test.ts
+++ b/__tests__/lib/digest/digest-generator.test.ts
@@ -44,8 +44,10 @@ vi.mock('../../../lib/db/client', () => ({
 }));
 
 // Issue #378 PR-E-③: generateWeeklyDigest now writes digest_generated inside its
-// withTenantScope tx. Mock writeAudit so the structure/counts unit test doesn't
-// hit the real advisory-lock execute path (audit behavior covered elsewhere).
+// withTenantScope tx. Mock writeAudit so this structure/counts unit test doesn't
+// hit the real advisory-lock execute path — writeAudit internals (lock, hash chain)
+// are covered by lib/audit + audit-chain tests; the digest route contract is
+// covered by tests/unit/api/digest-route.test.ts.
 vi.mock('../../../lib/audit', () => ({
   writeAudit: vi.fn().mockResolvedValue(undefined),
 }));

--- a/__tests__/lib/digest/digest-generator.test.ts
+++ b/__tests__/lib/digest/digest-generator.test.ts
@@ -43,6 +43,13 @@ vi.mock('../../../lib/db/client', () => ({
   ),
 }));
 
+// Issue #378 PR-E-③: generateWeeklyDigest now writes digest_generated inside its
+// withTenantScope tx. Mock writeAudit so the structure/counts unit test doesn't
+// hit the real advisory-lock execute path (audit behavior covered elsewhere).
+vi.mock('../../../lib/audit', () => ({
+  writeAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@anthropic-ai/sdk', () => ({
   default: vi.fn().mockImplementation(() => ({
     messages: {

--- a/app/api/ra/digest/generate/route.ts
+++ b/app/api/ra/digest/generate/route.ts
@@ -37,15 +37,10 @@ export const POST = withPermission('dashboard.view', async (req, _ctx, session) 
     );
   }
 
-  const payload = await generateWeeklyDigest(orgId, parsed.data.weekId);
-
-  await writeAudit({
-    actor_id: session.user.id,
-    action: 'digest_generated',
-    resource_type: 'weekly_digest',
-    resource_id: payload.week_id,
-    meta_json: { orgId, updateCount: payload.update_count },
-  });
+  // 21 CFR Part 11 §11.10(e) — Issue #378 PR-E-③: digest_generated audit now
+  // rides generateWeeklyDigest's internal withTenantScope tx (INSERT + audit
+  // atomic). Pass the session user as the audit actor.
+  const payload = await generateWeeklyDigest(orgId, parsed.data.weekId, session.user.id);
 
   if (parsed.data.sendEmail) {
     const prefs = await db

--- a/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
+++ b/docs/audit/writeaudit-tx-atomicity-audit-2026-07-08.md
@@ -404,3 +404,26 @@ PR-A/B/B-lib/C/D-1/D-2/E-①/workflows 연속. AuditDbHandle를 전사 표준 tx
 ### 잔여 후보 (후속 PR-E ③ 대상)
 - **PR-E ③ digest:42 통합**: generateWeeklyDigest withTenantScope(RLS tx) GUC 기반 구조적 설계 변경 — 마지막 구조적 청크.
 - (참고) #384 플래키는 PR #388로 CLOSED.
+
+## 17. PR-E-③ (#378) — digest:42 통합 (audit를 lib withTenantScope tx 내부로)
+
+PR-A/B/B-lib/C/D-1/D-2/E-①/workflows/E-② 연속. #378 마지막 구조적 청크. §10의 "digest:42 audit-only 안전" 분류를 직돀로 **정정**(L-013) → 실제 위반.
+
+### 직돀 정정 (§10 분류 오류)
+- §10은 digest:42를 "route writeAudit(digest_generated)은 audit-only 부수 기록, INSERT는 withTenantScope 원자적"으로 안전 분류.
+- **직돀**: route line 42 `digest_generated` audit는 resource_id=payload.week_id(INSERT된 digest) 기록 → INSERT와 **페어**이지만 **별도 tx**(INSERT는 lib withTenantScope 커밋 후, route는 autocommit) → **위반**. §10 "audit-only" 분류 오류.
+- 추가 발견: Inngest cron(weekly-digest.ts)은 generateWeeklyDigest 호출 후 audit **0건**(누락 — INSERT만, audit 없음).
+
+### 구현 (GUC 기반 통합, 3 파일 +36/-10)
+- **lib/digest/digest-generator.ts**: digest_generated audit를 generateWeeklyDigest 내부 withTenantScope(weeklyDigests upsert와 동일 tx)로 이동. INSERT+audit 원자적. `actorId?: string | null` param 추가(route=user, cron=system null).
+- **app/api/ra/digest/generate/route.ts**: route line 42 audit 제거(이제 lib에서). `generateWeeklyDigest(orgId, weekId, session.user.id)`로 actor 전달.
+- 효과: INSERT+audit 동일 RLS tx 원자적 + cron 경로 audit 누락 해소(system actor). digest:62(emailSentAt+digest_emailed)는 PR-B 래핑으로 이미 안전(변경 없음).
+- **테스트**: digest-generator.test.ts에 writeAudit mock 추가(구조/카운트 단위 테스트 — audit의 advisory-lock execute 경로 회피).
+
+### 검증 (직검, L-007/008/009/013/015)
+- typecheck 0 · lint 0 · full vitest **4787 passed 0 failed**(digest-generator 17/17, 회귀 0, 플래키 0)
+- ci:* 종 PASS — audit/format/rbac/module-boundaries/migrations 전 exit 0
+
+### 진척 — #378 사실상 완결
+- 본 PR로 #378 writeAudit tx 원자성 작업 **완결**: app/api/ra(PR-A/B/C) + non-ra(PR-D-1) + lib Priority Medium(PR-D-2) + 구조적(PR-E-① enqueueActionItems / E-② AuditDbHandle 전사 / E-③ digest 통합) + workflows(pccp) + impact(#366) 전 커버.
+- 잔여: 행위 테스트 보강(evaluator 권고, runImpactAnalysis action-items + pccp create/approve — 커버리지 갭, 회귀 아님).

--- a/lib/digest/digest-generator.ts
+++ b/lib/digest/digest-generator.ts
@@ -6,6 +6,7 @@ import crypto from 'node:crypto';
 import { generateText } from 'ai';
 import { and, desc, eq, gte, lte } from 'drizzle-orm';
 import { getLlmModel } from '../ai/llm-provider';
+import { writeAudit } from '../audit';
 import { withTenantScope } from '../db/client';
 import { orgUpdateRelevance, regulatoryUpdates, weeklyDigests } from '../db/schema';
 import { logger } from '../observability/logger';
@@ -126,7 +127,14 @@ async function generateImpactSummary(update: {
 // @MX:ANCHOR: [AUTO] generateWeeklyDigest — primary entry point for digest compilation
 // @MX:REASON: Called by API route POST /api/ra/digest/generate and Inngest cron stub
 // @MX:SPEC: SPEC-REGULA-DIGEST-001
-export async function generateWeeklyDigest(orgId: string, weekId?: string): Promise<DigestPayload> {
+export async function generateWeeklyDigest(
+  orgId: string,
+  weekId?: string,
+  // 21 CFR Part 11 §11.10(e) — Issue #378 PR-E-③: the digest_generated audit now
+  // rides the SAME withTenantScope tx as the weeklyDigests upsert (below). The
+  // route passes the session user; the Inngest cron omits it (system actor null).
+  actorId?: string | null,
+): Promise<DigestPayload> {
   const targetWeekId = weekId ?? getWeekId(new Date());
   const { start, end } = getWeekBounds(targetWeekId);
 
@@ -244,6 +252,22 @@ export async function generateWeeklyDigest(orgId: string, weekId?: string): Prom
           generatedAt: new Date(),
         },
       });
+
+    // 21 CFR Part 11 §11.10(e) — Issue #378 PR-E-③: digest_generated audit rides
+    // the SAME withTenantScope tx as the weeklyDigests upsert so a crash between
+    // them can never orphan the digest row without its audit. Moved from the
+    // route (which ran it as a separate autocommit). Auditing inside the lib also
+    // covers the Inngest cron path (previously unaudited — system actor null).
+    await writeAudit(
+      {
+        actor_id: actorId ?? null,
+        action: 'digest_generated',
+        resource_type: 'weekly_digest',
+        resource_id: targetWeekId,
+        meta_json: { orgId, updateCount: digestUpdates.length },
+      },
+      dbs,
+    );
   });
 
   // Reconstruct the payload for the return value (token may have been regenerated

--- a/lib/inngest/digest/weekly-digest.ts
+++ b/lib/inngest/digest/weekly-digest.ts
@@ -27,7 +27,11 @@ export async function processDigestPreference({
   sendDigestEmail,
   weekId,
 }: {
-  generateWeeklyDigest: (orgId: string, weekId?: string) => Promise<DigestPayload>;
+  generateWeeklyDigest: (
+    orgId: string,
+    weekId?: string,
+    actorId?: string | null,
+  ) => Promise<DigestPayload>;
   logger: DigestLogger;
   pref: DigestPreference;
   sendDigestEmail: (
@@ -38,6 +42,10 @@ export async function processDigestPreference({
   weekId?: string;
 }): Promise<1> {
   try {
+    // Issue #378 PR-E-③: generateWeeklyDigest writes digest_generated inside its
+    // withTenantScope tx. The cron omits actorId → the audit records actor_id: null
+    // (system actor). Prior to PR-E-③ the cron path wrote NO digest audit (gap);
+    // automated digest generation is now auditable per 21 CFR Part 11 §11.10(e).
     const payload = await generateWeeklyDigest(pref.orgId, weekId);
     if (pref.recipientEmails.length > 0) {
       const sent = await sendDigestEmail(pref.orgId, payload, pref.recipientEmails);


### PR DESCRIPTION
## PR-E-③ — digest:42 통합 (#378 마지막 구조적 청크)

§10 "digest:42 audit-only 안전" 분류를 직돀로 **정정**(L-013) → 실제 위반. route \`digest_generated\` audit가 weeklyDigests INSERT(lib withTenantScope 커밋 후)와 **별도 autocommit**. 추가: Inngest cron은 audit 0건(누락).

### 직돀 정정
- §10은 "route audit은 audit-only 부수 기록" 안전 분류. **직돀**: audit resource_id=payload.week_id(INSERT된 digest) → INSERT와 페어이지만 별도 tx → **위반**.
- cron(weekly-digest.ts)은 generateWeeklyDigest 호출 후 audit **0건**(INSERT만, 누락).

### 구현 (GUC 기반 통합, 3 파일 +36/-10)
- **lib/digest/digest-generator.ts**: digest_generated audit를 generateWeeklyDigest 내부 withTenantScope(weeklyDigests upsert와 동일 tx)로 이동 → INSERT+audit 원자적. \`actorId?: string | null\` param 추가.
- **route**: route audit 제거(이제 lib에서), \`generateWeeklyDigest(orgId, weekId, session.user.id)\`로 actor 전달.
- 효과: INSERT+audit 동일 RLS tx 원자적 + cron 경로 audit 누락 해소(system actor).
- digest:62(emailSentAt+digest_emailed)는 PR-B 래핑으로 이미 안전(변경 없음).
- 테스트: digest-generator.test.ts writeAudit mock 추가(구조/카운트 단위 테스트).

### 검증 (직검)
typecheck 0 · lint 0 · full vitest **4787 passed 0 failed**(digest-generator 17/17, 회귀 0) · ci:* 종 PASS(audit/format/rbac/module-boundaries/migrations).

### #378 완결
본 PR로 #378 writeAudit tx 원자성 작업 **완결**: app/api/ra(PR-A/B/C) + non-ra(PR-D-1) + lib(PR-D-2) + 구조적(PR-E-①②③) + workflows(pccp) + impact(#366) 전 커버. 잔여: 행위 테스트 보강(evaluator 권고, 커버리지 갭 — 회귀 아님).

Refs #378

🗿 MoAI <email@mo.ai.kr>