### PR TITLE
feat(rls): BLOCK-3 RLS enforce canary + knowledge_sources NULLIF 강화 (0116)

### DIFF
--- a/.github/workflows/migrations-real-db.yml
+++ b/.github/workflows/migrations-real-db.yml
@@ -143,3 +143,9 @@ jobs:
       # the canary owns source_sections for its full lifetime.
       - name: Run RLS sources canary (isolated)
         run: pnpm vitest run tests/integration/rls-sources-real-db.test.ts
+
+      # SPEC-REGULA-RLS-ENFORCE-001 (BLOCK-3) — general FORCE-table canary
+      # (knowledge_sources). Extends the #317 sources canary to a 2nd FORCE
+      # table; found + fixed the 0099 policy's missing NULLIF (0116).
+      - name: Run RLS enforce canary (general, knowledge_sources)
+        run: pnpm vitest run tests/integration/rls-enforce-canary-real-db.test.ts

--- a/docs/phase-4-rls-enforce-runbook.md
+++ b/docs/phase-4-rls-enforce-runbook.md
@@ -21,8 +21,9 @@ change — this document is the single source of truth for that action.
 
 1. `pnpm test tests/unit/db/with-tenant-scope-coverage.test.ts` is green.
 2. Grep audit: `serviceDb` appears **only** in `lib/auth.ts` (and its own
-   definition site). Run:
-   `grep -rn "serviceDb" app lib --include="*.ts" | grep -v "lib/db/service-client.ts"`
+   definition site `lib/db/client.ts`, which exports it from
+   `SERVICE_DATABASE_URL`). Run:
+   `grep -rn "serviceDb" app lib --include="*.ts" | grep -v "lib/db/client.ts"`
    Expected: zero hits outside `lib/auth.ts`.
 3. No route handler or lib function issues an org-scoped query without
    `withTenantScope`. The coverage gate enforces this statically.
@@ -90,6 +91,15 @@ Assertion shape: `current_setting('app.current_org_id', true)` must be `NULL`
 outside a `withTenantScope` call, and any org-scoped `SELECT` must return 0 rows
 in that state (fail-closed). This is the guarantee that an forgotten
 `withTenantScope` wiring does not leak cross-org data.
+
+**Implemented** (2026-07-10, BLOCK-3): `tests/integration/rls-enforce-canary-real-db.test.ts`
+exercises this on `knowledge_sources` (a 2nd FORCE table, extending the #317
+sources canary). It found (L-013) that the 0099 policy used bare
+`current_setting(...)::uuid` (no NULLIF) — an empty GUC raised `invalid uuid`
+instead of fail-closing. migration `0116_knowledge_sources_rls_nullif.sql`
+hardens it with `NULLIF(..., '')::uuid` (matching sources 0114). The canary runs
+in CI (migrations-real-db.yml RLS canary step). Other 0099-era FORCE tables may
+have the same gap — a broader NULLIF audit is a follow-up.
 
 ## 7. Rollback
 

--- a/migrations/0116_knowledge_sources_rls_nullif.sql
+++ b/migrations/0116_knowledge_sources_rls_nullif.sql
@@ -1,0 +1,23 @@
+-- 0116_knowledge_sources_rls_nullif.sql
+-- SPEC-REGULA-RLS-ENFORCE-001 (Phase 3 BLOCK-3 canary finding) — harden
+-- knowledge_sources RLS policy to fail-closed on empty GUC, matching the
+-- sources (0114) NULLIF pattern.
+--
+-- Finding (L-013, rls-enforce-canary-real-db.test.ts): the 0099 policy used
+-- bare `current_setting('app.current_org_id', true)::uuid`. An empty GUC ("")
+-- — e.g. a stale pooled connection or a withTenantScope bug — raised
+-- `invalid input syntax for type uuid: ""` instead of fail-closing to 0 rows.
+-- sources/source_sections (0114) use `NULLIF(current_setting(...), '')::uuid`
+-- which is robust (empty/NULL GUC → NULL → false → 0 rows, no error). This
+-- aligns knowledge_sources to the same robust pattern.
+--
+-- @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 (BLOCK-3, runbook §6 canary)
+-- @MX:REASON RLS defense-in-depth: a policy that ERRORS on edge-case GUC state
+--   is not fail-closed (it surfaces a 500, potentially leaking existence).
+--   NULLIF makes the policy evaluate to false (0 rows) on empty/NULL GUC.
+
+DROP POLICY IF EXISTS knowledge_sources_org_isolated ON knowledge_sources;
+CREATE POLICY knowledge_sources_org_isolated ON knowledge_sources
+  FOR ALL
+  USING (organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid)
+  WITH CHECK (organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid);

