### PR TITLE
test(observability): langfuse happy-path 커버리지 보강 (#402)

### DIFF
--- a/tests/unit/observability/langfuse.test.ts
+++ b/tests/unit/observability/langfuse.test.ts
@@ -7,11 +7,16 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the langfuse module to prevent real network connections
+// Shared mocks so happy-path tests can assert generation/flush were called.
+const generationMock = vi.fn();
+const flushAsyncMock = vi.fn().mockResolvedValue(undefined);
+const traceMock = vi.fn().mockReturnValue({ generation: generationMock });
+
+// Mock the langfuse module to prevent real network connections.
 vi.mock('langfuse', () => ({
   Langfuse: vi.fn().mockImplementation(() => ({
-    trace: vi.fn().mockReturnValue({ generation: vi.fn() }),
-    flushAsync: vi.fn().mockResolvedValue(undefined),
+    trace: traceMock,
+    flushAsync: flushAsyncMock,
   })),
 }));
 
@@ -19,7 +24,9 @@ beforeEach(() => {
   // Avoid assigning undefined, which process.env may coerce to a string.
   Reflect.deleteProperty(process.env, 'LANGFUSE_SECRET_KEY');
   Reflect.deleteProperty(process.env, 'LANGFUSE_PUBLIC_KEY');
+  Reflect.deleteProperty(process.env, 'LANGFUSE_BASEURL');
   vi.resetModules();
+  vi.clearAllMocks();
 });
 
 describe('getLangfuseClient (REQ-ENTERPRISE-051)', () => {
@@ -48,6 +55,68 @@ describe('traceLlmCall (REQ-ENTERPRISE-051)', () => {
         tokensOut: 20,
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('getLangfuseClient — happy path (env set)', () => {
+  it('returns a non-null singleton client when both keys are set', async () => {
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    const { getLangfuseClient } = await import('@/lib/observability/langfuse');
+    const c1 = getLangfuseClient();
+    const c2 = getLangfuseClient();
+    expect(c1).not.toBeNull();
+    expect(c1).toBe(c2); // singleton — constructed once, cached on the module
+  });
+
+  it('passes LANGFUSE_BASEURL override to the Langfuse constructor', async () => {
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    process.env.LANGFUSE_BASEURL = 'https://selfhosted.langfuse.example';
+    const { Langfuse } = await import('langfuse');
+    const { getLangfuseClient } = await import('@/lib/observability/langfuse');
+    getLangfuseClient();
+    expect(Langfuse).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'https://selfhosted.langfuse.example' }),
+    );
+  });
+
+  it('defaults baseUrl to cloud.langfuse.com when LANGFUSE_BASEURL unset', async () => {
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    const { Langfuse } = await import('langfuse');
+    const { getLangfuseClient } = await import('@/lib/observability/langfuse');
+    getLangfuseClient();
+    expect(Langfuse).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'https://cloud.langfuse.com' }),
+    );
+  });
+});
+
+describe('traceLlmCall — happy path (client exists)', () => {
+  it('records a trace + generation + flush when the client is initialized', async () => {
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    const { traceLlmCall } = await import('@/lib/observability/langfuse');
+    await traceLlmCall({
+      name: 'llm.call',
+      input: 'prompt-text',
+      output: 'completion-text',
+      model: 'gpt-oss:120b',
+      tokensIn: 42,
+      tokensOut: 7,
+    });
+    expect(traceMock).toHaveBeenCalledWith({ name: 'llm.call' });
+    expect(generationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'llm.call',
+        model: 'gpt-oss:120b',
+        input: 'prompt-text',
+        output: 'completion-text',
+        usage: { promptTokens: 42, completionTokens: 7 },
+      }),
+    );
+    expect(flushAsyncMock).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Phase 4 BLOCK-4 coverage ratchet-up (단계). langfuse.ts ~55%→~100%.

기존 테스트(null 경로)에 happy-path 추가: singleton + BASEURL override/기본값 + traceLlmCall trace+generation+flush. test-only, 회귀 0. 8/8 tests, typecheck 0.

Refs #402 Priority 1.

🗿 MoAI <email@mo.ai.kr>