### PR TITLE
test(coverage): ra/updates/[id] + feedback 실행형 테스트 (#402 Phase 4)

### DIFF
--- a/app/api/ra/updates/[id]/__tests__/route.exec.test.ts
+++ b/app/api/ra/updates/[id]/__tests__/route.exec.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET /api/ra/updates/[id] (SPEC-REGULA-RADAR-001).
+// @MX:SPEC SPEC-REGULA-RADAR-001
+//
+// No prior test existed (0% coverage). Invokes GET with db (select + cache update)
+// + Vercel AI SDK generateText + logger mocked. Covers: cached path, on-demand
+// analyze (generate + cache write), LLM failure fallback, 404, missing-id 400.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+let selectQueue: unknown[][] = [];
+
+const generateText = vi.fn();
+const updateWhere = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('ai', () => ({ generateText }));
+vi.mock('@/lib/ai/llm-provider', () => ({ getLlmModel: vi.fn(() => ({ id: 'main' })) }));
+vi.mock('@/lib/observability/logger', () => ({ logger: { error: vi.fn() } }));
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated) {
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        }
+        return handler(req, ctx, { user: { id: 'user-001', role: 'ra-member', organizationId } });
+      },
+  ),
+}));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued select result.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(selectQueue.shift() ?? []);
+  return {
+    db: {
+      select: () => chain,
+      update: () => ({ set: () => ({ where: updateWhere }) }),
+    },
+  };
+});
+
+const { GET } = await import('@/app/api/ra/updates/[id]/route');
+
+function getReq(query: string): Request {
+  return new Request(`http://localhost/api/ra/updates/u-1?${query}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  selectQueue = [];
+  generateText.mockResolvedValue({ text: 'LLM impact analysis text' });
+});
+
+describe('GET /api/ra/updates/[id] (SPEC-REGULA-RADAR-001)', () => {
+  it('returns 200 with the cached impact analysis when present (no LLM call)', async () => {
+    selectQueue = [[{ id: 'u-1', title: 'T', impactAnalysisText: 'cached analysis' }]];
+    const res = await GET(getReq(''), { params: { id: 'u-1' } });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.update.impactAnalysisText).toBe('cached analysis');
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it('does not regenerate when analyze=true but analysis is already cached', async () => {
+    selectQueue = [[{ id: 'u-1', title: 'T', impactAnalysisText: 'cached' }]];
+    const res = await GET(getReq('analyze=true'), { params: { id: 'u-1' } });
+    expect(res.status).toBe(200);
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it('generates + caches the analysis on demand when not yet cached', async () => {
+    selectQueue = [[{ id: 'u-1', title: 'T', impactAnalysisText: null }]];
+    const res = await GET(getReq('analyze=true'), { params: { id: 'u-1' } });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(generateText).toHaveBeenCalled();
+    expect(body.update.impactAnalysisText).toBe('LLM impact analysis text');
+    expect(updateWhere).toHaveBeenCalled();
+  });
+
+  it('falls back gracefully when the LLM call fails (no crash, null analysis)', async () => {
+    generateText.mockRejectedValueOnce(new Error('llm down'));
+    selectQueue = [[{ id: 'u-1', title: 'T', impactAnalysisText: null }]];
+    const res = await GET(getReq('analyze=true'), { params: { id: 'u-1' } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).update.impactAnalysisText).toBeNull();
+  });
+
+  it('returns 404 when the update does not exist', async () => {
+    selectQueue = [[]];
+    const res = await GET(getReq(''), { params: { id: 'ux' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 Missing update ID when id is absent', async () => {
+    const res = await GET(getReq(''), { params: {} });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/ra/updates/[id]/feedback/__tests__/route.exec.test.ts
+++ b/app/api/ra/updates/[id]/feedback/__tests__/route.exec.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for POST /api/ra/updates/[id]/feedback (SPEC-REGULA-RADAR-001).
+// @MX:SPEC SPEC-REGULA-RADAR-001
+//
+// No prior test existed (0% coverage). Invokes POST with db transaction mocked
+// (tx select + update/insert upsert + audit). Covers: insert path, update path,
+// invalid feedback 422, no-org 403, missing-id 400.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+let existingQueue: unknown[][] = [];
+
+type AuditInput = {
+  actor_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  meta_json?: Record<string, unknown>;
+};
+
+const writeAudit = vi.fn(async (_input: AuditInput) => {});
+const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+const txInsertValues = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/audit', () => ({ writeAudit }));
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated) {
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        }
+        return handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-member', organizationId },
+        });
+      },
+  ),
+}));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued select result.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(existingQueue.shift() ?? []);
+  return {
+    db: {
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({
+          select: () => chain,
+          update: () => ({ set: () => ({ where: txUpdateWhere }) }),
+          insert: () => ({ values: txInsertValues }),
+        }),
+      ),
+    },
+  };
+});
+
+const { POST } = await import('@/app/api/ra/updates/[id]/feedback/route');
+
+function postReq(body: unknown): Request {
+  return new Request('http://localhost/api/ra/updates/u-1/feedback', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+/** Extract audit inputs recorded by writeAudit, filtered by predicate. */
+function auditCalls(predicate: (input: AuditInput) => boolean): AuditInput[] {
+  return writeAudit.mock.calls
+    .map((call) => (call as unknown[])[0] as AuditInput)
+    .filter(predicate);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  existingQueue = [];
+});
+
+describe('POST /api/ra/updates/[id]/feedback (SPEC-REGULA-RADAR-001)', () => {
+  it('inserts a new relevance row + message.feedback audit when none exists', async () => {
+    existingQueue = [[]];
+    const res = await POST(postReq({ feedback: 'not_interested' }), { params: { id: 'u-1' } });
+    expect(res.status).toBe(200);
+    expect(txInsertValues).toHaveBeenCalled();
+    expect(txUpdateWhere).not.toHaveBeenCalled();
+    expect(auditCalls((i) => i.action === 'message.feedback')).toHaveLength(1);
+  });
+
+  it('updates the existing relevance row when one already exists', async () => {
+    existingQueue = [[{ id: 'rel-1' }]];
+    const res = await POST(postReq({ feedback: 'not_interested' }), { params: { id: 'u-1' } });
+    expect(res.status).toBe(200);
+    expect(txUpdateWhere).toHaveBeenCalled();
+    expect(txInsertValues).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 Invalid feedback value on a bad enum', async () => {
+    const res = await POST(postReq({ feedback: 'love_it' }), { params: { id: 'u-1' } });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 403 No organization context when orgId is missing', async () => {
+    organizationId = undefined as unknown as string;
+    const res = await POST(postReq({ feedback: 'not_interested' }), { params: { id: 'u-1' } });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 Missing update ID when id is absent', async () => {
+    const res = await POST(postReq({ feedback: 'not_interested' }), { params: {} });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 4 BLOCK-4 (#402). `ra/updates/[id]` (GET, LLM impact analysis + 캐시) + `ra/updates/[id]/feedback` (POST, upsert + audit) — 테스트 부재로 실행 0% → **실행형 테스트 추가**.

## Coverage (lcov, main 기준)
| file | before | after |
|---|---|---|
| ra/updates/[id]/route.ts | 0% | 전 분기 커버 (72L) |
| ra/updates/[id]/feedback/route.ts | 0% | 전 분기 커버 (72L) |
| **All files** | 67.36% | **67.54%** (+0.18) |

## Branches (SPEC-REGULA-RADAR-001)
- [id] GET: cached analysis 반환, analyze=true 이지만 캐시 시 미생성, on-demand 생성+DB 캐시, LLM 실패 graceful fallback, 404, missing id 400
- feedback POST: insert(신규)/update(기존) upsert 분기 + message.feedback audit, invalid 422, no org 403, missing id 400

## Gates (L-009/L-015 직검)
- `pnpm vitest run`: 11/11 · `ci:typecheck` 0 err · `ci:lint` clean · `ci:coverage` floor **66/75/66/66 PASS**

Refs #402 Phase 4

🗿 MoAI <email@mo.ai.kr>