### PR TITLE
test(coverage): review-notifier + dashboard + registry 100% (#402 단계)

### DIFF
--- a/tests/unit/model-governance/registry.test.ts
+++ b/tests/unit/model-governance/registry.test.ts
@@ -1,0 +1,461 @@
+// @MX:NOTE [AUTO] Unit tests for model-governance registry (SPEC-REGULA-MODEL-GOVERNANCE-001).
+// @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (REQ-MODELGOV-001, Issue 71)
+// @MX:REASON REQ-MODELGOV-001 gate: computeContentHash (pure SHA-256),
+//   registerPrompt (idempotent dedup + version increment + insert-only),
+//   listPrompts (org-scoped, optional kind filter, newest-first).
+
+import { createHash } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// computeContentHash is a pure function — test directly with known vectors.
+// No db mock needed. Uses dynamic import to stay compatible with
+// vi.resetModules() in the beforeEach below (which clears the module cache).
+// ---------------------------------------------------------------------------
+describe('computeContentHash (REQ-MODELGOV-001 — pure SHA-256)', () => {
+  it('returns 64-char lowercase hex digest', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    const hash = computeContentHash('test content');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('matches known SHA-256 vector for empty string', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expect(computeContentHash('')).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    );
+  });
+
+  it('matches known SHA-256 vector for "hello"', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    expect(computeContentHash('hello')).toBe(
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    );
+  });
+
+  it('matches known SHA-256 vector for "abc"', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    // SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+    expect(computeContentHash('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+    );
+  });
+
+  it('is deterministic — same input always produces same hash', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    const a = computeContentHash('deterministic input');
+    const b = computeContentHash('deterministic input');
+    expect(a).toBe(b);
+  });
+
+  it('different inputs produce different hashes', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    const a = computeContentHash('input one');
+    const b = computeContentHash('input two');
+    expect(a).not.toBe(b);
+  });
+
+  it('single character change produces different hash (avalanche)', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    const a = computeContentHash('prompt v1');
+    const b = computeContentHash('prompt v2');
+    expect(a).not.toBe(b);
+  });
+
+  it('handles unicode and emoji content', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    const hash = computeContentHash('안녕하세요 🌸 Résumé');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).toBe(createHash('sha256').update('안녕하세요 🌸 Résumé', 'utf8').digest('hex'));
+  });
+
+  it('handles multiline content with whitespace', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    const content = 'Line 1\nLine 2\n  Indented\n\n';
+    const hash = computeContentHash(content);
+    expect(hash).toBe(createHash('sha256').update(content, 'utf8').digest('hex'));
+  });
+
+  it('is consistent with node:crypto createHash directly', async () => {
+    const { computeContentHash } = await import('@/lib/model-governance/registry');
+    const content = 'consistency check content';
+    expect(computeContentHash(content)).toBe(
+      createHash('sha256').update(content, 'utf8').digest('hex'),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerPrompt + listPrompts — mock db for lookup/insert chains.
+//
+// Chain shapes:
+//   1. dedup:    select().from().where().limit(1)         → array
+//   2. version:  select().from().where().orderBy().limit() → array
+//   3. insert:   insert().values().returning()             → array
+//   4. list:     select().from().where().orderBy()         → thenable (array)
+// ---------------------------------------------------------------------------
+let dedupResult: unknown[] = [];
+let versionResult: unknown[] = [];
+let insertResult: unknown[] = [];
+let listResult: unknown[] = [];
+
+function makeMockDb() {
+  const selectMock = () => ({
+    from: () => ({
+      where: () => {
+        // Return object with both limit() (dedup path) and orderBy() (version/list path).
+        const thenable = Promise.resolve(listResult) as Promise<unknown[]> & {
+          limit: () => Promise<unknown[]>;
+          orderBy: () => Promise<unknown[]> & { limit: () => Promise<unknown[]> };
+        };
+        // Dedup path: where().limit()
+        thenable.limit = () => Promise.resolve(dedupResult);
+        // Version/list path: where().orderBy()
+        const orderByResult = Promise.resolve(listResult) as Promise<unknown[]> & {
+          limit: () => Promise<unknown[]>;
+        };
+        orderByResult.limit = () => Promise.resolve(versionResult);
+        thenable.orderBy = () => orderByResult;
+        return thenable;
+      },
+    }),
+  });
+  const insertMock = () => ({
+    values: () => ({
+      returning: () => Promise.resolve(insertResult),
+    }),
+  });
+  return { select: vi.fn(selectMock), insert: vi.fn(insertMock) };
+}
+
+beforeEach(() => {
+  dedupResult = [];
+  versionResult = [];
+  insertResult = [];
+  listResult = [];
+  vi.resetModules();
+  vi.doMock('@/lib/db/client', () => ({ db: makeMockDb() }));
+});
+
+// ---------------------------------------------------------------------------
+// registerPrompt — idempotent dedup
+// ---------------------------------------------------------------------------
+describe('registerPrompt — idempotent dedup (REQ-MODELGOV-001)', () => {
+  it('returns existing row when identical content already exists', async () => {
+    const existing = {
+      id: 'prompt-1',
+      kind: 'prompt' as const,
+      contentHash: computeContentHashRef('existing content'),
+      version: 3,
+      createdAt: new Date('2025-01-01'),
+    };
+    dedupResult = [existing];
+
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    const result = await registerPrompt({
+      orgId: 'org-1',
+      kind: 'prompt',
+      content: 'existing content',
+      createdBy: 'user-1',
+    });
+
+    expect(result).toEqual(existing);
+  });
+
+  it('does not call insert when dedup finds an existing row', async () => {
+    dedupResult = [
+      {
+        id: 'prompt-existing',
+        kind: 'prompt',
+        contentHash: 'hash',
+        version: 1,
+        createdAt: new Date(),
+      },
+    ];
+    const { db } = await import('@/lib/db/client');
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    await registerPrompt({
+      orgId: 'org-1',
+      kind: 'prompt',
+      content: 'same content',
+      createdBy: 'user-1',
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerPrompt — new version insert
+// ---------------------------------------------------------------------------
+describe('registerPrompt — new version insert (REQ-MODELGOV-001)', () => {
+  it('inserts version 1 when no prior versions exist', async () => {
+    dedupResult = []; // no existing
+    versionResult = []; // no latest version
+    insertResult = [
+      {
+        id: 'prompt-new',
+        kind: 'prompt',
+        contentHash: computeContentHashRef('new content'),
+        version: 1,
+        createdAt: new Date('2025-06-01'),
+      },
+    ];
+
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    const result = await registerPrompt({
+      orgId: 'org-1',
+      kind: 'prompt',
+      content: 'new content',
+      createdBy: 'user-1',
+    });
+
+    expect(result.version).toBe(1);
+    expect(result.id).toBe('prompt-new');
+  });
+
+  it('increments version from latest existing version', async () => {
+    dedupResult = []; // no existing dedup match
+    versionResult = [{ version: 5 }]; // latest version is 5
+    insertResult = [
+      {
+        id: 'prompt-v6',
+        kind: 'template',
+        contentHash: computeContentHashRef('version 6 content'),
+        version: 6,
+        createdAt: new Date('2025-06-02'),
+      },
+    ];
+
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    const result = await registerPrompt({
+      orgId: 'org-1',
+      kind: 'template',
+      content: 'version 6 content',
+      createdBy: 'user-2',
+    });
+
+    expect(result.version).toBe(6);
+  });
+
+  it('computes content hash from the input content for dedup lookup', async () => {
+    dedupResult = [];
+    versionResult = [];
+    insertResult = [
+      {
+        id: 'p',
+        kind: 'prompt',
+        contentHash: computeContentHashRef('hashable content'),
+        version: 1,
+        createdAt: new Date(),
+      },
+    ];
+
+    const { db } = await import('@/lib/db/client');
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    await registerPrompt({
+      orgId: 'org-1',
+      kind: 'prompt',
+      content: 'hashable content',
+      createdBy: null,
+    });
+
+    // select was called (dedup check). The mock doesn't inspect args, but we
+    // verify the content hash matches what computeContentHash would produce.
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('throws when insert returns no rows', async () => {
+    dedupResult = [];
+    versionResult = [];
+    insertResult = []; // insert returns nothing
+
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    await expect(
+      registerPrompt({
+        orgId: 'org-1',
+        kind: 'prompt',
+        content: 'orphan content',
+        createdBy: 'user-1',
+      }),
+    ).rejects.toThrow('prompt_registry insert returned no rows');
+  });
+
+  it('passes createdBy=null to insert', async () => {
+    dedupResult = [];
+    versionResult = [];
+    insertResult = [
+      {
+        id: 'p-null',
+        kind: 'prompt',
+        contentHash: 'h',
+        version: 1,
+        createdAt: new Date(),
+      },
+    ];
+
+    const { db } = await import('@/lib/db/client');
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    await registerPrompt({
+      orgId: 'org-1',
+      kind: 'prompt',
+      content: 'content',
+      createdBy: null,
+    });
+    expect(db.insert).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerPrompt — kind variants
+// ---------------------------------------------------------------------------
+describe('registerPrompt — kind variants', () => {
+  it('registers "template" kind successfully', async () => {
+    dedupResult = [];
+    versionResult = [];
+    insertResult = [
+      {
+        id: 'tpl-1',
+        kind: 'template',
+        contentHash: computeContentHashRef('template content'),
+        version: 1,
+        createdAt: new Date(),
+      },
+    ];
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    const result = await registerPrompt({
+      orgId: 'org-1',
+      kind: 'template',
+      content: 'template content',
+      createdBy: 'user-1',
+    });
+    expect(result.kind).toBe('template');
+  });
+
+  it('registers "prompt" kind successfully', async () => {
+    dedupResult = [];
+    versionResult = [];
+    insertResult = [
+      {
+        id: 'pmt-1',
+        kind: 'prompt',
+        contentHash: computeContentHashRef('prompt content'),
+        version: 1,
+        createdAt: new Date(),
+      },
+    ];
+    const { registerPrompt } = await import('@/lib/model-governance/registry');
+    const result = await registerPrompt({
+      orgId: 'org-1',
+      kind: 'prompt',
+      content: 'prompt content',
+      createdBy: 'user-1',
+    });
+    expect(result.kind).toBe('prompt');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listPrompts — org-scoped query with optional kind filter
+// ---------------------------------------------------------------------------
+describe('listPrompts (REQ-MODELGOV-001)', () => {
+  it('returns all prompts for an org (newest first)', async () => {
+    listResult = [
+      {
+        id: 'p-3',
+        kind: 'prompt',
+        contentHash: 'hash-3',
+        version: 3,
+        createdAt: new Date('2025-06-03'),
+        createdBy: 'user-1',
+      },
+      {
+        id: 'p-2',
+        kind: 'prompt',
+        contentHash: 'hash-2',
+        version: 2,
+        createdAt: new Date('2025-06-02'),
+        createdBy: 'user-1',
+      },
+      {
+        id: 'p-1',
+        kind: 'prompt',
+        contentHash: 'hash-1',
+        version: 1,
+        createdAt: new Date('2025-06-01'),
+        createdBy: null,
+      },
+    ];
+    const { listPrompts } = await import('@/lib/model-governance/registry');
+    const result = await listPrompts('org-1');
+    expect(result).toHaveLength(3);
+    expect(result[0]?.version).toBe(3);
+    expect(result[2]?.version).toBe(1);
+  });
+
+  it('returns empty array when no prompts exist', async () => {
+    listResult = [];
+    const { listPrompts } = await import('@/lib/model-governance/registry');
+    const result = await listPrompts('org-empty');
+    expect(result).toEqual([]);
+  });
+
+  it('filters by kind when provided', async () => {
+    listResult = [
+      {
+        id: 't-1',
+        kind: 'template',
+        contentHash: 'th-1',
+        version: 1,
+        createdAt: new Date(),
+        createdBy: 'user-1',
+      },
+    ];
+    const { listPrompts } = await import('@/lib/model-governance/registry');
+    const result = await listPrompts('org-1', 'template');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.kind).toBe('template');
+  });
+
+  it('filters by kind="prompt" when provided', async () => {
+    listResult = [
+      {
+        id: 'p-1',
+        kind: 'prompt',
+        contentHash: 'ph-1',
+        version: 2,
+        createdAt: new Date(),
+        createdBy: 'user-1',
+      },
+    ];
+    const { listPrompts } = await import('@/lib/model-governance/registry');
+    const result = await listPrompts('org-1', 'prompt');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.kind).toBe('prompt');
+  });
+
+  it('includes createdBy field in results', async () => {
+    listResult = [
+      {
+        id: 'p-1',
+        kind: 'prompt',
+        contentHash: 'h',
+        version: 1,
+        createdAt: new Date(),
+        createdBy: 'user-creator',
+      },
+    ];
+    const { listPrompts } = await import('@/lib/model-governance/registry');
+    const result = await listPrompts('org-1');
+    expect(result[0]?.createdBy).toBe('user-creator');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: reference SHA-256 for test data (avoids importing the function
+// under test into mock setup, which would break vi.resetModules isolation).
+// ---------------------------------------------------------------------------
+function computeContentHashRef(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}

--- a/tests/unit/source-governance/dashboard.test.ts
+++ b/tests/unit/source-governance/dashboard.test.ts
@@ -1,0 +1,301 @@
+// @MX:NOTE [AUTO] Unit tests for governance dashboard (SPEC-REGULA-SOURCE-GOVERNANCE-001, AC-06).
+// @MX:SPEC SPEC-REGULA-SOURCE-GOVERNANCE-001 (REQ-SOURCE-GOV-012/014, AC-06, Issue #48)
+// @MX:REASON AC-06 gate: getGovernanceDashboard aggregates 5 corpus counts +
+//   review-due list + stale-citation artifacts. getStaleCitationArtifacts
+//   reason branches (superseded vs sunset) are exercised.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock db — thenable pattern extended for count + innerJoin chains.
+//
+// The dashboard calls 5 count queries (select().from().where()), 1 review-due
+// query (same chain, delegated to the real getReviewDueSources), and 1 stale-
+// artifacts query (select().from().innerJoin().where().limit()). The count
+// queries are queued in Promise.all construction order; the innerJoin path
+// returns a separate result set.
+// ---------------------------------------------------------------------------
+let countQueue: unknown[][] = [];
+let staleArtifactsRows: unknown[] = [];
+
+function makeMockDb() {
+  const selectMock = () => ({
+    from: () => ({
+      // Count queries + review-due query use this path (thenable).
+      where: () => Promise.resolve(countQueue.shift() ?? []),
+      // Stale-citation artifacts query uses innerJoin → where → limit.
+      innerJoin: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(staleArtifactsRows),
+        }),
+      }),
+    }),
+  });
+  return { select: vi.fn(selectMock) };
+}
+
+beforeEach(() => {
+  countQueue = [];
+  staleArtifactsRows = [];
+  vi.resetModules();
+  vi.doMock('@/lib/db/client', () => ({ db: makeMockDb() }));
+});
+
+// ---------------------------------------------------------------------------
+// getGovernanceDashboard — full aggregate
+// ---------------------------------------------------------------------------
+describe('getGovernanceDashboard — full aggregate (REQ-SOURCE-GOV-012)', () => {
+  it('returns all counts populated with review-due and stale artifacts', async () => {
+    // Promise.all order: approved, pending, rejected, stale, superseded, reviewDue, staleArtifacts.
+    // First 5 are count queries ({n}), 6th is review-due source rows, 7th via innerJoin.
+    countQueue = [
+      [{ n: 3 }], // approved
+      [{ n: 1 }], // pending_review
+      [{ n: 0 }], // rejected
+      [{ n: 2 }], // stale (sunset past)
+      [{ n: 1 }], // superseded
+      // review-due query returns source rows (delegated to real getReviewDueSources):
+      [], // no review-due sources
+    ];
+    staleArtifactsRows = [
+      {
+        messageId: 'msg-1',
+        sourceId: 'src-sup',
+        sourceTitle: 'Old Guidance',
+        supersededBy: 'src-new',
+        sunsetDate: null,
+      },
+    ];
+
+    const { getGovernanceDashboard } = await import('@/lib/source-governance/dashboard');
+    const result = await getGovernanceDashboard({ orgId: 'org-1' });
+
+    expect(result.counts).toEqual({
+      approved: 3,
+      pendingReview: 1,
+      rejected: 0,
+      stale: 2,
+      superseded: 1,
+    });
+    expect(result.reviewDue).toEqual([]);
+    expect(result.staleCitationArtifacts).toHaveLength(1);
+    expect(result.staleCitationArtifacts[0]).toEqual({
+      messageId: 'msg-1',
+      sourceId: 'src-sup',
+      sourceTitle: 'Old Guidance',
+      reason: 'superseded by src-new',
+    });
+  });
+
+  it('returns zero counts when DB returns empty arrays', async () => {
+    countQueue = [[], [], [], [], [], []]; // all counts empty + no review-due
+    staleArtifactsRows = [];
+
+    const { getGovernanceDashboard } = await import('@/lib/source-governance/dashboard');
+    const result = await getGovernanceDashboard({ orgId: 'org-empty' });
+
+    expect(result.counts).toEqual({
+      approved: 0,
+      pendingReview: 0,
+      rejected: 0,
+      stale: 0,
+      superseded: 0,
+    });
+    expect(result.reviewDue).toEqual([]);
+    expect(result.staleCitationArtifacts).toEqual([]);
+  });
+
+  it('returns zero count when count query returns empty (rows[0] undefined)', async () => {
+    countQueue = [
+      [], // approved — no rows → num() returns 0
+      [{ n: 5 }],
+      [{ n: 2 }],
+      [{ n: 1 }],
+      [{ n: 3 }],
+      [],
+    ];
+    staleArtifactsRows = [];
+
+    const { getGovernanceDashboard } = await import('@/lib/source-governance/dashboard');
+    const result = await getGovernanceDashboard({ orgId: 'org-1' });
+
+    expect(result.counts.approved).toBe(0);
+    expect(result.counts.pendingReview).toBe(5);
+    expect(result.counts.rejected).toBe(2);
+    expect(result.counts.stale).toBe(1);
+    expect(result.counts.superseded).toBe(3);
+  });
+
+  it('maps review-due source rows through getReviewDueSources (daysOverdue computed)', async () => {
+    const lastReviewed = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    countQueue = [
+      [{ n: 1 }],
+      [{ n: 0 }],
+      [{ n: 0 }],
+      [{ n: 0 }],
+      [{ n: 0 }],
+      // 6th: review-due source rows
+      [
+        {
+          id: 'src-due',
+          title: 'Overdue Source',
+          ownerDepartment: 'QA',
+          reviewCycleDays: 90,
+          lastReviewedAt: lastReviewed,
+        },
+      ],
+    ];
+    staleArtifactsRows = [];
+
+    const { getGovernanceDashboard } = await import('@/lib/source-governance/dashboard');
+    const result = await getGovernanceDashboard({ orgId: 'org-1' });
+
+    expect(result.reviewDue).toHaveLength(1);
+    expect(result.reviewDue[0]?.id).toBe('src-due');
+    expect(result.reviewDue[0]?.daysOverdue).toBeGreaterThan(100);
+  });
+
+  it('maps stale artifacts with sunset reason (supersededBy is null)', async () => {
+    countQueue = [[{ n: 0 }], [{ n: 0 }], [{ n: 0 }], [{ n: 0 }], [{ n: 0 }], []];
+    staleArtifactsRows = [
+      {
+        messageId: 'msg-sunset',
+        sourceId: 'src-sunset',
+        sourceTitle: 'Expired Reg',
+        supersededBy: null,
+        sunsetDate: '2020-06-15',
+      },
+    ];
+
+    const { getGovernanceDashboard } = await import('@/lib/source-governance/dashboard');
+    const result = await getGovernanceDashboard({ orgId: 'org-1' });
+
+    expect(result.staleCitationArtifacts).toHaveLength(1);
+    expect(result.staleCitationArtifacts[0]?.reason).toContain('sunset date passed');
+    expect(result.staleCitationArtifacts[0]?.reason).toContain('2020-06-15');
+  });
+
+  it('maps multiple stale artifacts with mixed reasons', async () => {
+    countQueue = [[{ n: 0 }], [{ n: 0 }], [{ n: 0 }], [{ n: 0 }], [{ n: 0 }], []];
+    staleArtifactsRows = [
+      {
+        messageId: 'msg-1',
+        sourceId: 'src-1',
+        sourceTitle: 'Superseded Doc',
+        supersededBy: 'src-new',
+        sunsetDate: null,
+      },
+      {
+        messageId: 'msg-2',
+        sourceId: 'src-2',
+        sourceTitle: 'Expired Doc',
+        supersededBy: null,
+        sunsetDate: '2019-01-01',
+      },
+    ];
+
+    const { getGovernanceDashboard } = await import('@/lib/source-governance/dashboard');
+    const result = await getGovernanceDashboard({ orgId: 'org-1' });
+
+    expect(result.staleCitationArtifacts).toHaveLength(2);
+    expect(result.staleCitationArtifacts[0]?.reason).toBe('superseded by src-new');
+    expect(result.staleCitationArtifacts[1]?.reason).toContain('sunset date passed');
+  });
+
+  it('handles null sourceTitle in stale artifacts', async () => {
+    countQueue = [[{ n: 0 }], [{ n: 0 }], [{ n: 0 }], [{ n: 0 }], [{ n: 0 }], []];
+    staleArtifactsRows = [
+      {
+        messageId: 'msg-3',
+        sourceId: 'src-3',
+        sourceTitle: null,
+        supersededBy: 'src-new',
+        sunsetDate: null,
+      },
+    ];
+
+    const { getGovernanceDashboard } = await import('@/lib/source-governance/dashboard');
+    const result = await getGovernanceDashboard({ orgId: 'org-1' });
+
+    expect(result.staleCitationArtifacts[0]?.sourceTitle).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStaleCitationArtifacts — standalone reason branches (REQ-SOURCE-GOV-014)
+// ---------------------------------------------------------------------------
+describe('getStaleCitationArtifacts — reason branches (REQ-SOURCE-GOV-014)', () => {
+  it('returns "superseded by X" reason when supersededBy is not null', async () => {
+    staleArtifactsRows = [
+      {
+        messageId: 'msg-sup',
+        sourceId: 'src-sup',
+        sourceTitle: 'Old Doc',
+        supersededBy: 'src-replacement',
+        sunsetDate: null,
+      },
+    ];
+    const { getStaleCitationArtifacts } = await import('@/lib/source-governance/dashboard');
+    const result = await getStaleCitationArtifacts('org-1');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.reason).toBe('superseded by src-replacement');
+    expect(result[0]?.messageId).toBe('msg-sup');
+    expect(result[0]?.sourceId).toBe('src-sup');
+  });
+
+  it('returns "sunset date passed (X)" reason when supersededBy is null', async () => {
+    staleArtifactsRows = [
+      {
+        messageId: 'msg-sun',
+        sourceId: 'src-sun',
+        sourceTitle: 'Expired Doc',
+        supersededBy: null,
+        sunsetDate: '2021-03-20',
+      },
+    ];
+    const { getStaleCitationArtifacts } = await import('@/lib/source-governance/dashboard');
+    const result = await getStaleCitationArtifacts('org-1');
+    expect(result[0]?.reason).toBe('sunset date passed (2021-03-20)');
+  });
+
+  it('returns empty array when no stale citations exist', async () => {
+    staleArtifactsRows = [];
+    const { getStaleCitationArtifacts } = await import('@/lib/source-governance/dashboard');
+    const result = await getStaleCitationArtifacts('org-1');
+    expect(result).toEqual([]);
+  });
+
+  it('returns multiple stale citation artifacts', async () => {
+    staleArtifactsRows = [
+      {
+        messageId: 'msg-1',
+        sourceId: 'src-1',
+        sourceTitle: 'A',
+        supersededBy: 'src-a',
+        sunsetDate: null,
+      },
+      {
+        messageId: 'msg-2',
+        sourceId: 'src-2',
+        sourceTitle: 'B',
+        supersededBy: null,
+        sunsetDate: '2020-01-01',
+      },
+      {
+        messageId: 'msg-3',
+        sourceId: 'src-3',
+        sourceTitle: null,
+        supersededBy: 'src-c',
+        sunsetDate: null,
+      },
+    ];
+    const { getStaleCitationArtifacts } = await import('@/lib/source-governance/dashboard');
+    const result = await getStaleCitationArtifacts('org-1');
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.reason)).toEqual([
+      'superseded by src-a',
+      'sunset date passed (2020-01-01)',
+      'superseded by src-c',
+    ]);
+  });
+});

--- a/tests/unit/source-governance/review-notifier.test.ts
+++ b/tests/unit/source-governance/review-notifier.test.ts
@@ -1,0 +1,246 @@
+// @MX:NOTE [AUTO] Unit tests for review-notifier (SPEC-REGULA-SOURCE-GOVERNANCE-001, AC-06).
+// @MX:SPEC SPEC-REGULA-SOURCE-GOVERNANCE-001 (REQ-SOURCE-GOV-011/013, AC-06, Issue #48)
+// @MX:REASON AC-06 gate: getReviewDueSources must return sources whose review
+//   cycle has elapsed (or will within withinDays). daysOverdue arithmetic and
+//   the never-reviewed-approved branch are exercised.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock db — same thenable pattern as stale-check.test.ts.
+// ---------------------------------------------------------------------------
+let mockRows: unknown[] = [];
+
+function makeThenable(rowsFor: () => unknown[]) {
+  return Promise.resolve(rowsFor()) as Promise<unknown[]>;
+}
+
+function makeMockDb(rows: () => unknown[]) {
+  const selectMock = () => ({
+    from: () => ({
+      where: () => makeThenable(rows),
+    }),
+  });
+  return { select: vi.fn(selectMock) };
+}
+
+beforeEach(() => {
+  mockRows = [];
+  vi.resetModules();
+  vi.doMock('@/lib/db/client', () => ({ db: makeMockDb(() => mockRows) }));
+});
+
+// ---------------------------------------------------------------------------
+// getReviewDueSources — empty result
+// ---------------------------------------------------------------------------
+describe('getReviewDueSources — empty result (AC-06)', () => {
+  it('returns empty array when DB returns no rows', async () => {
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getReviewDueSources — daysOverdue calculation
+// ---------------------------------------------------------------------------
+describe('getReviewDueSources — daysOverdue arithmetic (REQ-SOURCE-GOV-013)', () => {
+  it('computes positive daysOverdue when review cycle has elapsed', async () => {
+    // 100-day cycle, last reviewed 150 days ago → 50 days overdue.
+    const cycleDays = 100;
+    const elapsedDays = 150;
+    const lastReviewedAt = new Date(Date.now() - elapsedDays * 24 * 60 * 60 * 1000).toISOString();
+    mockRows = [
+      {
+        id: 'src-1',
+        title: 'FDA Guidance',
+        ownerDepartment: 'QA',
+        reviewCycleDays: cycleDays,
+        lastReviewedAt,
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('src-1');
+    expect(result[0]?.daysOverdue).toBeGreaterThanOrEqual(49); // ~50 (allow ±1 for timing)
+    expect(result[0]?.daysOverdue).toBeLessThanOrEqual(51);
+  });
+
+  it('computes zero or negative daysOverdue when review is not yet due', async () => {
+    // 365-day cycle, last reviewed 10 days ago → -355 days "overdue" (not yet due).
+    const cycleDays = 365;
+    const elapsedDays = 10;
+    const lastReviewedAt = new Date(Date.now() - elapsedDays * 24 * 60 * 60 * 1000).toISOString();
+    mockRows = [
+      {
+        id: 'src-future',
+        title: 'Recent Source',
+        ownerDepartment: 'RA',
+        reviewCycleDays: cycleDays,
+        lastReviewedAt,
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result[0]?.daysOverdue).toBeLessThan(0);
+  });
+
+  it('returns daysOverdue=0 when reviewCycleDays is null', async () => {
+    // Null cycle → cycle=0 → daysOverdue=0 (the never-reviewed-but-approved branch).
+    mockRows = [
+      {
+        id: 'src-null-cycle',
+        title: 'No Cycle',
+        ownerDepartment: null,
+        reviewCycleDays: null,
+        lastReviewedAt: null,
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result[0]?.daysOverdue).toBe(0);
+    expect(result[0]?.reviewCycleDays).toBeNull();
+    expect(result[0]?.lastReviewedAt).toBeNull();
+  });
+
+  it('returns daysOverdue=0 when reviewCycleDays is 0', async () => {
+    mockRows = [
+      {
+        id: 'src-zero-cycle',
+        title: 'Zero Cycle',
+        ownerDepartment: 'QA',
+        reviewCycleDays: 0,
+        lastReviewedAt: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result[0]?.daysOverdue).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getReviewDueSources — withinDays parameter
+// ---------------------------------------------------------------------------
+describe('getReviewDueSources — withinDays parameter', () => {
+  it('defaults withinDays to 30 when not provided', async () => {
+    mockRows = [
+      {
+        id: 'src-default',
+        title: 'Default Window',
+        ownerDepartment: 'QA',
+        reviewCycleDays: 90,
+        lastReviewedAt: new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result).toHaveLength(1);
+    // The mock db doesn't enforce the SQL predicate; we verify the function
+    // accepts the default and returns rows. The SQL interval comparison is
+    // exercised in integration tests with a real DB.
+  });
+
+  it('accepts a custom withinDays value', async () => {
+    mockRows = [
+      {
+        id: 'src-custom',
+        title: 'Custom Window',
+        ownerDepartment: 'QA',
+        reviewCycleDays: 90,
+        lastReviewedAt: new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1', withinDays: 60 });
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getReviewDueSources — multiple rows + field mapping
+// ---------------------------------------------------------------------------
+describe('getReviewDueSources — multiple rows and field mapping', () => {
+  it('maps all returned rows preserving id/title/ownerDepartment/reviewCycleDays/lastReviewedAt', async () => {
+    const lastReviewed = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    mockRows = [
+      {
+        id: 'src-a',
+        title: 'Source A',
+        ownerDepartment: 'QA',
+        reviewCycleDays: 90,
+        lastReviewedAt: lastReviewed,
+      },
+      {
+        id: 'src-b',
+        title: 'Source B',
+        ownerDepartment: 'RA',
+        reviewCycleDays: 365,
+        lastReviewedAt: lastReviewed,
+      },
+      {
+        id: 'src-c',
+        title: 'Source C',
+        ownerDepartment: null,
+        reviewCycleDays: null,
+        lastReviewedAt: null,
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result).toHaveLength(3);
+    expect(result[0]?.id).toBe('src-a');
+    expect(result[0]?.title).toBe('Source A');
+    expect(result[0]?.ownerDepartment).toBe('QA');
+    expect(result[1]?.id).toBe('src-b');
+    expect(result[2]?.ownerDepartment).toBeNull();
+    // src-c has null cycle → daysOverdue = 0
+    expect(result[2]?.daysOverdue).toBe(0);
+    // src-a (90-day cycle, 200 days elapsed) → ~110 days overdue
+    expect(result[0]?.daysOverdue).toBeGreaterThan(100);
+    // src-b (365-day cycle, 200 days elapsed) → negative (not yet due)
+    expect(result[1]?.daysOverdue).toBeLessThan(0);
+  });
+
+  it('preserves null ownerDepartment in mapped rows', async () => {
+    mockRows = [
+      {
+        id: 'src-null-owner',
+        title: 'No Owner',
+        ownerDepartment: null,
+        reviewCycleDays: 30,
+        lastReviewedAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result[0]?.ownerDepartment).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getReviewDueSources — ReviewDueSource shape
+// ---------------------------------------------------------------------------
+describe('getReviewDueSources — return type shape', () => {
+  it('returns objects with all ReviewDueSource fields', async () => {
+    mockRows = [
+      {
+        id: 'src-shape',
+        title: 'Shape Test',
+        ownerDepartment: 'QA',
+        reviewCycleDays: 30,
+        lastReviewedAt: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+    const { getReviewDueSources } = await import('@/lib/source-governance/review-notifier');
+    const result = await getReviewDueSources({ orgId: 'org-1' });
+    expect(result[0]).toHaveProperty('id');
+    expect(result[0]).toHaveProperty('title');
+    expect(result[0]).toHaveProperty('ownerDepartment');
+    expect(result[0]).toHaveProperty('reviewCycleDays');
+    expect(result[0]).toHaveProperty('lastReviewedAt');
+    expect(result[0]).toHaveProperty('daysOverdue');
+    expect(typeof result[0]?.daysOverdue).toBe('number');
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 coverage ratchet-up. 3 Priority-1 파일 100% 커버리지.

- review-notifier.ts (10 tests, 100%): daysOverdue 산술 + withinDays + 다중 행 매핑.
- dashboard.ts (11 tests, 100%): Promise.all 5 count 집계 + getStaleCitationArtifacts reason 분기.
- registry.ts (24 tests, 100%): computeContentHash(SHA-256 벡터) + registerPrompt idempotent/version + listPrompts org 스코프.
- test-only, 회귀 0 (64 source-gov/model-gov 테스트 green, full test 0 failed). typecheck 0, biome 0.

Refs #402 Priority 1.

🗿 MoAI <email@mo.ai.kr>