### PR TITLE
test(traceability): #402 hooks 0→100% + evidence-packet — coverage ratchet-up (단계 1)

### DIFF
--- a/lib/traceability/__tests__/evidence-packet.test.ts
+++ b/lib/traceability/__tests__/evidence-packet.test.ts
@@ -2,18 +2,20 @@
 // @MX:SPEC SPEC-REGULA-TRACEABILITY-001 (REQ-TRACEABILITY-006, REQ-TRACEABILITY-007)
 
 import { describe, expect, it } from 'vitest';
-import type { EvidencePacket } from '../evidence-packet';
+import { type EvidencePacket, getEvidencePacket } from '../evidence-packet';
 import { packetToExportData } from '../export-packet';
 
 describe('traceability/evidence-packet — getEvidencePacket contract', () => {
-  // The drizzle query-chain shape makes a pure-stub test brittle without
-  // reaching into SQL predicate decoding. The real DB path is covered by
-  // integration-real-pipeline.test.ts (audit enum lock-step + export render).
-  // Here we verify the issue-surfacing contract indirectly via the export
-  // flattener, which consumes the same EvidencePacket shape the assembler
-  // produces.
-  it('returns null when the deliverable node is not found (documented contract)', () => {
-    expect(true).toBe(true);
+  it('returns null when the deliverable node is not found', async () => {
+    // Minimal db stub: the root lookup returns no rows → getEvidencePacket
+    // returns null before any traversal (REQ-TRACEABILITY-007 contract).
+    // Deeper BFS scenarios are covered by integration-real-pipeline.test.ts;
+    // this exercises the early-return + the root SELECT chain shape.
+    const db = {
+      select: () => ({ from: () => ({ where: () => ({ limit: () => [] }) }) }),
+    };
+    const r = await getEvidencePacket(db as never, { orgId: 'o1', deliverableId: 'missing' });
+    expect(r).toBeNull();
   });
 });
 

--- a/lib/traceability/__tests__/hooks.test.ts
+++ b/lib/traceability/__tests__/hooks.test.ts
@@ -1,0 +1,125 @@
+// @MX:NOTE [AUTO] Unit tests for stale-propagation hooks (coverage #402).
+// @MX:SPEC SPEC-REGULA-TRACEABILITY-001 (REQ-TRACEABILITY-009, AC-05)
+//
+// The hooks orchestrate findNodeByRef / upsertNode / propagateStaleFromNode /
+// writeAudit. We mock all four so the control flow (no-op when no node,
+// propagate + audit when node exists, non-blocking error swallow) is exercised
+// without touching drizzle SQL shape. Real DB wiring is covered by
+// integration-real-pipeline.test.ts.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db/client', () => ({ db: {} }));
+vi.mock('@/lib/audit', () => ({ writeAudit: vi.fn() }));
+vi.mock('../graph', () => ({
+  findNodeByRef: vi.fn(),
+  upsertNode: vi.fn(),
+}));
+vi.mock('../stale-propagation', () => ({ propagateStaleFromNode: vi.fn() }));
+
+import { writeAudit } from '@/lib/audit';
+import { findNodeByRef, upsertNode } from '../graph';
+import { onRegulatoryUpdateSuperseded, onSourceSectionSuperseded } from '../hooks';
+import { propagateStaleFromNode } from '../stale-propagation';
+
+const ORG = '00000000-0000-0000-0000-000000000001';
+const ACTOR = '00000000-0000-0000-0000-0000000000a1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('onSourceSectionSuperseded (hooks.ts — REQ-TRACEABILITY-009)', () => {
+  it('is a no-op (propagated:false) when no evidence_node exists yet', async () => {
+    vi.mocked(findNodeByRef).mockResolvedValue(null);
+    const r = await onSourceSectionSuperseded({ orgId: ORG, refId: 'sec-1', actorId: ACTOR });
+    expect(r).toEqual({ propagated: false, affectedCount: 0 });
+    expect(propagateStaleFromNode).not.toHaveBeenCalled();
+    expect(writeAudit).not.toHaveBeenCalled();
+  });
+
+  it('propagates stale_flags + emits traceability.stale_propagated audit when node exists', async () => {
+    vi.mocked(findNodeByRef).mockResolvedValue({ id: 'n1', orgId: ORG } as never);
+    vi.mocked(propagateStaleFromNode).mockResolvedValue({
+      affectedNodeIds: ['n2', 'n3'],
+    } as never);
+    const r = await onSourceSectionSuperseded({ orgId: ORG, refId: 'sec-1', actorId: ACTOR });
+    expect(r).toEqual({ propagated: true, affectedCount: 2 });
+    expect(propagateStaleFromNode).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ orgId: ORG, sourceNodeId: 'n1', reason: 'superseded_source' }),
+    );
+    expect(writeAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'traceability.stale_propagated',
+        resource_type: 'evidence_node',
+        resource_id: 'n1',
+      }),
+    );
+  });
+
+  it('NEVER throws — logs a propagationFailed audit and returns propagated:false on error', async () => {
+    vi.mocked(findNodeByRef).mockRejectedValue(new Error('db down'));
+    const r = await onSourceSectionSuperseded({ orgId: ORG, refId: 'sec-1', actorId: ACTOR });
+    expect(r).toEqual({ propagated: false, affectedCount: 0 });
+    expect(writeAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'traceability.stale_propagated',
+        meta_json: expect.objectContaining({ propagationFailed: true, error: 'db down' }),
+      }),
+    );
+  });
+});
+
+describe('onRegulatoryUpdateSuperseded (hooks.ts — impact #41 path)', () => {
+  it('upserts the evidence_node if absent, then propagates with reason superseded_regulation', async () => {
+    vi.mocked(findNodeByRef).mockResolvedValue(null);
+    vi.mocked(upsertNode).mockResolvedValue({ id: 'n2', orgId: ORG } as never);
+    vi.mocked(propagateStaleFromNode).mockResolvedValue({ affectedNodeIds: ['n3'] } as never);
+    const r = await onRegulatoryUpdateSuperseded({
+      orgId: ORG,
+      refId: 'ru-1',
+      createdBy: ACTOR,
+      actorId: ACTOR,
+    });
+    expect(r).toEqual({ propagated: true, affectedCount: 1 });
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ nodeType: 'regulatory_update', refId: 'ru-1' }),
+    );
+    expect(propagateStaleFromNode).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sourceNodeId: 'n2', reason: 'superseded_regulation' }),
+    );
+    expect(writeAudit).toHaveBeenCalledWith(expect.objectContaining({ resource_id: 'n2' }));
+  });
+
+  it('reuses the existing node when findNodeByRef returns one (no upsert)', async () => {
+    vi.mocked(findNodeByRef).mockResolvedValue({ id: 'n-existing', orgId: ORG } as never);
+    vi.mocked(propagateStaleFromNode).mockResolvedValue({ affectedNodeIds: [] } as never);
+    const r = await onRegulatoryUpdateSuperseded({
+      orgId: ORG,
+      refId: 'ru-1',
+      createdBy: ACTOR,
+      actorId: ACTOR,
+    });
+    expect(r).toEqual({ propagated: true, affectedCount: 0 });
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+
+  it('NEVER throws — logs propagationFailed audit on error', async () => {
+    vi.mocked(findNodeByRef).mockRejectedValue(new Error('graph corrupt'));
+    const r = await onRegulatoryUpdateSuperseded({
+      orgId: ORG,
+      refId: 'ru-1',
+      createdBy: ACTOR,
+      actorId: ACTOR,
+    });
+    expect(r).toEqual({ propagated: false, affectedCount: 0 });
+    expect(writeAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta_json: expect.objectContaining({ propagationFailed: true }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Coverage 85% ratchet-up — 단계 1 (Issue #402)

SPEC-REGULA-TRACEABILITY-001 도메인 coverage 상승. 이슈 #402 (REALDB-001 follow-up) 첫 단계.

### 구현
- **hooks.test.ts (신규 6 tests)**: onSourceSectionSuperseded / onRegulatoryUpdateSuperseded 제어 흐름 — no-op(노드 없음) / propagate+audit(노드 존재) / non-blocking error swallow. vi.mock 4종 (db/audit/graph/stale-propagation).
- **evidence-packet.test.ts**: placeholder(`expect(true)`) 제거 → getEvidencePacket null 케이스 (root 없음 early return).

### Coverage 효과
| 항목 | before | after |
|---|---|---|
| hooks.ts | 0% | **100%** |
| lib/traceability | 70.83% | 84.06% |
| **All files (Stmts)** | 60.84% | **61.11%** |

### 게이트 직검
- typecheck 0 · lint 0 · full \`pnpm test\` **4772 passed / 0 failed** · ci:coverage exit 0 (ratchet floor 60/70 유지).

### 후속 (이슈 #402)
evidence-packet BFS 심화(drizzle chain mock), validation/consumers (model-gov 54%·traceability 59%), cer/steps, deadlines route 실행 테스트. 단계적 ratchet-up.

Refs #402

🗿 MoAI <email@mo.ai.kr>