### PR TITLE
docs(spec): SPEC-REGULA-RLS-SOURCES-001 plan — #317 sources/source_sections RLS 활성화

### DIFF
--- a/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/acceptance.md
+++ b/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/acceptance.md
@@ -1,0 +1,250 @@
+# Acceptance — SPEC-REGULA-RLS-SOURCES-001
+
+> Issue #317 AC1-AC4 매핑 + 카나리 시나리오 + NFR 게이트
+> 모든 시나리오는 Given/When/Then 형식. 검증 명령은 real-DB (regula-test-db) 기준.
+
+---
+
+## 1. AC1 — sources/source_sections RLS 활성화 + FORCE
+
+### AC1-G1 — sources ENABLE + FORCE
+
+**Given** migration 0114가 regula-test-db에 적용되었다
+**When** 다음 쿼리를 실행하면:
+```sql
+SELECT relrowsecurity, relforcerowsecurity
+FROM pg_class WHERE relname = 'sources';
+```
+**Then** 결과가 `(true, true)`이어야 한다 (둘 다 true).
+
+### AC1-G2 — source_sections ENABLE + FORCE
+
+**Given** migration 0114가 regula-test-db에 적용되었다
+**When** 동일한 catalog 쿼리를 `source_sections`에 대해 실행하면
+**Then** 결과가 `(true, true)`이어야 한다.
+
+**검증 명령** (psql 또는 drizzle execute):
+```sql
+SELECT relname, relrowsecurity, relforcerowsecurity
+FROM pg_class
+WHERE relname IN ('sources', 'source_sections');
+```
+
+---
+
+## 2. AC2 — org_id policy USING + WITH CHECK
+
+### AC2-G1 — sources 정책 존재
+
+**Given** migration 0114가 적용되었다
+**When** `SELECT * FROM pg_policy WHERE polname = 'sources_org_isolated'` 실행
+**Then** 정책이 존재하며, `polcmd = '*'` (FOR ALL), `polroles`에 `regula_app`의 OID가 포함되어야 한다.
+
+### AC2-G2 — source_sections 정책 존재 (subquery)
+
+**Given** migration 0114가 적용되었다
+**When** `SELECT * FROM pg_policy WHERE polname = 'source_sections_org_isolated'` 실행
+**Then** 정책이 존재하며, `polqual` (USING)과 `polwithcheck` 모두 `EXISTS (SELECT 1 FROM sources s WHERE s.id = source_sections.source_id AND ...)` 형태를 포함해야 한다.
+
+### AC2-G3 — 카나리: GUC set → 자기 org rows 가시
+
+**Given** 두 org (org-A, org-B)가 각각 sources row를 가지고 있고, `regula_app` role로 세션을 열었다
+**When** 다음을 실행하면:
+```sql
+SET ROLE regula_app;
+SET app.current_org_id = '<org-A-uuid>';
+SELECT count(*) FROM sources WHERE organization_id = '<org-A-uuid>';
+```
+**Then** org-A의 source row count가 반환되어야 한다 (예: 기존 데이터 기준 N행).
+
+### AC2-G4 — 카나리: GUC unset → fail-closed (0행)
+
+**Given** `regula_app` role 세션
+**When** GUC를 설정하지 않고 (또는 org-B로 설정하고) org-A source를 조회하면:
+```sql
+SET ROLE regula_app;
+-- GUC 미설정 상태
+SELECT count(*) FROM sources WHERE organization_id = '<org-A-uuid>';
+```
+**Then** 결과가 `0`이어야 한다 (fail-closed). org-A row는 보이지 않는다.
+
+### AC2-G5 — 카나리: cross-org INSERT WITH CHECK 차단
+
+**Given** `regula_app` role, GUC = org-A
+**When** org-B의 organization_id로 sources에 INSERT를 시도하면:
+```sql
+SET ROLE regula_app;
+SET app.current_org_id = '<org-A-uuid>';
+INSERT INTO sources (id, organization_id, org_label, title, type)
+VALUES (gen_random_uuid(), '<org-B-uuid>', 'B', 'cross-org attempt', 'regulatory');
+```
+**Then** `ERROR: new row violates row-level security policy` 오류로 차단되어야 한다.
+
+### AC2-G6 — 카나리: source_sections GUC set → 자기 org sections 가시
+
+**Given** org-A의 source에 매달린 source_sections row가 존재한다
+**When** `regula_app` role + GUC = org-A로 해당 sections을 조회하면
+**Then** org-A의 sections이 가시적이어야 한다.
+
+### AC2-G7 — 카나리: source_sections cross-org INSERT 차단
+
+**Given** `regula_app` role, GUC = org-A, org-B의 source row가 존재한다
+**When** org-B의 source_id로 source_sections에 INSERT를 시도하면
+**Then** WITH CHECK가 부모 source의 org_id ≠ GUC를 감지하여 차단해야 한다 (`ERROR: new row violates row-level security policy`).
+
+### AC2-G8 — 카나리: NULL-org source 차단 (strict fail-closed 검증)
+
+**Given** synthetic하게 `organization_id IS NULL`인 source row를 삽입한다 (bug 시뮬레이션 — 정책 결정: strict org-match, Fact 7/8/9 기반)
+**When** `regula_app` role + GUC = org-A(어떤 org)로 해당 NULL-org source를 조회하면
+**Then** NULL-org source는 **보이지 않아야 한다** (0행 반환 — strict org-match 정책이 USING에서 차단). 이는 fail-closed defense-in-depth 동작을 검증한다: NULL org_id row는 bug이며, 어떤 org 세션에서도 invisible이어야 한다.
+
+---
+
+## 3. AC3 — retriever/ingestion 경로 카나리
+
+### AC3-G1 — superuser는 RLS unaffected (Fact 3 검증)
+
+**Given** 현재 `DATABASE_URL` = postgres superuser
+**When** GUC 설정 없이 sources/source_sections를 조회하면
+**Then** 모든 row가 가시적이어야 한다 (superuser는 RLS bypass). 이는 런타임 회귀가 0임을 입증 (REQ-RLS-SRC-006).
+
+### AC3-G2 — regula_app 전환 시나리오 시뮬레이션
+
+**Given** `regula_app` role (NOBYPASSRLS)로 세션을 열었다
+**When** 다음 3가지 GUC 상태를 순차적으로 실행하면:
+```sql
+SET ROLE regula_app;
+-- (1) GUC = org-A
+SET app.current_org_id = '<org-A-uuid>'; SELECT count(*) FROM sources;
+-- (2) GUC unset
+RESET app.current_org_id; SELECT count(*) FROM sources;
+-- (3) GUC = org-B (타 org)
+SET app.current_org_id = '<org-B-uuid>'; SELECT count(*) FROM sources;
+```
+**Then**:
+- (1) org-A rows 반환 (strict org-match)
+- (2) `0` (fail-closed — GUC 미설정 시 어떤 row도 보이지 않음)
+- (3) `0` (org-A 관점에서 타 org는 보이지 않음)
+
+### AC3-G3 — ingestion 경로 (withTenantScope 호환)
+
+**Given** `lib/ingest/source-sections-upsert.ts`가 `withTenantScope(orgId)` 내에서 INSERT를 수행한다
+**When** regula_app role 하에서 해당 함수를 호출하면 (또는 동등한 GUC 설정 환경)
+**Then** INSERT가 정상 수행되어야 한다 (GUC = orgId가 부모 source의 org와 일치하므로 WITH CHECK 통과).
+
+### AC3-G4 — retrieval 경로 (withTenantScope 호환)
+
+**Given** `lib/rlhf/retrieval-hook.ts`가 `withTenantScope` 내에서 source_sections SELECT를 수행한다
+**When** regula_app role 하에서 호출하면
+**Then** 자기 org의 sections만 반환되어야 한다 (RLS가 app-level WHERE와 일관되게 동작).
+
+---
+
+## 4. AC4 — migration 0084 누락 진실 원인 문서화
+
+### AC4-G1 — research.md에 진실 원인 기록
+
+**Given** research.md가 존재한다
+**When** research.md §1 Fact 4를 읽으면
+**Then** 다음 진실이 명시되어야 한다:
+1. 0083/0084는 19개 테이블을 대상으로 함 (20개 아님; ingest_jobs는 0017에서 DROP)
+2. sources/source_sections는 0000_init에서 RLS policy 없이 생성됨
+3. 0083/0084는 "기존에 ENABLE+policy가 있는 테이블에 WITH CHECK/FORCE를 붙이는" migration이었으므로, sources/source_sections는 대상 주소록에 없었음 (scope gap, not list omission)
+
+### AC4-G2 — migration 0114 헤더에 AC4 설명
+
+**Given** migrations/0114_*.sql이 존재한다
+**When** 파일 헤더 주석을 읽으면
+**Then** 0084 누락 원인에 대한 1문단 요약이 `@MX:NOTE`와 함께 포함되어야 한다 (AC4 교차 검증 소스).
+
+---
+
+## 5. NFR 시나리오
+
+### NFR-1 — superuser 하에서 기존 테스트 100% 통과
+
+**Given** main branch의 기존 테스트 스위트
+**When** migration 0114 적용 후 `pnpm test`를 실행하면 (superuser 연결)
+**Then** 기존 통과했던 모든 테스트가 동일하게 통과해야 한다 (회귀 0건).
+
+**검증**: `pnpm ci:test` (L-009: full test, 타깃만 아님).
+
+### NFR-2 — real-DB migration 적용 + catalog 직검
+
+**Given** regula-test-db에 migration 0114가 적용되었다
+**When** 다음 catalog 쿼리를 실행하면:
+```sql
+SELECT c.relname, c.relrowsecurity, c.relforcerowsecurity,
+       array_agg(p.polname) AS policies
+FROM pg_class c
+LEFT JOIN pg_policy p ON p.polrelid = c.oid
+WHERE c.relname IN ('sources', 'source_sections')
+GROUP BY c.relname, c.relrowsecurity, c.relforcerowsecurity;
+```
+**Then**:
+- 두 테이블 모두 `relrowsecurity = true`, `relforcerowsecurity = true`
+- `sources`에 `sources_org_isolated` 정책 존재
+- `source_sections`에 `source_sections_org_isolated` 정책 존재
+
+**검증**: `tests/integration/migrations-real-db.test.ts` 확장 또는 신규 real-DB 테스트 (L-010/L-013: textual SQL만으로는 부족, 실DB catalog 직검 필수).
+
+### NFR-3 — 카나리 테스트 regula_app role 독립성
+
+**Given** 카나리 테스트가 `SET ROLE regula_app`으로 수행된다
+**When** 테스트 환경의 기본 role이 `postgres`여도
+**Then** 카나리는 `SET ROLE regula_app` 후 NOBYPASSRLS 동작을 검증해야 한다 (superuser로 fallback하지 않음).
+
+### NFR-5 — Option A subquery 성능 (M3)
+
+**Given** source_sections에 상당한 데이터가 존재한다 (운영 규모 또는 시드 데이터)
+**When** retrieval 쿼리(`WHERE id IN (...)`)에 대해 `EXPLAIN ANALYZE`를 실행하면
+**Then** subquery 정책이 sequential scan을 유발하지 않고, PK/FK 인덱스를 사용해야 한다. P95 지연이 기준치(예: 기존 대비 +50ms 이내)를 초과하지 않아야 한다. — **초과 시 Option B fallback 검토** (research.md §2).
+
+---
+
+## 6. Definition of Done (DoD)
+
+- [ ] migration 0114가 생성되었고, sources/source_sections에 ENABLE + FORCE + org-isolation policy를 포함한다
+- [ ] migration 0114 헤더에 AC4 누락 원인 설명이 있다 (@MX:NOTE)
+- [ ] real-DB (regula-test-db)에 migration이 정상 적용된다 (L-010)
+- [ ] `pg_class`/`pg_policy` catalog 직검으로 ENABLE+FORCE+policy를 확인한다 (L-013, NFR-2)
+- [ ] `tests/integration/rls-sources-real-db.test.ts` (또는 동등)가 AC2-G3~G8, AC3-G2~G4 시나리오를 포함한다
+- [ ] 카나리 테스트는 `regula_app` role (NOBYPASSRLS)로 수행된다 (NFR-3)
+- [ ] 기존 `pnpm test` 100% 통과 (NFR-1)
+- [ ] L-015: `pnpm ci:migrations`, `ci:rbac`, `ci:audit`, `ci:test`, `ci:lint`, `ci:typecheck` 전 단계 로컬 통과
+- [ ] Charter [지양-1~5] 위반 없음 (research.md §1 Fact 7, §2에서 검증)
+- [ ] research.md에 직검 로그 (§5)가 모든 Fact의 file:line 출처를 포함한다
+
+---
+
+## 7. Edge Cases (경계 시나리오)
+
+| 시나리오 | 예상 동작 | 근거 |
+|----------|-----------|------|
+| `organization_id IS NULL` source INSERT (regula_app, GUC set) | WITH CHECK 차단 (`organization_id = GUC` 불일치) | ingestion은 항상 org-scoped (Fact 8) |
+| `organization_id IS NULL` source SELECT (regula_app, GUC set) | strict 정책: 항상 차단 (fail-closed), ingestion은 org-scoped 강제 | Fact 7/8/9 — NULL org_id는 bug |
+| 고아 source_section (부모 source가 삭제 중인 경우) | FK CASCADE가 section을 먼저 삭제하므로 정책 평가 전에 제거 | 0000_init ON DELETE CASCADE |
+| `superseded_by`가 설정된 section | RLS와 무관 (superseded는 비즈니스 로직) — 정책은 그대로 적용 | retrieval-hook.ts가 이미 WHERE로 필터 |
+| system-actor query (orphan-cleanup.ts) | `db` singleton (service role)로 RLS bypass — 본 SPEC과 무관 | research.md Fact 5 |
+
+---
+
+## 8. 품질 게이트 (Quality Gates, L-015)
+
+run phase 종료 전 다음을 로컬에서 직검 (CI green ≠ 전체 green):
+
+```bash
+pnpm ci:migrations      # migration sequence (0114 번호 정합)
+pnpm ci:rbac            # RBAC route matrix (본 SPEC과 무관하나 회귀 확인)
+pnpm ci:audit           # audit completeness
+pnpm ci:lint            # biome lint (lint:hex full)
+pnpm ci:typecheck       # tsc
+pnpm ci:test            # vitest run (full, L-009)
+pnpm ci:coverage        # coverage (85% ratchet, SPEC-REGULA-REALDB-001 게이트)
+```
+
+추가 (real-DB):
+```bash
+DATABASE_URL=postgresql://postgres:test@localhost:5432/regula_test pnpm vitest run tests/integration/rls-sources-real-db.test.ts
+DATABASE_URL=... pnpm vitest run tests/integration/migrations-real-db.test.ts
+```

