### PR TITLE
fix(security): SPEC-REGULA-RLS-SOURCES-001 — sources/source_sections RLS 활성화 (#317)

### DIFF
--- a/.github/workflows/migrations-real-db.yml
+++ b/.github/workflows/migrations-real-db.yml
@@ -135,5 +135,11 @@ jobs:
             tests/integration/knowledge-gap-replay-real.test.ts \
             tests/integration/rlhf-reranking-flow.test.ts \
             tests/integration/rlhf-calibration.test.ts \
-            tests/integration/model-governance-real-db.test.ts \
-            tests/integration/rls-sources-real-db.test.ts
+            tests/integration/model-governance-real-db.test.ts
+      # RLS sources canary runs in a SEPARATE step: rlhf-reranking-flow.test.ts
+      # truncates source_sections, and CI runs suites in parallel on one DB —
+      # running the canary concurrently would have its seed wiped mid-suite
+      # (local single-file runs are unaffected). Isolating the step guarantees
+      # the canary owns source_sections for its full lifetime.
+      - name: Run RLS sources canary (isolated)
+        run: pnpm vitest run tests/integration/rls-sources-real-db.test.ts

--- a/.github/workflows/migrations-real-db.yml
+++ b/.github/workflows/migrations-real-db.yml
@@ -135,4 +135,5 @@ jobs:
             tests/integration/knowledge-gap-replay-real.test.ts \
             tests/integration/rlhf-reranking-flow.test.ts \
             tests/integration/rlhf-calibration.test.ts \
-            tests/integration/model-governance-real-db.test.ts
+            tests/integration/model-governance-real-db.test.ts \
+            tests/integration/rls-sources-real-db.test.ts

--- a/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/plan.md
+++ b/.moai/specs/SPEC-REGULA-RLS-SOURCES-001/plan.md
@@ -27,8 +27,8 @@ DROP POLICY IF EXISTS sources_org_isolated ON sources;
 CREATE POLICY sources_org_isolated ON sources
   FOR ALL
   TO regula_app
-  USING (organization_id = current_setting('app.current_org_id', true)::uuid)
-  WITH CHECK (organization_id = current_setting('app.current_org_id', true)::uuid);
+  USING (organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid)
+  WITH CHECK (organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid);
 
 -- §2 source_sections (Option A: subquery 정책, research.md §2)
 ALTER TABLE source_sections ENABLE ROW LEVEL SECURITY;
@@ -43,14 +43,14 @@ CREATE POLICY source_sections_org_isolated ON source_sections
     EXISTS (
       SELECT 1 FROM sources s
       WHERE s.id = source_sections.source_id
-        AND s.organization_id = current_setting('app.current_org_id', true)::uuid
+        AND s.organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
     )
   )
   WITH CHECK (
     EXISTS (
       SELECT 1 FROM sources s
       WHERE s.id = source_sections.source_id
-        AND s.organization_id = current_setting('app.current_org_id', true)::uuid)
+        AND s.organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid)
     )
   );
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 
 > Placeholder for post-1.0.0 development.
 
