### PR TITLE
docs(spec): SPEC-REGULA-CORPUS-SEED-001 plan — 3-repo 지식베이스 구축 + #312 E2E + 문서 정정

### DIFF
--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/acceptance.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/acceptance.md
@@ -6,7 +6,7 @@
 
 ### AC-1: 공개 repo 연결 후 sync 성공 → 코퍼스 채워짐
 
-**Given**: 실DB(pgvector, 포트 5433)가 실행 중이고, `GITHUB_PAT`(repo:read) 가 환경에 설정되어 있으며, MD-process repo(`https://github.com/holee9/MD-process.git`) 가 연결 가능하다.
+**Given**: 실DB(pgvector, 포트 5433)가 실행 중이고, 유효한 `ra-lead` 세션(`session.user.organizationId` + `id`; `knowledgesources.manage` 권한, Task M1-0)이 설정되어 있으며, 운영자가 `GITHUB_PAT`(repo:read)를 확보하여 POST body `auth_token`으로 전달할 수 있고, MD-process repo(`https://github.com/holee9/MD-process.git`)가 연결 가능하다.
 
 **When**: 운영자가 `POST /api/ra/knowledge-sources` 로 MD-process를 knowledge_source로 등록한 후, `POST /api/ra/knowledge-sources/{id}/sync` 로 동기화를 트리거한다.
 
@@ -135,7 +135,7 @@
 
 ---
 
-### AC-9: ra-llm-wiki adapter 경로 운영 절처 문서화
+### AC-9: ra-llm-wiki adapter 경로 운영 절차 문서화
 
 **Given**: ra-llm-wiki Gitea adapter(`scripts/ingest-gitea-wiki.ts`) 가 존재하고, `GITEA_TOKEN`/`GITEA_URL`/`GITEA_WIKI_REPO` 환경 설정이 가능하다.
 
@@ -144,7 +144,7 @@
 **Then**:
 - `knowledge-base.md` 에 ra-llm-wiki ingest 절차(adapter 사용, 환경 변수, 트리거 명령) 가 문서화된다.
 - D1-A 결정(유지) 근거가 명시된다.
-- 직검: 문서 섹션 존재. (주: M2는 adapter 실행 그 자체보다 운영 절처 문서화가 주된 범위 — adapter는 이미 hardening됨)
+- 직검: 문서 섹션 존재. (주: M2는 adapter 실행 그 자체보다 운영 절차 문서화가 주된 범위 — adapter는 이미 hardening됨)
 
 **매핑**: REQ-KB-008 / Milestone M2
 

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/acceptance.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/acceptance.md
@@ -23,15 +23,16 @@
 
 ### AC-2: RAG 검색에서 해당 repo 인용 반환
 
-**Given**: AC-1이 완료되어 MD-process에서 ingest된 도메인 콘텐츠(FDA 510(k), EU MDR, MFDS, ISO13485, SOP 등) 가 `source_sections` 에 gx10 embedding과 함께 존재한다.
+**Given**: AC-1이 완료되어 MD-process에서 ingest된 도메인 콘텐츠(FDA 510(k), EU MDR, MFDS, ISO13485, SOP 등) 가 `source_sections` 에 gx10 embedding과 함께 존재한다. 단, ingest 직후 source 행들은 `approvalStatus='pending_review'`(sync.ts:543) 상태이며, `composeRetrievalGates`(lib/source-governance/retrieval-gate.ts) 가 `approvalStatus !== 'approved'`를 검색에서 영구 제외한다.
 
-**When**: 사용자가 RAG Q&A에 해당 도메인 질의를 보낸다 (예: "FDA 510(k) submission 요건은?").
+**When**: RA-owner가 `POST /api/source-governance/approve`(REQ-SOURCE-GOV-015)로 MD-process 출처 source 들을 `approved`로 전환한 후, 사용자가 RAG Q&A에 해당 도메인 질의를 보낸다 (예: "FDA 510(k) submission 요건은?").
 
 **Then**:
 - 응답에 MD-process에서 유래한 source 인용(source_host/owner/repo/path 메타) 이 포함된다.
-- 인용된 source의 `approvalStatus` 가 `pending_review` 임에도 불구하고, 검색 엔진이 해당 chunk를 반환함을 런타임 증거(로그 또는 응답 payload) 로 확인한다. (주: approval 게이트가 검색을 차단하는 경우, 그 현황을 기록하고 별도 검토로 위임 — 본 AC의 핵심은 "코퍼스가 채워져 있으면 검색이 가능" 입증)
+- 인용된 source의 `approvalStatus='approved'` 임을 직검(`SELECT approval_status FROM sources WHERE source_repo='MD-process'`)하고, `source.approved` audit 행이 기록됨을 확인한다.
+- 검색 엔진이 승인된 source의 chunk를 반환함을 런타임 증거(응답 payload 또는 로그)로 확인한다.
 
