### PR TITLE
test(api): predicate/export + expert-review/[id] route 테스트 (#402)

### DIFF
--- a/tests/unit/api/expert-review-item-route.test.ts
+++ b/tests/unit/api/expert-review-item-route.test.ts
@@ -1,0 +1,285 @@
+// @MX:NOTE [AUTO] Route tests for GET|PATCH|DELETE /api/ra/expert-review/[id]
+//   (coverage 402, SPEC-REGULA-ENTERPRISE-001).
+// @MX:SPEC SPEC-REGULA-ENTERPRISE-001 (REQ-ENTERPRISE-006..008)
+// @MX:TODO The existing expert-review-route.test.ts covers the collection route
+//   (POST + GET list) and has basic [id] coverage. This file adds deeper
+//   branch coverage for the [id] item route: PATCH invalid JSON, PATCH
+//   validation failure, PATCH with assignedTo/resolution optional fields,
+//   and the inner withPermission guard pattern (requiredAction per transition).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mutable session ---
+let sessionUser: { id: string; role: string; organizationId: string | null } = {
+  id: 'user-001',
+  role: 'ra-lead',
+  organizationId: 'org-001',
+};
+
+// withPermission is used BOTH at the top level (GET export) AND inside PATCH
+// (inner guard per transition). The mock must handle both: pass the session
+// through so the inner handler can access session.user.id for audit.
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, { user: sessionUser }),
+  ),
+}));
+
+// --- Mock db: queued select + update chain + transaction ---
+const selectResults: unknown[][] = [];
+
+function makeSelectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+const mockUpdateChain = {
+  set: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  returning: vi.fn(),
+};
+
+const mockDb = {
+  select: vi.fn(() => makeSelectChain(selectResults.shift() ?? [])),
+  update: vi.fn(() => mockUpdateChain),
+  // Issue #378: PATCH wraps UPDATE + audit in db.transaction; tx reuses chain.
+  transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb({ update: vi.fn(() => mockUpdateChain) }),
+  ),
+};
+
+vi.mock('@/lib/db/client', () => ({ db: mockDb }));
+
+// --- Mock audit ---
+vi.mock('@/lib/audit', () => ({
+  writeAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+// --- Test data ---
+const FAKE_RECORD = {
+  id: 'review-001',
+  conversationId: 'conv-001',
+  messageId: 'msg-001',
+  requestedBy: 'user-001',
+  assignedTo: null,
+  status: 'pending',
+  notes: 'test reason',
+  createdAt: new Date('2026-01-01'),
+  resolvedAt: null,
+};
+
+// --- Helpers ---
+function makeIdCtx(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+function makePatchRequest(body: unknown): Request {
+  return new Request('http://localhost/api/ra/expert-review/review-001', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('GET /api/ra/expert-review/[id] — detail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionUser = { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' };
+    selectResults.length = 0;
+    mockDb.select.mockImplementation(() => makeSelectChain(selectResults.shift() ?? []));
+  });
+
+  it('returns 200 with the record when found', async () => {
+    selectResults.push([FAKE_RECORD]);
+
+    const { GET } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await GET(
+      new Request('http://localhost/api/ra/expert-review/review-001'),
+      makeIdCtx('review-001'),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ id: 'review-001', status: 'pending' });
+  });
+
+  it('returns 404 not_found when record does not exist', async () => {
+    selectResults.push([]);
+
+    const { GET } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await GET(
+      new Request('http://localhost/api/ra/expert-review/nonexistent'),
+      makeIdCtx('nonexistent'),
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('not_found');
+  });
+});
+
+describe('PATCH /api/ra/expert-review/[id] — state machine + optional fields', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionUser = { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' };
+    selectResults.length = 0;
+    mockDb.select.mockImplementation(() => makeSelectChain(selectResults.shift() ?? []));
+  });
+
+  it('transitions pending → in_progress and writes expert_review.assign audit', async () => {
+    const pendingRecord = { ...FAKE_RECORD, status: 'pending' };
+    const updatedRecord = { ...FAKE_RECORD, status: 'in_progress' };
+    selectResults.push([pendingRecord]);
+    mockUpdateChain.returning.mockResolvedValueOnce([updatedRecord]);
+
+    const { writeAudit } = await import('@/lib/audit');
+    vi.mocked(writeAudit).mockClear();
+
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(makePatchRequest({ status: 'in_progress' }), makeIdCtx('review-001'));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe('in_progress');
+    expect(vi.mocked(writeAudit)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'expert_review.assign',
+        actor_id: 'user-001',
+        resource_type: 'expert_review',
+        resource_id: 'review-001',
+        meta_json: { from: 'pending', to: 'in_progress' },
+      }),
+      expect.anything(),
+    );
+    expect(mockDb.transaction).toHaveBeenCalled();
+  });
+
+  it('transitions in_progress → resolved and writes expert_review.resolve audit', async () => {
+    const inProgressRecord = { ...FAKE_RECORD, status: 'in_progress' };
+    const resolvedRecord = { ...FAKE_RECORD, status: 'resolved', resolvedAt: new Date() };
+    selectResults.push([inProgressRecord]);
+    mockUpdateChain.returning.mockResolvedValueOnce([resolvedRecord]);
+
+    const { writeAudit } = await import('@/lib/audit');
+    vi.mocked(writeAudit).mockClear();
+
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(makePatchRequest({ status: 'resolved' }), makeIdCtx('review-001'));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(writeAudit)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'expert_review.resolve',
+        meta_json: { from: 'in_progress', to: 'resolved' },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('includes assignedTo in update payload when provided', async () => {
+    const pendingRecord = { ...FAKE_RECORD, status: 'pending' };
+    selectResults.push([pendingRecord]);
+    mockUpdateChain.returning.mockResolvedValueOnce([
+      { ...FAKE_RECORD, status: 'in_progress', assignedTo: 'expert-002' },
+    ]);
+
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(
+      makePatchRequest({ status: 'in_progress', assignedTo: 'expert-002' }),
+      makeIdCtx('review-001'),
+    );
+
+    expect(res.status).toBe(200);
+    // set() should have been called with a payload containing assignedTo
+    expect(mockUpdateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'in_progress', assignedTo: 'expert-002' }),
+    );
+  });
+
+  it('includes resolution as notes in update payload when provided', async () => {
+    const inProgressRecord = { ...FAKE_RECORD, status: 'in_progress' };
+    selectResults.push([inProgressRecord]);
+    mockUpdateChain.returning.mockResolvedValueOnce([
+      { ...FAKE_RECORD, status: 'resolved', notes: 'approved by RA' },
+    ]);
+
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(
+      makePatchRequest({ status: 'resolved', resolution: 'approved by RA' }),
+      makeIdCtx('review-001'),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ notes: 'approved by RA' }),
+    );
+  });
+
+  it('returns 400 on invalid JSON body', async () => {
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(makePatchRequest('not-json'), makeIdCtx('review-001'));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid JSON');
+  });
+
+  it('returns 400 when status is not a valid enum value', async () => {
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(makePatchRequest({ status: 'cancelled' }), makeIdCtx('review-001'));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Validation failed');
+    expect(body.issues).toBeDefined();
+  });
+
+  it('returns 404 when PATCH target not found', async () => {
+    selectResults.push([]);
+
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(makePatchRequest({ status: 'in_progress' }), makeIdCtx('nonexistent'));
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('not_found');
+  });
+
+  it('returns 422 invalid_transition for pending → resolved (skips a state)', async () => {
+    selectResults.push([{ ...FAKE_RECORD, status: 'pending' }]);
+
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(makePatchRequest({ status: 'resolved' }), makeIdCtx('review-001'));
+
+    expect(res.status).toBe(422);
+    expect((await res.json()).error).toBe('invalid_transition');
+  });
+
+  it('returns 422 invalid_transition for resolved → any (terminal state)', async () => {
+    selectResults.push([{ ...FAKE_RECORD, status: 'resolved' }]);
+
+    const { PATCH } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await PATCH(makePatchRequest({ status: 'in_progress' }), makeIdCtx('review-001'));
+
+    expect(res.status).toBe(422);
+  });
+});
+
+describe('DELETE /api/ra/expert-review/[id] — method not allowed', () => {
+  it('returns 405 with Allow header', async () => {
+    const { DELETE } = await import('@/app/api/ra/expert-review/[id]/route');
+    const res = await DELETE(
+      new Request('http://localhost/api/ra/expert-review/review-001', {
+        method: 'DELETE',
+      }),
+      {},
+    );
+
+    expect(res.status).toBe(405);
+    expect(res.headers.get('Allow')).toBe('GET, PATCH');
+    expect((await res.json()).error).toBe('method_not_allowed');
+  });
+});

