### PR TITLE
test(api): cer + cer-literature + signature + admin-upload route 테스트 (#402)

### DIFF
--- a/tests/unit/api/admin-upload-route.test.ts
+++ b/tests/unit/api/admin-upload-route.test.ts
@@ -1,0 +1,326 @@
+// @MX:NOTE [AUTO] Route tests for POST /api/ra/admin/documents/upload (coverage 402, SPEC-REGULA-QUALITY-001).
+// @MX:SPEC SPEC-REGULA-QUALITY-001 (REQ-QUAL-015..019)
+// @MX:TODO Deep ingest pipeline (chunk/embed/extract edge cases) covered by lib/ingest/*.test.ts.
+//   These tests exercise the route handler surface: auth passthrough, multipart
+//   parsing, RBAC license gate, size/MIME validation, audit-in-transaction,
+//   201 response shape, and the license-gate denial branch.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mutable session ---
+let sessionUser: {
+  id: string;
+  role: string;
+  organizationId: string | null;
+} = {
+  id: 'user-001',
+  role: 'admin',
+  organizationId: 'org-001',
+};
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, { user: sessionUser }),
+  ),
+}));
+
+// --- Mock db: transaction with insert chain (sourceSections INSERT) ---
+const mockInsertChain = {
+  values: vi.fn().mockReturnThis(),
+};
+
+const mockDb = {
+  transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb({ insert: vi.fn(() => mockInsertChain) }),
+  ),
+};
+
+vi.mock('@/lib/db/client', () => ({ db: mockDb }));
+
+// --- Mock audit ---
+vi.mock('@/lib/audit', () => ({
+  writeAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+// --- Mock ingest deps ---
+const chunkMock = vi.fn();
+vi.mock('@/lib/ingest/chunkers', () => ({
+  chunk: (...a: unknown[]) => chunkMock(...a),
+}));
+
+const embedChunksMock = vi.fn();
+vi.mock('@/lib/ingest/embed', () => ({
+  embedChunks: (...a: unknown[]) => embedChunksMock(...a),
+}));
+
+const extractTextMock = vi.fn();
+vi.mock('@/lib/ingest/extract', () => ({
+  SUPPORTED_MIME_TYPES: ['application/pdf'],
+  extractText: (...a: unknown[]) => extractTextMock(...a),
+}));
+
+// --- Mock dynamic-import deps (license-gate + review-workflow) ---
+// These are loaded via `await import(...)` inside the route, so they must also
+// be registered via vi.mock for the module system to intercept.
+const assertIngestionLicensedMock = vi.fn();
+vi.mock('@/lib/corpus-license/license-gate', () => ({
+  assertIngestionLicensed: (...a: unknown[]) => assertIngestionLicensedMock(...a),
+}));
+
+const setPendingReviewOnIngestMock = vi.fn();
+vi.mock('@/lib/source-governance/review-workflow', () => ({
+  setPendingReviewOnIngest: (...a: unknown[]) => setPendingReviewOnIngestMock(...a),
+}));
+
+// --- Helpers ---
+function makeUploadRequest(
+  opts: {
+    fileContent?: string;
+    fileName?: string;
+    mimeType?: string;
+    docClass?: string;
+    sourceId?: string | null;
+  } = {},
+): Request {
+  const {
+    fileContent = 'This is a test document with sufficient content for chunking.',
+    fileName = 'test.pdf',
+    mimeType = 'application/pdf',
+    docClass = 'clinical_report',
+    sourceId = 'src-001',
+  } = opts;
+
+  const form = new FormData();
+  const file = new File([fileContent], fileName, { type: mimeType });
+  form.append('file', file);
+  form.append('docClass', docClass);
+  if (sourceId !== null) {
+    form.append('sourceId', sourceId);
+  }
+  return new Request('http://localhost/api/ra/admin/documents/upload', {
+    method: 'POST',
+    body: form,
+  });
+}
+
+const CHUNK_FIXTURE = [{ text: 'chunk-one content', metadata: { sectionPath: 'intro' } }];
+
+const EMBEDDING_FIXTURE = [[0.1, 0.2, 0.3]];
+
+describe('POST /api/ra/admin/documents/upload — handler surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionUser = { id: 'user-001', role: 'admin', organizationId: 'org-001' };
+    chunkMock.mockReturnValue(CHUNK_FIXTURE);
+    embedChunksMock.mockResolvedValue(EMBEDDING_FIXTURE);
+    extractTextMock.mockResolvedValue('Extracted PDF text content with enough length.');
+    assertIngestionLicensedMock.mockResolvedValue({ allowed: true });
+    setPendingReviewOnIngestMock.mockResolvedValue(undefined);
+  });
+
+  it('returns 201 with sourceId + sectionCount on valid upload', async () => {
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest(), {});
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      sourceId: 'src-001',
+      sectionCount: 1,
+    });
+    expect(mockDb.transaction).toHaveBeenCalled();
+    expect(chunkMock).toHaveBeenCalled();
+    expect(embedChunksMock).toHaveBeenCalled();
+  });
+
+  it('writes document.upload + document.chunk audit inside transaction', async () => {
+    const { writeAudit } = await import('@/lib/audit');
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    await POST(makeUploadRequest(), {});
+
+    const auditCalls = vi.mocked(writeAudit).mock.calls;
+    const actions = auditCalls.map((c) => (c[0] as { action: string }).action);
+    expect(actions).toContain('document.upload');
+    expect(actions).toContain('document.chunk');
+    // Both audit rows must ride the transaction (tx arg present).
+    for (const call of auditCalls) {
+      expect(call[1]).toBeDefined();
+    }
+  });
+
+  it('returns 400 file_missing when no file in multipart payload', async () => {
+    const form = new FormData();
+    form.append('docClass', 'clinical_report');
+    form.append('sourceId', 'src-001');
+    const req = new Request('http://localhost/api/ra/admin/documents/upload', {
+      method: 'POST',
+      body: form,
+    });
+
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(req, {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('file_missing');
+  });
+
+  it('returns 400 docClass_invalid when docClass is not a valid enum value', async () => {
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest({ docClass: 'not-a-real-class' }), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('docClass_invalid');
+  });
+
+  it('returns 400 no_licensed_source when sourceId is absent', async () => {
+    const { writeAudit } = await import('@/lib/audit');
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest({ sourceId: null }), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('no_licensed_source');
+    // Ingestion-blocked audit should fire (REQ-003 corpus gate).
+    const auditCalls = vi.mocked(writeAudit).mock.calls;
+    const actions = auditCalls.map((c) => (c[0] as { action: string }).action);
+    expect(actions).toContain('corpus.ingestion_blocked');
+    // Should short-circuit BEFORE chunking/embedding.
+    expect(chunkMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 ingestion_license_blocked when license gate denies', async () => {
+    assertIngestionLicensedMock.mockResolvedValue({
+      allowed: false,
+      reason: 'license expired',
+      licenseType: 'paid_standard',
+    });
+
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest(), {});
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: 'ingestion_license_blocked',
+      reason: 'license expired',
+      licenseType: 'paid_standard',
+    });
+    expect(chunkMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 415 unsupported_mime when MIME type is not allowed', async () => {
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(
+      makeUploadRequest({ mimeType: 'application/x-gzip', fileName: 'bad.gz' }),
+      {},
+    );
+
+    expect(res.status).toBe(415);
+    const body = await res.json();
+    expect(body.error).toBe('unsupported_mime');
+  });
+
+  it('returns 413 file_too_large when file exceeds UPLOAD_MAX_BYTES (10MB default)', async () => {
+    // MAX_UPLOAD_BYTES is evaluated at module load (IIFE) from process.env, so
+    // stubbing env post-import won't re-evaluate. Instead, build a file just
+    // over the 10MB (10 * 1024 * 1024 = 10485760) default cap.
+    const oversized = 'x'.repeat(10 * 1024 * 1024 + 1);
+
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest({ fileContent: oversized }), {});
+
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.error).toBe('file_too_large');
+    expect(body.max_bytes).toBe(10 * 1024 * 1024);
+    expect(body.actual_bytes).toBe(10 * 1024 * 1024 + 1);
+  });
+
+  it('returns 422 empty_document when extracted text is blank', async () => {
+    chunkMock.mockReturnValue([]); // empty chunks → chunking_produced_empty
+    // Actually test the empty-text path: chunk returns empty when text is blank.
+    // The route checks rawText.trim().length === 0 BEFORE chunking, so an
+    // all-whitespace text/plain file triggers 422 empty_document.
+
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(
+      makeUploadRequest({
+        fileContent: '   \n\n  ',
+        mimeType: 'text/plain',
+        fileName: 'blank.txt',
+      }),
+      {},
+    );
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe('empty_document');
+  });
+
+  it('returns 422 chunking_produced_empty when chunker yields zero chunks', async () => {
+    chunkMock.mockReturnValue([]);
+
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest(), {});
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe('chunking_produced_empty');
+  });
+
+  it('returns 502 embedding_failed when embedChunks throws non-PII error', async () => {
+    embedChunksMock.mockRejectedValue(new Error('embedding service unavailable'));
+
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest(), {});
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe('embedding_failed');
+  });
+
+  it('returns 422 pii_detected when embedChunks throws PII guard error', async () => {
+    embedChunksMock.mockRejectedValue(new Error('PII guard triggered: SSN detected'));
+
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest(), {});
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe('pii_detected');
+  });
+
+  it('accepts text/plain without calling extractText (inline path)', async () => {
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(
+      makeUploadRequest({
+        mimeType: 'text/plain',
+        fileName: 'notes.txt',
+        fileContent: 'Inline text/plain content for the inline extraction path.',
+      }),
+      {},
+    );
+
+    expect(res.status).toBe(201);
+    expect(extractTextMock).not.toHaveBeenCalled();
+  });
+
+  it('skips license gate when session has no organizationId (no-op branch)', async () => {
+    sessionUser = { id: 'user-001', role: 'admin', organizationId: null };
+
+    const { POST } = await import('@/app/api/ra/admin/documents/upload/route');
+    const res = await POST(makeUploadRequest(), {});
+
+    // License gate import is conditional on organizationId being set; with null
+    // the gate is skipped, pipeline proceeds to 201.
+    expect(res.status).toBe(201);
+    expect(assertIngestionLicensedMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/cer-literature-route.test.ts
+++ b/tests/unit/api/cer-literature-route.test.ts
@@ -1,0 +1,258 @@
+// @MX:NOTE [AUTO] Route tests for POST /api/ra/workflows/cer/literature (coverage 402, SPEC-REGULA-CER-001).
+// @MX:SPEC REQ-CLINLIT-001..025
+// @MX:TODO Deep PICO/screening/synthesis covered by lib/cer/*.test.ts. These tests
+//   exercise the route handler surface: SSE framing, Zod validation, pipeline
+//   event ordering, no-articles short-circuit, and error-event emission.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mock withPermission: pass-through with fixed session ---
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' },
+        }),
+  ),
+}));
+
+// --- Mock db: insert chains for literatureSearches / literatureReferences / evidenceSyntheses ---
+const mockSearchInsertChain = {
+  values: vi.fn().mockReturnThis(),
+  returning: vi.fn(),
+};
+
+const mockDb = {
+  insert: vi.fn(() => mockSearchInsertChain),
+};
+
+vi.mock('@/lib/db/client', () => ({ db: mockDb }));
+
+// --- Mock CER pipeline deps ---
+const generatePicoQueryMock = vi.fn();
+vi.mock('@/lib/cer/pico-generator', () => ({
+  generatePicoQuery: (...a: unknown[]) => generatePicoQueryMock(...a),
+}));
+
+const searchPubMedMock = vi.fn();
+vi.mock('@/lib/cer/pubmed-client', () => ({
+  searchPubMed: (...a: unknown[]) => searchPubMedMock(...a),
+}));
+
+const screenArticlesMock = vi.fn();
+vi.mock('@/lib/cer/screening-pipeline', () => ({
+  screenArticles: (...a: unknown[]) => screenArticlesMock(...a),
+}));
+
+const appraiseEvidenceMock = vi.fn();
+vi.mock('@/lib/cer/literature-appraisal', () => ({
+  appraiseEvidence: (...a: unknown[]) => appraiseEvidenceMock(...a),
+}));
+
+const formatVancouverMock = vi.fn();
+vi.mock('@/lib/cer/citation-formatter', () => ({
+  formatVancouver: (...a: unknown[]) => formatVancouverMock(...a),
+}));
+
+const synthesizeEvidenceMock = vi.fn();
+vi.mock('@/lib/cer/evidence-synthesis', () => ({
+  synthesizeEvidence: (...a: unknown[]) => synthesizeEvidenceMock(...a),
+}));
+
+const auditCerLiteratureSearchMock = vi.fn();
+vi.mock('@/lib/cer/audit', () => ({
+  auditCerLiteratureSearch: (...a: unknown[]) => auditCerLiteratureSearchMock(...a),
+}));
+
+// --- Helpers ---
+function makePostRequest(body: unknown): Request {
+  return new Request('http://localhost/api/ra/workflows/cer/literature', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  cerRunId: '550e8400-e29b-41d4-a716-446655440000',
+  deviceDescription: 'A battery-powered cardiac pacemaker for chronic implantation therapy.',
+};
+
+const ARTICLE_FIXTURE = {
+  pmid: '11111111',
+  title: 'Pacemaker outcomes in bradycardia patients',
+  abstract: 'Systematic review of pacing modalities.',
+  authors: ['Lee K'],
+  journal: 'JAMA',
+  year: 2023,
+};
+
+const PICO_FIXTURE = {
+  patient: 'Adults with symptomatic bradycardia',
+  intervention: 'Dual-chamber pacemaker implantation',
+  comparator: 'Single-chamber pacemaker',
+  outcome: 'Quality of life and complication rate',
+  searchQuery: 'dual-chamber pacemaker bradycardia randomized',
+  meshTerms: ['Pacemaker, Artificial', 'Bradycardia'],
+};
+
+const SCREENING_FIXTURE = [{ pmid: '11111111', decision: 'include' as const, reason: null }];
+
+const APPRAISAL_FIXTURE = {
+  sign50Level: '1+',
+  gradeQuality: 'moderate',
+  riskOfBias: 'low',
+};
+
+const SYNTHESIS_FIXTURE = {
+  gradeCounts: { high: 0, moderate: 1, low: 0, veryLow: 0 },
+  gradeSummary: 'Evidence body moderate quality based on one included RCT.',
+  narrativeSynthesis: 'The evidence supports dual-chamber pacing benefit.',
+  cerSection6Draft: '## Section 6 draft',
+  cerSection7Draft: '## Section 7 draft',
+  cerSection8Draft: '## Section 8 draft',
+};
+
+/** Drain SSE Response into parsed event payloads. */
+async function readSseEvents(res: Response): Promise<Array<Record<string, unknown>>> {
+  const text = await res.text();
+  const events: Array<Record<string, unknown>> = [];
+  for (const block of text.split('\n\n')) {
+    const line = block.trim();
+    if (line.startsWith('data: ')) {
+      events.push(JSON.parse(line.slice(6)));
+    }
+  }
+  return events;
+}
+
+describe('POST /api/ra/workflows/cer/literature — handler surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generatePicoQueryMock.mockResolvedValue(PICO_FIXTURE);
+    searchPubMedMock.mockResolvedValue([ARTICLE_FIXTURE]);
+    screenArticlesMock.mockResolvedValue(SCREENING_FIXTURE);
+    appraiseEvidenceMock.mockReturnValue(APPRAISAL_FIXTURE);
+    formatVancouverMock.mockReturnValue('Lee K. JAMA 2023.');
+    synthesizeEvidenceMock.mockResolvedValue(SYNTHESIS_FIXTURE);
+    auditCerLiteratureSearchMock.mockResolvedValue(undefined);
+    mockSearchInsertChain.returning.mockResolvedValue([{ id: 'search-001' }]);
+  });
+
+  it('returns SSE response with correct headers (200)', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(res.headers.get('Cache-Control')).toBe('no-cache, no-transform');
+    expect(res.headers.get('Connection')).toBe('keep-alive');
+  });
+
+  it('streams pico → search → screening → synthesis → done events', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    const events = await readSseEvents(res);
+    const eventTypes = events.map((e) => e.event);
+    expect(eventTypes).toContain('pico');
+    expect(eventTypes).toContain('search');
+    expect(eventTypes).toContain('screening');
+    expect(eventTypes).toContain('synthesis');
+    expect(eventTypes[eventTypes.length - 1]).toBe('done');
+
+    const done = events[events.length - 1];
+    // Route wraps payload: { event, data: {...} }
+    expect(done?.event).toBe('done');
+    expect(done?.data).toMatchObject({
+      searchId: 'search-001',
+      includedCount: 1,
+      totalCount: 1,
+    });
+  });
+
+  it('returns 400 on invalid JSON body', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await POST(makePostRequest('not-json'), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid JSON');
+  });
+
+  it('returns 400 when deviceDescription is shorter than 10 chars', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await POST(makePostRequest({ ...VALID_BODY, deviceDescription: 'short' }), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Validation failed');
+  });
+
+  it('returns 400 when cerRunId is not a valid UUID', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await POST(makePostRequest({ ...VALID_BODY, cerRunId: 'not-a-uuid' }), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Validation failed');
+  });
+
+  it('emits done with null searchId when no articles found (short-circuit)', async () => {
+    searchPubMedMock.mockResolvedValue([]);
+
+    const { POST } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    const events = await readSseEvents(res);
+    const done = events[events.length - 1];
+    expect(done?.event).toBe('done');
+    expect(done?.data).toMatchObject({
+      searchId: null,
+      message: 'No articles found for this query.',
+    });
+    // Screening/synthesis should NOT run when articles are empty.
+    expect(screenArticlesMock).not.toHaveBeenCalled();
+  });
+
+  it('emits SSE error event when pipeline throws', async () => {
+    searchPubMedMock.mockRejectedValue(new Error('PubMed network timeout'));
+
+    const { POST } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(200);
+    const events = await readSseEvents(res);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent?.event).toBe('error');
+    expect(errorEvent?.data).toMatchObject({
+      message: 'Literature search failed. Please try again.',
+    });
+  });
+
+  it('writes cer_literature_search audit after pipeline completes', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+    await res.text();
+
+    expect(auditCerLiteratureSearchMock).toHaveBeenCalledWith(
+      'user-001',
+      '550e8400-e29b-41d4-a716-446655440000',
+      'dual-chamber pacemaker bradycardia randomized',
+      1,
+    );
+  });
+});
+
+describe('GET /api/ra/workflows/cer/literature — method not allowed', () => {
+  it('returns 405 for GET requests', async () => {
+    const { GET } = await import('@/app/api/ra/workflows/cer/literature/route');
+    const res = await GET();
+
+    expect(res.status).toBe(405);
+  });
+});