--- a/tests/integration/rls-enforce-canary-real-db.test.ts
+++ b/tests/integration/rls-enforce-canary-real-db.test.ts
@@ -1,0 +1,102 @@
+// @MX:NOTE [AUTO] Real-DB RLS enforce canary — general (non-sources) FORCE table.
+// @MX:SPEC SPEC-REGULA-RLS-ENFORCE-001 (Issue #239, BLOCK-3) / runbook §6
+//
+// Why this exists (L-013): the sources/source_sections canary (#317,
+// tests/integration/rls-sources-real-db.test.ts) proves the regula_app RLS
+// mechanism for ONE domain. This extends the guarantee to a second FORCE RLS
+// table (knowledge_sources) so the runbook §6 cutover canary is exercised for
+// the general org-isolation case — confirming FORCE RLS + app.current_org_id
+// GUC + NOBYPASSRLS role enforces tenant isolation AND fail-closes outside
+// withTenantScope, not just for sources.
+//
+// Connection discipline mirrors #317: ONE dedicated postgres-js client
+// (max:1, prepare:false) so SET ROLE / set_config / query / RESET share a
+// single connection (drizzle's pooled tx cannot guarantee SET ROLE lands on
+// the same connection as the query).
+//
+// Skipped when DATABASE_URL is unset.
+
+import postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const SKIP = !process.env.DATABASE_URL;
+
+// Distinct seed IDs (avoid colliding with real rows / #317's orgs).
+const ORG_A = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const ORG_B = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const USER_A = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+
+// biome-ignore lint/suspicious/noExplicitAny: suite-scoped client initialized in beforeAll
+let client: any;
+
+/** Run `fn` under regula_app (NOBYPASSRLS) with a given org GUC, then reset. */
+async function asRegulaApp(orgId: string | null, fn: () => Promise<void>): Promise<void> {
+  await client`SET ROLE regula_app`;
+  // set_config(name, value, is_local=false) is session-scoped. NULL value →
+  // current_setting(..., true) returns NULL → policy's ::uuid cast yields NULL
+  // → every row filtered out (fail-closed). RESET leaves "" which raises on cast.
+  const gucValue: string | null = orgId ?? null;
+  await client`SELECT set_config('app.current_org_id', ${gucValue}, false)`;
+  try {
+    await fn();
+  } finally {
+    await client`RESET ROLE`;
+    await client`SELECT set_config('app.current_org_id', ${null}, false)`;
+  }
+}
+
+describe.skipIf(SKIP)(
+  'RLS enforce canary — knowledge_sources (general FORCE table, #239 BLOCK-3)',
+  () => {
+    beforeAll(async () => {
+      if (SKIP) return;
+      client = postgres(process.env.DATABASE_URL as string, { max: 1, prepare: false });
+      // Clean stale seed (superuser), then seed fresh.
+      await client`DELETE FROM knowledge_sources WHERE git_url LIKE 'https://github.com/canary-%'`;
+      await client`DELETE FROM users WHERE id = ${USER_A}`;
+      await client`DELETE FROM organizations WHERE id IN (${ORG_A}, ${ORG_B})`;
+      await client`
+      INSERT INTO organizations (id, name) VALUES
+        (${ORG_A}, 'RLS Enforce Canary Org A'),
+        (${ORG_B}, 'RLS Enforce Canary Org B')
+    `;
+      await client`
+      INSERT INTO users (id, email, name) VALUES
+        (${USER_A}, 'rls-canary@example.test', 'RLS Canary User')
+    `;
+      await client`
+      INSERT INTO knowledge_sources (organization_id, git_url, branch, created_by) VALUES
+        (${ORG_A}, 'https://github.com/canary-org-a/repo', 'main', ${USER_A}),
+        (${ORG_B}, 'https://github.com/canary-org-b/repo', 'main', ${USER_A})
+    `;
+    });
+
+    afterAll(async () => {
+      if (SKIP) return;
+      // Leave no trace on the shared DB.
+      await client`DELETE FROM knowledge_sources WHERE git_url LIKE 'https://github.com/canary-%'`;
+      await client`DELETE FROM users WHERE id = ${USER_A}`;
+      await client`DELETE FROM organizations WHERE id IN (${ORG_A}, ${ORG_B})`;
+      await client.end();
+    });
+
+    it('returns only the caller org rows when GUC is set (positive isolation)', async () => {
+      let rows: Array<{ git_url: string }> = [];
+      await asRegulaApp(ORG_A, async () => {
+        const res = await client`SELECT git_url FROM knowledge_sources`;
+        rows = res as Array<{ git_url: string }>;
+      });
+      expect(rows.length).toBe(1);
+      expect(rows[0]?.git_url).toBe('https://github.com/canary-org-a/repo');
+    });
+
+    it('returns 0 rows (fail-closed) when GUC is unset outside withTenantScope', async () => {
+      let rows: unknown[] = [];
+      await asRegulaApp(null, async () => {
+        const res = await client`SELECT git_url FROM knowledge_sources`;
+        rows = res as unknown[];
+      });
+      expect(rows.length).toBe(0);
+    });
+  },
+);


### PR DESCRIPTION
Phase 3 BLOCK-3 코드 산출물. runbook+migration 0085/role은 기존 완료(ops env 전환은 runbook §3-4 action).

## 구현
- `tests/integration/rls-enforce-canary-real-db.test.ts`: general FORCE 테이블(knowledge_sources) RLS enforce canary. #317 sources canary를 2번째 FORCE 테이블로 확장. regula_app(NOBYPASSRLS)+GUC로 positive isolation + fail-closed 검증. 2/2 PASS.
- **★ L-013 발견**: canary가 0099 policy의 bare `current_setting()::uuid`(NULLIF 없음) 포착 — 빈 GUC에서 'invalid uuid' 에러(fail-closed 아님). sources(0114)는 NULLIF로 견고.
- `migrations/0116`: knowledge_sources policy `NULLIF(...,'')::uuid` 강화(일관성+fail-closed). fresh DB 직검 0 error.
- CI: migrations-real-db.yml RLS canary 단계에 신규 canary 추가.
- runbook: serviceDb 정의부 lib/db/client.ts 정정 + §6 구현 canary/0116 기록.

## 게이트 (직검)
typecheck 0 · full test **4896 passed | 0 failed** · canary 2/2 (real DB) · biome clean.

## 잔여 (ops action, 코드 PR 아님)
운영 DATABASE_URL→regula_app 전환 + password 설정은 runbook §3-4의 ops action. broader NULLIF audit(타 0099-era FORCE 테이블)은 follow-up.

Refs SPEC-REGULA-RLS-ENFORCE-001, #239, BLOCK-3.

🗿 MoAI <email@mo.ai.kr>