+### SPEC-REGULA-RLS-SOURCES-001 — sources/source_sections RLS 활성화, org-isolation defense-in-depth (#317)
+
+- **배경** — #239 (SPEC-REGULA-RLS-ENFORCE-001, project-wide RLS WITH CHECK + GUC)에서 sources/source_sections(RAG corpus)가 누락. GUC `app.current_org_id`가 inert 상태 → query-layer org filter 누락 시 cross-org 노출 위험. expert-security M-2 (#313/#314).
+- **AC4 진실** — sources/source_sections는 0000에서 CREATE TABLE만 생성되고 RLS policy가 전혀 없었음 → 0083/0084(WITH CHECK/FORCE)가 붙일 대상이 없어 **scope gap** (19 tables, ingest_jobs 0017 §3 DROP). migration 헤더에 문서화.
+- **구현 (migration 0114)** — sources + source_sections `ENABLE`+`FORCE ROW LEVEL SECURITY` + strict org-match policy (fail-closed). source_sections는 `organization_id` 컬럼이 없어 **부모 sources EXISTS subquery** (Option A). `NULLIF(current_setting(...), '')::uuid`로 빈/NULL GUC를 안전 처리 (sibling 0099보다 견고). `DROP POLICY IF EXISTS` idempotency guard.
+- **real-DB 카나리 8종** (`tests/integration/rls-sources-real-db.test.ts`) — 단일 postgres-js client(`max:1`)로 SET ROLE/GUC pool 오염 차단. regula_app role로 own-org 가시 / other-org 차단 / GUC unset fail-closed(0행) / cross-org INSERT WITH CHECK 차단 / source_sections EXISTS scoping / superuser bypass 증명.
+- **직검 정정 3건 (L-013)** — (1) 이슈 전제 "회귀 매우 높음" → 실제 superuser 하 런타임 영향 0 (enforce는 regula_app 전환 후); (2) NULLIF policy — 빈 GUC cast 에러를 fail-closed로 견고화; (3) CI real-db suite 병렬 실행 시 rlhf-reranking-flow의 source_sections truncate가 카나리 seed 삭제 → 격리 step으로 해결 (superuser sanity pre-check로 직접 포착).
+- **게이트 직검** — typecheck/ci:migrations/lint/ci:rbac/ci:audit/ci:module-boundaries 0 · 실DB 카나리 8/8 · full `pnpm test` 4763 passed/0 failed · CI real-db suite(from-scratch) PASS. evaluator-active APPROVE 98.75/100.
+
 ### SPEC-REGULA-REALDB-001 — (B)클래스 real-db 전환 4건 + Coverage ratchet 게이트 (#395)
 
 - **배경** — #364(PR #394) foundation(cer-persist 패턴) 기반 잔여. data/schema-dependent mock-db 통합 테스트를 real-db로 전환하여 L-013 안전망 확장. plan-auditor annotation cycle 거침(v1.1.0: D1-D8 정정, docingest-e2e (A)-class 제외).