--- a/tests/unit/api/predicate-export-route.test.ts
+++ b/tests/unit/api/predicate-export-route.test.ts
@@ -1,0 +1,273 @@
+// @MX:NOTE [AUTO] Route tests for POST /api/ra/predicate/export (coverage 402, SPEC-REGULA-PREDICATE-001).
+// @MX:SPEC SPEC-REGULA-PREDICATE-001 (REQ-PRE-014, REQ-PRE-015, REQ-PRE-029)
+// @MX:TODO Deep PDF/DOCX rendering (@react-pdf/renderer tree, docx builders) is
+//   mocked here. Format-specific rendering correctness is validated by visual
+//   inspection of exported artifacts. These tests exercise the route handler
+//   surface: auth passthrough, Zod validation, department RBAC, ownership
+//   check, 404 for unknown/wrong-type runs, audit contract, and response shape.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mutable session ---
+let sessionUser: { id: string; role: string; organizationId: string | null } = {
+  id: 'user-001',
+  role: 'ra-lead',
+  organizationId: 'org-001',
+};
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, { user: sessionUser }),
+  ),
+}));
+
+// --- Mock db: queued select results (department lookup + workflowRuns lookup) ---
+// Each db.select() call pops the next array from selectResults.
+const selectResults: unknown[][] = [];
+
+function makeSelectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+const mockDb = {
+  select: vi.fn(() => makeSelectChain(selectResults.shift() ?? [])),
+};
+
+vi.mock('@/lib/db/client', () => ({ db: mockDb }));
+
+// --- Mock audit ---
+vi.mock('@/lib/audit', () => ({
+  writeAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+// --- Mock predicate-permissions (mutable: tests flip for 403 department branch) ---
+const canExportComparisonsMock = vi.fn();
+vi.mock('@/lib/auth/predicate-permissions', () => ({
+  canExportComparisons: (...a: unknown[]) => canExportComparisonsMock(...a),
+}));
+
+// --- Mock @react-pdf/renderer (avoid real PDF rendering in unit tests) ---
+vi.mock('@react-pdf/renderer', () => ({
+  Document: function Document() {},
+  Page: function Page() {},
+  StyleSheet: { create: (s: unknown) => s },
+  Text: function Text() {},
+  View: function View() {},
+  renderToBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-pdf-content')),
+}));
+
+// --- Mock docx (avoid real DOCX rendering in unit tests) ---
+vi.mock('docx', () => {
+  class Stub {
+    [k: string]: unknown;
+  }
+  return {
+    AlignmentType: { CENTER: 'center' },
+    Document: Stub,
+    HeadingLevel: { HEADING_1: 'heading1' },
+    Packer: { toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-docx-content')) },
+    Paragraph: Stub,
+    Table: Stub,
+    TableCell: Stub,
+    TableRow: Stub,
+    TextRun: Stub,
+    WidthType: { PERCENTAGE: 'pct' },
+  };
+});
+
+// --- Helpers ---
+function makePostRequest(body: unknown): Request {
+  return new Request('http://localhost/api/ra/predicate/export', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = { workflow_run_id: 'run-001', format: 'pdf' as const };
+
+// A saved comparison fixture matching PredicateComparison shape.
+const COMPARISON_FIXTURE = {
+  subject_device_name: 'CardioFlow X1',
+  selected_predicates: [
+    { k_number: 'K123456', device_name: 'PredDevice A', applicant_name: 'Acme' },
+  ],
+  cells: [
+    {
+      dimension: 'intended_use',
+      subject_text: 'Subject intended use text',
+      predicate_texts: ['Predicate intended use text'],
+      approved: [true],
+    },
+  ],
+  created_at: new Date('2026-01-01'),
+};
+
+// A workflow run row matching the select shape in the route.
+const WORKFLOW_RUN_ROW = {
+  id: 'run-001',
+  userId: 'user-001',
+  workflowType: 'predicate_comparison',
+  resultJson: COMPARISON_FIXTURE,
+};
+
+describe('POST /api/ra/predicate/export — handler surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionUser = { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' };
+    selectResults.length = 0;
+    canExportComparisonsMock.mockReturnValue(true);
+  });
+
+  it('returns 200 with PDF content-type and attachment disposition', async () => {
+    selectResults.push([{ department: 'RA' }]); // getDepartment
+    selectResults.push([WORKFLOW_RUN_ROW]); // workflowRuns select
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/pdf');
+    expect(res.headers.get('Content-Disposition')).toBe(
+      'attachment; filename="predicate-comparison-run-001.pdf"',
+    );
+    const buf = await res.arrayBuffer();
+    expect(new Uint8Array(buf)).toEqual(new Uint8Array(Buffer.from('fake-pdf-content')));
+  });
+
+  it('returns 200 with DOCX content-type when format=docx', async () => {
+    selectResults.push([{ department: 'Dev' }]);
+    selectResults.push([WORKFLOW_RUN_ROW]);
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest({ workflow_run_id: 'run-001', format: 'docx' }), {});
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    );
+    expect(res.headers.get('Content-Disposition')).toContain('.docx');
+  });
+
+  it('writes predicate_comparison_exported audit row', async () => {
+    selectResults.push([{ department: 'RA' }]);
+    selectResults.push([WORKFLOW_RUN_ROW]);
+    const { writeAudit } = await import('@/lib/audit');
+    vi.mocked(writeAudit).mockClear();
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    await POST(makePostRequest(VALID_BODY), {});
+
+    expect(vi.mocked(writeAudit)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'predicate_comparison_exported',
+        actor_id: 'user-001',
+        resource_type: 'predicate_comparison',
+        resource_id: 'run-001',
+        meta_json: { format: 'pdf' },
+      }),
+    );
+  });
+
+  it('returns 400 on invalid JSON body', async () => {
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest('not-json'), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid JSON');
+  });
+
+  it('returns 400 when workflow_run_id is missing', async () => {
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest({ format: 'pdf' }), {});
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Validation failed');
+  });
+
+  it('returns 400 when format is not pdf or docx', async () => {
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest({ workflow_run_id: 'run-001', format: 'html' }), {});
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Validation failed');
+  });
+
+  it('returns 403 permission_denied when department is not RA/Dev (REQ-PRE-029)', async () => {
+    canExportComparisonsMock.mockReturnValue(false);
+    selectResults.push([{ department: 'QA' }]); // getDepartment still called
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: 'permission_denied', reason: 'department' });
+  });
+
+  it('returns 404 when workflow run does not exist', async () => {
+    selectResults.push([{ department: 'RA' }]);
+    selectResults.push([]); // no workflow run found
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('Not Found');
+  });
+
+  it('returns 404 when workflowType is not predicate_comparison', async () => {
+    selectResults.push([{ department: 'RA' }]);
+    selectResults.push([{ ...WORKFLOW_RUN_ROW, workflowType: 'device_classification' }]);
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when resultJson is null', async () => {
+    selectResults.push([{ department: 'RA' }]);
+    selectResults.push([{ ...WORKFLOW_RUN_ROW, resultJson: null }]);
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 permission_denied ownership when run belongs to another user (REQ-PRE-014)', async () => {
+    selectResults.push([{ department: 'RA' }]);
+    selectResults.push([{ ...WORKFLOW_RUN_ROW, userId: 'other-user-002' }]);
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: 'permission_denied', reason: 'ownership' });
+  });
+
+  it('handles null department from missing user row (getDepartment returns null)', async () => {
+    // User row exists but department is null → canExportComparisons(null) returns false → 403
+    canExportComparisonsMock.mockReturnValue(false);
+    selectResults.push([{ department: null }]);
+
+    const { POST } = await import('@/app/api/ra/predicate/export/route');
+    const res = await POST(makePostRequest(VALID_BODY), {});
+
+    expect(res.status).toBe(403);
+    expect(canExportComparisonsMock).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 Priority 2. 2 대형 route (최대 미커버).

- predicate/export 321L (12 tests): PDF/DOCX export + RBAC + IDOR + 404 분기.
- expert-review/[id] 159L (12 tests): GET/PATCH 상태전이(assign/resolve audit-in-tx) + 422 invalid_transition + 404.
- test-only, 회귀 0 (full test 5347 passed 0 failed). typecheck/biome 0.

Refs #402 Priority 2.

🗿 MoAI <email@mo.ai.kr>