--- a/tests/unit/api/cer-route.test.ts
+++ b/tests/unit/api/cer-route.test.ts
@@ -1,0 +1,283 @@
+// @MX:NOTE [AUTO] Route tests for POST /api/ra/workflows/cer (coverage 402, SPEC-REGULA-CER-001).
+// @MX:SPEC SPEC-REGULA-CER-001 (REQ-CER-036..040) + SPEC-REGULA-PMS-001 (AC-04, REQ-PMS-004)
+// @MX:TODO Deep PubMed/appraisal/assembly pipeline covered by lib/cer/*.test.ts.
+//   These tests exercise the route handler surface only: auth passthrough, Zod
+//   validation, IDOR guard, audit contract, transaction persistence, response shape.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mutable session: IDOR / org tests flip organizationId/null ---
+let sessionUser: { id: string; role: string; organizationId: string | null } = {
+  id: 'user-001',
+  role: 'ra-lead',
+  organizationId: 'org-001',
+};
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, { user: sessionUser }),
+  ),
+}));
+
+// --- Mock db: transaction with insert chain ---
+const mockInsertChain = {
+  values: vi.fn().mockReturnThis(),
+  returning: vi.fn(),
+};
+
+const mockDb = {
+  transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb({ insert: vi.fn(() => mockInsertChain) }),
+  ),
+};
+
+vi.mock('@/lib/db/client', () => ({ db: mockDb }));
+
+// --- Mock audit ---
+vi.mock('@/lib/audit', () => ({
+  writeAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+// --- Mock CER deps ---
+const searchPubMedMock = vi.fn();
+vi.mock('@/lib/cer/pubmed-client', () => ({
+  searchPubMed: (...a: unknown[]) => searchPubMedMock(...a),
+}));
+
+const appraiseEvidenceMock = vi.fn();
+vi.mock('@/lib/cer/literature-appraisal', () => ({
+  appraiseEvidence: (...a: unknown[]) => appraiseEvidenceMock(...a),
+}));
+
+const formatVancouverMock = vi.fn();
+vi.mock('@/lib/cer/citation-formatter', () => ({
+  formatVancouver: (...a: unknown[]) => formatVancouverMock(...a),
+}));
+
+const assembleCerMock = vi.fn();
+vi.mock('@/lib/cer/cer-assembler', () => ({
+  assembleCer: (...a: unknown[]) => assembleCerMock(...a),
+}));
+
+const auditCerCreatedMock = vi.fn();
+const auditCerLiteratureSearchMock = vi.fn();
+vi.mock('@/lib/cer/audit', () => ({
+  auditCerCreated: (...a: unknown[]) => auditCerCreatedMock(...a),
+  auditCerLiteratureSearch: (...a: unknown[]) => auditCerLiteratureSearchMock(...a),
+}));
+
+// --- Mock project-ownership IDOR guard (mutable: tests flip to denial) ---
+const assertPmsProjectAccessMock = vi.fn().mockResolvedValue(null);
+vi.mock('@/lib/cer/project-ownership', () => ({
+  assertPmsProjectAccess: (...a: unknown[]) => assertPmsProjectAccessMock(...a),
+}));
+
+// --- Mock logger (unused by route but imported transitively) ---
+vi.mock('@/lib/observability/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// --- Helpers ---
+function makePostRequest(body: unknown): Request {
+  return new Request('http://localhost/api/ra/workflows/cer', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  deviceName: 'Acme Pacemaker X1',
+  manufacturer: 'Acme Medical Inc.',
+  pubmedQuery: 'cardiac pacemaker bradycardia',
+};
+
+const ARTICLE_FIXTURE = {
+  pmid: '12345678',
+  title: 'Dual-chamber pacing in bradycardia',
+  abstract: 'A randomized controlled trial of dual-chamber pacing.',
+  authors: ['Smith J', 'Doe A'],
+  journal: 'NEJM',
+  year: 2024,
+};
+
+const APPRAISAL_FIXTURE = {
+  sign50Level: '1++' as const,
+  gradeQuality: 'high' as const,
+  riskOfBias: 'low' as const,
+};
+
+const CER_DOC_FIXTURE = {
+  runId: 'cer-run-fixed',
+  stages: [],
+  literature: [],
+};
+
+describe('POST /api/ra/workflows/cer — handler surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionUser = { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' };
+    searchPubMedMock.mockResolvedValue([ARTICLE_FIXTURE]);
+    appraiseEvidenceMock.mockReturnValue(APPRAISAL_FIXTURE);
+    formatVancouverMock.mockReturnValue('Smith J, Doe A. NEJM 2024.');
+    assembleCerMock.mockReturnValue(CER_DOC_FIXTURE);
+    auditCerCreatedMock.mockResolvedValue(undefined);
+    auditCerLiteratureSearchMock.mockResolvedValue(undefined);
+    assertPmsProjectAccessMock.mockResolvedValue(null);
+    mockInsertChain.returning.mockResolvedValue([{ id: 'wf-run-001' }]);
+  });
+
+  it('returns 202 with runId + cerDocument + literature on valid input (no projectId)', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      workflowType: 'cer',
+      status: 'queued',
+      cerDocument: CER_DOC_FIXTURE,
+      literatureCount: 1,
+    });
+    expect(body.runId).toEqual(expect.any(String));
+    expect(body.queuedAt).toEqual(expect.any(String));
+    // No projectId → no workflow_runs row → no workflowRunId in response.
+    expect(body.workflowRunId).toBeUndefined();
+    // Without org context, transaction should NOT be called.
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it('calls searchPubMed + appraiseEvidence + assembleCer pipeline', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    await POST(makePostRequest(VALID_BODY), {});
+
+    expect(searchPubMedMock).toHaveBeenCalledWith('cardiac pacemaker bradycardia', 50);
+    expect(appraiseEvidenceMock).toHaveBeenCalledWith(ARTICLE_FIXTURE);
+    expect(formatVancouverMock).toHaveBeenCalledWith(ARTICLE_FIXTURE);
+    expect(assembleCerMock).toHaveBeenCalled();
+  });
+
+  it('writes cer_created + cer_literature_search audit rows', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    await POST(makePostRequest(VALID_BODY), {});
+
+    expect(auditCerCreatedMock).toHaveBeenCalledWith('user-001', expect.any(String));
+    expect(auditCerLiteratureSearchMock).toHaveBeenCalledWith(
+      'user-001',
+      expect.any(String),
+      'cardiac pacemaker bradycardia',
+      1,
+    );
+  });
+
+  it('persists workflow_runs + cer_persisted audit in transaction when projectId present', async () => {
+    const { writeAudit } = await import('@/lib/audit');
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    const res = await POST(
+      makePostRequest({
+        ...VALID_BODY,
+        projectId: '550e8400-e29b-41d4-a716-446655440000',
+      }),
+      {},
+    );
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.workflowRunId).toBe('wf-run-001');
+    expect(mockDb.transaction).toHaveBeenCalled();
+
+    // cer_persisted audit rides the transaction (21 CFR Part 11 atomicity).
+    expect(vi.mocked(writeAudit)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'cer_persisted',
+        resource_type: 'cer_run',
+        meta_json: expect.objectContaining({
+          workflowRunId: 'wf-run-001',
+          persisted: true,
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('runs IDOR guard (assertPmsProjectAccess) when projectId + orgId present', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    await POST(
+      makePostRequest({
+        ...VALID_BODY,
+        projectId: '550e8400-e29b-41d4-a716-446655440000',
+      }),
+      {},
+    );
+
+    expect(assertPmsProjectAccessMock).toHaveBeenCalledWith(
+      '550e8400-e29b-41d4-a716-446655440000',
+      'org-001',
+    );
+  });
+
+  it('returns 403 Forbidden when projectId present but session lacks orgId', async () => {
+    sessionUser = { id: 'user-001', role: 'ra-lead', organizationId: null };
+
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    const res = await POST(
+      makePostRequest({
+        ...VALID_BODY,
+        projectId: '550e8400-e29b-41d4-a716-446655440000',
+      }),
+      {},
+    );
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Forbidden');
+    expect(assertPmsProjectAccessMock).not.toHaveBeenCalled();
+  });
+
+  it('returns denied Response when IDOR guard rejects project access', async () => {
+    const denied = Response.json({ error: 'project_not_found' }, { status: 404 });
+    assertPmsProjectAccessMock.mockResolvedValue(denied);
+
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    const res = await POST(
+      makePostRequest({
+        ...VALID_BODY,
+        projectId: '550e8400-e29b-41d4-a716-446655440000',
+      }),
+      {},
+    );
+
+    expect(res.status).toBe(404);
+    expect(searchPubMedMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on invalid JSON body', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    const res = await POST(makePostRequest('not-json'), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when deviceName is empty (Zod validation)', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    const res = await POST(makePostRequest({ ...VALID_BODY, deviceName: '' }), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when pubmedQuery exceeds 500 chars', async () => {
+    const { POST } = await import('@/app/api/ra/workflows/cer/route');
+    const res = await POST(makePostRequest({ ...VALID_BODY, pubmedQuery: 'x'.repeat(501) }), {});
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/unit/api/message-signature-route.test.ts
+++ b/tests/unit/api/message-signature-route.test.ts
@@ -1,0 +1,299 @@
+// @MX:NOTE [AUTO] Route tests for POST|GET /api/ra/messages/[messageId]/signature (coverage 402).
+// @MX:SPEC SPEC-REGULA-ESIG-001 (REQ-ESIG-001, REQ-ESIG-002, REQ-ESIG-004)
+// @MX:TODO Deep hash/manifestation logic covered by lib/signature/*.test.ts.
+//   These tests exercise the route handler surface: auth passthrough, Zod
+//   validation, 404/409 conflict branches, audit-in-transaction, GET manifestation.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mutable session ---
+let sessionUser: {
+  id: string;
+  role: string;
+  organizationId: string | null;
+  email?: string;
+  name?: string;
+} = {
+  id: 'user-001',
+  role: 'ra-lead',
+  organizationId: 'org-001',
+  email: 'lead@regula.test',
+  name: 'RA Lead',
+};
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, { user: sessionUser }),
+  ),
+}));
+
+// --- Mock db: select chain for messageBlocks + transaction for signature INSERT ---
+const mockSelectChain = {
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  orderBy: vi.fn(),
+};
+
+const mockInsertChain = {
+  values: vi.fn().mockReturnThis(),
+  returning: vi.fn(),
+};
+
+const mockDb = {
+  select: vi.fn(() => mockSelectChain),
+  transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb({ insert: vi.fn(() => mockInsertChain) }),
+  ),
+};
+
+vi.mock('@/lib/db/client', () => ({ db: mockDb }));
+
+// --- Mock audit ---
+vi.mock('@/lib/audit', () => ({
+  writeAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+// --- Mock signature authorization (mutable: tests flip to null for 404) ---
+const getAuthorizedSignatureMessageMock = vi.fn();
+vi.mock('@/lib/signature/authorization', () => ({
+  getAuthorizedSignatureMessage: (...a: unknown[]) => getAuthorizedSignatureMessageMock(...a),
+}));
+
+// --- Mock getActiveSignature (mutable: tests flip for 409) + insertSignature ---
+const getActiveSignatureMock = vi.fn();
+const insertSignatureMock = vi.fn();
+vi.mock('@/lib/signature/queries', () => ({
+  getActiveSignature: (...a: unknown[]) => getActiveSignatureMock(...a),
+  insertSignature: (...a: unknown[]) => insertSignatureMock(...a),
+}));
+
+// --- Mock computeAnswerHash (pure-ish, but mocked for determinism) ---
+const computeAnswerHashMock = vi.fn();
+vi.mock('@/lib/signature/hash', () => ({
+  computeAnswerHash: (...a: unknown[]) => computeAnswerHashMock(...a),
+}));
+
+// --- Helpers ---
+function makePostRequest(body: unknown): Request {
+  return new Request('http://localhost/api/ra/messages/msg-001/signature', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+function makeGetRequest(): Request {
+  return new Request('http://localhost/api/ra/messages/msg-001/signature', {
+    method: 'GET',
+  });
+}
+
+const VALID_BODY = {
+  meaning: 'I approve this answer for regulatory submission.',
+  signerTitle: 'RA Lead',
+};
+
+const MESSAGE_FIXTURE = {
+  id: 'msg-001',
+  contentProse: 'The device is classified as Class II.',
+  conversationId: 'conv-001',
+};
+
+const SIGNATURE_FIXTURE = {
+  id: 'sig-001',
+  messageId: 'msg-001',
+  signerId: 'user-001',
+  signerName: 'RA Lead',
+  signerTitle: 'RA Lead',
+  meaning: 'I approve this answer for regulatory submission.',
+  recordHash: 'abc123hash',
+  signedAt: '2026-07-11T00:00:00.000Z',
+  revokedAt: null,
+};
+
+describe('POST /api/ra/messages/[messageId]/signature — handler surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionUser = {
+      id: 'user-001',
+      role: 'ra-lead',
+      organizationId: 'org-001',
+      email: 'lead@regula.test',
+      name: 'RA Lead',
+    };
+    getAuthorizedSignatureMessageMock.mockResolvedValue(MESSAGE_FIXTURE);
+    getActiveSignatureMock.mockResolvedValue(null);
+    computeAnswerHashMock.mockResolvedValue('abc123hash');
+    mockSelectChain.orderBy.mockResolvedValue([
+      {
+        id: 'blk-001',
+        blockType: 'prose',
+        blockJson: { text: 'The device is classified as Class II.' },
+        orderIndex: 0,
+      },
+    ]);
+    insertSignatureMock.mockResolvedValue(SIGNATURE_FIXTURE);
+  });
+
+  it('returns 201 with signature record on valid input', async () => {
+    const { POST } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await POST(makePostRequest(VALID_BODY), { params: { messageId: 'msg-001' } });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      id: 'sig-001',
+      messageId: 'msg-001',
+      signerName: 'RA Lead',
+    });
+    expect(mockDb.transaction).toHaveBeenCalled();
+  });
+
+  it('writes signature.applied audit inside transaction (21 CFR Part 11)', async () => {
+    const { writeAudit } = await import('@/lib/audit');
+    const { POST } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    await POST(makePostRequest(VALID_BODY), { params: { messageId: 'msg-001' } });
+
+    expect(vi.mocked(writeAudit)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'signature.applied',
+        actor_id: 'user-001',
+        resource_type: 'signature',
+        resource_id: 'sig-001',
+        meta_json: expect.objectContaining({
+          messageId: 'msg-001',
+          hash: 'abc123hash',
+          meaning: 'I approve this answer for regulatory submission.',
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('computes recordHash from ordered message blocks', async () => {
+    const { POST } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    await POST(makePostRequest(VALID_BODY), { params: { messageId: 'msg-001' } });
+
+    expect(computeAnswerHashMock).toHaveBeenCalled();
+    const callArgs = computeAnswerHashMock.mock.calls[0];
+    // First arg = message contentProse; second = hashable blocks array.
+    expect(callArgs?.[0]).toBe('The device is classified as Class II.');
+    expect(Array.isArray(callArgs?.[1])).toBe(true);
+  });
+
+  it('returns 404 when message is not found / not authorized', async () => {
+    getAuthorizedSignatureMessageMock.mockResolvedValue(null);
+
+    const { POST } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await POST(makePostRequest(VALID_BODY), { params: { messageId: 'unknown' } });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Message not found');
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when active signature already exists', async () => {
+    getActiveSignatureMock.mockResolvedValue({ id: 'existing-sig-001' });
+
+    const { POST } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await POST(makePostRequest(VALID_BODY), { params: { messageId: 'msg-001' } });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: 'answer_already_signed',
+      signatureId: 'existing-sig-001',
+    });
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on invalid JSON body', async () => {
+    const { POST } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await POST(makePostRequest('not-json'), {
+      params: { messageId: 'msg-001' },
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid JSON');
+  });
+
+  it('returns 400 when meaning is empty (Zod min(1))', async () => {
+    const { POST } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await POST(makePostRequest({ meaning: '' }), {
+      params: { messageId: 'msg-001' },
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Validation failed');
+  });
+});
+
+describe('GET /api/ra/messages/[messageId]/signature — manifestation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAuthorizedSignatureMessageMock.mockResolvedValue(MESSAGE_FIXTURE);
+    getActiveSignatureMock.mockResolvedValue(SIGNATURE_FIXTURE);
+  });
+
+  it('returns 200 with §11.50 signature manifestation fields', async () => {
+    const { GET } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await GET(makeGetRequest(), { params: { messageId: 'msg-001' } });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      id: 'sig-001',
+      signerName: 'RA Lead',
+      signerTitle: 'RA Lead',
+      meaning: 'I approve this answer for regulatory submission.',
+      recordHash: 'abc123hash',
+      isRevoked: false,
+      revokedAt: null,
+    });
+  });
+
+  it('returns 404 when message not found', async () => {
+    getAuthorizedSignatureMessageMock.mockResolvedValue(null);
+
+    const { GET } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await GET(makeGetRequest(), { params: { messageId: 'unknown' } });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Message not found');
+  });
+
+  it('returns 404 when no active signature exists', async () => {
+    getActiveSignatureMock.mockResolvedValue(null);
+
+    const { GET } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await GET(makeGetRequest(), { params: { messageId: 'msg-001' } });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('No signature found');
+  });
+
+  it('reports isRevoked=true when signature.revokedAt is set', async () => {
+    getActiveSignatureMock.mockResolvedValue({
+      ...SIGNATURE_FIXTURE,
+      revokedAt: '2026-07-10T00:00:00.000Z',
+    });
+
+    const { GET } = await import('@/app/api/ra/messages/[messageId]/signature/route');
+    const res = await GET(makeGetRequest(), { params: { messageId: 'msg-001' } });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.isRevoked).toBe(true);
+    expect(body.revokedAt).toBe('2026-07-10T00:00:00.000Z');
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 Priority 2. 4 대형 route.

- cer (10), cer-literature (9, SSE 이벤트 순서), message-signature (11, Part 11 audit + 해시), admin-upload (14, 라이선스 게이트+청크+임베딩 실패 등 전 분기).
- 기존 route-test 패턴 준수. test-only, 회귀 0 (full test 5323 passed 0 failed). typecheck/biome 0.

Refs #402 Priority 2.

🗿 MoAI <email@mo.ai.kr>