-**매핑**: REQ-KB-006, REQ-KB-031 / Milestone M1
+**매핑**: REQ-KB-006, REQ-KB-009, REQ-KB-031 / Milestone M1
 
 ---
 

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/acceptance.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/acceptance.md
@@ -1,0 +1,263 @@
+# Acceptance Criteria — SPEC-REGULA-CORPUS-SEED-001
+
+> 작성일: 2026-07-10 | 매핑: #312 AC 4건 + M0-M4 + EARS REQ-KB-###
+
+## 1. #312 E2E AC (핵심 — 실DB 직검, L-013 방어)
+
+### AC-1: 공개 repo 연결 후 sync 성공 → 코퍼스 채워짐
+
+**Given**: 실DB(pgvector, 포트 5433)가 실행 중이고, `GITHUB_PAT`(repo:read) 가 환경에 설정되어 있으며, MD-process repo(`https://github.com/holee9/MD-process.git`) 가 연결 가능하다.
+
+**When**: 운영자가 `POST /api/ra/knowledge-sources` 로 MD-process를 knowledge_source로 등록한 후, `POST /api/ra/knowledge-sources/{id}/sync` 로 동기화를 트리거한다.
+
+**Then**:
+- `syncStatus` 전이가 `idle → syncing → synced` 로 관측된다 (직검 `SELECT sync_status FROM knowledge_sources`).
+- `lastSyncedAt` 이 현재 시각으로 갱신된다.
+- `SELECT COUNT(*) FROM sources WHERE source_repo = 'MD-process'` 결과가 동기화 전보다 증가한다 (파일 수만큼 sources 행 생성; MAX_FILES=500 cap 내).
+- `SELECT COUNT(*) FROM source_sections` 결과가 증가한다 (chunk 수만큼).
+- `corpus_sync_runs` 테이블에 status=`synced` 행이 추가된다 (직검).
+
+**매핑**: REQ-KB-001, REQ-KB-002, REQ-KB-003, REQ-KB-030 / Milestone M1
+
+---
+
+### AC-2: RAG 검색에서 해당 repo 인용 반환
+
+**Given**: AC-1이 완료되어 MD-process에서 ingest된 도메인 콘텐츠(FDA 510(k), EU MDR, MFDS, ISO13485, SOP 등) 가 `source_sections` 에 gx10 embedding과 함께 존재한다.
+
+**When**: 사용자가 RAG Q&A에 해당 도메인 질의를 보낸다 (예: "FDA 510(k) submission 요건은?").
+
+**Then**:
+- 응답에 MD-process에서 유래한 source 인용(source_host/owner/repo/path 메타) 이 포함된다.
+- 인용된 source의 `approvalStatus` 가 `pending_review` 임에도 불구하고, 검색 엔진이 해당 chunk를 반환함을 런타임 증거(로그 또는 응답 payload) 로 확인한다. (주: approval 게이트가 검색을 차단하는 경우, 그 현황을 기록하고 별도 검토로 위임 — 본 AC의 핵심은 "코퍼스가 채워져 있으면 검색이 가능" 입증)
+
+**매핑**: REQ-KB-006, REQ-KB-031 / Milestone M1
+
+---
+
+### AC-3: 실패 시 syncStatus='failed' + audit
+
+**Given**: 실DB가 실행 중이고, MD-process knowledge_source가 등록되어 있다.
+
+**When**: 의도적으로 실패를 유발한다 (예: 잘못된 branch 이름, 또는 일시적 네트워크 차단, 또는 auth_token 무효화).
+
+**Then**:
+- `syncStatus` 가 `failed` 로 갱신된다 (직검).
+- `audit_logs` 테이블에 `action='knowledge_source.synced'`, `resource_type='knowledgeSource'`, `meta_json.status='failed'` 인 행이 동일 트랜잭션에 기록된다 (직검 — UPDATE와 audit 행이 원자적).
+- `corpus_sync_runs` 행이 status=`failed` + `error_message` 와 함께 기록된다.
+
+**매핑**: REQ-KB-004, NFR-KB-AUD-001, NFR-KB-AUD-002 / Milestone M1
+
+---
+
+### AC-4: re-sync 시 supersession (기존 chunk superseded)
+
+**Given**: AC-1이 완료되어 MD-process의 특정 파일에 대해 `source_sections` 행들이 존재한다.
+
+**When**: 동일 knowledge_source에 대해 re-sync를 트리거한다.
+
+**Then**:
+- 새 `corpus_sync_runs` 행이 생성된다 (새 ingestionRunId).
+- 기존 chunk 들에 대해 `applyOutdateOperations` 이 적용되어 outdated 상태로 전이된다 (직검 — `resolveExistingChunkIds` + outdate 결과, `chunksOutdated > 0`).
+- 동일 파일의 새 chunk 가 삽입된다 (`chunksAdded > 0`).
+- `sources` 행은 재사용된다 (동일 provenance key: orgId + host/owner/repo/path).
+
+**매핑**: REQ-KB-005 / Milestone M1
+
+---
+
+## 2. M0 — 문서 수정 AC
+
+### AC-5: `docs/architecture/knowledge-base.md` 단일 진실 원천 생성
+
+**Given**: `docs/architecture/knowledge-base.md` 가 존재하지 않는다 (또는 KB에 대한 단일 SoT가 부재하다).
+
+**When**: M0 작업을 완료한다.
+
+**Then**:
+- `docs/architecture/knowledge-base.md` 가 생성되고, 다음을 포함한다:
+  - "지식베이스 = 3개 git repo (ra-project, MD-process, ra-llm-wiki)" 선언.
+  - 데이터 소싱(repo → knowledge_sources) vs 검색 도메인(FDA/EU MDR/...) 분리 섹션 (spec.md §5 선언과 동일).
+  - repo별 접근 방식(GitHub: GITHUB_PAT + knowledge_sources git sync; Gitea: adapter + GITEA_TOKEN).
+  - auth-token 평문 저장 현황 주의(NFR-KB-SEC-002) + diskstation SSRF 현황(NFR-KB-SEC-003).
+- 직검: 파일 존재 + 섹션 헤더 포함.
+
+**매핑**: REQ-KB-010, REQ-KB-011 / Milestone M0
+
+---
+
+### AC-6: production-deployment-gap BLOCK-1 정정
+
+**Given**: `docs/proposals/production-deployment-gap-2026-07-10.md` BLOCK-1 이 "6개 코퍼스 seed" / "FDA 510(k) · EU MDR · MFDS · PMDA · internal SOP" 프레이밍을 포함한다.
+
+**When**: M0 작업을 완료한다.
+
+**Then**:
+- BLOCK-1이 "3개 git repo 연동 (ra-project, MD-process, ra-llm-wiki)" 프레이밍으로 정정된다.
+- "FDA/EU MDR/MFDS/NMPA/PMDA/SOP" 가 검색 도메인으로 재기술된다.
+- `knowledge-base.md` 를 참조하도록 링크가 추가된다.
+- 직검: 수정된 BLOCK-1 텍스트가 "3개" / "repo" 키워드를 포함하고, "6개 코퍼스 seed" 가 제거되었다.
+
+**매핑**: REQ-KB-012 / Milestone M0
+
+---
+
+### AC-7: seed scripts 헤더 정정 + product.md
+
+**Given**: `scripts/seed-corpus.ts` L1-8, `scripts/seed-fda-corpus.ts` L1-9 가 `Requires: OPENAI_API_KEY` stale heuristic 을 포함하고, `.moai/project/product.md` L63/L90 이 "6개 corpus" 프레이밍을 포함한다.
+
+**When**: M0/M3 작업을 완료한다.
+
+**Then**:
+- 두 seed script 헤더가 "test fixture 전용, 운영 코퍼스는 git 연동(`knowledge-base.md` 참조)" 을 명시한다.
+- stale `OPENAI_API_KEY` heuristic 이 gx10 embed 경로 안내로 대체된다 (M3).
+- `product.md` L63/L90 이 데이터 소싱(3 repo)과 검색 도메인을 분리 기술한다.
+- 직검: 각 파일의 수정된 행 확인.
+
+**매핑**: REQ-KB-013, REQ-KB-014, REQ-KB-021 / Milestone M0 (헤더/product), M3 (OPENAI_API_KEY)
+
+---
+
+## 3. M2 — ra-project + ra-llm-wiki AC
+
+### AC-8: ra-project repo 동기화
+
+**Given**: AC-1(MD-process) 이 완료되어 파이프라인이 검증되었다.
+
+**When**: ra-project(`https://github.com/holee9/ra-project.git`) 를 knowledge_source로 등록 후 동기화한다.
+
+**Then**:
+- AC-1과 동일한 검증(코퍼스 채워짐, 상태 전이, audit)이 통과한다.
+- 154 md 파일이 ingest된다 (MAX_FILES=500 cap 내).
+
+**매핑**: REQ-KB-007 / Milestone M2
+
+---
+
+### AC-9: ra-llm-wiki adapter 경로 운영 절처 문서화
+
+**Given**: ra-llm-wiki Gitea adapter(`scripts/ingest-gitea-wiki.ts`) 가 존재하고, `GITEA_TOKEN`/`GITEA_URL`/`GITEA_WIKI_REPO` 환경 설정이 가능하다.
+
+**When**: M2 작업을 완료한다.
+
+**Then**:
+- `knowledge-base.md` 에 ra-llm-wiki ingest 절차(adapter 사용, 환경 변수, 트리거 명령) 가 문서화된다.
+- D1-A 결정(유지) 근거가 명시된다.
+- 직검: 문서 섹션 존재. (주: M2는 adapter 실행 그 자체보다 운영 절처 문서화가 주된 범위 — adapter는 이미 hardening됨)
+
+**매핑**: REQ-KB-008 / Milestone M2
+
+---
+
+## 4. M3 — gx10 cleanup AC
+
+### AC-10: stale OPENAI_API_KEY heuristic 제거
+
+**Given**: `scripts/seed-corpus.ts` 와 `scripts/seed-fda-corpus.ts` 에 `Requires: DATABASE_URL, OPENAI_API_KEY in environment` 주석이 존재한다.
+
+**When**: M3 작업을 완료한다.
+
+**Then**:
+- 두 스크립트의 헤더에서 `OPENAI_API_KEY` 요구 명시가 제거되거나, gx10 embed 경로 안내로 대체된다.
+- `seed-corpus.ts` 의 runtime 경로는 이미 `embedChunks` → gx10 을 사용하므로 코드 변경 불필요 (헤더만).
+- `seed-fda-corpus.ts` 의 `import { openai } from '@ai-sdk/openai'` + 직접 `embed()` 호출은 test fixture 허용 범위로 주석 명시 (runtime ingestion 아님).
+- 직검: 두 파일 헤더에 `OPENAI_API_KEY` 가 필수 요구로 표기되지 않음.
+
+**매핑**: REQ-KB-020, REQ-KB-021 / Milestone M3
+
+---
+
+## 5. M4 — 게이트 AC (L-013 방어)
+
+### AC-11: 품질 게이트 통과
+
+**Given**: M0-M3 코드/문서 변경이 완료되었다.
+
+**When**: M4 게이트를 실행한다.
+
+**Then**:
+- `pnpm typecheck` — 0 errors (직검 출력).
+- `pnpm lint` (lint:hex 포함 full) — 0 errors, 코드 줄 `#NNN` 금지 (L-008).
+- `pnpm test` (full, 타깃만 아님) — 0 failures (L-009).
+- `pnpm ci:*` 전 단계 — 0 failures (L-015: 일부 green ≠ 전체 green, 로컬 직검).
+- 커밋 범위가 staged 범위와 일치 (L-009).
+
+**매핑**: NFR-KB-TRC-001 / Milestone M4
+
+---
+
+### AC-12: 실DB E2E 직검 (L-013 핵심 방어)
+
+**Given**: AC-1 ~ AC-4 가 mock 기반이 아닌 실DB(pgvector)에서 실행 가능하다.
+
+**When**: M4 검증을 완료한다.
+
+**Then**:
+- AC-1 ~ AC-4 의 모든 `SELECT COUNT(*)` / 상태 전이 / audit / supersession 검증이 실DB에서 직검된다.
+- mock-only 또는 self-report 로 본 SPEC 완료를 선언하지 않는다 (REQ-KB-032).
+- 직검 증거(DB 쿼리 출력, RAG 응답 payload, audit_rows) 가 커밋 메시지 또는 PR 본문에 첨부된다.
+
+**매핑**: REQ-KB-030, REQ-KB-031, REQ-KB-032 / Milestone M1 (실행), M4 (검증)
+
+---
+
+## 6. 엣지 케이스
+
+### EC-1: MD-process 549파일 > MAX_FILES=500
+
+- **시나리오**: 단일 동기화에서 500파일 cap 도달.
+- **기대**: 500파일만 ingest되고, 나머지 49파일은 건너뛰어지며 경고 로그가 기록된다 (sync.ts L374-379).
+- **처리**: NFR-KB-PERF-001 로 문서화. 본 SPEC은 MAX_FILES 변경을 포함하지 않는다(EXCL). 별도 검토.
+
+### EC-2: 단일 파일 추출/임베딩 실패
+
+- **시나리오**: MD-process의 한 파일이 손상되었거나 미지원 형식.
+- **기대**: 해당 파일은 `stats.errors` 에 기록되고, 전체 동기화는 계속된다 (per-file try/catch, sync.ts L318-326).
+- **검증**: AC-1 에서 `errors` 배열이 비어있지 않더라도 `syncStatus='synced'` 가 유지됨을 확인.
+
+### EC-3: 모든 파일 실패
+
+- **시나리오**: MD-process의 전체 파일 ingest 실패 (예: 권한 문제).
+- **기대**: all-files-failed guard(sync.ts L330-332) 가 발동하여 `syncStatus='failed'` 로 전이.
+- **검증**: AC-3 경로로 흡수.
+
+### EC-4: auth_token 없이 공개 repo 동기화
+
+- **시나리오**: MD-process가 공개 repo라 auth_token 없이 동기화.
+- **기대**: `cloneRepo` 의 `if (authToken && gitUrl.startsWith('https://'))` 분기(sync.ts L188) 가 우회되어 비인증 clone 시도. 공개 repo이므로 성공.
+- **검증**: M1에서 `GITHUB_PAT` 없이도 동작하는지 직검 (공개이므로 예상 성공). 단, rate limit 회피를 위해 PAT 사용을 권장.
+
+### EC-5: re-sync 중 콘텐츠 변화 없음
+
+- **시나리오**: MD-process 내용 변화 없이 re-sync.
+- **기대**: 동일 chunk_hash 로 재삽입 시도 + 기존 chunk supersession. `chunksAdded > 0` (재삽입), `chunksOutdated > 0` (이전 chunk).
+
+---
+
+## 7. Definition of Done
+
+- [ ] AC-1 ~ AC-4 (#312 E2E, 실DB 직검) 통과
+- [ ] AC-5 ~ AC-7 (M0 문서 수정) 통과
+- [ ] AC-8 ~ AC-9 (M2 ra-project + Gitea 문서화) 통과
+- [ ] AC-10 (M3 gx10 cleanup) 통과
+- [ ] AC-11 (M4 품질 게이트) 통과
+- [ ] AC-12 (M4 실DB 직검 증거) 통과
+- [ ] 모든 EARS REQ-KB-### (REQ-KB-001..014, 020..021, 030..032) 가 하나 이상의 AC에 매핑됨
+- [ ] 검색 도메인 참조(`lib/ai/retrievers/*`, `lib/classification/*`) 미수정 확인
+- [ ] `syncKnowledgeSource` / `ingestDocuments` 시그니처 불변 확인 (비파괴)
+- [ ] 커밋 메시지가 `SPEC-REGULA-CORPUS-SEED-001` + `#312` 참조
+- [ ] `docs/architecture/knowledge-base.md` 가 단일 진실 원천으로 확립
+
+---
+
+## 8. 품질 게이트 기준
+
+| 게이트 | 기준 | 근거 |
+|--------|------|------|
+| typecheck | 0 errors | ci 엄수 |
+| lint (full, lint:hex 포함) | 0 errors, 줄 `#NNN` 금지 | L-008 |
+| test (full) | 0 failures, staged 범위 직검 | L-009 |
+| ci:* (전 단계) | 0 failures, 로컬 직검 | L-015 |
+| 실DB E2E | AC-1..4 직검, mock-only 기각 | L-013 |
+| SSRF guard | 약화 금지 (isInternalHost 불변) | NFR-KB-SEC-003 |
+| auth-token | 평문 저장 현황 기록, 암호화는 별도 이슈 | NFR-KB-SEC-002 |

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/research.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/research.md
@@ -15,8 +15,8 @@
 
 | Repo | URL | 파일 수 | 내용 | 접근 |
 |------|-----|---------|------|------|
-| **ra-project** | `https://github.com/holee9/ra-project.git` | 154 md | RA scheduler docs, regulatory identification radar, 2026 Q2 regulatory landscape | `GITHUB_PAT` (repo:read), 또는 local `RA_PROJECT_PATH` |
-| **MD-process** | `https://github.com/holee9/MD-process.git` | 549 md | 도메인별 구조화: `00_프로젝트관리/`, `01_법규_규제/{01_국내_MFDS,02_국제_ISO13485,03_미국_FDA,04_유럽_MDR}`, `02_품질경영시스템_QMS`, `03_설계_개발관리`, ... `13_규제평가_체크리스트` | `GITHUB_PAT` (repo:read), 또는 local `MD_PROCESS_PATH` |
+| **ra-project** | `https://github.com/holee9/ra-project.git` | 154 md | RA scheduler docs, regulatory identification radar, 2026 Q2 regulatory landscape | `GITHUB_PAT` (repo:read) → POST `auth_token` body (§2.4) |
+| **MD-process** | `https://github.com/holee9/MD-process.git` | 549 md | 도메인별 구조화: `00_프로젝트관리/`, `01_법규_규제/{01_국내_MFDS,02_국제_ISO13485,03_미국_FDA,04_유럽_MDR}`, `02_품질경영시스템_QMS`, `03_설계_개발관리`, ... `13_규제평가_체크리스트` | `GITHUB_PAT` (repo:read) → POST `auth_token` body (§2.4) |
 | **ra-llm-wiki** | Gitea `http://diskstation:7001/DR_RnD/ra-llm-wiki` | (wiki) | 사내 SOP wiki | HTTP 200 (비인증 목록), 콘텐츠는 `GITEA_TOKEN` 필요 |
 
 직검 명령:
@@ -176,7 +176,7 @@ knowledge_sources:
 
 - `GITHUB_PAT` (repo:read) → POST 생성 API `auth_token` 필드 → `authTokenEncrypted` 열에 저장(평문, 열 이름과 불일치) → cloneRepo에서 HTTPS username으로 주입.
 - 본 SPEC은 이 경로를 있는 그대로 사용. **저장 시 암호화는 본 SPEC 범위 외** (REG-395 계열 별도 이슈). NFR-KB-SEC-002로 명시.
-- M1 검증: `GITHUB_PAT` 가 없는 환경에서는 local clone 경로(`RA_PROJECT_PATH` / `MD_PROCESS_PATH`) fallback 문서화 (runbook).
+- M1 검증 (plan-auditor M1 정정): 코드는 `RA_PROJECT_PATH`/`MD_PROCESS_PATH` 환경변수를 읽지 않음(직검 `grep -rn` 결과 0건 — `.env.example`의 주석 처리된 local clone 경로는 구식 접근). GitHub 인증은 운영자가 `GITHUB_PAT`(repo:read)를 확보 후 POST `auth_token` body로 전달 → `authTokenEncrypted` 저장 → cloneRepo HTTPS username 주입(sync.ts:188-193). 공개 repo는 `auth_token` 생략 가능(비인증 clone). runbook은 이 실제 경로를 문서화.
 
 ### D4. MD-process를 M1 de-risk 대상으로 선택
 

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/research.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/research.md
@@ -1,0 +1,215 @@
+# Research — SPEC-REGULA-CORPUS-SEED-001
+
+> 작성일: 2026-07-10 | 작성자: manager-spec | Branch: `feat/spec-regula-corpus-seed-001-plan`
+> 상태: 직검 기반 (L-013 anti-pattern — 정적 분석/CI mock/self-report 의존 금지)
+
+## 1. 핵심 재정의 (Reframing) — 데이터 소싱 vs 검색 도메인
+
+### 1.1 오개념 (Misrepresentation) 원본
+
+`docs/proposals/production-deployment-gap-2026-07-10.md` BLOCK-1은 본 작업을 "seed 6 corpora: FDA / EU MDR / MFDS / NMPA / PMDA / SOP"로 정의했다. **이것은 데이터 소싱(data-sourcing)에 대한 잘못된 표현이다.**
+
+직검 결과, 지식베이스 데이터 소스는 **3개의 기존 git 저장소**다. "FDA/EU MDR/MFDS/NMPA/PMDA"는 별도의 seed 대상 repo가 아니라, `MD-process` repo 내부 `01_법규_규제/` 하위 디렉토리 구조이자 합법적인 **검색·분류 도메인(retrieval/classification domain)**이다.
+
+### 1.2 진실 (Ground-Truth) — 3개 repo (직검 2026-07-10)
+
+| Repo | URL | 파일 수 | 내용 | 접근 |
+|------|-----|---------|------|------|
+| **ra-project** | `https://github.com/holee9/ra-project.git` | 154 md | RA scheduler docs, regulatory identification radar, 2026 Q2 regulatory landscape | `GITHUB_PAT` (repo:read), 또는 local `RA_PROJECT_PATH` |
+| **MD-process** | `https://github.com/holee9/MD-process.git` | 549 md | 도메인별 구조화: `00_프로젝트관리/`, `01_법규_규제/{01_국내_MFDS,02_국제_ISO13485,03_미국_FDA,04_유럽_MDR}`, `02_품질경영시스템_QMS`, `03_설계_개발관리`, ... `13_규제평가_체크리스트` | `GITHUB_PAT` (repo:read), 또는 local `MD_PROCESS_PATH` |
+| **ra-llm-wiki** | Gitea `http://diskstation:7001/DR_RnD/ra-llm-wiki` | (wiki) | 사내 SOP wiki | HTTP 200 (비인증 목록), 콘텐츠는 `GITEA_TOKEN` 필요 |
+
+직검 명령:
+```
+git ls-remote https://github.com/holee9/ra-project.git HEAD    → e7aa8ac0...  ✓
+git ls-remote https://github.com/holee9/MD-process.git HEAD    → 0c0cfc26...  ✓
+curl -s -o /dev/null -w "%{http_code}" http://diskstation:7001/DR_RnD/ra-llm-wiki → 303 (redirect, alive)  ✓
+```
+
+### 1.3 데이터 소싱 vs 검색 도메인 — 명시적 분류
+
+| 개념 | 정의 | 본 SPEC에서의 처리 |
+|------|------|-------------------|
+| **데이터 소싱 (Data SOURCING)** | 코퍼스를 채우는 **물리적 데이터 원본** | 3개 git repo → `knowledge_sources` 등록, `syncKnowledgeSource()` 로 ingest |
+| **검색 도메인 (Retrieval/Classification DOMAIN)** | RAG 검색·문서 분류 시 사용하는 **논리적 분류 체계** | FDA / EU MDR / MFDS / NMPA / PMDA / ISO13485 / SOP. `lib/ai/retrievers/{fda,eu-mdr}.ts`, `lib/classification/*`, `lib/ingest/doc-classifier.ts` 에서 사용. **이들은 CORRECT — 수정 금지.** |
+
+**결론**: "NMPA/PMDA를 seed-target corpus로 seed한다"는 표현은 잘못이다 (별도 repo가 아님). 그러나 "FDA/EU MDR을 검색 도메인으로 사용한다"는 정확하다. 본 SPEC은 이 둘을 명확히 분리하여, 데이터 소싱 misframing만 수정하고 검색 도메인 참조는 보존한다.
+
+---
+
+## 2. 인프라 인벤토리 (직검 — 재지정 금지)
+
+### 2.1 `syncKnowledgeSource` + `ingestDocuments` — 이미 구현됨
+
+`lib/knowledge-sources/sync.ts` (직검 전체 560라인):
+
+- **cloneRepo** (L165): `execFile('git', ['clone','--depth','1','--single-branch','--branch', branch, cloneUrl, targetDir])` — execFile(argument array, shell=false) → RCE 방어. branch는 `GIT_REF_PATTERN` (`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`) 로 검증. `..` / leading `-` 차단.
+- **SSRF guard** (`isInternalHost`, L36): localhost, ::1, 127/8, 10/8, 192.168/16, 172.16-31, 0/8, `.local` suffix, `metadata.google.internal` 차단.
+- **ingestDocuments** (L258): scan → corpus_sync_runs INSERT (1 per repo) → per-file pipeline: extract → classify → chunk → embed → upsert source_sections. MAX_FILES=500, MAX_FILE_SIZE=10MB, MAX_TOTAL_SIZE=100MB. per-file try/catch (1 bad file → continue).
+- **supersession**: `resolveExistingChunkIds` → `applyOutdateOperations` (delta-sync 패턴 재사용). re-sync 시 기존 chunk outdated 처리.
+- **audit**: 성공/실패 모두 `db.transaction` 내 `writeAudit` (Part 11 §11.10(e), Issue #378 원자성).
+- **상태 전이**: syncStatus `idle → syncing → synced | failed`. lastSyncedAt 갱신. corpus_sync_runs `pending → synced | failed`.
+
+### 2.2 임베딩 — gx10 단일 SoT (이미 gx10)
+
+`lib/ai/embedding-provider.ts` (직검):
+
+- gx10 Ollama `qwen3-embedding:latest` (1536-dim MRL truncation, `http://192.168.100.1:11434/v1`).
+- `embedBatchTexts()` → `embedMany()` via `getEmbeddingModel()`. 모든 consumer (embedChunks, retrievers, knowledge-promo, ingest)가 라우팅.
+- MRL truncation은 fetch layer에서 주입 (`withEmbeddingDimensions`, L66) — pgvector `vector(1536)` byte-compatible.
+- **Direct-verified 2026-07-01** (L-013). OpenAI runtime dependency 없음.
+
+`lib/ingest/embed.ts` `embedChunks` → `embedBatchTexts` (gx10). 따라서 **ingestion 경로는 이미 gx10을 사용 중**. M3 cleanup은 seed scripts의 stale heuristic 제거만 해당.
+
+### 2.3 knowledge_sources 스키마
+
+`lib/db/schema.ts:3272` (직검):
+
+```
+knowledge_sources:
+  id, organizationId, orgLabel, gitUrl, branch,
+  sourceHost, sourceOwner, sourceRepo,
+  lastSyncedAt, syncStatus (default 'idle'),
+  authTokenEncrypted (text),    ← 열 이름은 "encrypted"지만...
+  createdBy, createdAt
+```
+
+### 2.4 auth-token 경로 — 중요 발견 (보안 GAP)
+
+직검 결과 (`app/api/ra/knowledge-sources/route.ts:40,62`, `[id]/sync/route.ts:50`):
+
+- POST 생성: `body.auth_token` → `authTokenEncrypted: auth_token || null` (route.ts:62). **실제 암호화 없음** — 열 이름과 달리 평문 저장.
+- POST 동기화: `auth_token: source.authTokenEncrypted` ([id]/sync/route.ts:50) → `syncKnowledgeSource({ auth_token })` → `cloneRepo(authToken)` → HTTPS URL에 username으로 주입 (sync.ts:188-193).
+
+**결론**: auth-token은 이미 end-to-end로 연결되어 작동한다. 단, **저장 시 암호화가 누락**되어 있다 (열 이름과 불일치). 이것은 본 SPEC의 직접 범위가 아니나, NFR-KB-SEC-002로 명시하고 연계 이슈(REG-395 계열)로 위임한다. 본 SPEC은 **기존 메커니즘을 있는 그대로 사용**한다 (비파괴 원칙).
+
+### 2.5 Gitea wiki adapter — 별도 경로 (knowledge_sources 아님)
+
+`scripts/ingest-gitea-wiki.ts` (직검):
+
+- **GraphQL API** 방식 (`/api/graphql`, wiki.pages.nodes). git clone 아님.
+- 자체 SSRF guard (`assertGiteaUrlAllowed`, `lib/gitea/url-guard`) — https OR internal host 허용 (이슈 작성 경로와 동일 정책).
+- token-leak sanitizer (`sanitizeGiteaErrorBody`) — Gitea error body가 Authorization header를 echo하는 것 방지.
+- `sources`/`source_sections`에 **직접 INSERT** (knowledge_sources 테이블 거치지 않음). `knowledge_sources`의 syncStatus/lastSyncedAt/corpus_sync_runs 추적 없음.
+- 환경: `GITEA_URL`, `GITEA_TOKEN`, `GITEA_WIKI_REPO`.
+
+### 2.6 SSRF guard — diskstation 거동 (직검)
+
+`isInternalHost("diskstation")` (sync.ts:36-49):
+- `localhost`? No. `::1`? No. `127./10./192.168./172.16-31./0.` regex? No (hostname, not IP). `.local` suffix? No. `metadata.google.internal`? No.
+- **결과: NOT blocked.** diskstation은 hostname이므로 IP regex를 우회한다. 그러나 실제로는 LAN-internal 호스트다.
+- `lib/gitea/url-guard`의 `assertGiteaUrlAllowed`는 다른 정책 (https OR internal 허용)을 사용하므로 adapter 경로는 정상 작동한다. 그러나 `knowledge_sources` 경로로 Gitea wiki를 연결하면 `isInternalHost` 통과 → 직접 LAN 접근. **이것이 M2 design decision의 핵심.**
+
+### 2.7 API 경로
+
+- `POST /api/ra/knowledge-sources` (route.ts) — 생성. body: `{ git_url, branch, auth_token }`.
+- `POST /api/ra/knowledge-sources/[id]/sync` — 동기화 트리거.
+- `GET/PATCH/DELETE /api/ra/knowledge-sources/[id]`.
+
+### 2.8 기존 테스트 (mock-based, L-013 맹점)
+
+- `tests/integration/knowledge-sources.test.ts` — mock 기반, IDOR + audit 검증.
+- `tests/unit/knowledge-sources/{parse-git-url,ingest-documents}.test.ts`.
+- **실DB E2E (#312 AC) 미검증** — 본 SPEC M1/M4가 해결.
+
+---
+
+## 3. 오개념 (Misrepresentation) 수정 대상 분류표
+
+다음은 "데이터 소싱 misframing" grep hit 파일 분류다. **일괄 재작성 금지** — 개별 분류 후 수정.
+
+### 3.1 REVISE (데이터 소싱 misframing — 수정 대상)
+
+| 파일 | 행 | 현재 내용 | 수정 방향 |
+|------|----|-----------|-----------|
+| `docs/proposals/production-deployment-gap-2026-07-10.md` | BLOCK-1 | "코퍼스 seed: FDA 510(k) · EU MDR · MFDS · PMDA · internal SOP" / "SPEC ... 6개 코퍼스 seed" | "3개 git repo 연동 (ra-project, MD-process, ra-llm-wiki) → ingestion. FDA/EU MDR/MFDS/NMPA/PMDA/SOP는 검색·분류 도메인(별도 repo 아님)" |
+| `scripts/seed-corpus.ts` | L1-8 header | "운영 DB에서는 사용 금지" + `Requires: DATABASE_URL, OPENAI_API_KEY` | test-only 명시 강화 + `OPENAI_API_KEY` → gx10 embed 경로 안내 + `knowledge-base.md` 참조 추가 |
+| `scripts/seed-fda-corpus.ts` | L1-9 header | `Requires: DATABASE_URL, OPENAI_API_KEY` | 동일. `import { openai } from '@ai-sdk/openai'` (L10) + `embed()` 직접 호출은 test fixture 허용 범위로 문서화 (runtime ingestion 아님) |
+| `.moai/project/product.md` | L63, L90 | "RAG Q&A (6개 corpus)" / "FDA/EU MDR/MFDS/NMPA/PMDA + internal SOP 전용" | "RAG Q&A (3개 지식 repo 연동)" / 도메인 설명은 유지하되 "소싱=3 repo, 도메인=FDA/..." 분리 명시 |
+
+### 3.2 KEEP (검색·분류 도메인 참조 — 수정 금지)
+
+| 파일 | 근거 |
+|------|------|
+| `lib/ai/retrievers/fda.ts`, `lib/ai/retrievers/eu-mdr.ts` | 검색 도메인 분류기. CORRECT. |
+| `lib/classification/*` | 문서 분류. CORRECT. |
+| `lib/ingest/doc-classifier.ts` | 분류 로직. CORRECT. |
+| `lib/ingest/chunkers/*` (sop, iso13485 등) | 도메인별 chunker. CORRECT. |
+| chunker 라우팅에서 NMPA/PMDA 키워드 | 도메인 분류 키워드로서 CORRECT (별도 repo 아님). |
+
+### 3.3 NOTE (참조만, 수정 불필요)
+
+| 파일 | 비고 |
+|------|------|
+| `docs/architecture/` 기존 문서 | `knowledge-base.md` 신규 생성 후 역참조 추가 여부는 M0에서 결정 |
+| `CLAUDE.md`, `.claude/rules/` | 본 SPEC 범위 외 (규칙 파일은 수정 금지) |
+
+> 전체 grep hit 파일 목록 (~40건) 은 M0에서 `knowledge-base.md` 작성 시 개별 직검하여 위 3分类로 최종 배치한다. 본 research.md에서는 분류 **규칙**을 확정한다.
+
+---
+
+## 4. Design Decisions
+
+### D1. Gitea wiki 경로 — `ingest-gitea-wiki.ts` adapter 유지 (권장)
+
+**옵션 A (권장): 기존 `ingest-gitea-wiki.ts` GraphQL adapter 유지**
+- 근거: (a) 이미 운영 검증 — token-leak sanitizer + url-guard + withRetry hardened; (b) knowledge_sources git-clone 경로는 wiki의 파일 구조를 repo로 취급하여 provenance 메타(host/owner/repo/path) 부정확; (c) knowledge_sources의 SSRF guard(`isInternalHost`)는 diskstation hostname을 우회하여 LAN 직접 접근 → SS-1 보안 우려.
+- 단점: 두 경로(knowledge_sources + adapter)가 병존 → 운영 복잡도. 단, 서로 다른 데이터 소스(GitHub repo vs Gitea wiki) 담당이므로 정당화 가능.
+- M2에서 `knowledge-base.md`에 두 경로의 역할 분담 명시.
+
+**옵션 B: knowledge_sources로 통일 (기각)**
+- 근거: 위 D1-A의 단점 역방향. 단일 경로 단순화.
+- 기각 사유: SSRF guard 약화 필요 (`isInternalHost` 예외 추가) → 보안 부채. wiki GraphQL 접근이 이미 hardening되어 있으므로 중복 작업.
+
+> **D1 결론**: 옵션 A 채택. ra-llm-wiki는 adapter 경로 유지. 본 SPEC은 adapter의 존재를 문서화하고, M2에서 ra-llm-wiki ingest를 트리거하는 절차(runbook)를 정의한다. 단, M1 E2E de-risk는 GitHub repo(MD-process)로 수행한다.
+
+### D2. SSRF allowlist — 지금은 약화 금지, config 기반 도입 검토
+
+**현황**: `isInternalHost` 는 IP regex 기반. `diskstation` hostname은 통과(LAN-internal이지만 차단 안 됨). 이는 **기존 보안 우려**다.
+
+**본 SPEC 입장**:
+- D1-A 채택으로 ra-llm-wiki는 adapter 경로 → knowledge_sources SSRF guard를 경유하지 않음. 따라서 **본 SPEC에서 SSRF guard 수정 불필요**.
+- 단, 장기적으로 knowledge_sources가 LAN Gitea를 지원해야 할 경우, env 기반 allowlist (`KB_INTERNAL_HOSTS_ALLOWLIST`) 도입이 권장됨. 이것은 **별도 SPEC/이슈**로 위임 (본 SPEC 범위 외, NFR-KB-SEC-003로만 명시).
+- **SS-1**: 본 SPEC은 SSRF guard를 약화하지 않는다. diskstation이 실제로 차단되지 않는 현황을 문서화만 한다.
+
+### D3. auth-token — 기존 메커니즘 사용 (비파괴)
+
+- `GITHUB_PAT` (repo:read) → POST 생성 API `auth_token` 필드 → `authTokenEncrypted` 열에 저장(평문, 열 이름과 불일치) → cloneRepo에서 HTTPS username으로 주입.
+- 본 SPEC은 이 경로를 있는 그대로 사용. **저장 시 암호화는 본 SPEC 범위 외** (REG-395 계열 별도 이슈). NFR-KB-SEC-002로 명시.
+- M1 검증: `GITHUB_PAT` 가 없는 환경에서는 local clone 경로(`RA_PROJECT_PATH` / `MD_PROCESS_PATH`) fallback 문서화 (runbook).
+
+### D4. MD-process를 M1 de-risk 대상으로 선택
+
+- 549 md 파일 → 가장 풍부 + 다도메인 (FDA/EU MDR/MFDS/ISO13485/SOP 혼재).
+- 단일 GitHub host → auth-token 경로 단순 (`GITHUB_PAT`).
+- #312 AC 4건을 가장 빠르게 end-to-end 검증 가능.
+
+### D5. 코퍼스 seed 방식 — test fixture scripts는 runtime에서 제거 검토
+
+- `seed-corpus.ts` / `seed-fda-corpus.ts` 는 `pnpm db:seed:corpus` / 수동 실행 → test fixture.
+- 본 SPEC은 운영 코퍼스를 **오직 knowledge_sources git 연동**으로만 구축한다는 원칙을 확정. seed scripts는 test fixture로 명시적 격리 (M3).
+
+---
+
+## 5. Charter 정합성
+
+- [지양-1] 범위 이탈 방지: RA Q&A 지식 구축 (영업/마케팅/인사 지식 아님). 3개 repo 모두 RA 도메인.
+- [지양-2] 인용 필수: #312 AC-2 "RAG 검색에서 해당 repo 인용 반환" 으로 보장.
+- 본 SPEC은 지식 소싱(운영 데이터 주입)이지 일반 KB 기능 추가가 아님 → Charter 범위 내.
+
+## 6. 의존성 및 환경
+
+- 실DB (pgvector, 포트 5433) — #312 AC의 회귀 높음(L-013), 별도 세션 권장.
+- `GITHUB_PAT` (repo:read, ra-project + MD-process) — M1/M2.
+- `GITEA_TOKEN` + `GITEA_URL` + `GITEA_WIKI_REPO` — M2 (ra-llm-wiki adapter).
+- gx10 Ollama (`192.168.100.1:11434`) embedding — 이미 구성됨.
+
+## 7. 참조
+
+- Issue #312 (E2E driver, AC 4건)
+- Issue #307 (Phase D — knowledge-sources 구현 완료)
+- `docs/proposals/production-deployment-gap-2026-07-10.md` BLOCK-1 (수정 대상)
+- `docs/proposals/phase-d-2b-ingestion-plan-2026-06-30.md` (ingestion 설계)
+- SPEC-REGULA-DOCINGEST-001 (파이프라인 원본)
+- SPEC-LLM-MIGRATION-A Phase A-revised (gx10 embedding)
+- L-013 (정적 테스트 + CI mock + self-report 3중 맹점 — 실DB 직검 필수)

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/spec.md
@@ -1,0 +1,198 @@
+# SPEC-REGULA-CORPUS-SEED-001 — 3-Repo 지식베이스 구축 + #312 E2E + 문서 수정
+
+```yaml
+---
+id: SPEC-REGULA-CORPUS-SEED-001
+title: 3-Repo Knowledge Base Population + #312 E2E + Documentation Revision
+version: 1.0.0
+status: planned
+created: 2026-07-10
+updated: 2026-07-10
+author: manager-spec
+priority: high
+issue_number: 312
+related:
+  - SPEC-REGULA-DOCINGEST-001
+  - SPEC-LLM-MIGRATION-A
+  - SPEC-REGULA-SOURCE-GOVERNANCE-001
+  - SPEC-REGULA-REALDB-001
+---
+```
+
+## HISTORY
+
+- 2026-07-10 생성 (manager-spec). `production-deployment-gap-2026-07-10.md` BLOCK-1 "6개 코퍼스 seed" 프레이밍을 직검하여 **3개 git repo 연동**으로 재정의. 데이터 소싱 vs 검색 도메인 분리 확립. #312 E2E AC를 M1 de-risk로 매핑. (main `9bcdd23`)
+
+---
+
+## 1. 배경 및 목적
+
+### 1.1 문제
+
+RAG 코퍼스가 비어 있다 (`sources=1, source_sections=19, knowledge_sources=0` 직검). 제품 핵심 가치(RA Q&A with citation)가 실현되지 않는다. 그러나 기존 프레이밍("6개 코퍼스 seed")은 **데이터 소싱을 잘못 표현**하고 있었다.
+
+### 1.2 진실 (직검)
+
+지식베이스 데이터 소스는 **3개의 기존 git 저장소**다 (research.md §1.2):
+
+1. **ra-project** (GitHub, 154 md) — RA scheduler, radar, 규제 동향
+2. **MD-process** (GitHub, 549 md) — 도메인별 구조화 규제/QMS/SOP 문서
+3. **ra-llm-wiki** (Gitea, LAN) — 사내 SOP wiki
+
+"FDA / EU MDR / MFDS / NMPA / PMDA / SOP"는 별도 repo가 아니라 **검색·분류 도메인**이다 (주로 MD-process 내부 디렉토리 구조 + retriever/classifier 라우팅 키). 이들을 "seed 대상"으로 지정하는 것은 데이터 소싱에 대한 잘못된 표현이다.
+
+### 1.3 목적
+
+본 SPEC은 두 가지를 동시에 달성한다:
+
+1. **지식 구축 (Data population)**: 3개 repo를 `knowledge_sources` (또는 Gitea adapter) 로 연동하여 운영 코퍼스를 실제로 채운다. #312 E2E AC 4건을 실DB(pgvector)에서 직검한다 (L-013 방어).
+2. **문서 수정 (Documentation revision)**: 단일 진실 원천(`docs/architecture/knowledge-base.md`)을 확립하고, 데이터 소싱 misframing을 정정한다. 검색 도메인 참조는 보존한다.
+
+---
+
+## 2. 범위 (Scope)
+
+### 2.1 포함 (In Scope)
+
+- MD-process repo를 knowledge_source로 등록 후 동기화 → 실DB ingest → RAG 인용 검증 (#312 E2E, M1).
+- ra-project repo 동기화 (M2).
+- ra-llm-wiki Gitea adapter 경로 운영 절차 문서화 (M2, D1-A).
+- `docs/architecture/knowledge-base.md` 신규 작성 — 단일 진실 원천 (M0).
+- `production-deployment-gap-2026-07-10.md` BLOCK-1 정정 (M0).
+- `seed-corpus.ts` / `seed-fda-corpus.ts` 헤더 정정 + test-only 명시 (M0/M3).
+- `product.md` KB 프레이밍 정정 (M0).
+- stale `OPENAI_API_KEY` heuristic 제거 (M3).
+- 게이트: typecheck/lint/full regression/ci:* + 실DB E2E 직검 (M4).
+
+### 2.2 제외 (Exclusions — What NOT to Build)
+
+- **[EXCL-1]** NMPA / PMDA를 별도 seed-target repo로 지정하거나 신규 코퍼스를 생성하지 **않는다**. 이들은 검색 도메인일 뿐이며, repo 내부 콘텐츠로서 이미 존재한다.
+- **[EXCL-2]** auth-token 저장 시 암호화 구현을 **포함하지 않는다** (`authTokenEncrypted` 열 이름과 불일치 문제). 기존 메커니즘을 있는 그대로 사용. 별도 SPEC/이슈(REG-395 계열)로 위임.
+- **[EXCL-3]** SSRF guard(`isInternalHost`)를 약화하거나 예외를 추가하지 **않는다**. diskstation hostname 우회 현황은 문서화만 한다. LAN Gitea allowlist 도입은 별도 이슈.
+- **[EXCL-4]** `syncKnowledgeSource` / `ingestDocuments` 함수 시그니처 변경을 **포함하지 않는다** (비파괴 원칙). config/env 기반 해결 우선.
+- **[EXCL-5]** retriever (`lib/ai/retrievers/{fda,eu-mdr}.ts`) 및 classifier (`lib/classification/*`) 수정을 **포함하지 않는다**. 이들은 검색 도메인으로서 CORRECT.
+- **[EXCL-6]** 일반 KB 기능(영업/마케팅/인사 지식, Notion/Confluence 대체)을 **포함하지 않는다** (Charter [지양-1]).
+- **[EXCL-7]** seed-corpus.ts/seed-fda-corpus.ts 스크립트 자체를 삭제하지 **않는다**. test fixture로 유지, 헤더/의존성만 정정.
+- **[EXCL-8]** Gitea wiki adapter(`scripts/ingest-gitea-wiki.ts`)를 knowledge_sources 경로로 마이그레이션하지 **않는다** (D1-A 결정).
+
+---
+
+## 3. 요구사항 (Requirements — EARS)
+
+### 3.1 데이터 소싱 — 3-Repo 연동
+
+**REQ-KB-001** (Event-Driven): 사용자가 knowledge_source 생성 API에 MD-process repo git URL과 branch를 제출**할 때**, 시스템은 해당 repo를 `knowledge_sources` 테이블에 등록**해야 한다 (shall)**.
+
+**REQ-KB-002** (Event-Driven): knowledge_source의 동기화가 트리거**될 때**, 시스템은 `syncKnowledgeSource` 를 호출하여 git clone → extract → classify → chunk → gx10 embed → source_sections upsert 파이프라인을 실행**해야 한다 (shall)**.
+
+**REQ-KB-003** (Event-Driven): MD-process repo 동기화가 성공**할 때**, 시스템은 `syncStatus` 를 `synced`로, `lastSyncedAt`을 현재 시각으로 갱신하고 `corpus_sync_runs` 행을 `synced` 상태로 기록**해야 한다 (shall)**.
+
+**REQ-KB-004** (Unwanted): 동기화 중 어느 시점에서 실패가 발생**하면**, 시스템은 `syncStatus`를 `failed`로 갱신하고 `knowledge_source.synced` audit 행을 `meta.status='failed'` 와 함께 동일 트랜잭션에 기록**해야 한다 (shall)**. (#312 AC-3, Part 11 §11.10(e))
+
+**REQ-KB-005** (Event-Driven): 동일 knowledge_source에 대해 re-sync가 트리거**될 때**, 시스템은 기존 chunk들에 대해 `applyOutdateOperations`(supersession)을 적용**해야 한다 (shall)**. (#312 AC-4)
+
+**REQ-KB-006** (Event-Driven): RAG 검색 쿼리가 MD-process에서 ingest된 도메인(예: FDA 510(k), EU MDR)을 포함**할 때**, 시스템은 해당 repo에서 유래한 source 인용을 검색 결과에 반환**해야 한다 (shall)**. (#312 AC-2, Charter [지양-2])
+
+**REQ-KB-007** (Event-Driven): ra-project repo가 knowledge_source로 등록·동기화**될 때**, 시스템은 MD-process와 동일한 파이프라인으로 ingest**해야 한다 (shall)**.
+
+**REQ-KB-008** (State-Driven): ra-llm-wiki(Gitea) ingest를 운영자가 요청**하는 동안**, 시스템은 기존 `scripts/ingest-gitea-wiki.ts` GraphQL adapter 경로(`GITEA_TOKEN` + url-guard)를 통해 ingest**해야 한다 (shall)** — knowledge_sources git-clone 경로가 아님. (D1-A)
+
+### 3.2 문서 — 단일 진실 원천
+
+**REQ-KB-010** (Ubiquitous): 시스템 문서는 "지식베이스 = 3개 git repo (ra-project, MD-process, ra-llm-wiki)"를 단일 진실 원천으로 `docs/architecture/knowledge-base.md`에 명시**해야 한다 (shall)**.
+
+**REQ-KB-011** (Ubiquitous): `docs/architecture/knowledge-base.md`는 데이터 소싱(3 repo → knowledge_sources)과 검색 도메인(FDA/EU MDR/MFDS/NMPA/PMDA/SOP → retrieval/classification)의 구분을 명시**해야 한다 (shall)**.
+
+**REQ-KB-012** (Ubiquitous): `docs/proposals/production-deployment-gap-2026-07-10.md` BLOCK-1은 "6개 코퍼스 seed" 프레이밍을 "3개 git repo 연동"으로 정정**해야 한다 (shall)**.
+
+**REQ-KB-013** (Ubiquitous): `scripts/seed-corpus.ts`와 `scripts/seed-fda-corpus.ts` 헤더는 test fixture 전용임을 명시하고, 운영 코퍼스는 `knowledge-base.md` 에 기술된 git 연동 경로로만 구축함을 안내**해야 한다 (shall)**.
+
+**REQ-KB-014** (Ubiquitous): `.moai/project/product.md`의 KB 관련 행(L63, L90)은 데이터 소싱(3 repo)과 검색 도메인(FDA/EU MDR/...)을 분리하여 기술**해야 한다 (shall)**.
+
+### 3.3 임베딩 — gx10 단일
+
+**REQ-KB-020** (Ubiquitous): 모든 운영 ingestion 경로는 gx10 Ollama qwen3-embedding (1536-dim MRL) 을 사용**해야 한다 (shall)**. OpenAI runtime dependency는 존재하지 않는다.
+
+**REQ-KB-021** (Unwanted): `scripts/seed-corpus.ts` 에서 운영 ingestion이 OpenAI API key를 필요로 한다는 stale heuristic(헤더의 `Requires: OPENAI_API_KEY` 등)이 발견**되면**, 이를 gx10 embed 경로 안내로 대체**해야 한다 (shall)**.
+
+### 3.4 검증 — 실DB E2E (L-013 방어)
+
+**REQ-KB-030** (Event-Driven): M1 검증이 완료**될 때**, 시스템은 실DB(pgvector)에서 `sources`/`source_sections` 행 수가 증가했음을 직검(SELECT COUNT)으로 확인**해야 한다 (shall)**.
+
+**REQ-KB-031** (Event-Driven): M1 검증이 완료**될 때**, 시스템은 실제 RAG 쿼리 응답에 MD-process 출처 인용이 포함됨을 런타임 증거로 확인**해야 한다 (shall)**.
+
+**REQ-KB-032** (Unwanted): mock 기반 단위 테스트만으로 본 SPEC의 완료를 선언**하려 하면**, 이는 기각**해야 한다 (shall)** — 실DB E2E 직검이 필수다 (L-013).
+
+---
+
+## 4. 비기능 요구사항 (NFR)
+
+### 보안
+
+**NFR-KB-SEC-001**: `cloneRepo` 는 `execFile`(argument array, shell=false) + `GIT_REF_PATTERN` branch 검증을 유지**해야 한다 (shall)** — RCE 방어 (sync.ts L165-204).
+
+**NFR-KB-SEC-002**: `authTokenEncrypted` 열 이름과 달리 평문 저장되는 현황을 인지하고, 본 SPEC은 기존 메커니즘을 비파괴로 사용한다. 저장 시 암호화는 **별도 SPEC/이슈(REG-395 계열)**로 위임한다. 본 SPEC M1 검증 시 평문 저장 여부를 직검하여 기록한다.
+
+**NFR-KB-SEC-003**: `isInternalHost` SSRF guard를 약화하지 않는다. diskstation hostname이 IP regex를 우회하는 현황을 `knowledge-base.md`에 문서화한다. LAN Gitea allowlist 도입(`KB_INTERNAL_HOSTS_ALLOWLIST`)은 별도 이슈로 위험한다.
+
+**NFR-KB-SEC-004**: ra-llm-wiki adapter 경로는 기존 hardening(`assertGiteaUrlAllowed` + `sanitizeGiteaErrorBody` + `withRetry`)을 유지한다.
+
+### 감사 (Audit — 21 CFR Part 11)
+
+**NFR-KB-AUD-001**: 모든 동기화(성공/실패)는 `writeAudit`(`knowledge_source.synced`, resource_type=`knowledgeSource`) 로 기록**되어야 한다 (shall)** — Part 11 §11.10(e). 성공/실패 UPDATE와 audit 행은 동일 `db.transaction` 내 원자적 기록(sync.ts L90-148).
+
+**NFR-KB-AUD-002**: corpus_sync_runs 테이블에 repo 단위 동기화 실행이 기록**되어야 한다 (shall)** — status `pending → synced | failed`, chunksAdded/chunksOutdated 메타 포함.
+
+### 성능
+
+**NFR-KB-PERF-001**: MD-process(549 md) 단일 repo 동기화 시 MAX_FILES=500 cap 내에서 완료되어야 한다. 549 > 500이므로 **첫 동기화에서 최대 500개 파일만 ingest**되며, 이 현황을 `knowledge-base.md`에 문서화한다. 549 전체 ingest가 필요한 경우 MAX_FILES 조정은 별도 검토(본 SPEC 범위 외).
+
+**NFR-KB-PERF-002**: 동기화 중 하나의 파일 실패가 전체 repo 동기화를 실패시키지 않아야 한다 (per-file try/catch, sync.ts L318-326).
+
+### 추적성
+
+**NFR-KB-TRC-001**: 모든 커밋은 `SPEC-REGULA-CORPUS-SEED-001` 을 참조하고, 관련 이슈 #312를 연결한다.
+
+---
+
+## 5. 검색 도메인 보존 선언 (Jurisdiction-as-Retrieval-Domain Clarification)
+
+본 SPEC은 다음을 명시적으로 선언한다:
+
+> **FDA / EU MDR / MFDS / NMPA / PMDA / ISO13485 / SOP** 는 Regula의 **검색·분류 도메인(retrieval/classification domain)**이다. 이들은 `lib/ai/retrievers/*`, `lib/classification/*`, `lib/ingest/doc-classifier.ts`, `lib/ingest/chunkers/*` 에서 라우팅 키로 사용되며, **수정 대상이 아니다.**
+>
+> 데이터 소싱은 오직 3개 git repo(REQ-KB-001 ~ 008)로만 이루어진다. "6개 코퍼스 seed" 프레이밍은 데이터 소싱에 대한 잘못된 표현이며 본 SPEC이 정정한다(REQ-KB-010 ~ 014).
+
+이 선언은 `docs/architecture/knowledge-base.md` 의 핵심 섹션으로 포함된다.
+
+---
+
+## 6. 이슈 매핑
+
+| AC (#312) | 본 SPEC REQ | Milestone |
+|-----------|-------------|-----------|
+| 공개 repo 연결 후 sync 성공 → 코퍼스 채워짐 | REQ-KB-001..003, 007, 030 | M1 (MD-process), M2 (ra-project) |
+| RAG 검색에서 해당 repo 인용 반환 | REQ-KB-006, 031 | M1 |
+| 실패 시 syncStatus='failed' + audit | REQ-KB-004, NFR-KB-AUD-001 | M1 (실패 경로 검증) |
+| re-sync 시 supersession | REQ-KB-005 | M1 |
+
+---
+
+## 7. 위험 및 완화
+
+| 위험 | 완화 |
+|------|------|
+| MD-process 549파일 > MAX_FILES=500 cap | NFR-KB-PERF-001 문서화 + 필요시 별도 검토 |
+| auth-token 평문 저장 (NFR-KB-SEC-002) | 본 SPEC 비파괴; 별도 이슈 위임 |
+| 실DB E2E 회귀 (L-013 맹점) | REQ-KB-030..032 직검 강제; mock-only 완료 선언 기각 |
+| diskstation SSRF 우회 현황 | D1-A(adapter 유지) + NFR-KB-SEC-003 문서화; guard 약화 금지 |
+
+---
+
+## 8. 참조
+
+- research.md (본 디렉토리) — 직검 인프라 인벤토리, design decisions D1-D5
+- acceptance.md — AC + Given/When/Then
+- tasks.md — Milestone M0-M4
+- Issue #312 (E2E driver), #307 (Phase D 완료)
+- SPEC-REGULA-DOCINGEST-001, SPEC-LLM-MIGRATION-A, SPEC-REGULA-SOURCE-GOVERNANCE-001

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/spec.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/spec.md
@@ -22,6 +22,7 @@ related:
 ## HISTORY
 
 - 2026-07-10 생성 (manager-spec). `production-deployment-gap-2026-07-10.md` BLOCK-1 "6개 코퍼스 seed" 프레이밍을 직검하여 **3개 git repo 연동**으로 재정의. 데이터 소싱 vs 검색 도메인 분리 확립. #312 E2E AC를 M1 de-risk로 매핑. (main `9bcdd23`)
+- 2026-07-10 (orchestrator 직검 정정, v1.0.0→1.0.1): **REQ-KB-009 신설** — AC-2 RAG 인용에 source-governance 승인 단계(`POST /api/source-governance/approve`)가 필수임을 코드 직검 확정(sync.ts:543 `pending_review` + `composeRetrievalGates` 미승인 영구 제외). 기존 AC-2/Task M1-4의 "별도 검토 위임"은 결함 — 승인은 source-governance 설계(게이트 우회 아님).
 
 ---
 
@@ -91,7 +92,9 @@ RAG 코퍼스가 비어 있다 (`sources=1, source_sections=19, knowledge_source
 
 **REQ-KB-005** (Event-Driven): 동일 knowledge_source에 대해 re-sync가 트리거**될 때**, 시스템은 기존 chunk들에 대해 `applyOutdateOperations`(supersession)을 적용**해야 한다 (shall)**. (#312 AC-4)
 
-**REQ-KB-006** (Event-Driven): RAG 검색 쿼리가 MD-process에서 ingest된 도메인(예: FDA 510(k), EU MDR)을 포함**할 때**, 시스템은 해당 repo에서 유래한 source 인용을 검색 결과에 반환**해야 한다 (shall)**. (#312 AC-2, Charter [지양-2])
+**REQ-KB-006** (Event-Driven): RAG 검색 쿼리가 MD-process에서 ingest되고 **승인된(approvalStatus='approved')** 도메인(예: FDA 510(k), EU MDR)을 포함**할 때**, 시스템은 해당 repo에서 유래한 source 인용을 검색 결과에 반환**해야 한다 (shall)**. (#312 AC-2, Charter [지양-2]; 승인 전제 REQ-KB-009)
+
+**REQ-KB-009** (Event-Driven): knowledge_source 동기화로 ingest된 source 행들이 `approvalStatus='pending_review'`(sync.ts:543)로 생성**될 때**, E2E 검증은 RA-owner/source-governance 승인 절차(`POST /api/source-governance/approve`, REQ-SOURCE-GOV-015)로 해당 source들을 `approved`로 전환**해야 한다 (shall)**. `composeRetrievalGates`(lib/source-governance/retrieval-gate.ts)가 `approvalStatus !== 'approved'`를 검색에서 영구 제외하므로, **승인 없이는 AC-2(RAG 인용) 달성이 불가**하다. 이는 source-governance 설계(미검증 콘텐츠 Q&A 차단, Charter [지양-2])이며 본 SPEC은 게이트를 우회하지 않는다 (직검 정정 — 기존 "별도 검토 위임"은 결함이었음).
 
 **REQ-KB-007** (Event-Driven): ra-project repo가 knowledge_source로 등록·동기화**될 때**, 시스템은 MD-process와 동일한 파이프라인으로 ingest**해야 한다 (shall)**.
 
@@ -172,7 +175,7 @@ RAG 코퍼스가 비어 있다 (`sources=1, source_sections=19, knowledge_source
 | AC (#312) | 본 SPEC REQ | Milestone |
 |-----------|-------------|-----------|
 | 공개 repo 연결 후 sync 성공 → 코퍼스 채워짐 | REQ-KB-001..003, 007, 030 | M1 (MD-process), M2 (ra-project) |
-| RAG 검색에서 해당 repo 인용 반환 | REQ-KB-006, 031 | M1 |
+| RAG 검색에서 해당 repo 인용 반환 | REQ-KB-006, 009, 031 | M1 |
 | 실패 시 syncStatus='failed' + audit | REQ-KB-004, NFR-KB-AUD-001 | M1 (실패 경로 검증) |
 | re-sync 시 supersession | REQ-KB-005 | M1 |
 

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/tasks.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/tasks.md
@@ -1,0 +1,244 @@
+# Tasks & Milestones — SPEC-REGULA-CORPUS-SEED-001
+
+> 작성일: 2026-07-10 | 순서: M0 → M1 → M2 → M3 → M4 (순차, 일부 병렬 가능)
+> 시간 추정 금지 (L-007) — Priority + 선행 관계로 순서 표기.
+
+## Milestone 개요
+
+| Milestone | 이름 | Priority | 선행 | 핵심 산출물 |
+|-----------|------|----------|------|------------|
+| M0 | 문서 수정 — 단일 진실 원천 확립 | High | 없음 | `knowledge-base.md`, gap doc 정정, seed headers, product.md |
+| M1 | MD-process E2E (#312 de-risk) | High | M0 | AC-1..4 실DB 직검, MD-process 코퍼스 populated |
+| M2 | ra-project + ra-llm-wiki 확장 | Medium | M1 | ra-project 코퍼스, Gitea adapter 운영 절처 문서화 |
+| M3 | gx10 embedding cleanup | Medium | M0 | stale OPENAI_API_KEY heuristic 제거 |
+| M4 | 게이트 (품질 + 실DB 직검) | High | M1..M3 | typecheck/lint/test/ci:* + 실DB E2E 증거 |
+
+> M3는 M0와 병렬 가능 (seed script 헤더 정정이 M0의 일부이기도 함). M4는 모든 마일스톤 완료 후 최종 검증.
+
+---
+
+## M0 — 문서 수정 (단일 진실 원천 확립)
+
+> 근거: 데이터 소싱 misframing 정정 + `knowledge-base.md` 확립. 이 마일스톤이 SPEC의 "재정의"를 공식화한다.
+
+### Task M0-1: `docs/architecture/knowledge-base.md` 신규 작성 — Priority High
+
+- **파일**: `docs/architecture/knowledge-base.md` (신규)
+- **내용**:
+  - 섹션 1: "지식베이스 = 3개 git repo" 선언 (ra-project, MD-process, ra-llm-wiki).
+  - 섹션 2: 데이터 소싱 vs 검색 도메인 분리 (spec.md §5 선언과 동일).
+  - 섹션 3: repo별 접근 방식 — GitHub(ra-project, MD-process): `GITHUB_PAT` + `knowledge_sources` git sync 경로. Gitea(ra-llm-wiki): `ingest-gitea-wiki.ts` adapter + `GITEA_TOKEN` 경로 (D1-A 결정).
+  - 섹션 4: auth-token 현황 주의(NFR-KB-SEC-002) + diskstation SSRF 현황(NFR-KB-SEC-003).
+  - 섹션 5: 운영 절처(runbook) — 동기화 트리거, 상태 전이, 실패 시 대응.
+- **매핑**: REQ-KB-010, REQ-KB-011 / AC-5
+
+### Task M0-2: `production-deployment-gap-2026-07-10.md` BLOCK-1 정정 — Priority High
+
+- **파일**: `docs/proposals/production-deployment-gap-2026-07-10.md` (수정)
+- **내용**: BLOCK-1 "6개 코퍼스 seed" / "SPEC ... 6개 코퍼스 seed" 를 "3개 git repo 연동" 으로 정정. FDA/EU MDR/MFDS/NMPA/PMDA/SOP 를 검색 도메인으로 재기술. `knowledge-base.md` 링크 추가.
+- **매핑**: REQ-KB-012 / AC-6
+
+### Task M0-3: seed scripts 헤더 정정 — Priority Medium
+
+- **파일**: `scripts/seed-corpus.ts` (헤더 L1-8), `scripts/seed-fda-corpus.ts` (헤더 L1-9)
+- **내용**:
+  - "test fixture 전용, 운영 DB 사용 금지" 강화 (이미 seed-corpus.ts L2-3에 있음 — 보강).
+  - "운영 코퍼스는 `docs/architecture/knowledge-base.md` 기술된 git 연동 경로로만 구축" 안내 추가.
+  - stale `Requires: OPENAI_API_KEY` → gx10 embed 경로 안내로 대체 (M3와 중복, M0에서 헤더 라인만).
+- **매핑**: REQ-KB-013 / AC-7
+
+### Task M0-4: `.moai/project/product.md` KB 행 정정 — Priority Medium
+
+- **파일**: `.moai/project/product.md` (L63, L90)
+- **내용**: "RAG Q&A (6개 corpus)" → "RAG Q&A (3개 지식 repo 연동)". "FDA/EU MDR/MFDS/NMPA/PMDA + internal SOP 전용" → 소싱(3 repo)과 도메인(FDA/...) 분리 기술.
+- **매핑**: REQ-KB-014 / AC-7
+
+### Task M0-5: misframing grep hit 파일 분류 확정 — Priority Medium
+
+- **내용**: research.md §3 분류 규칙(REVISE / KEEP / NOTE)에 따라, grep hit ~40건을 개별 직검하여 최종 배치. REVISE 대상만 수정. KEEP(`lib/ai/retrievers/*`, `lib/classification/*` 등) 은 불변.
+- **매핑**: REQ-KB-011 (간접)
+
+---
+
+## M1 — MD-process E2E (#312 de-risk)
+
+> 근거: #312 AC 4건을 MD-process(549 md, 다도메인) 단일 repo로 가장 빠르게 실DB 검증.
+
+### Task M1-1: 환경 준비 — Priority High
+
+- **확인**: 실DB(pgvector, 포트 5433) 실행. `GITHUB_PAT`(repo:read) 설정. gx10 Ollama(`192.168.100.1:11434`) embedding 접근.
+- **산출물**: 환경 준비 체크리스트(커밋 불필요, 실행 로그만).
+
+### Task M1-2: MD-process knowledge_source 등록 — Priority High
+
+- **API**: `POST /api/ra/knowledge-sources` body: `{ git_url: 'https://github.com/holee9/MD-process.git', branch: 'main', auth_token: '<GITHUB_PAT>' }`.
+- **검증**: `SELECT * FROM knowledge_sources WHERE source_repo = 'MD-process'` 행 존재 직검. `authTokenEncrypted` 열에 token 저장됨(평문 — NFR-KB-SEC-002 현황 기록).
+- **매핑**: REQ-KB-001 / AC-1
+
+### Task M1-3: 동기화 트리거 + 성공 검증 — Priority High
+
+- **API**: `POST /api/ra/knowledge-sources/{id}/sync`.
+- **검증(직검)**:
+  - `syncStatus` `idle → syncing → synced` 전이.
+  - `lastSyncedAt` 갱신.
+  - `SELECT COUNT(*) FROM sources WHERE source_repo = 'MD-process'` 증가 (MAX_FILES=500 cap 내).
+  - `SELECT COUNT(*) FROM source_sections` 증가.
+  - `corpus_sync_runs` status=`synced` 행 추가.
+- **매핑**: REQ-KB-002, REQ-KB-003, REQ-KB-030 / AC-1, AC-12
+
+### Task M1-4: RAG 인용 검증 — Priority High
+
+- **실행**: 도메인 질의(예: "FDA 510(k) submission 요건은?") 로 RAG Q&A 호출.
+- **검증**: 응답에 MD-process 출처 인용(source_host=github.com, source_owner=holee9, source_repo=MD-process, source_path) 포함. 런타임 증거(응답 payload 또는 로그) 기록.
+- **주의**: approval_status=`pending_review` 가 검색을 차단하는 경우 현황 기록 + 별도 검토(본 SPEC 범위 외).
+- **매핑**: REQ-KB-006, REQ-KB-031 / AC-2, AC-12
+
+### Task M1-5: 실패 경로 검증 — Priority High
+
+- **실행**: 의도적 실패 유발(잘못된 branch, 무효 token, 일시적 네트워크 차단 중 택 1).
+- **검증(직검)**: `syncStatus='failed'`, `audit_logs` 행 `meta_json.status='failed'` 동일 tx 기록, `corpus_sync_runs` status=`failed` + error_message.
+- **매핑**: REQ-KB-004, NFR-KB-AUD-001, NFR-KB-AUD-002 / AC-3
+
+### Task M1-6: re-sync supersession 검증 — Priority High
+
+- **실행**: 동일 knowledge_source에 re-sync 트리거.
+- **검증(직검)**: `chunksOutdated > 0` (기존 chunk supersession), `chunksAdded > 0` (새 chunk), `sources` 행 재사용(동일 provenance key). `corpus_sync_runs` 새 행(새 runId).
+- **매핑**: REQ-KB-005 / AC-4
+
+### Task M1-7: M1 증거 기록 — Priority Medium
+
+- **산출물**: M1 직검 증거(DB 쿼리 출력, RAG payload, audit rows) 를 PR 본문 또는 커밋 메시지에 첨록.
+- **매핑**: REQ-KB-032 / AC-12
+
+---
+
+## M2 — ra-project + ra-llm-wiki 확장
+
+> 근거: M1 de-risk 완료 후 나머지 2 repo로 확장.
+
+### Task M2-1: ra-project knowledge_source 등록 + 동기화 — Priority Medium
+
+- **API**: `POST /api/ra/knowledge-sources` body: `{ git_url: 'https://github.com/holee9/ra-project.git', branch: 'main', auth_token: '<GITHUB_PAT>' }`.
+- **검증**: AC-1 동일 검증(154 md 파일, MAX_FILES=500 cap 내).
+- **매핑**: REQ-KB-007 / AC-8
+
+### Task M2-2: ra-project RAG 인용 검증 — Priority Medium
+
+- **실행**: RA scheduler/radar 도메인 질의.
+- **검증**: ra-project 출처 인용 포함.
+- **매핑**: REQ-KB-007 / AC-8
+
+### Task M2-3: ra-llm-wiki adapter 운영 절처 문서화 — Priority Medium
+
+- **파일**: `docs/architecture/knowledge-base.md` (M0-1에서 생성한 파일에 섹션 추가).
+- **내용**: D1-A 결정(유지) 근거, adapter 환경(`GITEA_URL`, `GITEA_TOKEN`, `GITEA_WIKI_REPO`), 트리거 명령(`pnpm tsx scripts/ingest-gitea-wiki.ts`), hardening 요약(url-guard + sanitizer + withRetry).
+- **매핑**: REQ-KB-008 / AC-9
+
+### Task M2-4: ra-llm-wiki ingest 실행(선택) — Priority Low
+
+- **주**: adapter가 이미 hardening되어 있으므로, 본 SPEC은 실행 그 자체보다 문서화가 주 범위. 환경(`GITEA_TOKEN`) 이용 가능한 경우 실행하여 AC-9를 런타임 검증. 불가능한 경우 문서화로 충족.
+- **매핑**: REQ-KB-008 / AC-9
+
+---
+
+## M3 — gx10 embedding cleanup
+
+> 근거: stale OPENAI_API_KEY heuristic 제거 (runtime은 이미 gx10).
+
+### Task M3-1: seed-corpus.ts stale heuristic 제거 — Priority Medium
+
+- **파일**: `scripts/seed-corpus.ts` (헤더 L8 `Requires: DATABASE_URL, OPENAI_API_KEY`).
+- **내용**: `OPENAI_API_KEY` 요구 명시 제거. gx10 embed 경로 안내로 대체. (이미 `embedChunks` → gx10 사용 중이므로 코드 변경 불필요, 헤더만.)
+- **매핑**: REQ-KB-020, REQ-KB-021 / AC-10
+
+### Task M3-2: seed-fda-corpus.ts stale heuristic 제거 — Priority Medium
+
+- **파일**: `scripts/seed-fda-corpus.ts` (헤더 L8, L10 `import { openai }`, L298).
+- **내용**: 헤더 `Requires: OPENAI_API_KEY` 제거 + gx10 안내. `import { openai }` + 직접 `embed()` 호출은 test fixture 허용 범위로 주석 명시(runtime ingestion 아님).
+- **매핑**: REQ-KB-021 / AC-10
+
+### Task M3-3: runtime ingestion OpenAI 의존성 부재 직검 — Priority Medium
+
+- **직검**: `lib/ingest/embed.ts` → `embedBatchTexts` → gx10 (embedding-provider.ts). `lib/knowledge-sources/sync.ts` → `embedChunks` → gx10. runtime 경로에 OpenAI 직접 호출 부재 grep 확인.
+- **매핑**: REQ-KB-020
+
+---
+
+## M4 — 게이트 (품질 + 실DB 직검)
+
+> 근거: L-013(실DB 직검) + L-008(lint) + L-009(full test) + L-015(ci:* 로컬 직검).
+
+### Task M4-1: typecheck — Priority High
+
+- **실행**: `pnpm typecheck`.
+- **기준**: 0 errors (직검 출력).
+- **매핑**: AC-11
+
+### Task M4-2: lint (full, lint:hex 포함) — Priority High
+
+- **실행**: `pnpm lint` (full).
+- **기준**: 0 errors, 코드 줄 `#NNN` 금지 (L-008).
+- **매핑**: AC-11
+
+### Task M4-3: test (full, 타깃만 아님) — Priority High
+
+- **실행**: `pnpm test` (full).
+- **기준**: 0 failures (L-009). staged 범위 직검.
+- **매핑**: AC-11
+
+### Task M4-4: ci:* (전 단계 로컬 직검) — Priority High
+
+- **실행**: `pnpm ci:*` 전 단계 로컬 실행.
+- **기준**: 0 failures (L-015: 일부 green ≠ 전체 green).
+- **매핑**: AC-11
+
+### Task M4-5: 실DB E2E 직검 증거 취합 — Priority High
+
+- **산출물**: M1(Task M1-3..M1-7) 의 실DB 직검 증거를 PR 본문에 정리. mock-only 선언 금지(REQ-KB-032).
+- **매핑**: AC-12
+
+### Task M4-6: 비파괴 + 검색 도메인 보존 직검 — Priority Medium
+
+- **직검**:
+  - `syncKnowledgeSource` / `ingestDocuments` 시그니처 불변 (git diff 확인).
+  - `lib/ai/retrievers/*`, `lib/classification/*` 미수정 (git diff 확인).
+  - SSRF guard(`isInternalHost`) 불변 (NFR-KB-SEC-003).
+- **매핑**: EXCL-4, EXCL-5, NFR-KB-SEC-003 / AC-11
+
+---
+
+## 선행 관계 그래프
+
+```
+M0-1 (knowledge-base.md) ─┬─→ M0-2 (gap doc) ──→ M0-5 (grep 분류)
+                          ├─→ M0-3 (seed headers) ──→ M3-1, M3-2
+                          └─→ M0-4 (product.md)
+M1 (순차: M1-1 → M1-2 → M1-3 → M1-4 → M1-5 → M1-6 → M1-7)  [선행: M0 완료]
+M2 (M1 완료 후: M2-1 → M2-2; M2-3/M2-4는 M0-1 완료 후 병렬 가능)
+M3 (M0-3와 병렬 가능: M3-1, M3-2, M3-3)
+M4 (M1, M2, M3 완료 후: M4-1..M4-6)
+```
+
+---
+
+## 위험 추적
+
+| 위험 | Milestone | 완화 | 상태 |
+|------|-----------|------|------|
+| 549파일 > MAX_FILES=500 | M1 | NFR-KB-PERF-001 문서화, MAX_FILES 변경은 본 SPEC 외 | Open |
+| auth-token 평문 저장 | M1 | NFR-KB-SEC-002 기록, 별도 이슈 위임 | Open |
+| diskstation SSRF 우회 | M2 | D1-A(adapter 유지), guard 약화 금지, 문서화 | Open |
+| approval_status pending_review 검색 차단 가능 | M1 | 현황 기록, 별도 검토 | Open |
+| L-013 mock 맹점 | M4 | 실DB 직검 강제(AC-12), mock-only 기각 | Mitigated by design |
+
+---
+
+## 커밋 전략 (참고용 — 실제 커밋은 orchestrator/manager-git 관장)
+
+- M0: `docs(knowledge-base): 단일 진실 원천 + misframing 정정 — SPEC-REGULA-CORPUS-SEED-001`
+- M1: `feat(knowledge-sources): MD-process E2E 실DB 직검 — #312 AC-1..4 (SPEC-REGULA-CORPUS-SEED-001)`
+- M2: `feat(knowledge-sources): ra-project + ra-llm-wiki adapter 문서화 (SPEC-REGULA-CORPUS-SEED-001)`
+- M3: `chore(seed): stale OPENAI_API_KEY heuristic 제거 — gx10 단일 (SPEC-REGULA-CORPUS-SEED-001)`
+- M4: `test(gates): typecheck/lint/test/ci + 실DB E2E 증거 (SPEC-REGULA-CORPUS-SEED-001)`
+
+> 본 tasks.md는 milestone/작업 분해만 제공. 실제 commit/push/PR은 orchestrator가 manager-git으로 위임.

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/tasks.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/tasks.md
@@ -9,7 +9,7 @@
 |-----------|------|----------|------|------------|
 | M0 | 문서 수정 — 단일 진실 원천 확립 | High | 없음 | `knowledge-base.md`, gap doc 정정, seed headers, product.md |
 | M1 | MD-process E2E (#312 de-risk) | High | M0 | AC-1..4 실DB 직검, MD-process 코퍼스 populated |
-| M2 | ra-project + ra-llm-wiki 확장 | Medium | M1 | ra-project 코퍼스, Gitea adapter 운영 절처 문서화 |
+| M2 | ra-project + ra-llm-wiki 확장 | Medium | M1 | ra-project 코퍼스, Gitea adapter 운영 절차 문서화 |
 | M3 | gx10 embedding cleanup | Medium | M0 | stale OPENAI_API_KEY heuristic 제거 |
 | M4 | 게이트 (품질 + 실DB 직검) | High | M1..M3 | typecheck/lint/test/ci:* + 실DB E2E 증거 |
 
@@ -29,7 +29,7 @@
   - 섹션 2: 데이터 소싱 vs 검색 도메인 분리 (spec.md §5 선언과 동일).
   - 섹션 3: repo별 접근 방식 — GitHub(ra-project, MD-process): `GITHUB_PAT` + `knowledge_sources` git sync 경로. Gitea(ra-llm-wiki): `ingest-gitea-wiki.ts` adapter + `GITEA_TOKEN` 경로 (D1-A 결정).
   - 섹션 4: auth-token 현황 주의(NFR-KB-SEC-002) + diskstation SSRF 현황(NFR-KB-SEC-003).
-  - 섹션 5: 운영 절처(runbook) — 동기화 트리거, 상태 전이, 실패 시 대응.
+  - 섹션 5: 운영 절차(runbook) — 동기화 트리거, 상태 전이, 실패 시 대응.
 - **매핑**: REQ-KB-010, REQ-KB-011 / AC-5
 
 ### Task M0-2: `production-deployment-gap-2026-07-10.md` BLOCK-1 정정 — Priority High
@@ -64,6 +64,16 @@
 
 > 근거: #312 AC 4건을 MD-process(549 md, 다도메인) 단일 repo로 가장 빠르게 실DB 검증.
 
+### Task M1-0: E2E 인증/조직 컨텍스트 준비 — Priority High (필수 선행)
+
+- **근거 (plan-auditor C1)**: `POST /api/ra/knowledge-sources`(`knowledgesources.manage`)와 `POST /api/source-governance/approve`(`sourcegov.manage`) 모두 `ra-lead` 세션(`session.user.organizationId` + `session.user.id`)을 요구(permissions.ts:346,465). 누락 시 첫 API 호출에서 401/403 → AC-1..4 전부 차단.
+- **준비**:
+  1. 실DB에 `organizations` 행 존재/seed 확인 (기존 dev 조직 재사용 권장).
+  2. 해당 조직에 `ra-lead` 역할 사용자 존재/seed 확인.
+  3. E2E API 호출용 세션 획득 방식 확정 (dev 로그인 세션 쿠키, 또는 테스트 bearer/스크립트 인증).
+- **검증**: 세션이 `knowledgesources.manage` + `sourcegov.manage` 권한을 모두 가짐을 직검.
+- **매핑**: REQ-KB-001, REQ-KB-009 / AC-1 Given (신규 전제)
+
 ### Task M1-1: 환경 준비 — Priority High
 
 - **확인**: 실DB(pgvector, 포트 5433) 실행. `GITHUB_PAT`(repo:read) 설정. gx10 Ollama(`192.168.100.1:11434`) embedding 접근.
@@ -89,6 +99,7 @@
 ### Task M1-4: source 승인 + RAG 인용 검증 — Priority High
 
 - **M1-4a source 승인 (필수 선행)**: ingest된 MD-process source 행들이 `approvalStatus='pending_review'`로 생성됨을 직검. 이후 `POST /api/source-governance/approve`(REQ-SOURCE-GOV-015)로 `approved` 전환 — `composeRetrievalGates`가 미승인 source를 검색에서 영구 제외하므로 **승인 없이는 RAG 인용 불가** (source-governance 설계, Charter [지양-2]). 게이트 우회 아님.
+- **M1-4a-scaling (plan-auditor H1)**: 승인 API는 `sourceId` 1건씩만 처리(types.ts:46). MD-process는 파일당 1 `sources` 행(최대 500건) 생성 → 일괄 승인 필요: `SELECT id FROM sources WHERE source_repo='MD-process' AND approval_status='pending_review'` → loop POST(각 `source.approved` audit 기록), 또는 일괄 승인 쿼리 + audit 보강. 승인 대상 source 수를 AC-2 검증 전 직검.
 - **M1-4b RAG 인용 검증**: 도메인 질의(예: "FDA 510(k) submission 요건은?") 로 RAG Q&A 호출.
 - **검증(직검)**: `SELECT approval_status FROM sources WHERE source_repo='MD-process'` = `approved`. 응답에 MD-process 출처 인용(source_host=github.com, source_owner=holee9, source_repo=MD-process, source_path) 포함. `source.approved` audit 행 존재. 런타임 증거(응답 payload 또는 로그) 기록.
 - **매핑**: REQ-KB-006, REQ-KB-009, REQ-KB-031 / AC-2, AC-12
@@ -128,7 +139,7 @@
 - **검증**: ra-project 출처 인용 포함.
 - **매핑**: REQ-KB-007 / AC-8
 
-### Task M2-3: ra-llm-wiki adapter 운영 절처 문서화 — Priority Medium
+### Task M2-3: ra-llm-wiki adapter 운영 절차 문서화 — Priority Medium
 
 - **파일**: `docs/architecture/knowledge-base.md` (M0-1에서 생성한 파일에 섹션 추가).
 - **내용**: D1-A 결정(유지) 근거, adapter 환경(`GITEA_URL`, `GITEA_TOKEN`, `GITEA_WIKI_REPO`), 트리거 명령(`pnpm tsx scripts/ingest-gitea-wiki.ts`), hardening 요약(url-guard + sanitizer + withRetry).

--- a/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/tasks.md
+++ b/.moai/specs/SPEC-REGULA-CORPUS-SEED-001/tasks.md
@@ -86,12 +86,12 @@
   - `corpus_sync_runs` status=`synced` 행 추가.
 - **매핑**: REQ-KB-002, REQ-KB-003, REQ-KB-030 / AC-1, AC-12
 
-### Task M1-4: RAG 인용 검증 — Priority High
+### Task M1-4: source 승인 + RAG 인용 검증 — Priority High
 
-- **실행**: 도메인 질의(예: "FDA 510(k) submission 요건은?") 로 RAG Q&A 호출.
-- **검증**: 응답에 MD-process 출처 인용(source_host=github.com, source_owner=holee9, source_repo=MD-process, source_path) 포함. 런타임 증거(응답 payload 또는 로그) 기록.
-- **주의**: approval_status=`pending_review` 가 검색을 차단하는 경우 현황 기록 + 별도 검토(본 SPEC 범위 외).
-- **매핑**: REQ-KB-006, REQ-KB-031 / AC-2, AC-12
+- **M1-4a source 승인 (필수 선행)**: ingest된 MD-process source 행들이 `approvalStatus='pending_review'`로 생성됨을 직검. 이후 `POST /api/source-governance/approve`(REQ-SOURCE-GOV-015)로 `approved` 전환 — `composeRetrievalGates`가 미승인 source를 검색에서 영구 제외하므로 **승인 없이는 RAG 인용 불가** (source-governance 설계, Charter [지양-2]). 게이트 우회 아님.
+- **M1-4b RAG 인용 검증**: 도메인 질의(예: "FDA 510(k) submission 요건은?") 로 RAG Q&A 호출.
+- **검증(직검)**: `SELECT approval_status FROM sources WHERE source_repo='MD-process'` = `approved`. 응답에 MD-process 출처 인용(source_host=github.com, source_owner=holee9, source_repo=MD-process, source_path) 포함. `source.approved` audit 행 존재. 런타임 증거(응답 payload 또는 로그) 기록.
+- **매핑**: REQ-KB-006, REQ-KB-009, REQ-KB-031 / AC-2, AC-12
 
 ### Task M1-5: 실패 경로 검증 — Priority High
 
@@ -228,7 +228,7 @@ M4 (M1, M2, M3 완료 후: M4-1..M4-6)
 | 549파일 > MAX_FILES=500 | M1 | NFR-KB-PERF-001 문서화, MAX_FILES 변경은 본 SPEC 외 | Open |
 | auth-token 평문 저장 | M1 | NFR-KB-SEC-002 기록, 별도 이슈 위임 | Open |
 | diskstation SSRF 우회 | M2 | D1-A(adapter 유지), guard 약화 금지, 문서화 | Open |
-| approval_status pending_review 검색 차단 가능 | M1 | 현황 기록, 별도 검토 | Open |
+| approval_status pending_review 검색 차단 | M1 | REQ-KB-009 승인 단계(M1-4a)로 해결 — 게이트 우회 아님, source-governance 설계 | Mitigated |
 | L-013 mock 맹점 | M4 | 실DB 직검 강제(AC-12), mock-only 기각 | Mitigated by design |
 
 ---


### PR DESCRIPTION
## 요약

Phase 1 BLOCK-1(RAG corpus seed)의 plan phase 산출물. **gap 문서의 "6개 코퍼스 seed" 프레이밍을 직검하여 "3개 git repo 연동"으로 재정의** (사용자 정정 반영).

## 핵심 재정의

**지식베이스 데이터 소스 = 3개 기존 git repo** (전부 실존·내용 직검):
| Repo | URL | 파일 |
|---|---|---|
| ra-project | github.com/holee9/ra-project | 154 md |
| MD-process | github.com/holee9/MD-process | 549 md (FDA/EU MDR/MFDS/ISO13485 도메인 내장) |
| ra-llm-wiki | Gitea diskstation:7001/DR_RnD/ra-llm-wiki | wiki (내부 SOP) |

**FDA/EU MDR/MFDS/NMPA/PMDA/SOP는 별도 repo가 아니라 검색·분류 도메인** (MD-process 내부 디렉토리 구조 + retriever/classifier 라우팅 키). 데이터 소싱 vs 검색 도메인을 명확히 분리 (spec.md §5).

## 산출물 (4문서)
- `research.md` — 직검 인프라 인벤토리, design decisions D1-D5, misframing 분류표
- `spec.md` — 18 EARS REQ + 9 NFR + 8 EXCL (v1.0.1)
- `acceptance.md` — 12 AC (#312 AC-1..4 + M0-M4) + 5 EC + DoD
- `tasks.md` — M0(문서) → M1(MD-process E2E) → M2(확장) → M3(gx10 cleanup) → M4(게이트)

## 주요 결정
- **AC-2 승인 단계 필수화** (REQ-KB-009): RAG 인용은 source-governance 승인(`POST /api/source-governance/approve`) 후에만 가능 — `composeRetrievalGates`가 미승인 source 영구 제외. 게이트 우회 아님 (Charter [지양-2]).
- **Gitea wiki**: adapter 유지 (D1-A, SSRF 약화 회피).
- **gx10 qwen3-embedding**: 이미 단일 SoT (lib/ai/embedding-provider.ts), seed 스크립트 stale OPENAI heuristic만 정정.

## 감사 (plan-auditor)
**PASS-WITH-CONDITIONS** → C1(ra-lead 세션 전제 Task M1-0)/H1(승인 API scaling)/M1(RA_PROJECT_PATH 허구 제거)/m1-m3(오타) 전건 정정 완료. 재감사 불필요 (EARS/추적성/보안 경계 건전).

## 후속 이슈 (별도)
- #412 auth-token 평문 저장 → 암호화 (NFR-KB-SEC-002)
- #413 SSRF LAN hostname 우회 → allowlist (NFR-KB-SEC-003)

## 비파괴
`syncKnowledgeSource`/`ingestDocuments` 시그니처 불변, 검색 도메인 코드 미수정.

Closes: 없음 (plan PR). Refs #312, #412, #413.

🗿 MoAI <email@mo.ai.kr>