--- a/migrations/0114_rls_sources_source_sections.sql
+++ b/migrations/0114_rls_sources_source_sections.sql
@@ -1,0 +1,77 @@
+-- 0114_rls_sources_source_sections.sql
+-- SPEC-REGULA-RLS-SOURCES-001 (Issue #317) — sources/source_sections RLS 활성화
+--
+-- AC4 (0084 omission root cause):
+--   migration 0083 (WITH CHECK) / 0084 (FORCE)는 19개 테이블에 적용되었다.
+--   sources (0000_init.sql:89) + source_sections (0000_init.sql:126)는 0000에서
+--   CREATE TABLE만 생성되고 RLS policy가 전혀 없었다 → 0083/0084가 붙일 대상이
+--   없어 scope gap이 발생한 것이다. 이는 "20-table 목록에서 빠뜨렸다"가 아니라
+--   "policy 자체가 없어 WITH CHECK/FORCE를 부착할 수 없었다"는 구조적 누락이다.
+--   (참고: 0084 대상은 실제 19개 — ingest_jobs는 0017 §3에서 DROP됨.)
+--   본 migration이 #239 (SPEC-REGULA-RLS-ENFORCE-001) project-wide RLS의 마지막
+--   누락 도메인(sources/source_sections, RAG corpus)을 메운다.
+--
+-- @MX:SPEC SPEC-REGULA-RLS-SOURCES-001
+-- @MX:REASON RLS는 21 CFR Part 11 §11.10(c) 감사 추적성과 tenant isolation의
+--   이중 안전망이다. sources/source_sections에 RLS policy가 없으면 GUC
+--   app.current_org_id가 inert가 되어, query-layer org filter(eq(orgId))가
+--   누락될 때 cross-org 데이터 노출로 이어진다. 본 활성화로 fail-closed
+--   defense-in-depth를 확보한다.
+--
+-- @MX:NOTE 현재 앱 DB role = postgres superuser → RLS는 런타임에 bypass(BYPASSRLS)
+--   된다. 따라서 본 migration 적용 자체는 no-op에 가깝다(superuser). 실제
+--   enforce는 ops가 DATABASE_URL을 regula_app(NOBYPASSRLS, migration 0085 생성)으로
+--   전환한 후에야 발생한다. 카나리 검증(rls-sources-real-db.test.ts)은
+--   SET ROLE regula_app으로 이 동작을 증명한다.
+--
+-- NULL 정책: strict org-match (fail-closed). 실DB 직검 결과 sources는 전량
+--   org-scoped(organization_id non-NULL, NULL 0행)이며 knowledge_sources.organization_id
+--   가 NOT NULL이라 ingestion은 아키텍처적으로 항상 org-scoped다. 따라서 NULL
+--   organization_id는 bug이며 차단한다(IS NULL OR disjunction 배제).
+--
+-- source_sections: organization_id 컬럼이 없다 → 부모 sources에 대한 EXISTS
+--   subquery로 org 소유권을 판정한다(Option A). sources.id는 PK, source_sections.
+--   source_id는 FK이므로 PK-to-PK join으로 hot retrieval 경로 성능 저하 없음.
+
+-- ============================================================
+-- §1 sources — ENABLE + FORCE + org-isolation policy (strict org-match)
+-- ============================================================
+ALTER TABLE sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sources FORCE ROW LEVEL SECURITY;
+
+-- PostgreSQL has no CREATE POLICY IF NOT EXISTS; DROP guard for idempotent re-apply.
+-- NULLIF(..., '') normalizes an empty/unset GUC to NULL before the ::uuid cast:
+--   GUC=valid-uuid ⇒ match;  GUC="" or unset ⇒ NULL ⇒ organization_id = NULL ⇒ false (fail-closed).
+-- Without NULLIF, a "" GUC raises `invalid input syntax for type uuid` instead of
+-- filtering to 0 rows. This is strictly more defensive than the sibling 0099 policy.
+DROP POLICY IF EXISTS sources_org_isolated ON sources;
+CREATE POLICY sources_org_isolated ON sources
+  FOR ALL
+  TO regula_app
+  USING (organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid)
+  WITH CHECK (organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid);
+
+-- ============================================================
+-- §2 source_sections — Option A subquery policy (부모 sources EXISTS)
+-- ============================================================
+ALTER TABLE source_sections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE source_sections FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS source_sections_org_isolated ON source_sections;
+CREATE POLICY source_sections_org_isolated ON source_sections
+  FOR ALL
+  TO regula_app
+  USING (
+    EXISTS (
+      SELECT 1 FROM sources s
+      WHERE s.id = source_sections.source_id
+        AND s.organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM sources s
+      WHERE s.id = source_sections.source_id
+        AND s.organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
+    )
+  );

--- a/tests/integration/rls-sources-real-db.test.ts
+++ b/tests/integration/rls-sources-real-db.test.ts
@@ -1,0 +1,185 @@
+// @MX:NOTE [AUTO] Real-DB RLS canary for sources/source_sections.
+// @MX:SPEC SPEC-REGULA-RLS-SOURCES-001 (Issue #317)
+//
+// Why this exists (L-013): enterprise-migrations.test.ts parses migration SQL
+// textually only — it cannot prove that `SET ROLE regula_app` + GUC actually
+// enforces org isolation at runtime. This canary connects to a live PostgreSQL
+// (DATABASE_URL) and verifies migration 0114's RLS policies behave correctly
+// under a NOBYPASSRLS role.
+//
+// Connection discipline: SET ROLE is session-level and survives tx rollback,
+// and drizzle's pooled db.transaction cannot guarantee SET ROLE lands on the
+// same connection as the subsequent query. So we open ONE dedicated postgres-js
+// client (max: 1, prepare: false) for the whole suite — every SET ROLE /
+// set_config / query / RESET shares that single connection, eliminating pool
+// contamination (the uuid:"" + "scope begin" errors seen with the pooled path).
+//
+// Skipped when DATABASE_URL is unset (mirrors migrations-real-db.test.ts).
+
+import postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const SKIP = !process.env.DATABASE_URL;
+
+// Unique seed orgs (distinct from any real row, e.g. ...0010).
+const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ORG_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+// biome-ignore lint/suspicious/noExplicitAny: suite-scoped client initialized in beforeAll
+let client: any;
+
+/** Run `fn` under regula_app (NOBYPASSRLS) with a given org GUC, then reset. */
+async function asRegulaApp(orgId: string | null, fn: () => Promise<void>): Promise<void> {
+  await client`SET ROLE regula_app`;
+  // set_config(name, value, is_local=false) is session-scoped. A NULL value
+  // makes current_setting(..., true) return NULL (not ""), so the policy's
+  // `...::uuid` cast yields NULL and every row is filtered out (fail-closed).
+  // RESET would leave "" which raises on the ::uuid cast.
+  const gucValue: string | null = orgId ?? null;
+  await client`SELECT set_config('app.current_org_id', ${gucValue}, false)`;
+  try {
+    await fn();
+  } finally {
+    await client`RESET ROLE`;
+    await client`SELECT set_config('app.current_org_id', ${null}, false)`;
+  }
+}
+
+describe('RLS sources/source_sections — real-DB canary (SPEC-REGULA-RLS-SOURCES-001, #317)', () => {
+  beforeAll(async () => {
+    if (SKIP) return;
+    client = postgres(process.env.DATABASE_URL as string, { max: 1, prepare: false });
+    // Clean any stale seed from prior failed runs, then seed fresh (superuser).
+    await client`DELETE FROM sources WHERE org_label IN ('canary-a', 'canary-b')`;
+    await client`DELETE FROM organizations WHERE id IN (${ORG_A}, ${ORG_B})`;
+    await client`
+      INSERT INTO organizations (id, name) VALUES
+        (${ORG_A}, 'RLS Canary Org A'),
+        (${ORG_B}, 'RLS Canary Org B')
+    `;
+    await client`
+      INSERT INTO sources (organization_id, org_label, title, type) VALUES
+        (${ORG_A}, 'canary-a', 'Canary Source A', 'Internal'),
+        (${ORG_B}, 'canary-b', 'Canary Source B', 'Internal')
+    `;
+    await client`
+      INSERT INTO source_sections (source_id, anchor, heading, text)
+      SELECT id, 'sec-1', 'Section 1', 'canary section text'
+      FROM sources WHERE org_label IN ('canary-a', 'canary-b')
+    `;
+  });
+
+  afterAll(async () => {
+    if (SKIP) return;
+    await client`DELETE FROM sources WHERE org_label IN ('canary-a', 'canary-b')`;
+    await client`DELETE FROM organizations WHERE id IN (${ORG_A}, ${ORG_B})`;
+    await client.end();
+  });
+
+  // ---- AC1: migration 0114 structure (ENABLE + FORCE + 2 policies) ----
+
+  it.skipIf(SKIP)('sources: ENABLE + FORCE ROW LEVEL SECURITY (AC1)', async () => {
+    const rows = await client`
+      SELECT relrowsecurity AS enabled, relforcerowsecurity AS forced
+      FROM pg_class WHERE relname = 'sources'
+    `;
+    expect(rows[0]?.enabled, 'sources must have RLS enabled').toBe(true);
+    expect(rows[0]?.forced, 'sources must FORCE RLS').toBe(true);
+  });
+
+  it.skipIf(SKIP)('source_sections: ENABLE + FORCE ROW LEVEL SECURITY (AC1)', async () => {
+    const rows = await client`
+      SELECT relrowsecurity AS enabled, relforcerowsecurity AS forced
+      FROM pg_class WHERE relname = 'source_sections'
+    `;
+    expect(rows[0]?.enabled, 'source_sections must have RLS enabled').toBe(true);
+    expect(rows[0]?.forced, 'source_sections must FORCE RLS').toBe(true);
+  });
+
+  it.skipIf(SKIP)('sources/source_sections: org-isolation policies exist (AC2)', async () => {
+    const rows = await client`
+      SELECT tablename, policyname FROM pg_policies
+      WHERE tablename IN ('sources', 'source_sections') ORDER BY tablename
+    `;
+    const names = rows.map(
+      (r: { tablename: string; policyname: string }) => `${r.tablename}.${r.policyname}`,
+    );
+    expect(names, JSON.stringify(names)).toContain('sources.sources_org_isolated');
+    expect(names).toContain('source_sections.source_sections_org_isolated');
+  });
+
+  // ---- AC3: canary under regula_app role ----
+
+  it.skipIf(SKIP)(
+    'regula_app + GUC set: own-org sources visible, other-org blocked (AC3)',
+    async () => {
+      await asRegulaApp(ORG_A, async () => {
+        const rows = await client`
+        SELECT organization_id AS org FROM sources WHERE org_label IN ('canary-a', 'canary-b')
+      `;
+        expect(
+          rows.map((r: { org: string }) => r.org),
+          JSON.stringify(rows),
+        ).toEqual([ORG_A]);
+      });
+    },
+  );
+
+  it.skipIf(SKIP)('regula_app + GUC unset: fail-closed (0 rows) (AC3)', async () => {
+    await asRegulaApp(null, async () => {
+      const rows = await client`SELECT count(*)::int AS n FROM sources`;
+      expect(Number(rows[0]?.n), 'no GUC ⇒ RLS must hide ALL rows (fail-closed)').toBe(0);
+    });
+  });
+
+  it.skipIf(SKIP)('regula_app cross-org INSERT blocked by WITH CHECK (AC2)', async () => {
+    await expect(
+      asRegulaApp(ORG_A, async () => {
+        await client`
+          INSERT INTO sources (organization_id, org_label, title, type)
+          VALUES (${ORG_B}, 'canary-sneak', 'Should Be Blocked', 'Internal')
+        `;
+      }),
+    ).rejects.toThrow(/row-level security|violates/i);
+  });
+
+  it.skipIf(SKIP)(
+    'source_sections EXISTS subquery: scoped to parent source org (REQ-RLS-SRC-003)',
+    async () => {
+      await asRegulaApp(ORG_A, async () => {
+        const rows = await client`
+        SELECT s.org_label AS lbl FROM source_sections ss
+        JOIN sources s ON s.id = ss.source_id
+        WHERE s.org_label IN ('canary-a', 'canary-b')
+      `;
+        expect(
+          rows.map((r: { lbl: string }) => r.lbl),
+          JSON.stringify(rows),
+        ).toEqual(['canary-a']);
+      });
+      await asRegulaApp(ORG_B, async () => {
+        const rows = await client`
+        SELECT s.org_label AS lbl FROM source_sections ss
+        JOIN sources s ON s.id = ss.source_id
+        WHERE s.org_label IN ('canary-a', 'canary-b')
+      `;
+        expect(
+          rows.map((r: { lbl: string }) => r.lbl),
+          JSON.stringify(rows),
+        ).toEqual(['canary-b']);
+      });
+    },
+  );
+
+  // ---- AC3 negative: superuser bypasses RLS (confirms the inert-today framing) ----
+
+  it.skipIf(SKIP)(
+    'superuser bypasses RLS (no GUC) — confirms runtime inert until regula_app switch',
+    async () => {
+      const rows = await client`
+      SELECT count(*)::int AS n FROM sources WHERE org_label IN ('canary-a', 'canary-b')
+    `;
+      expect(Number(rows[0]?.n), 'superuser must see all canary rows regardless of RLS').toBe(2);
+    },
+  );
+});

--- a/tests/integration/rls-sources-real-db.test.ts
+++ b/tests/integration/rls-sources-real-db.test.ts
@@ -146,6 +146,21 @@ describe('RLS sources/source_sections — real-DB canary (SPEC-REGULA-RLS-SOURCE
   it.skipIf(SKIP)(
     'source_sections EXISTS subquery: scoped to parent source org (REQ-RLS-SRC-003)',
     async () => {
+      // Superuser sanity: confirm beforeAll seeded exactly one section per canary
+      // source. CI runs all real-db suites sequentially on one DB — a prior suite
+      // (e.g. rlhf) can leave source_sections rows or alter state. This pre-check
+      // isolates "beforeAll seed leak" from "RLS scoping" before asserting under role.
+      const seeded = await client`
+        SELECT s.org_label AS lbl FROM source_sections ss
+        JOIN sources s ON s.id = ss.source_id
+        WHERE s.org_label IN ('canary-a', 'canary-b')
+        ORDER BY s.org_label
+      `;
+      expect(
+        seeded.map((r: { lbl: string }) => r.lbl),
+        `superuser seed sanity: ${JSON.stringify(seeded)}`,
+      ).toEqual(['canary-a', 'canary-b']);
+
       await asRegulaApp(ORG_A, async () => {
         const rows = await client`
         SELECT s.org_label AS lbl FROM source_sections ss


### PR DESCRIPTION
## SPEC-REGULA-RLS-SOURCES-001 — Run Phase (Issue #317)

sources/source_sections RLS 활성화로 org-isolation defense-in-depth. #239 project-wide RLS의 마지막 누락 도메인(RAG corpus) 메움. Plan: PR #399 (머지됨, main \`ed369f7\`).

### 구현 (4 files)
- **migration 0114**: sources + source_sections `ENABLE`+`FORCE ROW LEVEL SECURITY` + org-isolation policy (strict org-match, fail-closed). source_sections는 \`organization_id\` 컬럼이 없어 **부모 sources EXISTS subquery** (Option A). \`DROP POLICY IF EXISTS\` idempotency guard (plan-auditor D1).
- **NULLIF(current_setting(...), '')::uuid** — 빈/NULL GUC를 안전 처리. **실DB 카나리로 발견**: RESET/빈 GUC가 \`::uuid\` cast에서 \`invalid input syntax\` 에러. NULLIF로 fail-closed 보장 (sibling 0099보다 견고).
- **tests/integration/rls-sources-real-db.test.ts**: real-DB 카나리 **8종**. 단일 postgres-js client(\`max:1\`)로 SET ROLE/GUC pool 오염 원천 차단. regula_app role로 own-org 가시 / other 차단 / GUC unset fail-closed / cross-org INSERT WITH CHECK / source_sections EXISTS / superuser bypass 증명.
- **CI**: 카나리를 \`migrations-real-db.yml\` real-db suite에 등록 (11번째).
- **SPEC plan.md**: migration SQL에 NULLIF 동기화.

### AC4 (0084 omission root cause)
sources/source_sections는 0000에서 CREATE TABLE만 생성되고 RLS policy가 전혀 없었음 → 0083/0084(WITH CHECK/FORCE)가 붙일 대상이 없어 **scope gap** (19 tables, ingest_jobs 0017 §3 DROP). migration 헤더에 문서화.

### 게이트 직검 (orchestrator, L-007/008/009/013/015)
| 게이트 | 결과 |
|---|---|
| typecheck | 0 |
| ci:migrations | 0 (0114 시퀀스) |
| lint (biome + lint:hex) | 0 |
| ci:rbac · ci:audit · ci:module-boundaries | 0 |
| **실DB 카나리** (regula-test-db) | **8/8 PASS** |
| full \`pnpm test\` | **4763 passed / 0 failed** (회귀 0, 카나리 1 skip) |

### 런타임 영향
**영향 0** — 현재 DB role = postgres superuser → RLS bypass (BYPASSRLS). 실제 enforce는 ops가 DATABASE_URL을 \`regula_app\` (NOBYPASSRLS, migration 0085)으로 전환 후. 본 PR은 defense-in-depth 층 활성화 + 카나리로 미래 enforce 시 동작 증명.

Closes #317

🗿 MoAI <email@mo.ai.kr>