### PR TITLE
fix(test): radar _base retry unhandled rejection (CI red 복구)

### DIFF
--- a/tests/unit/radar/crawlers/base.test.ts
+++ b/tests/unit/radar/crawlers/base.test.ts
@@ -128,16 +128,19 @@ describe('fetchWithRetry (REQ-RADAR-009)', () => {
   it('throws after exhausting retries on persistent 503', async () => {
     vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 503 }));
     const promise = fetchWithRetry(`${ORIGIN}/feed`, {}, 2);
-    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
-    await expect(promise).rejects.toThrow('HTTP 503');
+    // Promise.all: the expect(...).rejects handler attaches BEFORE timers drain,
+    // so the rejection is never "unhandled" (the vitest fake-timer pitfall).
+    await Promise.all([expect(promise).rejects.toThrow('HTTP 503'), vi.runAllTimersAsync()]);
     expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
   });
 
   it('retries on network error then throws if all fail', async () => {
     vi.mocked(fetch).mockRejectedValue(new Error('connection reset'));
     const promise = fetchWithRetry(`${ORIGIN}/feed`, {}, 2);
-    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
-    await expect(promise).rejects.toThrow('connection reset');
+    await Promise.all([
+      expect(promise).rejects.toThrow('connection reset'),
+      vi.runAllTimersAsync(),
+    ]);
   });
 });
 


### PR DESCRIPTION
main red 복구. #440 radar _base 테스트의 fake-timer retry 케이스가 CI에서 unhandled error로 실패. Promise.all 패턴으로 rejection 핸들러 즉시 부착. 13/13 pass, unhandled 0. 🗿 MoAI <email@mo.ai.kr>