### PR TITLE
test(coverage): dispatcher + structured-blocks + evidence-packet (#402 Priority 2/3)

### DIFF
--- a/tests/unit/ai/structured-blocks.test.ts
+++ b/tests/unit/ai/structured-blocks.test.ts
@@ -1,0 +1,372 @@
+// @MX:NOTE [AUTO] Unit tests for structured-blocks generator (SPEC-REGULA-STRUCTURED-001, REQ-STRUCT-001~010).
+// @MX:SPEC SPEC-REGULA-STRUCTURED-001 (REQ-STRUCT-001..010, Issue #402)
+// @MX:REASON REQ-STRUCT-001..010 gate: generateStructuredBlocks async generator
+//   yields checklist/comparison/timeline/related events in fixed order.
+//   Classifiers decide emit/skip; generators produce JSON parsed via Zod.
+//   ai.generateText + getLlmFastModel mocked — no real LLM calls.
+
+import type { BlockEvent } from '@/lib/ai/structured-blocks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock ai.generateText — each test sets the return sequence.
+// ---------------------------------------------------------------------------
+const generateTextMock = vi.fn();
+
+vi.mock('ai', () => ({
+  generateText: (...args: unknown[]) => generateTextMock(...args),
+}));
+
+vi.mock('@/lib/ai/llm-provider', () => ({
+  getLlmFastModel: () => ({ id: 'mock-model' }),
+}));
+
+vi.mock('@/lib/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  generateTextMock.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const baseInput = {
+  question: 'MDR 문서화 요구사항은?',
+  prose: 'MDR Annex II 문서화 요구사항은 기술문서에 포함되어야 합니다.',
+  topSources: [
+    { title: 'MDR Annex II', orgLabel: 'EU', year: 2017 },
+    { title: 'FDA Guidance', orgLabel: 'FDA', year: 2023 },
+  ],
+  messageId: 'msg-1',
+  locale: 'ko' as const,
+};
+
+/** Configure generateTextMock to return the given text values in sequence. */
+function setResponses(texts: string[]) {
+  for (const t of texts) {
+    generateTextMock.mockResolvedValueOnce({ text: t });
+  }
+}
+
+async function collectEvents(gen: AsyncGenerator<BlockEvent>): Promise<BlockEvent[]> {
+  const events: BlockEvent[] = [];
+  for await (const ev of gen) events.push(ev);
+  return events;
+}
+
+function findByType(events: BlockEvent[], type: string): BlockEvent | undefined {
+  return events.find((e) => e.type === type);
+}
+
+// ---------------------------------------------------------------------------
+// OrderViolationError (REQ-STRUCT-003)
+// ---------------------------------------------------------------------------
+describe('OrderViolationError (REQ-STRUCT-003)', () => {
+  it('is constructible with event type in message', async () => {
+    const { OrderViolationError } = await import('@/lib/ai/structured-blocks');
+    const err = new OrderViolationError('checklist');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('OrderViolationError');
+    expect(err.message).toBe('structured event emitted before prose_done: checklist');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStructuredBlocks — checklist branch
+// ---------------------------------------------------------------------------
+describe('generateStructuredBlocks — checklist (REQ-STRUCT-001)', () => {
+  it('yields checklist event when classifier says yes and generator returns valid JSON', async () => {
+    const checklistJson = JSON.stringify({
+      type: 'checklist',
+      items: [{ id: 'c1', title: '기술문서 준비', completed: false }],
+    });
+    setResponses(['yes', checklistJson]);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    const checklist = findByType(events, 'checklist');
+    expect(checklist).toBeDefined();
+    expect(checklist?.type === 'checklist' && checklist.items).toHaveLength(1);
+    expect(checklist?.type === 'checklist' && checklist.items[0]?.title).toBe('기술문서 준비');
+  });
+
+  it('skips checklist when classifier says no', async () => {
+    setResponses(['no', 'no', 'no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'checklist')).toBeUndefined();
+  });
+
+  it('skips checklist when generator returns invalid JSON (REQ-STRUCT-006)', async () => {
+    setResponses(['yes', 'not valid json', 'no', 'no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'checklist')).toBeUndefined();
+    const { logger } = await import('@/lib/observability/logger');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('[structured-blocks] JSON parse error'),
+    );
+  });
+
+  it('skips checklist when generator returns valid JSON that fails Zod (REQ-STRUCT-006)', async () => {
+    setResponses(['yes', JSON.stringify({ type: 'checklist' }), 'no', 'no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'checklist')).toBeUndefined();
+  });
+
+  it('strips markdown code fences from generator response', async () => {
+    const fenced =
+      '```json\n{"type":"checklist","items":[{"id":"c1","title":"x","completed":true}]}\n```';
+    setResponses(['yes', fenced, 'no', 'no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'checklist')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStructuredBlocks — comparison branch
+// ---------------------------------------------------------------------------
+describe('generateStructuredBlocks — comparison (REQ-STRUCT-002)', () => {
+  it('yields comparison event when classifier says yes and generator returns valid JSON', async () => {
+    const cmpJson = JSON.stringify({
+      type: 'comparison',
+      title: 'EU vs FDA',
+      cols: ['기준', 'EU', 'FDA'],
+      rows: [['문서화', 'Annex II', '21 CFR 820']],
+    });
+    setResponses(['no', 'yes', cmpJson, 'no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    const cmp = findByType(events, 'comparison');
+    expect(cmp).toBeDefined();
+    expect(cmp?.type === 'comparison' && cmp.title).toBe('EU vs FDA');
+    expect(cmp?.type === 'comparison' && cmp.cols).toHaveLength(3);
+  });
+
+  it('skips comparison when classifier says no', async () => {
+    setResponses(['no', 'no', 'no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'comparison')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStructuredBlocks — timeline branch
+// ---------------------------------------------------------------------------
+describe('generateStructuredBlocks — timeline (REQ-STRUCT-004)', () => {
+  it('yields timeline event when classifier says yes and generator returns valid JSON', async () => {
+    const tlJson = JSON.stringify({
+      type: 'timeline',
+      items: [{ date: '2027-05-26', title: 'MDR 적용', description: 'MDR 전면 적용' }],
+    });
+    setResponses(['no', 'no', 'yes', tlJson, '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    const tl = findByType(events, 'timeline');
+    expect(tl).toBeDefined();
+    expect(tl?.type === 'timeline' && tl.items[0]?.date).toBe('2027-05-26');
+  });
+
+  it('skips timeline when generator returns items with bad date format', async () => {
+    const badDateJson = JSON.stringify({
+      type: 'timeline',
+      items: [{ date: 'not-a-date', title: 'x', description: 'y' }],
+    });
+    setResponses(['no', 'no', 'yes', badDateJson, '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'timeline')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStructuredBlocks — related branch (always generated, REQ-STRUCT-005)
+// ---------------------------------------------------------------------------
+describe('generateStructuredBlocks — related (REQ-STRUCT-005, REQ-STRUCT-008)', () => {
+  it('yields related event on first try when generator returns valid 3+ items', async () => {
+    const relJson = JSON.stringify({
+      type: 'related',
+      items: ['질문1', '질문2', '질문3'],
+    });
+    setResponses(['no', 'no', 'no', relJson]);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    const rel = findByType(events, 'related');
+    expect(rel).toBeDefined();
+    expect(rel?.type === 'related' && rel.items).toHaveLength(3);
+  });
+
+  it('retries once when first related generation returns null (REQ-STRUCT-008)', async () => {
+    setResponses([
+      'no',
+      'no',
+      'no',
+      'invalid',
+      JSON.stringify({ type: 'related', items: ['q1', 'q2', 'q3'] }),
+    ]);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    const rel = findByType(events, 'related');
+    expect(rel).toBeDefined();
+    expect(rel?.type === 'related' && rel.items).toHaveLength(3);
+  });
+
+  it('does not yield related when both first and retry fail', async () => {
+    setResponses(['no', 'no', 'no', 'invalid', 'also-invalid']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'related')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStructuredBlocks — event ordering (REQ-STRUCT-001)
+// ---------------------------------------------------------------------------
+describe('generateStructuredBlocks — event ordering', () => {
+  it('emits events in fixed order: checklist → comparison → timeline → related', async () => {
+    const checklistJson = JSON.stringify({
+      type: 'checklist',
+      items: [{ id: 'c1', title: 'x', completed: false }],
+    });
+    const cmpJson = JSON.stringify({
+      type: 'comparison',
+      title: 'T',
+      cols: ['a', 'b'],
+      rows: [['1', '2']],
+    });
+    const tlJson = JSON.stringify({
+      type: 'timeline',
+      items: [{ date: '2027-01-01', title: 'x', description: 'y' }],
+    });
+    const relJson = JSON.stringify({ type: 'related', items: ['q1', 'q2', 'q3'] });
+    setResponses(['yes', checklistJson, 'yes', cmpJson, 'yes', tlJson, relJson]);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(['checklist', 'comparison', 'timeline', 'related']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStructuredBlocks — abort signal handling
+// ---------------------------------------------------------------------------
+describe('generateStructuredBlocks — abort signal', () => {
+  it('yields nothing when signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput, controller.signal));
+    expect(events).toHaveLength(0);
+    expect(generateTextMock).not.toHaveBeenCalled();
+  });
+
+  it('stops emitting after signal aborts mid-stream', async () => {
+    const checklistJson = JSON.stringify({
+      type: 'checklist',
+      items: [{ id: 'c1', title: 'x', completed: false }],
+    });
+    const controller = new AbortController();
+    setResponses(['yes', checklistJson]);
+    // comparison classifier call aborts the signal.
+    generateTextMock.mockImplementationOnce(async () => {
+      controller.abort();
+      return { text: 'yes' };
+    });
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput, controller.signal));
+    const types = events.map((e) => e.type);
+    expect(types).toContain('checklist');
+    expect(types).not.toContain('comparison');
+    expect(types).not.toContain('related');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStructuredBlocks — error handling (fire-and-forget per block)
+// ---------------------------------------------------------------------------
+describe('generateStructuredBlocks — error handling', () => {
+  it('logs error and continues when checklist classifier throws', async () => {
+    generateTextMock.mockRejectedValueOnce(new Error('LLM down'));
+    setResponses(['no', 'no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'checklist')).toBeUndefined();
+    const { logger } = await import('@/lib/observability/logger');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('[structured-blocks] checklist error:'),
+      expect.any(Error),
+    );
+  });
+
+  it('logs error and continues when comparison generator throws', async () => {
+    setResponses(['no']);
+    generateTextMock.mockRejectedValueOnce(new Error('comparison LLM error'));
+    setResponses(['no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    const events = await collectEvents(generateStructuredBlocks(baseInput));
+    expect(findByType(events, 'comparison')).toBeUndefined();
+    const { logger } = await import('@/lib/observability/logger');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('[structured-blocks] comparison error:'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStructuredBlocks — input handling
+// ---------------------------------------------------------------------------
+describe('generateStructuredBlocks — input handling', () => {
+  it('truncates topSources to 3 for prompt input', async () => {
+    // Checklist classifier says yes → generator is called with formatSources.
+    // The generator prompt (2nd call) includes the topSources formatted as
+    // "[1] orgLabel — title (year)" — only the first 3 should appear.
+    const checklistJson = JSON.stringify({
+      type: 'checklist',
+      items: [{ id: 'c1', title: 'x', completed: false }],
+    });
+    setResponses(['yes', checklistJson, 'no', 'no', '{}', '{}']);
+    const { generateStructuredBlocks } = await import('@/lib/ai/structured-blocks');
+    await collectEvents(
+      generateStructuredBlocks({
+        ...baseInput,
+        topSources: [
+          { title: 'A', orgLabel: 'X', year: 2020 },
+          { title: 'B', orgLabel: 'Y', year: 2021 },
+          { title: 'C', orgLabel: 'Z', year: 2022 },
+          { title: 'D', orgLabel: 'W', year: 2023 },
+          { title: 'E', orgLabel: 'V', year: 2024 },
+        ],
+      }),
+    );
+    // 2nd call is the checklist generator prompt (includes formatSources).
+    const generatorArgs = generateTextMock.mock.calls[1]?.[0] as
+      | { messages?: Array<{ content?: string }> }
+      | undefined;
+    const promptText = generatorArgs?.messages?.[0]?.content ?? '';
+    // First 3 sources appear as "[N] orgLabel — title (year)".
+    expect(promptText).toContain('[1] X — A (2020)');
+    expect(promptText).toContain('[2] Y — B (2021)');
+    expect(promptText).toContain('[3] Z — C (2022)');
+    // 4th and 5th sources are truncated.
+    expect(promptText).not.toContain('[4]');
+    expect(promptText).not.toContain('W — D');
+    expect(promptText).not.toContain('V — E');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// module exports
+// ---------------------------------------------------------------------------
+describe('structured-blocks module exports', () => {
+  it('exports generateStructuredBlocks and OrderViolationError', async () => {
+    const mod = await import('@/lib/ai/structured-blocks');
+    expect(typeof mod.generateStructuredBlocks).toBe('function');
+    expect(mod.OrderViolationError).toBeDefined();
+  });
+});

--- a/tests/unit/notifications/dispatcher.test.ts
+++ b/tests/unit/notifications/dispatcher.test.ts
@@ -1,0 +1,432 @@
+// @MX:NOTE [AUTO] Unit tests for notification dispatcher (SPEC-REGULA-NOTIFICATIONS-001, REQ-NOTIFY-001..005).
+// @MX:SPEC SPEC-REGULA-NOTIFICATIONS-001 (REQ-NOTIFY-001..005, Issue #402)
+// @MX:REASON REQ-NOTIFY-001..005 gate: dispatch() routes to 3 channels
+//   (slack/teams/email) with fire-and-forget isolation. escapeHtml is a pure
+//   helper used by sendEmail — tested directly. fetch is stubbed via
+//   vi.stubGlobal so no real network calls occur.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock logger so dispatch() does not emit real log output.
+vi.mock('@/lib/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers — stub fetch + env per test.
+// ---------------------------------------------------------------------------
+
+function makeOkResponse(): Response {
+  return new Response('{}', { status: 200, statusText: 'OK' });
+}
+
+function makeBadResponse(status = 500): Response {
+  return new Response('{}', { status, statusText: 'ERROR' });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetModules();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(makeOkResponse());
+  vi.stubGlobal('fetch', fetchMock);
+  // Clean env so each test starts from a known state.
+  // Reflect.deleteProperty is used instead of `delete` to satisfy biome
+  // noDelete rule — Node coerces `process.env.X = undefined` to the string
+  // "undefined" which would break truthiness checks in the dispatcher.
+  Reflect.deleteProperty(process.env, 'SENDGRID_API_KEY');
+  Reflect.deleteProperty(process.env, 'SENDGRID_FROM_EMAIL');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(process.env, 'SENDGRID_API_KEY');
+  Reflect.deleteProperty(process.env, 'SENDGRID_FROM_EMAIL');
+});
+
+// ---------------------------------------------------------------------------
+// escapeHtml — pure helper (tested via sendEmail dispatch path)
+// ---------------------------------------------------------------------------
+// escapeHtml is not exported — we verify its behavior indirectly through
+// the HTML payload that sendEmail builds. The dispatch → sendEmail path
+// is the only way to observe escapeHtml output.
+
+describe('dispatch — slack channel (REQ-NOTIFY-001)', () => {
+  it('sends to slack webhook when orgSlackWebhookUrl is set', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'expert_review.assigned',
+      title: 'Review Assigned',
+      body: 'Please review',
+      orgSlackWebhookUrl: 'https://hooks.slack.com/services/T000/B000/XXX',
+    });
+    expect(result.slack).toBe('sent');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://hooks.slack.com/services/T000/B000/XXX');
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse(init?.body as string);
+    expect(body.text).toBe('*Review Assigned*\nPlease review');
+  });
+
+  it('sets slack to error when webhook returns non-ok', async () => {
+    fetchMock.mockResolvedValueOnce(makeBadResponse(503));
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'expert_review.assigned',
+      title: 'T',
+      body: 'B',
+      orgSlackWebhookUrl: 'https://hooks.slack.com/services/T/B/X',
+    });
+    expect(result.slack).toBe('error');
+    const { logger } = await import('@/lib/observability/logger');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('[notifications] Slack dispatch failed:'),
+      expect.any(Error),
+    );
+  });
+
+  it('sets slack to error when fetch throws', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'expert_review.assigned',
+      title: 'T',
+      body: 'B',
+      orgSlackWebhookUrl: 'https://hooks.slack.com/services/T/B/X',
+    });
+    expect(result.slack).toBe('error');
+  });
+
+  it('sets slack to skipped when no webhook url', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'expert_review.assigned',
+      title: 'T',
+      body: 'B',
+    });
+    expect(result.slack).toBe('skipped');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('dispatch — teams channel (REQ-NOTIFY-003)', () => {
+  it('sends to teams webhook with MessageCard format', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'workflow.completed',
+      title: 'Workflow Done',
+      body: 'All steps complete',
+      orgTeamsWebhookUrl: 'https://outlook.office.com/webhook/XXX',
+    });
+    expect(result.teams).toBe('sent');
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://outlook.office.com/webhook/XXX');
+    const body = JSON.parse(init?.body as string);
+    expect(body['@type']).toBe('MessageCard');
+    expect(body.summary).toBe('Workflow Done');
+    expect(body.sections[0].activityTitle).toBe('Workflow Done');
+    expect(body.sections[0].activityText).toBe('All steps complete');
+  });
+
+  it('sets teams to error when webhook returns non-ok', async () => {
+    fetchMock.mockResolvedValueOnce(makeBadResponse(404));
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'workflow.completed',
+      title: 'T',
+      body: 'B',
+      orgTeamsWebhookUrl: 'https://outlook.office.com/webhook/XXX',
+    });
+    expect(result.teams).toBe('error');
+  });
+
+  it('sets teams to skipped when no webhook url', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'workflow.completed',
+      title: 'T',
+      body: 'B',
+    });
+    expect(result.teams).toBe('skipped');
+  });
+});
+
+describe('dispatch — email channel (REQ-NOTIFY-004)', () => {
+  it('skips email when SENDGRID_API_KEY is not set', async () => {
+    Reflect.deleteProperty(process.env, 'SENDGRID_API_KEY');
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'SLA Warning',
+      body: 'Review overdue',
+      recipientEmail: 'reviewer@example.com',
+    });
+    expect(result.email).toBe('skipped');
+    const { logger } = await import('@/lib/observability/logger');
+    expect(logger.info).toHaveBeenCalledWith(
+      '[notifications] Email skipped — SENDGRID_API_KEY not set',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends email via SendGrid v3 when API key is set', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    process.env.SENDGRID_FROM_EMAIL = 'noreply@regula.test';
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'SLA Warning',
+      body: 'Review overdue',
+      actionUrl: 'https://app.regula.ai/review/123',
+      recipientEmail: 'reviewer@example.com',
+    });
+    expect(result.email).toBe('sent');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init?.headers as Record<string, string> | undefined;
+    expect(url).toBe('https://api.sendgrid.com/v3/mail/send');
+    expect(headers?.Authorization).toBe('Bearer SG.test-key');
+    expect(headers?.['Content-Type']).toBe('application/json');
+    const body = JSON.parse(init?.body as string);
+    expect(body.personalizations[0].to[0].email).toBe('reviewer@example.com');
+    expect(body.from.email).toBe('noreply@regula.test');
+    expect(body.subject).toBe('SLA Warning');
+    expect(body.content[0].type).toBe('text/html');
+  });
+
+  it('uses default from email when SENDGRID_FROM_EMAIL is not set', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    Reflect.deleteProperty(process.env, 'SENDGRID_FROM_EMAIL');
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'T',
+      body: 'B',
+      recipientEmail: 'r@example.com',
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body.from.email).toBe('noreply@regula.ai');
+  });
+
+  it('includes actionUrl CTA link in HTML when provided', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'T',
+      body: 'B',
+      actionUrl: 'https://app.regula.ai/r/1',
+      recipientEmail: 'r@example.com',
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const html = body.content[0].value;
+    expect(html).toContain('href="https://app.regula.ai/r/1"');
+    expect(html).toContain('Regula에서 보기');
+  });
+
+  it('omits CTA link when actionUrl is not provided', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'T',
+      body: 'B',
+      recipientEmail: 'r@example.com',
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const html = body.content[0].value;
+    expect(html).not.toContain('Regula에서 보기');
+  });
+
+  it('sets email to error when SendGrid returns non-ok', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.bad-key';
+    fetchMock.mockResolvedValueOnce(makeBadResponse(401));
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'T',
+      body: 'B',
+      recipientEmail: 'r@example.com',
+    });
+    expect(result.email).toBe('error');
+    const { logger } = await import('@/lib/observability/logger');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('[notifications] Email dispatch failed:'),
+      expect.any(Error),
+    );
+  });
+
+  it('sets email to skipped when recipientEmail is not provided', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'T',
+      body: 'B',
+    });
+    expect(result.email).toBe('skipped');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeHtml — exercised through the email HTML payload (REQ-NOTIFY-004)
+// ---------------------------------------------------------------------------
+describe('dispatch — escapeHtml via email HTML payload', () => {
+  beforeEach(() => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+  });
+
+  it('escapes < > & " in title', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: '<script>alert("xss")</script>',
+      body: 'safe body',
+      recipientEmail: 'r@example.com',
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const html = body.content[0].value;
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&quot;xss&quot;');
+  });
+
+  it('escapes & < > in body', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'Safe Title',
+      body: 'a & b < c > d',
+      recipientEmail: 'r@example.com',
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const html = body.content[0].value;
+    expect(html).toContain('a &amp; b &lt; c &gt; d');
+  });
+
+  it('escapes single quotes in actionUrl', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: 'T',
+      body: 'B',
+      actionUrl: "https://app.regula.ai/r?id=1'or'1",
+      recipientEmail: 'r@example.com',
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const html = body.content[0].value;
+    expect(html).toContain('&apos;or&apos;1');
+  });
+
+  it('preserves unicode and emoji in title and body', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: '경고 🚨 알림',
+      body: '본문 — 검토 필요',
+      recipientEmail: 'r@example.com',
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    const html = body.content[0].value;
+    expect(html).toContain('경고 🚨 알림');
+    expect(html).toContain('본문 — 검토 필요');
+  });
+
+  it('returns empty string escape for empty input (no crash)', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    await dispatch({
+      eventType: 'expert_review.sla_warning',
+      title: '',
+      body: '',
+      recipientEmail: 'r@example.com',
+    });
+    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
+    // Should not throw; HTML still well-formed.
+    expect(body.content[0].value).toContain('<h2></h2>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatch — multi-channel isolation (fire-and-forget, REQ-NOTIFY-005)
+// ---------------------------------------------------------------------------
+describe('dispatch — multi-channel isolation (REQ-NOTIFY-005)', () => {
+  it('sends to all 3 channels when all configured', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'regulatory_update.high_risk',
+      title: 'High Risk Update',
+      body: 'New regulation',
+      orgSlackWebhookUrl: 'https://hooks.slack.com/services/T/B/X',
+      orgTeamsWebhookUrl: 'https://outlook.office.com/webhook/XXX',
+      recipientEmail: 'team@example.com',
+    });
+    expect(result).toEqual({ slack: 'sent', teams: 'sent', email: 'sent' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not block other channels when slack fails', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    // Slack call (first fetch) fails, teams + email succeed.
+    fetchMock.mockRejectedValueOnce(new Error('slack down'));
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'regulatory_update.high_risk',
+      title: 'T',
+      body: 'B',
+      orgSlackWebhookUrl: 'https://hooks.slack.com/services/T/B/X',
+      orgTeamsWebhookUrl: 'https://outlook.office.com/webhook/XXX',
+      recipientEmail: 'team@example.com',
+    });
+    expect(result.slack).toBe('error');
+    expect(result.teams).toBe('sent');
+    expect(result.email).toBe('sent');
+  });
+
+  it('does not block other channels when email fails', async () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    // dispatch calls slack (1st), teams (2nd), email (3rd). Make only the
+    // 3rd fetch return non-ok so email fails while slack/teams succeed.
+    fetchMock
+      .mockResolvedValueOnce(makeOkResponse()) // slack
+      .mockResolvedValueOnce(makeOkResponse()) // teams
+      .mockResolvedValueOnce(makeBadResponse(500)); // email (SendGrid)
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'regulatory_update.high_risk',
+      title: 'T',
+      body: 'B',
+      orgSlackWebhookUrl: 'https://hooks.slack.com/services/T/B/X',
+      orgTeamsWebhookUrl: 'https://outlook.office.com/webhook/XXX',
+      recipientEmail: 'team@example.com',
+    });
+    expect(result.slack).toBe('sent');
+    expect(result.teams).toBe('sent');
+    expect(result.email).toBe('error');
+  });
+
+  it('returns all-skipped when no channels configured', async () => {
+    const { dispatch } = await import('@/lib/notifications/dispatcher');
+    const result = await dispatch({
+      eventType: 'regulatory_update.high_risk',
+      title: 'T',
+      body: 'B',
+    });
+    expect(result).toEqual({ slack: 'skipped', teams: 'skipped', email: 'skipped' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// module exports
+// ---------------------------------------------------------------------------
+describe('dispatcher module exports', () => {
+  it('exports dispatch function', async () => {
+    const mod = await import('@/lib/notifications/dispatcher');
+    expect(typeof mod.dispatch).toBe('function');
+  });
+});

--- a/tests/unit/traceability/evidence-packet.test.ts
+++ b/tests/unit/traceability/evidence-packet.test.ts
@@ -1,0 +1,561 @@
+// @MX:NOTE [AUTO] Unit tests for evidence-packet assembly (SPEC-REGULA-TRACEABILITY-001, REQ-TRACEABILITY-006/007).
+// @MX:SPEC SPEC-REGULA-TRACEABILITY-001 (REQ-TRACEABILITY-006, REQ-TRACEABILITY-007, Issue #402)
+// @MX:REASON REQ-TRACEABILITY-006 gate: getEvidencePacket BFS-traverses the
+//   evidence graph and surfaces 3 issue kinds: missing_citation, stale_source,
+//   unresolved_review. Tests use a mock db (select/from/where/limit thenable)
+//   to exercise each branch without real DB access.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock db schema so the drizzle imports resolve without loading real columns.
+vi.mock('@/lib/db/schema', () => ({
+  evidenceNodes: { id: 'id', orgId: 'org_id' },
+  evidenceEdges: {
+    id: 'id',
+    orgId: 'org_id',
+    fromNodeId: 'from_node_id',
+    toNodeId: 'to_node_id',
+    relation: 'relation',
+  },
+}));
+
+// Mock drizzle-orm operators — return sentinel objects that the mock db ignores.
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((col, val) => ({ __eq: true, col, val })),
+  and: vi.fn((...args) => ({ __and: true, args })),
+  inArray: vi.fn((col, vals) => ({ __inArray: true, col, vals })),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock db builder
+// ---------------------------------------------------------------------------
+// The mock db simulates drizzle's query builder chain:
+//   db.select().from(table).where(...).limit(n) → Promise<row[]>
+// We dispatch based on which table is queried:
+//   - evidenceNodes lookups: return rows from nodeRows
+//   - evidenceEdges lookups: return rows from edgeRows (filtered by the
+//     inArray value in the where clause — we extract the node id)
+
+interface MockNode {
+  id: string;
+  orgId: string;
+  projectId: string | null;
+  nodeType: string;
+  refTable: string;
+  refId: string;
+  authority: string | null;
+  version: string | null;
+  effectiveDate: Date | null;
+  reviewerId: string | null;
+  artifactHash: string | null;
+  createdAt: Date;
+  createdBy: string;
+}
+
+interface MockEdge {
+  id: string;
+  orgId: string;
+  fromNodeId: string;
+  toNodeId: string;
+  relation: string;
+  createdBy: string;
+  createdAt: Date;
+}
+
+interface MockDbState {
+  nodes: MockNode[];
+  edges: MockEdge[];
+}
+
+function makeThenable(rows: unknown[]) {
+  const p = Promise.resolve(rows) as Promise<unknown[]> & {
+    limit: () => Promise<unknown[]>;
+  };
+  p.limit = () => Promise.resolve(rows);
+  return p;
+}
+
+function makeMockDb(state: MockDbState) {
+  const selectMock = vi.fn((_args?: unknown) => ({
+    from: (table: unknown) => ({
+      where: (condition: unknown) => {
+        // Determine table by reference identity from our mock schema.
+        const schema = table as { id: string; orgId?: string };
+        // Extract inArray values and all eq values from the `and(...)` condition.
+        const cond = condition as { __and?: boolean; args?: unknown[] };
+        let inArrayVals: string[] | null = null;
+        const eqVals: string[] = [];
+        if (cond?.__and && Array.isArray(cond.args)) {
+          for (const a of cond.args) {
+            const arg = a as { __inArray?: boolean; __eq?: boolean; val?: unknown; vals?: unknown };
+            if (arg?.__inArray && Array.isArray(arg.vals)) {
+              inArrayVals = arg.vals as string[];
+            }
+            if (arg?.__eq && typeof arg.val === 'string') {
+              eqVals.push(arg.val);
+            }
+          }
+        }
+
+        // evidenceEdges table (has fromNodeId/toNodeId keys in mock)
+        if ('fromNodeId' in schema) {
+          // Filter edges by inArray value matching fromNodeId or toNodeId.
+          if (inArrayVals && inArrayVals.length > 0) {
+            const nodeId = inArrayVals[0];
+            if (nodeId === undefined) return makeThenable([]);
+            const matched = state.edges.filter(
+              (e) => e.fromNodeId === nodeId || e.toNodeId === nodeId,
+            );
+            return makeThenable(matched);
+          }
+          return makeThenable([]);
+        }
+
+        // evidenceNodes table — match by id (the eq val that matches a node id).
+        if (inArrayVals && inArrayVals.length > 0) {
+          const nodeId = inArrayVals[0];
+          if (nodeId === undefined) return makeThenable([]);
+          const matched = state.nodes.filter((n) => n.id === nodeId);
+          return makeThenable(matched);
+        }
+        // Try each eq val — the one matching a node id is the lookup key.
+        for (const v of eqVals) {
+          const matched = state.nodes.filter((n) => n.id === v);
+          if (matched.length > 0) return makeThenable(matched);
+        }
+        // No eq matched a node id — return empty (e.g. root not found).
+        return makeThenable([]);
+      },
+    }),
+  }));
+  return { select: selectMock } as unknown as import('@/lib/db/client').Database;
+}
+
+function makeNode(overrides: Partial<MockNode> = {}): MockNode {
+  return {
+    id: 'node-1',
+    orgId: 'org-1',
+    projectId: null,
+    nodeType: 'message',
+    refTable: 'messages',
+    refId: 'msg-1',
+    authority: null,
+    version: null,
+    effectiveDate: null,
+    reviewerId: null,
+    artifactHash: null,
+    createdAt: new Date('2026-01-01'),
+    createdBy: 'user-1',
+    ...overrides,
+  };
+}
+
+function makeEdge(overrides: Partial<MockEdge> = {}): MockEdge {
+  return {
+    id: 'edge-1',
+    orgId: 'org-1',
+    fromNodeId: 'node-src',
+    toNodeId: 'node-1',
+    relation: 'cites',
+    createdBy: 'user-1',
+    createdAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+// ---------------------------------------------------------------------------
+// getEvidencePacket — root not found (returns null)
+// ---------------------------------------------------------------------------
+describe('getEvidencePacket — root not found', () => {
+  it('returns null when deliverable node does not exist', async () => {
+    const db = makeMockDb({ nodes: [], edges: [] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'nonexistent',
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvidencePacket — single node, no edges (missing_citation issue)
+// ---------------------------------------------------------------------------
+describe('getEvidencePacket — single node, no edges (REQ-TRACEABILITY-006)', () => {
+  it('returns deliverable with no children and missing_citation issue', async () => {
+    const root = makeNode({ id: 'root-1', nodeType: 'message' });
+    const db = makeMockDb({ nodes: [root], edges: [] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    expect(result).not.toBeNull();
+    expect(result?.deliverable.id).toBe('root-1');
+    expect(result?.deliverable.relation).toBe('root');
+    expect(result?.deliverable.children).toEqual([]);
+    expect(result?.issues).toContainEqual({
+      kind: 'missing_citation',
+      detail: 'deliverable has no upstream evidence edge',
+    });
+  });
+
+  it('marks deliverable as not stale when not in staleNodeIds', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const db = makeMockDb({ nodes: [root], edges: [] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    expect(result?.deliverable.stale).toBe(false);
+  });
+
+  it('marks deliverable as stale when in staleNodeIds', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const db = makeMockDb({ nodes: [root], edges: [] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+      staleNodeIds: new Set(['root-1']),
+    });
+    expect(result?.deliverable.stale).toBe(true);
+    expect(result?.issues).toContainEqual({
+      kind: 'stale_source',
+      detail: 'node root-1 flagged stale',
+    });
+  });
+
+  it('populates node fields from db row', async () => {
+    const root = makeNode({
+      id: 'root-1',
+      nodeType: 'submission_package',
+      refTable: 'submissions',
+      refId: 'sub-42',
+      authority: 'FDA',
+      version: 'v2',
+      effectiveDate: new Date('2026-03-01'),
+      artifactHash: 'abc123',
+    });
+    const db = makeMockDb({ nodes: [root], edges: [] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    expect(result).not.toBeNull();
+    const d = result?.deliverable;
+    expect(d?.nodeType).toBe('submission_package');
+    expect(d?.refTable).toBe('submissions');
+    expect(d?.refId).toBe('sub-42');
+    expect(d?.authority).toBe('FDA');
+    expect(d?.version).toBe('v2');
+    expect(d?.effectiveDate).toEqual(new Date('2026-03-01'));
+    expect(d?.artifactHash).toBe('abc123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvidencePacket — upstream evidence (cites/derived_from)
+// ---------------------------------------------------------------------------
+describe('getEvidencePacket — upstream evidence edges', () => {
+  it('does NOT flag missing_citation when a cites edge exists', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const src = makeNode({ id: 'src-1', nodeType: 'source_section' });
+    const edge = makeEdge({
+      id: 'e-1',
+      fromNodeId: 'src-1',
+      toNodeId: 'root-1',
+      relation: 'cites',
+    });
+    const db = makeMockDb({ nodes: [root, src], edges: [edge] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    expect(result?.issues).not.toContainEqual(
+      expect.objectContaining({ kind: 'missing_citation' }),
+    );
+  });
+
+  it('does NOT flag missing_citation when a derived_from edge exists', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const src = makeNode({ id: 'src-1' });
+    const edge = makeEdge({
+      fromNodeId: 'src-1',
+      toNodeId: 'root-1',
+      relation: 'derived_from',
+    });
+    const db = makeMockDb({ nodes: [root, src], edges: [edge] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    expect(result?.issues).not.toContainEqual(
+      expect.objectContaining({ kind: 'missing_citation' }),
+    );
+  });
+
+  it('builds child tree from upstream cites edge', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const src = makeNode({ id: 'src-1', nodeType: 'source_section', authority: 'EU' });
+    const edge = makeEdge({
+      fromNodeId: 'src-1',
+      toNodeId: 'root-1',
+      relation: 'cites',
+    });
+    const db = makeMockDb({ nodes: [root, src], edges: [edge] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    expect(result?.deliverable.children).toHaveLength(1);
+    const child = result?.deliverable.children[0];
+    expect(child?.id).toBe('src-1');
+    expect(child?.relation).toBe('cites');
+    expect(child?.authority).toBe('EU');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvidencePacket — unresolved_review issue (REQ-TRACEABILITY-006)
+// ---------------------------------------------------------------------------
+describe('getEvidencePacket — unresolved_review issue (REQ-TRACEABILITY-006)', () => {
+  it('flags unresolved_review when reviewed_by edge exists but reviewer has no reviewerId', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const reviewer = makeNode({ id: 'rev-1', nodeType: 'expert_review', reviewerId: null });
+    const edge = makeEdge({
+      fromNodeId: 'rev-1',
+      toNodeId: 'root-1',
+      relation: 'reviewed_by',
+    });
+    const db = makeMockDb({ nodes: [root, reviewer], edges: [edge] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    expect(result?.issues).toContainEqual({
+      kind: 'unresolved_review',
+      detail: 'review node has no reviewer_id',
+    });
+  });
+
+  it('does NOT flag unresolved_review when reviewer has reviewerId', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const reviewer = makeNode({ id: 'rev-1', nodeType: 'expert_review', reviewerId: 'user-42' });
+    const edge = makeEdge({
+      fromNodeId: 'rev-1',
+      toNodeId: 'root-1',
+      relation: 'reviewed_by',
+    });
+    // Also add a cites edge so missing_citation is not flagged.
+    const citesEdge = makeEdge({
+      id: 'e-cites',
+      fromNodeId: 'src-1',
+      toNodeId: 'root-1',
+      relation: 'cites',
+    });
+    const src = makeNode({ id: 'src-1' });
+    const db = makeMockDb({ nodes: [root, reviewer, src], edges: [edge, citesEdge] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    expect(result?.issues).not.toContainEqual(
+      expect.objectContaining({ kind: 'unresolved_review' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvidencePacket — stale_source issue (REQ-TRACEABILITY-006)
+// ---------------------------------------------------------------------------
+describe('getEvidencePacket — stale_source issue (REQ-TRACEABILITY-006)', () => {
+  it('flags stale_source for each stale node in the graph', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const src1 = makeNode({ id: 'src-1' });
+    const src2 = makeNode({ id: 'src-2' });
+    const edge1 = makeEdge({
+      id: 'e-1',
+      fromNodeId: 'src-1',
+      toNodeId: 'root-1',
+      relation: 'cites',
+    });
+    const edge2 = makeEdge({
+      id: 'e-2',
+      fromNodeId: 'src-2',
+      toNodeId: 'root-1',
+      relation: 'derived_from',
+    });
+    const db = makeMockDb({ nodes: [root, src1, src2], edges: [edge1, edge2] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+      staleNodeIds: new Set(['src-1', 'src-2']),
+    });
+    const staleIssues = result?.issues.filter((i) => i.kind === 'stale_source') ?? [];
+    expect(staleIssues).toHaveLength(2);
+    const details = staleIssues.map((i) => i.detail).sort();
+    expect(details).toEqual(['node src-1 flagged stale', 'node src-2 flagged stale']);
+  });
+
+  it('marks child nodes as stale when in staleNodeIds', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const src = makeNode({ id: 'src-1' });
+    const edge = makeEdge({
+      fromNodeId: 'src-1',
+      toNodeId: 'root-1',
+      relation: 'cites',
+    });
+    const db = makeMockDb({ nodes: [root, src], edges: [edge] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+      staleNodeIds: new Set(['src-1']),
+    });
+    expect(result?.deliverable.children[0]?.stale).toBe(true);
+    expect(result?.deliverable.stale).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvidencePacket — multi-level graph (BFS traversal)
+// ---------------------------------------------------------------------------
+describe('getEvidencePacket — multi-level BFS traversal', () => {
+  it('traverses 2-level upstream graph: root ← cites ← src1 ← derived_from ← src2', async () => {
+    const root = makeNode({ id: 'root-1', nodeType: 'message' });
+    const src1 = makeNode({ id: 'src-1', nodeType: 'source_section', authority: 'FDA' });
+    const src2 = makeNode({ id: 'src-2', nodeType: 'source_section', authority: 'EU' });
+    const edge1 = makeEdge({
+      id: 'e-1',
+      fromNodeId: 'src-1',
+      toNodeId: 'root-1',
+      relation: 'cites',
+    });
+    const edge2 = makeEdge({
+      id: 'e-2',
+      fromNodeId: 'src-2',
+      toNodeId: 'src-1',
+      relation: 'derived_from',
+    });
+    const db = makeMockDb({ nodes: [root, src1, src2], edges: [edge1, edge2] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    // root has child src-1 (cites), src-1 has child src-2 (derived_from).
+    expect(result?.deliverable.children).toHaveLength(1);
+    const child = result?.deliverable.children[0];
+    expect(child?.id).toBe('src-1');
+    expect(child?.relation).toBe('cites');
+    expect(child?.children).toHaveLength(1);
+    const grandchild = child?.children[0];
+    expect(grandchild?.id).toBe('src-2');
+    expect(grandchild?.relation).toBe('derived_from');
+  });
+
+  it('handles diamond graph without infinite loop (shared seen set)', async () => {
+    // root ← cites ← src1, root ← cites ← src2, src1 ← derived_from ← src2
+    // The `seen` Set is shared across the entire buildTree recursion (passed
+    // by reference). Root processes src-1 first, recurses, and src-1 adds
+    // src-2 to `seen` before root processes its second edge. So root ends up
+    // with 1 direct child (src-1), and src-1 has src-2 as its child.
+    // The key invariant: no node appears twice in the tree (no infinite loop).
+    const root = makeNode({ id: 'root-1' });
+    const src1 = makeNode({ id: 'src-1' });
+    const src2 = makeNode({ id: 'src-2' });
+    const e1 = makeEdge({ id: 'e-1', fromNodeId: 'src-1', toNodeId: 'root-1', relation: 'cites' });
+    const e2 = makeEdge({ id: 'e-2', fromNodeId: 'src-2', toNodeId: 'root-1', relation: 'cites' });
+    const e3 = makeEdge({
+      id: 'e-3',
+      fromNodeId: 'src-2',
+      toNodeId: 'src-1',
+      relation: 'derived_from',
+    });
+    const db = makeMockDb({ nodes: [root, src1, src2], edges: [e1, e2, e3] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    // Collect all node ids in the tree — each should appear exactly once.
+    const allIds: string[] = [];
+    function collectIds(node: { id: string; children: (typeof node)[] }): void {
+      allIds.push(node.id);
+      for (const c of node.children) collectIds(c);
+    }
+    collectIds(result?.deliverable ?? { id: '', children: [] });
+    const idCounts = allIds.reduce<Record<string, number>>((acc, id) => {
+      acc[id] = (acc[id] ?? 0) + 1;
+      return acc;
+    }, {});
+    for (const [id, count] of Object.entries(idCounts)) {
+      expect(count).toBe(1);
+    }
+    expect(allIds).toContain('root-1');
+    expect(allIds).toContain('src-1');
+    expect(allIds).toContain('src-2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEvidencePacket — edge cases
+// ---------------------------------------------------------------------------
+describe('getEvidencePacket — edge cases', () => {
+  it('handles outgoing-only edge (reviewed_by) without missing_citation false negative', async () => {
+    // root has only a reviewed_by edge (no cites/derived_from) → missing_citation.
+    const root = makeNode({ id: 'root-1' });
+    const reviewer = makeNode({ id: 'rev-1', reviewerId: 'user-1' });
+    const edge = makeEdge({
+      fromNodeId: 'rev-1',
+      toNodeId: 'root-1',
+      relation: 'reviewed_by',
+    });
+    const db = makeMockDb({ nodes: [root, reviewer], edges: [edge] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    // reviewed_by is not a citation edge, so missing_citation should still fire.
+    expect(result?.issues).toContainEqual({
+      kind: 'missing_citation',
+      detail: 'deliverable has no upstream evidence edge',
+    });
+  });
+
+  it('defaults staleNodeIds to empty set when not provided', async () => {
+    const root = makeNode({ id: 'root-1' });
+    const db = makeMockDb({ nodes: [root], edges: [] });
+    const { getEvidencePacket } = await import('@/lib/traceability/evidence-packet');
+    const result = await getEvidencePacket(db, {
+      orgId: 'org-1',
+      deliverableId: 'root-1',
+    });
+    // No stale issues when staleNodeIds is omitted.
+    expect(result?.issues).not.toContainEqual(expect.objectContaining({ kind: 'stale_source' }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// module exports
+// ---------------------------------------------------------------------------
+describe('evidence-packet module exports', () => {
+  it('exports getEvidencePacket function', async () => {
+    const mod = await import('@/lib/traceability/evidence-packet');
+    expect(typeof mod.getEvidencePacket).toBe('function');
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 coverage ratchet-up. 3 Priority-2/3 파일.

- notifications/dispatcher.ts (24 tests, 98.8%): escapeHtml XSS 방어 + dispatch fetch mock(slack/email/teams) + 실패 분기.
- ai/structured-blocks.ts (20 tests, 100%): classifier yes/no + Zod parse 실패 + code fence strip + abort + 에러 격리.
- traceability/evidence-packet.ts (17 tests, 0%→98.1%): BFS 그래프 순회 + diamond shared-seen + edge cases.
- test-only, 회귀 0 (182 인접 테스트 green, full test 5084 passed 0 failed). typecheck 0, biome 0.

Refs #402 Priority 2/3.

🗿 MoAI <email@mo.ai.kr>