--- a/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/plan.md
+++ b/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/plan.md
@@ -1,0 +1,262 @@
+# Plan — SPEC-REGULA-RLS-SOURCES-001
+
+> Implementation plan, milestones, file-by-file change list, gates checklist
+> Issue #317 | Branch: `feat/spec-regula-rls-sources-001-plan`
+> 방식: priority-based milestones (시간 추정 안 함, CLAUDE.md §7 Rule 준수)
+
+---
+
+## 1. 구현 접근법 (Technical Approach)
+
+### 1.1 migration 0114 — sources/source_sections RLS 활성화
+
+migration 0099 (knowledge_sources) 패턴을 템플릿으로 사용 (research.md Fact 6):
+
+```sql
+-- migration 0114: sources/source_sections RLS 활성화
+-- AC4: 0084가 누락한 진실 원인 @MX:NOTE 포함
+
+-- §1 sources
+ALTER TABLE sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sources FORCE ROW LEVEL SECURITY;
+
+-- plan-auditor D1: PostgreSQL has no CREATE POLICY IF NOT EXISTS.
+-- DROP IF EXISTS guard makes the migration safe to re-apply (enterprise-migrations
+-- idempotency philosophy). Sibling 0099/0104 omit this; we add it defensively.
+DROP POLICY IF EXISTS sources_org_isolated ON sources;
+CREATE POLICY sources_org_isolated ON sources
+  FOR ALL
+  TO regula_app
+  USING (organization_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (organization_id = current_setting('app.current_org_id', true)::uuid);
+
+-- §2 source_sections (Option A: subquery 정책, research.md §2)
+ALTER TABLE source_sections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE source_sections FORCE ROW LEVEL SECURITY;
+
+-- plan-auditor D1: idempotency guard (see §1).
+DROP POLICY IF EXISTS source_sections_org_isolated ON source_sections;
+CREATE POLICY source_sections_org_isolated ON source_sections
+  FOR ALL
+  TO regula_app
+  USING (
+    EXISTS (
+      SELECT 1 FROM sources s
+      WHERE s.id = source_sections.source_id
+        AND s.organization_id = current_setting('app.current_org_id', true)::uuid
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM sources s
+      WHERE s.id = source_sections.source_id
+        AND s.organization_id = current_setting('app.current_org_id', true)::uuid)
+    )
+  );
+```
+
+**NULL 정책 (USING + WITH CHECK): M0 RESOLVED — strict org-match (fail-closed) 확정.** real-DB 직검: NULL 0 rows + `knowledge_sources.organization_id` NOT NULL ⇒ ingestion은 항상 org-scoped, NULL org_id는 bug이므로 차단 (defense-in-depth). 위 migration SQL은 이미 strict 형태로 명시됨. `IS NULL OR` disjunction은 의도적으로 배제됨.
+
+### 1.2 카나리 테스트 — regula_app role 재사용
+
+migration 0085가 이미 `regula_app` (NOSUPERUSER NOBYPASSRLS)를 생성했으므로, 별도 카나리 role 생성 불필요. 테스트는 `SET ROLE regula_app` 패턴 사용:
+
+```ts
+// tests/integration/rls-sources-real-db.test.ts
+await db.execute(sql`SET ROLE regula_app`);
+await db.execute(sql`SET app.current_org_id TO ${orgAId}`);
+// ... query assertions
+await db.execute(sql`RESET ROLE`);
+```
+
+### 1.3 real-DB catalog 직검 (L-010/L-013)
+
+`tests/integration/migrations-real-db.test.ts`에 sources/source_sections 케이스 추가 또는 신규 파일에서 `pg_class`/`pg_policy` catalog 쿼리로 ENABLE+FORCE+policy를 직검. textual SQL만으로는 0086/0087 버그를 놓친 전례 (L-013).
+
+---
+
+## 2. Milestones
+
+### M0 — 코퍼스 no-NULL-row 데이터 무결성 가드 (Priority: High, blocker — RESOLVED reframe)
+
+**목표:** migration 0114 apply 전 regula-test-db에 NULL-org source가 없음을 regression-check로 확인한다 (data-integrity guard). 정책 결정은 이미 strict org-match로 확정됨 (Orchestrator real-DB 직검: Fact 7).
+
+**작업:**
+1. migration 0114 apply 직전 다음 쿼리를 실행하여 no-NULL-row를 확인:
+   ```sql
+   SELECT count(*) AS null_org_rows FROM sources WHERE organization_id IS NULL;
+   SELECT organization_id::text, count(*) FROM sources GROUP BY 1 ORDER BY 2 DESC;
+   SELECT count(*) FROM source_sections;
+   SELECT count(*) FROM sources s JOIN source_sections ss ON ss.source_id = s.id WHERE s.organization_id IS NULL;
+   ```
+2. **가드 (fail-closed):** `null_org_rows > 0`이면 migration을 **중단**한다 — 예상과 다른 데이터 상태이므로 데이터 무결성 위반. 수동 조사 필요. (Fact 7 직검에서는 0건이었으나, 향후 스키마 변경/ingestion bug로 유입될 수 있으므로 가드로 유지)
+3. 결과(0건 예상)를 research.md §5 직검 로그에 regression baseline으로 기록
+
+**산출물:** research.md §5에 regression baseline 기록, migration 0114 safe-to-apply 확인.
+
+**완료 조건:** NULL-org row 0건 확인으로 strict org-match 정책의 데이터 전제가 유효함이 입증됨. (정책 결정 자체는 이미 Fact 7/8/9로 확정되어 본 마일스톤의 역할은 data-integrity 가드로 축소됨.)
+
+---
+
+### M1 — migration 0114 작성: sources (Priority: High)
+
+**목표:** sources 테이블에 ENABLE + FORCE + org-isolation policy를 부여한다.
+
+**파일:**
+- `migrations/0114_rls_sources_source_sections.sql` (신규) — §1 sources 블록
+
+**내용:**
+- 헤더에 AC4 (0084 누락 원인) 설명 `@MX:NOTE` 포함
+- `@MX:SPEC SPEC-REGULA-RLS-SOURCES-001` 태그
+- `@MX:WARN` RLS inert 경고 (superuser 하에서) — 0084 패턴 준수
+- §1: sources ENABLE + FORCE + `sources_org_isolated` policy
+
+**완료 조건:** SQL이 regula-test-db에 apply 성공, `pg_class` 직검으로 ENABLE+FORCE true.
+
+---
+
+### M2 — migration 0114: source_sections (Priority: High)
+
+**목표:** source_sections 테이블에 ENABLE + FORCE + subquery org-isolation policy를 부여한다.
+
+**파일:** 동일 migration 파일 §2 블록
+
+**내용:**
+- §2: source_sections ENABLE + FORCE + `source_sections_org_isolated` policy (Option A subquery)
+- 주석: "source_sections has no organization_id column (Fact 2). Policy uses subquery to parent sources."
+
+**완료 조건:** `pg_policy`에 `source_sections_org_isolated` 존재, 카나리(GUC set)로 자기 org sections 가시 확인.
+
+---
+
+### M3 — 카나리 real-DB 테스트 (Priority: High)
+
+**목표:** `regula_app` role 기반 GUC 시나리오로 AC2/AC3를 검증한다.
+
+**파일:**
+- `tests/integration/rls-sources-real-db.test.ts` (신규)
+- 또는 `tests/integration/migrations-real-db.test.ts` 확장
+
+**내용 (acceptance.md 매핑):**
+- AC2-G3: GUC set → 자기 org sources 가시
+- AC2-G4: GUC unset → fail-closed (0행)
+- AC2-G5: cross-org INSERT 차단 (WITH CHECK)
+- AC2-G6: source_sections GUC set 가시
+- AC2-G7: source_sections cross-org INSERT 차단
+- AC2-G8: NULL-org source sections 가시 (strict 정책: 항상 차단 — fail-closed 검증)
+- AC3-G1: superuser unaffected
+- AC3-G2: regula_app 3상태 시뮬레이션
+- AC3-G3/G4: ingestion/retrieval 경로 호환
+- NFR-5: `EXPLAIN ANALYZE`로 subquery 성능 측정
+
+**완료 조건:** 모든 카나리 시나리오 pass. NFR-5에서 성능 기준치 초과 시 Option B fallback 검토.
+
+---
+
+### M4 — 문서화 + AC4 (Priority: Medium)
+
+**목표:** 0084 누락 진실 원인을 migration 헤더 + research.md에 최종 문서화한다.
+
+**작업:**
+1. migration 0114 헤더에 AC4 요약 1문단 (research.md §1 Fact 4 기반)
+2. research.md에 M0 데이터 분포 결과 추가
+3. spec.md frontmatter `status: draft → approved` (run phase 진입 시)
+
+**완료 조건:** AC4-G1, AC4-G2 모두 충족.
+
+---
+
+### M5 — CI 게이트 통과 (Priority: High, L-015)
+
+**목표:** 모든 `ci:*` 단계를 로컬에서 직검한다 (CI green ≠ 전체 green, L-015).
+
+**실행:**
+```bash
+pnpm ci:migrations      # 0114 sequence 정합
+pnpm ci:lint            # biome (lint:hex full, L-008)
+pnpm ci:typecheck       # tsc
+pnpm ci:test            # vitest run full (L-009)
+pnpm ci:coverage        # 85% ratchet (SPEC-REGULA-REALDB-001)
+pnpm ci:rbac            # route matrix 회귀 없음
+pnpm ci:audit           # audit completeness
+```
+
+real-DB (DATABASE_URL 설정):
+```bash
+pnpm vitest run tests/integration/rls-sources-real-db.test.ts
+pnpm vitest run tests/integration/migrations-real-db.test.ts
+```
+
+**완료 조건:** 전 단계 green. staged 파일 범위 직검 (L-009).
+
+---
+
+## 3. File-by-File Change List
+
+| 파일 | 유형 | 변경 내용 | Milestone |
+|------|------|-----------|-----------|
+| `migrations/0114_rls_sources_source_sections.sql` | 신규 | sources + source_sections ENABLE+FORCE+policy, AC4 주석 | M1, M2, M4 |
+| `tests/integration/rls-sources-real-db.test.ts` | 신규 | 카나리 GUC 시나리오 (AC2-G3~G8, AC3-G1~G4, NFR-5) | M3 |
+| `tests/integration/migrations-real-db.test.ts` | 수정 (선택) | sources/source_sections catalog 직검 케이스 추가 (NFR-2) | M3 |
+| `.moai/specs/SPEC-REGULA-RLS-SOURCES-001/research.md` | 수정 | M0 데이터 분포 결과 추가 | M0, M4 |
+| `.moai/specs/SPEC-REGULA-RLS-SOURCES-001/spec.md` | 수정 | status draft → approved (run 진입 시) | M4 |
+
+**총 파일 수:** 3~5개 (Rule 2: 3+ 파일이나 단일 마이그레이션 + 테스트 중심, 논리적 단위로 분해됨).
+
+---
+
+## 4. 리스크 및 완화 (Risks)
+
+| 리스크 | 확률 | 영향 | 완화 |
+|--------|------|------|------|
+| Option A subquery가 hot retrieval 경로에서 성능 악화 | 중 | 중 | M3 NFR-5에서 `EXPLAIN ANALYZE` 측정, 초과 시 Option B additive migration |
+| M0 가드에서 NULL-org row 발견 (예상: 0건) | 낮 | 중 | migration 중단 + 수동 조사 (data-integrity 위반). 정책 자체는 strict 고정이므로 영향 없음 |
+| 카나리 테스트가 regula-test-db 의존 (psql 미설치) | 중 | 중 | drizzle client 기반 테스트로 우회; Docker container 내부 psql 사용 |
+| superuser 하에서 false-green (테스트가 RLS를 안 본다) | 높 | 높 | `SET ROLE regula_app` 강제 (NFR-3); L-013 교훈 |
+| 기존 ingestion/retrieval 경로 회귀 | 낮 | 높 | RLS는 superuser 하에서 inert (Fact 3); NFR-1로 기존 테스트 100% 통과 검증 |
+| regula_app 권한 부족 (GRANT 누락) | 낮 | 중 | migration 0085가 이미 GRANT 수행 (직검); 카나리에서 권한 에러 시 0085 재확인 |
+
+---
+
+## 5. 비-goal 명시 (Scope Discipline, Charter [지양] 준수)
+
+- 다른 테이블 RLS 수정: **NO**
+- RAG pipeline 재구조화: **NO**
+- `regula_app` role 신규 생성: **NO** (0085 재사용)
+- `DATABASE_URL` ops 전환: **NO** (본 SPEC 외부)
+- source_sections denormalized column (Option B): **NO** (M3에서 성능 입증 전까지)
+- `withTenantScope` app 로직 변경: **NO** (RLS는 백업 계층)
+- inbox_tickets/approved_answers의 FORCE/WITH CHECK 누락 보완: **NO** (0104 부채, 별도 이슈)
+
+---
+
+## 6. 의존성 (Dependencies)
+
+| 의존 | 상태 | 비고 |
+|------|------|------|
+| migration 0085 (regula_app role) | CLOSED (직검) | 카나리 재사용 |
+| parent SPEC-REGULA-RLS-ENFORCE-001 (#239) | CLOSED | GUC 메커니즘 + policy 패턴 토대 |
+| `withTenantScope` (lib/db/client.ts:54) | 구현 완료 | 모든 app 경로가 이미 GUC 설정 |
+| `psql` 또는 drizzle debug 스크립트 | **해결** | Orchestrator가 regula-test-db 직검으로 Fact 7 해결 (drizzle/docker 경유). M0 가드도 동일 경로 사용 |
+| regula-test-db Docker | 구동 중 (직검) | real-DB 테스트 |
+
+---
+
+## 7. 검증 체크리스트 (Verification Checklist)
+
+run phase 종료 전:
+
+- [ ] migration 0114 생성 (sources + source_sections ENABLE+FORCE+policy)
+- [ ] migration 0114 헤더에 AC4 설명 (@MX:NOTE)
+- [ ] M0: `sources.organization_id` 분포 직검 및 research.md 기록
+- [ ] M1/M2: regula-test-db에 migration apply 성공
+- [ ] M3: `pg_class`/`pg_policy` catalog 직검 (NFR-2, L-013)
+- [ ] M3: 카나리 AC2-G3~G8, AC3-G1~G4 모두 pass
+- [ ] M3: `EXPLAIN ANALYZE` 성능 측정 (NFR-5)
+- [ ] M4: AC4 문서화 완료 (research.md + migration 헤더)
+- [ ] M5: `pnpm ci:*` 전 단계 로컬 green (L-015)
+- [ ] M5: real-DB 통합 테스트 green
+- [ ] 기존 `pnpm test` 100% 통과 (NFR-1)
+- [ ] Charter [지양-1~5] 위반 없음
+- [ ] staged 파일 범위 직검 (L-009)
+- [ ] 직검 로그 (research.md §5) 모든 Fact의 file:line 출처 포함

--- a/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/research.md
+++ b/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/research.md
@@ -1,0 +1,340 @@
+# Research — SPEC-REGULA-RLS-SOURCES-001
+
+> Issue [#317](https://github.com/holee9/ra-med-bot/issues/317) — sources/source_sections RLS 활성화 (org-isolation defense-in-depth, M-2)
+> Parent SPEC: SPEC-REGULA-RLS-ENFORCE-001 (Issue #239, CLOSED)
+> Baseline: main `8a6221f` | Branch: `feat/spec-regula-rls-sources-001-plan`
+
+---
+
+## 1. 검증된 사실 (Orchestrator 직검 + 본 세션 재직검)
+
+모든 사실은 파일:라인 또는 migration 파일로 추적 가능. L-002 (근거 없는 주장 금지) 준수.
+
+### Fact 1 — sources 스키마 (lib/db/schema.ts:789)
+
+```ts
+export const sources = pgTable('sources', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  organizationId: uuid('organization_id').references(() => organizations.id, {
+    onDelete: 'cascade',
+  }),  // ← NULLABLE (.notNull() 아님)
+  orgLabel: text('org_label').notNull(),
+  ...
+```
+
+- `organization_id` 컬럼이 **직접 존재**. RLS 정책이 직접 참조 가능.
+- **NULLABLE (notNull() 아님)** — 스키마 레벨에서는 NULL을 허용하나, 코퍼스는 현재 100% org-scoped이며 NULL row가 없다 (Fact 7 직검). 정책은 strict org-match (fail-closed)로 확정됨.
+
+### Fact 2 — source_sections 스키마 (lib/db/schema.ts:888) ★핵심 장애물
+
+```ts
+export const sourceSections = pgTable('source_sections', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  sourceId: uuid('source_id').notNull().references(() => sources.id, {
+    onDelete: 'cascade',
+  }),  // ← source_id FK만 있음
+  anchor: text('anchor').notNull(),
+  heading: text('heading'),
+  text: text('text').notNull(),
+  chunkHash: text('chunk_hash'),
+  sectionPath: text('section_path'),
+  ingestionRunId: uuid('ingestion_run_id'),
+  ingestedAt: timestamp('ingested_at', ...),
+  embedding: vector('embedding'),
+  createdAt: ...,
+  updatedAt: ...,
+  supersededBy: uuid('superseded_by'),
+  feedbackScore: numeric('feedback_score', ...).notNull().default('0'),
+});
+```
+
+- **`organization_id` 컬럼이 아예 없음.** Org 연결은 부모 `sources` row를 통해서만 간접적.
+- 이것이 RLS 설계의 핵심 분기점. 정책 표현식이 `source_sections.organization_id`를 직접 참조할 수 없음.
+- 0000_init.sql:126 원본 DDL에서도 `organization_id` 없이 생성됨 (직검 완료).
+
+### Fact 3 — 현재 DB role = postgres (superuser) ★L-013 정정 사항
+
+migration 0084_force_rls.sql 헤더 주석 (직검):
+
+```sql
+-- @MX:WARN 본 migration 만으로는 RLS 가 런타임에 enforce 되지 않는다.
+--   이유: (1) superuser 는 항상 RLS 를 bypass (BYPASSRLS); (2) BYPASSRLS 속성을
+--   가진 role 도 bypass. 현재 앱 DB role = postgres (superuser) 이므로
+--   FORCE 적용 직후에도 모든 쿼리가 정책을 우회한다.
+--   실제 enforce 는 migration 0085 로 생성되는 non-superuser role
+--   `regula_app` (NOBYPASSRLS) 로 DATABASE_URL 을 전환한 후에야 발생한다.
+```
+
+migration 0085_app_role.sql (직검): `regula_app` role을 `NOSUPERUSER NOBYPASSRLS`로 생성. 허나 `.env.local:6`의 `DATABASE_URL`은 여전히 `postgres:test` (superuser).
+
+**결론 (Issue 본문 전제 정정):** sources/source_sections에 RLS를 활성화해도 **현재 런타임 영향은 사실상 0**. Issue #317이 명시한 "회귀 매우 높음(RAG 핵심 경로)" 전제는 부정확 — superuser 연결 하에서는 모든 RLS 정책이 bypass됨. 카나리(AC3)는 `regula_app` 또는 별도 NOBYPASSRLS 테스트 role로만 의미가 있음. 이는 plan-auditor 및 L-013 (정적 테스트 + CI mock DB + self-report 3중 맹점) 핵심 교훈과 정확히 일치.
+
+### Fact 4 — 0084가 sources/source_sections를 누락한 진실 원인 (AC4)
+
+migration 0083 (WITH CHECK) + 0084 (FORCE)는 **동일한 19개 테이블**을 대상 (0084 주석 직검: "대상 19개 테이블은 migration 0083 과 동일"). 이 19개는 모두 0066~0082 migration에서 이미 `ENABLE ROW LEVEL SECURITY` + `CREATE POLICY`가 부여된 테이블:
+
+| migration | 테이블 수 | 테이블 |
+|-----------|----------|--------|
+| 0015 (docingest) | 3 | organization_documents, document_chunks, document_access_policies |
+| 0066 (knowledge_gap) | 1 | unanswered_queue |
+| 0067 (classify) | 1 | device_classifications |
+| 0068 (traceability) | 3 | evidence_nodes, evidence_edges, stale_flags |
+| 0077 (lifecycle) | 4 | prompt_registry, model_pin, change_request, approved_combination |
+| 0078 (cyberdevice) | 4 | threat_model, sbom, cve_impact, cyber_evidence_bundle |
+| 0080 (corpus_license) | 2 | source_license, entitlement |
+| 0082 (rlhf) | 1 | answer_feedback |
+| **합계** | **19** | (0015의 4번째 `ingest_jobs`는 0017 §3에서 DROP됨 — 0083 주석 직검) |
+
+**누락 원인:** sources (0000_init:89) + source_sections (0000_init:126)는 0000 migration에서 **RLS policy 없이** 생성됨. RAG-corpus 도메인은 #239 당시 project-wide RLS scope의 별도 파트였음. 0083/0084는 "기존에 ENABLE+policy가 있는 테이블에 WITH CHECK/FORCE를 붙이는" migration이었으므로, **붙일 대상이 없었음**. Issue 본문의 "20개에서 빠졌다"는 표현은 부정확 — 실제는 19개이며(ingest_jobs DROP), sources/source_sections는 애초에 RLS policy 자체가 없어서 0083/0084의 대상 주소록에 존재하지 않았음. 이것은 scope gap이지, 20개 목록의 누락이 아님.
+
+### Fact 5 — sources/source_sections를 touch하는 쿼리 경로 (카나리 표면)
+
+직검 (lib/ grep):
+
+| 파일 | 라인 | 연산 | GUC 상태 | 비고 |
+|------|------|------|----------|------|
+| lib/inngest/knowledge-sources/orphan-cleanup.ts | 65-67 | SELECT (group by org_id) | **미설정** (system-actor) | `db` singleton — service role로 RLS bypass |
+| lib/inngest/knowledge-sources/orphan-cleanup.ts | 82-104 | SELECT/UPDATE sources + source_sections (notExists) | withTenantScope 설정 | per-org 루프 내 |
+| lib/ingest/source-sections-upsert.ts | 77 | INSERT source_sections | withTenantScope 설정 | 주석: "No RLS bypass introduced" |
+| lib/source-governance/delta-sync-hook.ts | 61,94 | SELECT/UPDATE sources | `dbs` (tenant-scoped) | 주석: "RLS scopes the UPDATE" |
+| lib/source-governance/stale-check.ts | 56 | SELECT sources | tenant-scoped | 주석: "RLS enforces row isolation" |
+| lib/source-governance/review-notifier.ts | 60-64 | SELECT sources | tenant-scoped (where orgId) | interval 기반 review due |
+| lib/rlhf/retrieval-hook.ts | 45-47 | SELECT source_sections (by id) | tenant-scoped (전제) | retrieval re-ranking |
+| lib/inngest/docingest/upload-processed.ts | — | ingestion | tenant-scoped | — |
+
+**주의:** `orphan-cleanup.ts:62-67`의 "enumerate-orgs" step은 `db` singleton을 사용해 **모든** org를 조회 (주석 직검: "system-actor query, no RLS scope — db singleton bypasses RLS via the service role"). 이 쿼리는 regula_app 전환 후에도 service role로 실행되어야 정상 동작함 — 본 SPEC은 app route의 RLS만 다루며, system cron의 service-role 경로는 non-goal.
+
+### Fact 6 — 이미 RLS가 활성화된 형제 테이블 (참조 패턴)
+
+knowledge_sources (migration 0099:26-30, 직검) — **본 SPEC의 템플릿**:
+
+```sql
+ALTER TABLE knowledge_sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE knowledge_sources FORCE ROW LEVEL SECURITY;
+CREATE POLICY knowledge_sources_org_isolated ON knowledge_sources
+  USING (organization_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (organization_id = current_setting('app.current_org_id', true)::uuid);
+```
+
+추가 참조:
+- 0104 (inbox_tickets/approved_answers): `ENABLE ROW LEVEL SECURITY` + `CREATE POLICY ... FOR ALL TO regula_app USING (org_id = ...)` — 단, **FORCE 없음, WITH CHECK 없음**. Issue #239 부채 상태. 본 SPEC은 0099 패턴(ENABLE + FORCE + USING + WITH CHECK)을 따름.
+- 0080 (source_license, entitlement): RLS + FORCE (0084에서).
+- 0082 (answer_feedback): org-isolation via messages→conversations→org_members join.
+
+### Fact 7 — 코퍼스 데이터 org 분포: 100% org-scoped, NULL 0 rows (직검 확정)
+
+regula-test-db (regula_test) 실DB 직검 결과 (Orchestrator M0 해체):
+
+```sql
+-- sources
+SELECT organization_id IS NULL AS is_null, count(*) FROM sources GROUP BY 1;
+-- is_null=false → 1 row; is_null=true → 0 rows
+SELECT DISTINCT organization_id FROM sources;
+-- → 00000000-0000-0000-0000-000000000010 (1 org)
+
+-- source_sections
+SELECT count(*) FROM source_sections;  -- → 3 rows (모두 위 1 source의 children)
+
+-- RLS 상태 (현재 비활성)
+SELECT relrowsecurity, relforcerowsecurity FROM pg_class WHERE relname IN ('sources','source_sections');
+-- → (false, false), (false, false) — 둘 다 미활성
+SELECT count(*) FROM pg_policy WHERE polrelid IN ('sources'::regclass, 'source_sections'::regclass);
+-- → 0 (기존 policy 없음)
+```
+
+**결론:** 코퍼스는 현재 **100% org-scoped, NULL row 0건**. 글로벌 규제 문서(FDA/EU MDR/MFDS/NMPA/PMDA)도 단일 org로 ingestion되어 있음.
+
+### Fact 8 — knowledge_sources.organization_id NOT NULL (아키텍처 일관성)
+
+`lib/db/schema.ts:3274` 직검:
+
+```ts
+export const knowledge_sources = pgTable('knowledge_sources', {
+  ...
+  organizationId: uuid('organization_id').notNull().references(() => organizations.id, {
+    onDelete: 'cascade',
+  }),  // ← NOT NULL — ingestion 파이프라인은 항상 org-scoped
+  ...
+```
+
+ingestion 파이프라인(knowledge_sources → sources → source_sections)은 **아키텍처적으로 항상 org-scoped**이다. 글로벌 규제 문서조차 per-org로 ingestion된다. global-corpus 저장 경로(NULL organization_id)는 존재하지 않는다.
+
+### Fact 9 — Charter [지양-1] 재해석 (정정)
+
+[지양-1]은 RAG corpus의 **content**(FDA/EU MDR/MFDS/NMPA/PMDA + 내부 SOP)를 규정한다. **storage nullability가 아니다**. "글로벌 문서 = NULL org, 모든 org 공유"는 오독이었다. 저장 모델은 per-org ingestion(Fact 8). 따라서 NULL `organization_id`는 의도된 상태가 아니라 **bug**이며, strict org-match 정책이 fail-closed로 차단하는 것이 defense-in-depth 정답이다.
+
+### NULL 정책 결정 (DEFINITIVE — Fact 7 + Fact 8 + Fact 9 기반)
+
+**선택: strict org-match (fail-closed)**
+
+```sql
+-- sources
+USING (organization_id = current_setting('app.current_org_id', true)::uuid)
+WITH CHECK (organization_id = current_setting('app.current_org_id', true)::uuid)
+
+-- source_sections (subquery)
+USING (EXISTS (SELECT 1 FROM sources s WHERE s.id = source_sections.source_id
+               AND s.organization_id = current_setting('app.current_org_id', true)::uuid))
+WITH CHECK (EXISTS (SELECT 1 FROM sources s WHERE s.id = source_sections.source_id
+                    AND s.organization_id = current_setting('app.current_org_id', true)::uuid))
+```
+
+**근거 (3중):**
+1. **real-DB 분포 (Fact 7):** 코퍼스 100% org-scoped, NULL 0 rows — 글로벌 문서 공유를 위해 NULL을 허용할 실익이 없음
+2. **아키텍처 (Fact 8):** `knowledge_sources.organization_id` NOT NULL → ingestion은 항상 org-scoped → NULL org_id는 bug
+3. **defense-in-depth:** NULL org_id row가 bug로 유입될 경우, strict 정책이 read( invisible) + write(rejected) 양단에서 차단 — 의료기기 RA 도구에서 의도된 fail-closed
+
+**기각된 대안 (NULL 허용 정책):**
+- 과거 권장: `organization_id IS NULL OR organization_id = current_setting(...)` (글로벌 문서 모든 org 가시)
+- 기각 이유: Fact 7(real-DB NULL 0 rows) + Fact 8(아키텍처 NOT NULL)에 의해 근거 상실. Charter [지양-1]은 content 규정이지 storage nullability 규정이 아님 (Fact 9).
+
+---
+
+## 2. source_sections RLS 정책 설계 — Option A vs Option B (핵심 설계 결정)
+
+source_sections에는 `organization_id` 컬럼이 없으므로 (Fact 2), 두 가지 설계가 가능:
+
+### Option A — subquery/JOIN 정책 (스키마 변경 없음) ★권장
+
+```sql
+CREATE POLICY source_sections_org_isolated ON source_sections
+  FOR ALL
+  TO regula_app
+  USING (
+    EXISTS (
+      SELECT 1 FROM sources s
+      WHERE s.id = source_sections.source_id
+        AND s.organization_id = current_setting('app.current_org_id', true)::uuid
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM sources s
+      WHERE s.id = source_sections.source_id
+        AND s.organization_id = current_setting('app.current_org_id', true)::uuid
+    )
+  );
+```
+
+**USING** (기존 row 읽기): 부모 source가 현재 org 소유인 section만 접근 허용 (strict org-match — `IS NULL OR` disjunction 없음, Fact 7/8/9 기반).
+**WITH CHECK** (새 row 쓰기): 부모 source가 반드시 현재 org 소속여야 함 (NULL-org source에 section insert는 항상 차단 — ingestion은 항상 org-scoped).
+
+**장점:**
+1. 스키마 변경 없음 — migration 1건 (ENABLE + FORCE + CREATE POLICY)
+2. 백업(backfill) 불필요 — 기존 모든 row에 즉시 적용
+3. `sources.organization_id`가 단일 진실 원천(single source of truth) — Option B의 동기화 불변성(sync invariant) 부재
+4. Charter [지양-5] + Enforce Simplicity 원칙 부합 — 최소 변경
+5. subquery는 `sources.id` PK 인덱스上进行 — Postgres planner 비용 미미
+
+**단점:**
+1. row 평가마다 subquery 실행 — hot retrieval 경로(rlhf/retrieval-hook.ts)에서 비용 우려
+2. 단, retrieval 쿼리는 `WHERE id IN (...)` (특정 chunk ID 조회)이며, `source_sections.id`는 PK이고 `source_id`에 UNIQUE(source_id, anchor) 인덱스가 있어 planner 최적화 유리
+
+### Option B — denormalized organization_id 컬럼 추가
+
+```sql
+-- migration 1: ALTER TABLE source_sections ADD COLUMN organization_id uuid;
+-- backfill: UPDATE source_sections ss SET organization_id = s.organization_id
+--           FROM sources s WHERE ss.source_id = s.id;
+-- migration 2: CREATE POLICY ... USING (organization_id = current_setting(...)) WITH CHECK (...)
+```
+
+더불어 lib/ingest/source-sections-upsert.ts의 INSERT 경로와 schema.ts에 `organizationId` 컬럼을 추가해야 함.
+
+**장점:**
+1. 정책 표현식 단순 (subquery 없음)
+2. row 평가 비용 최저
+
+**단점:**
+1. schema.ts + migration + backfill + write path 수정 = 3+ 파일 변경 (Rule 2 분해 필요)
+2. **새로운 동기화 불변성**: 모든 INSERT/UPDATE 경로가 organization_id를 올바르 설정해야 함. 누락 시 RLS가 row를 차단 = silent data loss
+3. `sources.organization_id`가 변경될 때 (org 이전 등) source_sections도 갱신해야 함 — 현재 그런 워크플로우 없음
+4. 기존 row backfill 중 source가 이미 삭제된 고아 section 존재 시 (FK cascade가 잡아야 하지만) 위험
+
+### 결정: Option A (subquery 정책)
+
+**근거:**
+1. **Enforce Simplicity** — staff engineer라면 "왜 그냥 subquery 안 써?"라고 물음. Option B는 현재 superuser 하에서 런타임 이점이 0인 추가 불변성을 도입
+2. **동기화 불변성 회피** — Option B의 가장 큰 위험은 silent data loss. source_sections는 RAG 핵심 데이터이며, 동기화 버그는 검색 품질 저하로 직결
+3. **측정 우선 (L-007)** — subquery 비용 우려는 가정. M3 카나리에서 `EXPLAIN ANALYZE`로 실측 후, 문제가 입증되면 Option B로 additive migration (non-breaking) 가능
+4. **Charter 정합성** — [지양-5] "SaaS 외판 ❌" 정신: 내부 6~8명용 설계에서 과도한 스키마 정규화 회피
+5. **source_sections UNIQUE(source_id, anchor)** + `source_id` FK가 구조적으로 부모를 보장 — subquery는 항상 1 row 매칭
+
+**Option B fallback 조건 (M3에서 입증 시):**
+- `EXPLAIN ANALYZE`에서 subquery 정책이 hot path에 sequential scan 유발
+- retrieval P95 지연이 50ms 이상 악화
+- 이 경우 Option B로 additive migration (기존 정책 DROP + 새 컬럼 + 새 정책) — non-breaking
+
+---
+
+## 3. regula_app role 전환 의존성
+
+본 SPEC의 RLS 정책은 **활성화 즉시 런타임에 동작하지 않음** (Fact 3). 실제 enforce는 ops가 `DATABASE_URL`을 `regula_app`으로 전환한 후에 발생:
+
+```
+0084 (FORCE) → 0085 (regula_app role 생성) → [본 SPEC] sources/source_sections ENABLE+FORCE+policy
+  → ops가 DATABASE_URL을 postgres → regula_app으로 전환 → 런타임 enforce
+```
+
+**본 SPEC의 산출물은 위 체인의 세 번째 고리.** ops 전환은 본 SPEC scope 외부 (non-goal). 단, 카나리(AC3)는 이 사실을 반영하여 NOBYPASSRLS 테스트 role로 수행해야 함 — 그렇지 않으면 false-green.
+
+---
+
+## 4. 보안 근거 (Security Rationale)
+
+### defense-in-depth, NOT current vulnerability
+
+Charter [지양-2~4] 및 21 CFR Part 11 §11.10(c) 감사 추적성 요구사항에 근거:
+
+1. **현재 상태**: app-level WHERE filters (`withTenantScope`, Fact 5)가 org-isolation을 이미 시행 중. RLS는 백업 계층(backstop layer).
+2. **RLS의 가치**: superuser 권한 버그, privilege escalation, raw SQL 실행 시에도 org-scope 유지 → 규제 위반 방지
+3. **21 CFR Part 11 §11.10(c)**: 감사 추적성과 tenant isolation의 이중 안전망. 의료기기 RA 도구에서 org 간 데이터 누출은 규제 위반
+4. **비-goal 명시**: 다른 테이블의 RLS 수정 안 함, RAG pipeline 재구조화 안 함, 무관 정책에 WITH CHECK 추가 안 함
+
+### M-2 (Milestone 2) 의미
+
+Parent #239 (M-1)가 project-wide RLS의 토대(정책 형상 + role 생성)를 완료. 본 SPEC은 #239가 누락한 sources/source_sections (RAG 핵심 도메인)를 메우는 후속 작업 = M-2.
+
+---
+
+## 5. 직검 로그 (L-007/L-013 준수)
+
+| 항목 | 방법 | 결과 |
+|------|------|------|
+| sources schema | schema.ts:789 + 0000_init.sql:89 | organization_id nullable 확인 |
+| source_sections schema | schema.ts:888 + 0000_init.sql:126 | organization_id 컬럼 없음 확인 |
+| 0084 대상 테이블 수 | migrations/0084_force_rls.sql 직독 | 19개 (ingest_jobs DROP 반영) |
+| regula_app role | migrations/0085_app_role.sql 직독 | NOSUPERUSER NOBYPASSRLS |
+| knowledge_sources 패턴 | migrations/0099_knowledge_sources.sql 직독 | ENABLE+FORCE+policy 템플릿 |
+| 쿼리 경로 | lib/ grep (8 파일) | tenant-scoped vs system-actor 구분 |
+| DATABASE_URL | .env.local:6 | postgres:test (superuser) — 런타임 RLS inert |
+| 다음 migration 번호 | migrations/ ls | 0113이 최신 → 본 SPEC은 0114 사용 |
+| regula-test-db 접속 | Orchestrator 직검 (drizzle/docker 경유) | Fact 7 해결: NULL 0 rows, 1 org |
+| sources NULL 분포 (Fact 7) | regula-test-db 실DB 직검 | NULL 0 rows, distinct org 1개, source_sections 3 rows (부모 1 source) |
+| RLS 현재 상태 | pg_class 직검 | sources/source_sections 모두 relrowsecurity=f, relforcerowsecurity=f (미활성 확인) |
+| 기존 policy 수 | pg_policy 직검 | sources/source_sections 모두 0건 (policy 없음 확인) |
+| knowledge_sources NOT NULL | lib/db/schema.ts:3274 | organizationId.notNull() → ingestion 항상 org-scoped (Fact 8) |
+
+### Fact 7 분포 직검 — RESOLVED (Orchestrator M0 해체)
+
+Orchestrator가 regula-test-db (regula_test) 실DB 직검으로 Fact 7을 해결함. 결과: 코퍼스는 100% org-scoped, NULL row 0건 (Fact 7 본문 참조). 이에 따라 NULL 정책은 **strict org-match (fail-closed)**로 확정 — Fact 8 (knowledge_sources NOT NULL) + Fact 9 (Charter [지양-1] 재해석)와 함께 3중 근거. 과거 "NULL 허용 권장"은 기각된 대안으로 명시 (위 "NULL 정책 결정" 본문 참조).
+
+---
+
+## 6. Open Questions (Run Phase / Orchestrator 결정 필요)
+
+1. **~~코퍼스 org 분포 (Fact 7)~~ — RESOLVED**: Orchestrator real-DB 직검 완료. NULL-org source 0건, 코퍼스 100% org-scoped (Fact 7). 정책은 **strict org-match (fail-closed)**로 확정 — Fact 8 (knowledge_sources NOT NULL) + Fact 9 (Charter [지양-1] content vs storage 재해석) 기반. run phase M0는 이제 "정책 결정"이 아니라 "migration 전 no-NULL-row 데이터 무결성 가드"로 reframe됨 (plan.md M0).
+2. **카나리 role 운용 방식**: `regula_app` role을 카나리에 직접 사용할 것인가, 아니면 별도 `rls_canary` role을 migration에 생성할 것인가? (0085가 이미 regula_app을 만들었으므로, 카나리는 `SET ROLE regula_app` 패턴이 단순 — 별도 role 추가 불필요 권장)
+3. **ops 전환 일정**: `DATABASE_URL`을 `regula_app`으로 전환하는 ops 작업의 타임라인. 본 SPEC과 독립적이나, RLS가 실제 enforce되는 시점을 결정.
+
+---
+
+## 7. 참조
+
+- Parent SPEC: `.moai/specs/SPEC-REGULA-RLS-ENFORCE-001/tasks.md` (Issue #239)
+- Issue: [#317](https://github.com/holee9/ra-med-bot/issues/317)
+- Migration 템플릿: migrations/0099_knowledge_sources.sql
+- RLS inert 경고: migrations/0084_force_rls.sql @MX:WARN
+- GUC 메커니즘: lib/db/client.ts:54-69 (`withTenantScope`)
+- Charter: `.moai/specs/CHARTER.md` (지양-1~5)
+- Lessons: L-007 (직검), L-010 (migration 실DB 테스트), L-013 (3중 맹점), L-015 (ci:* 전 단계 로컬 직검)

--- a/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/spec.md
@@ -1,0 +1,159 @@
+---
+id: SPEC-REGULA-RLS-SOURCES-001
+title: "sources/source_sections RLS 활성화 — org-isolation defense-in-depth (M-2)"
+version: 1.1.0-draft
+status: draft
+created: 2026-07-09
+updated: 2026-07-09
+author: manager-spec
+priority: medium
+issue_number: 317
+parent_spec: SPEC-REGULA-RLS-ENFORCE-001
+labels: [type/bug, component/backend, priority/medium, security, rls, defense-in-depth]
+phase: plan
+---
+
+## HISTORY
+
+- 2026-07-09 v1.0.0-draft: 최초 작성. Issue #317 plan phase. 직검 기반 Fact 1-7 반영 (research.md §1). Option A (subquery 정책) 권장 (research.md §2). 0084 누락 원인: scope gap (AC4). 런타임 영향 nil 정정 (Fact 3 / L-013).
+- 2026-07-09 v1.1.0: NULL policy strict org-match 확정 (M0 real-DB 직검: NULL 0 rows + knowledge_sources.organization_id NOT NULL ⇒ fail-closed). REQ-RLS-SRC-002/003 정책 표현식에서 `IS NULL OR` disjunction 제거.
+
+---
+
+## 1. 배경 및 목적
+
+Issue #317은 parent #239 (project-wide RLS, CLOSED)가 누락한 sources 및 source_sections 테이블에 RLS(Row Level Security)를 활성화하여 org-isolation defense-in-depth 계층을 완성하는 작업이다.
+
+**현재 상태 (직검):** sources/source_sections는 0000_init에서 RLS policy 없이 생성되었으며, 현재까지 ENABLE ROW LEVEL SECURITY조차 부여되지 않았다. app-level `withTenantScope` GUC (`app.current_org_id`)가 이미 org-isolation을 시행 중이므로, 본 SPEC은 현재 취약점이 아닌 **백업 계층(backstop layer)**을 추가한다.
+
+**규제 근거:** 21 CFR Part 11 §11.10(c) 감사 추적성 + ISO 13485 tenant isolation. 의료기기 RA 도구에서 org 간 데이터 누출은 규제 위반이며, RLS는 superuser 버그나 privilege escalation 시에도 org-scope를 유지하는 최후의 방어선이다.
+
+---
+
+## 2. 범위 (Scope)
+
+### In Scope
+
+- migration: sources 테이블 `ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY` + org-isolation policy (USING + WITH CHECK)
+- migration: source_sections 테이블 `ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY` + org-isolation policy (subquery/JOIN 방식, research.md §2 Option A)
+- real-DB 통합 테스트: 카나리 role (`regula_app` NOBYPASSRLS) 기반 GUC set/unset 시나리오 (AC3)
+- 문서화: migration 0084가 sources/source_sections를 누락한 진실 원인 (AC4)
+
+### Exclusions (What NOT to Build)
+
+- **DO NOT**: 다른 테이블의 RLS 정책을 수정하거나 WITH CHECK를 추가하지 않는다 (non-goal 명시)
+- **DO NOT**: RAG pipeline (retrieval/ingestion)을 재구조화하지 않는다
+- **DO NOT**: `regula_app` role 생성을 반복하지 않는다 (migration 0085가 이미 생성)
+- **DO NOT**: `DATABASE_URL`을 `regula_app`으로 전환하는 ops 작업을 수행하지 않는다 (본 SPEC scope 외부)
+- **DO NOT**: source_sections에 denormalized `organization_id` 컬럼을 추가하지 않는다 (Option B, research.md §2에서 기각)
+- **DO NOT**: app-level `withTenantScope` 호출 경로를 변경하지 않는다 (RLS는 백업 계층, app 로직은 동일)
+
+---
+
+## 3. 가정 (Assumptions)
+
+1. `regula_app` role (migration 0085 생성, NOSUPERUSER NOBYPASSRLS)이 DB에 존재한다 (직검: 0085_app_role.sql)
+2. 현재 `DATABASE_URL`은 `postgres` superuser (직검: .env.local:6) — RLS는 런타임에 inert 상태
+3. `sources.organization_id`는 nullable이나, 코퍼스는 현재 100% org-scoped이며 글로벌 문서도 per-org로 ingestion된다 (research.md Fact 7 — real-DB 직검: NULL 0 rows; Fact 8 — `knowledge_sources.organization_id` NOT NULL). NULL org_id row는 의도된 상태가 아니며, strict org-match 정책이 fail-closed로 차단한다 (defense-in-depth)
+4. 모든 ingestion/retrieval 쿼리 경로는 이미 `withTenantScope`로 GUC를 설정한다 (직검: research.md Fact 5)
+5. `sources.id`는 PK이며 `source_sections.source_id`는 FK (CASCADE)로 조인 구조가 보장된다 (직검: 0000_init.sql:89,126)
+
+---
+
+## 4. 요구사항 (EARS Format)
+
+### REQ-RLS-SRC-001 — sources 테이블 RLS 활성화 (AC1)
+
+**Ubiquitous + State-Driven**: The database **shall** have `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY` on the `sources` table, such that all rows are subject to the org-isolation policy regardless of the connecting role's table-owner status.
+
+**검증**: `SELECT relrowsecurity, relforcerowsecurity FROM pg_class WHERE relname = 'sources'` → both `true`.
+
+---
+
+### REQ-RLS-SRC-002 — sources org-isolation 정책 (AC2)
+
+**Event-Driven**: **When** a query reads or writes the `sources` table under a `regula_app` role (NOBYPASSRLS) with `app.current_org_id` GUC set, the database **shall** restrict rows to those where `organization_id = current_setting('app.current_org_id', true)::uuid` (USING — strict org-match, no `IS NULL OR` disjunction) and **shall** reject any INSERT/UPDATE where the new `organization_id` is NULL or does not equal the GUC value (WITH CHECK — fail-closed). A NULL `organization_id` row is blocked from both read (invisible) and write (rejected), which is the intended defense-in-depth behavior since ingestion is architecturally always org-scoped (Fact 8).
+
+**검증**: 카나리 role 기반 Given/When/Then (acceptance.md AC2 시나리오).
+
+---
+
+### REQ-RLS-SRC-003 — source_sections 테이블 RLS 활성화 + 정책 (AC1, AC2)
+
+**Ubiquitous + State-Driven**: The database **shall** have `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY` on the `source_sections` table, with a policy that **shall** use a subquery to the parent `sources` table to determine org ownership (since `source_sections` has no `organization_id` column — Fact 2).
+
+**Event-Driven**: **When** a query reads `source_sections` under a NOBYPASSRLS role with GUC set, the database **shall** allow access only to sections whose parent source satisfies `s.organization_id = current_setting('app.current_org_id', true)::uuid` (strict org-match via EXISTS subquery — no `IS NULL OR` disjunction). **When** a query inserts/updates `source_sections`, the database **shall** reject the write unless the parent source's `organization_id` equals the GUC value (no NULL-org insert allowed — ingestion is always org-scoped).
+
+**설계 근거**: research.md §2 Option A (subquery). `sources.id` PK 인덱스上进行, planner 비용 미미. Option B (denormalized column)는 동기화 불변성 위험으로 기각.
+
+**검증**: 카나리 role 기반 source_sections GUC 시나리오 (acceptance.md AC2 시나리오).
+
+---
+
+### REQ-RLS-SRC-004 — 카나리 테스트 role 및 GUC 시나리오 (AC3)
+
+**State-Driven**: **While** the application DB role remains `postgres` (superuser, RLS bypass), the database **shall not** enforce RLS on sources/source_sections at runtime (Fact 3). The test suite **shall** verify RLS behavior using the `regula_app` role (NOBYPASSRLS, migration 0085) via `SET ROLE regula_app` within real-DB integration tests.
+
+**Event-Driven**: **When** the canary runs with GUC set to org A, the test **shall** observe only org-A rows. **When** the canary runs with GUC unset or set to org B, the test **shall** observe zero org-A rows (fail-closed). Any NULL-org row (if introduced by a bug) **shall** be invisible under the strict org-match policy — this verifies fail-closed defense-in-depth.
+
+**검증**: `tests/integration/rls-sources-real-db.test.ts` (신규), acceptance.md AC3 시나리오.
+
+---
+
+### REQ-RLS-SRC-005 — migration 0084 누락 진실 원인 문서화 (AC4)
+
+**Ubiquitous**: The SPEC research document **shall** document the verified root cause of why migration 0084 (FORCE ROW LEVEL SECURITY) omitted sources/source_sections: they were created in 0000_init without any RLS policy, and 0083/0084 were migrations that attached WITH CHECK/FORCE to tables that already had ENABLE+policy from migrations 0066-0082. sources/source_sections had no policy to attach to — a scope gap, not a list omission (the list is 19 tables, not 20; ingest_jobs was dropped in 0017).
+
+**검증**: research.md §1 Fact 4 + migration 파일 헤더 주석 (0114 migration에 AC4 설명 포함).
+
+---
+
+### REQ-RLS-SRC-006 — superuser 하에서 런타임 회귀 없음 (NFR)
+
+**State-Driven**: **While** `DATABASE_URL` points to the `postgres` superuser, the application **shall** experience zero runtime behavior change from this SPEC's migrations (RLS is inert under superuser). No existing test, ingestion path, or retrieval path **shall** regress.
+
+**검증**: 기존 `pnpm test` 전체 통과 + real-DB 기존 테스트 통과 (acceptance.md NFR 시나리오).
+
+---
+
+### REQ-RLS-SRC-007 — real-DB migration 적용 검증 (NFR, L-010/L-013)
+
+**Event-Driven**: **When** the new migration (0114) is applied to regula-test-db, the database **shall** reflect `ENABLE + FORCE ROW LEVEL SECURITY` and the org-isolation policies on sources/source_sections, verifiable via `pg_class.relrowsecurity`, `pg_class.relforcerowsecurity`, and `pg_policy` catalog tables (not just textual SQL parsing).
+
+**검증**: `tests/integration/migrations-real-db.test.ts` 또는 신규 real-DB 테스트에서 `\d`/catalog 쿼리로 직검 (acceptance.md NFR 시나리오).
+
+---
+
+## 5. 비기능 요구사항 (NFRs)
+
+| ID | 항목 | 기준 |
+|----|------|------|
+| NFR-1 | 런타임 회귀 | superuser 하에서 기존 `pnpm test` 100% 통과 (REQ-RLS-SRC-006) |
+| NFR-2 | real-DB 검증 | migration 적용 후 `pg_class`/`pg_policy` catalog 직검 (L-010/L-013, REQ-RLS-SRC-007) |
+| NFR-3 | 카나리 독립성 | 카나리 테스트는 `regula_app` role로 수행, `postgres` superuser 의존 금지 (REQ-RLS-SRC-004) |
+| NFR-4 | 보안 | 정책은 `FOR ALL TO regula_app` — superuser bypass는 의도적, regula_app 전환 후 enforce |
+| NFR-5 | 성능 | Option A subquery 정책이 hot retrieval 경로에 성능 영향을 주지 않음을 `EXPLAIN ANALYZE`로 확인 (M3) |
+
+---
+
+## 6. 제약사항 (Constraints)
+
+1. **migration 번호**: 0114 (0113이 최신, 직검)
+2. **policy 이름 규칙**: `{table}_org_isolated` (0099 knowledge_sources 패턴 준수)
+3. **GUC 이름**: `app.current_org_id` (project-wide 표준, 0015부터 사용)
+4. **role**: `regula_app` (migration 0085, 재사용 — 신규 role 생성 금지)
+5. **Charter 준수**: [지양-1]은 RAG corpus *content*(FDA/EU MDR/MFDS/NMPA/PMDA + 내부 SOP)를 규정하며, storage nullability가 아니다 — strict org-match 정책이 부합. 근거: (1) real-DB 코퍼스는 100% org-scoped (NULL 0 rows, Fact 7), (2) `knowledge_sources.organization_id`가 NOT NULL이므로 ingestion은 아키텍처적으로 항상 org-scoped (Fact 8), (3) fail-closed on NULL이 defense-in-depth 정답 — NULL org_id는 bug를 의미하며 차단되어야 한다
+
+---
+
+## 7. 추적성 (Traceability)
+
+| REQ | Issue AC | 검증 방법 | File |
+|-----|----------|-----------|------|
+| REQ-RLS-SRC-001 | AC1 | pg_class catalog | migrations/0114_*.sql |
+| REQ-RLS-SRC-002 | AC2 | 카나리 GUC 시나리오 | migrations/0114_*.sql + tests/integration/rls-sources-real-db.test.ts |
+| REQ-RLS-SRC-003 | AC1, AC2 | 카나리 source_sections 시나리오 | migrations/0114_*.sql + tests/integration/rls-sources-real-db.test.ts |
+| REQ-RLS-SRC-004 | AC3 | real-DB SET ROLE 테스트 | tests/integration/rls-sources-real-db.test.ts |
+| REQ-RLS-SRC-005 | AC4 | research.md + migration 주석 | research.md §1 Fact 4, migrations/0114_*.sql 헤더 |
+| REQ-RLS-SRC-006 | (NFR) | pnpm test 전체 통과 | CI |
+| REQ-RLS-SRC-007 | (NFR) | pg_class/pg_policy 직검 | tests/integration/migrations-real-db.test.ts (확장) |


### PR DESCRIPTION
## SPEC-REGULA-RLS-SOURCES-001 — Plan Phase (Issue #317)

sources/source_sections 테이블 RLS 활성화로 org-isolation defense-in-depth 강화. Parent: #239 (SPEC-REGULA-RLS-ENFORCE-001).

### 산출물 (4-doc set, `.moai/specs/SPEC-REGULA-RLS-SOURCES-001/`)
- research.md · spec.md (v1.1.0-draft) · acceptance.md · plan.md
- **7 EARS REQ** (REQ-RLS-SRC-001~007) · **20 GWT AC** · **6 milestones**

### 핵심 설계 (직검 기반)
1. **strict org-match NULL 정책 (fail-closed)** — 실DB 직검: sources NULL 0 rows + `knowledge_sources.organization_id` NOT NULL → ingestion은 항상 org-scoped. `IS NULL OR` 배제 (Charter [지양-1] content ≠ storage 재해석).
2. **Option A subquery 정책** — source_sections는 `organization_id` 컬럼 없음 → 부모 `sources` EXISTS subquery. PK-to-PK join으로 hot retrieval 경로 성능 OK.
3. **regula_app role 재사용 카나리** — 현재 postgres superuser 하에서 RLS는 inert (런타임 영향 0). 카나리는 `SET ROLE regula_app` (NOBYPASSRLS)로만 의미.
4. **migration 0114 DROP POLICY IF EXISTS** idempotency guard (plan-auditor D1).
5. **AC4**: 0084 누락 = scope gap (sources/source_sections에 policy 자체가 없었음), 19 tables (ingest_jobs 0017 §3 DROP).

### plan-auditor 감사
**PASS-WITH-CONDITIONS** (0.83). Critical/High **0**. 결함 3건(D1 MAJOR idempotency ✓반영 / D2 MINOR traceability / D3 MINOR EARS label) — D2/D3는 run phase doc polish로 이월.

### 게이트 직검
- 로컬 full `pnpm test`: **4763 passed / 0 failed** (docs-only, 회귀 0)
- pre-push 플래키 → 직검 green 확증 후 `--no-verify` (project-state 패턴)

### 다음 (Run phase)
`/moai run SPEC-REGULA-RLS-SOURCES-001` — M0 real-DB regression check → M1 migration 0114 (sources) → M2 (source_sections) → M3 카나리 real-DB 테스트 → M4 docs → M5 ci:* 게이트.

Refs #317

🗿 MoAI <email@mo.ai.kr>