### PR TITLE
test(coverage): admin/radar/run 실행형 테스트 (#402 Phase 4)

### DIFF
--- a/app/api/admin/radar/run/__tests__/route.exec.test.ts
+++ b/app/api/admin/radar/run/__tests__/route.exec.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for POST /api/admin/radar/run (SPEC-REGULA-RADAR-001).
+// @MX:SPEC SPEC-REGULA-RADAR-001
+//
+// No prior test existed (0% coverage). Admin-only manual crawler trigger.
+// runCrawler + the three crawler fns + db are mocked. Covers: success + audit,
+// non-admin 403, invalid crawler 422, crawler-error 500.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+type Role = 'viewer' | 'ra-member' | 'ra-lead' | 'admin';
+let userRole: Role = 'admin';
+
+type AuditInput = {
+  actor_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  meta_json?: Record<string, unknown>;
+};
+
+const writeAudit = vi.fn(async (_input: AuditInput) => {});
+const runCrawler = vi.fn();
+
+vi.mock('@/lib/audit', () => ({ writeAudit }));
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated) {
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        }
+        return handler(req, ctx, {
+          user: { id: 'user-001', role: userRole, organizationId },
+        });
+      },
+  ),
+}));
+
+vi.mock('@/lib/db/client', () => ({ db: {} }));
+vi.mock('@/lib/radar/crawlers/_base', () => ({ runCrawler }));
+vi.mock('@/lib/radar/crawlers/eu-oj', () => ({ crawlEuOj: vi.fn() }));
+vi.mock('@/lib/radar/crawlers/fda-federal-register', () => ({ crawlFdaFederalRegister: vi.fn() }));
+vi.mock('@/lib/radar/crawlers/mfds-notice', () => ({ crawlMfdsNotice: vi.fn() }));
+
+const { POST } = await import('@/app/api/admin/radar/run/route');
+
+function postReq(body: unknown): Request {
+  return new Request('http://localhost/api/admin/radar/run', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+/** Extract audit inputs recorded by writeAudit, filtered by predicate. */
+function auditCalls(predicate: (input: AuditInput) => boolean): AuditInput[] {
+  return writeAudit.mock.calls
+    .map((call) => (call as unknown[])[0] as AuditInput)
+    .filter(predicate);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  userRole = 'admin';
+  runCrawler.mockResolvedValue({ records: [{ id: 'r1' }, { id: 'r2' }], errors: [] });
+});
+
+describe('POST /api/admin/radar/run (SPEC-REGULA-RADAR-001)', () => {
+  it('returns 200 + radar.crawler_run audit on success', async () => {
+    const res = await POST(postReq({ crawler: 'fda-federal-register' }), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ crawler: 'fda-federal-register', records_added: 2, errors: [] });
+    const audits = auditCalls((i) => i.action === 'radar.crawler_run');
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.meta_json).toMatchObject({ records_added: 2, errors: 0 });
+  });
+
+  it('returns 403 Admin access required for non-admin roles', async () => {
+    userRole = 'ra-lead';
+    const res = await POST(postReq({ crawler: 'eu-oj' }), {});
+    expect(res.status).toBe(403);
+    expect(runCrawler).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 Invalid crawler name on a bad enum', async () => {
+    const res = await POST(postReq({ crawler: 'not-a-crawler' }), {});
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 500 when runCrawler throws', async () => {
+    runCrawler.mockRejectedValueOnce(new Error('crawler crashed'));
+    const res = await POST(postReq({ crawler: 'mfds-notice' }), {});
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 4 BLOCK-4 (#402). `admin/radar/run/route.ts` (76L) — 테스트 부재로 실행 0% → **실행형 테스트 추가** (admin 전용 수동 crawler 트리거).

## Coverage (lcov, main 기준)
| file | before | after |
|---|---|---|
| admin/radar/run/route.ts | 0% | 전 분기 커버 (76L) |
| **All files** | 67.36% | **67.44%** (+0.08) |

## Branches (SPEC-REGULA-RADAR-001)
- 200 + radar.crawler_run audit (records_added/errors 메타)
- non-admin → 403 Admin access required
- invalid crawler name → 422
- runCrawler throw → 500

runCrawler + 3 crawler fns + db mock.

## Gates (L-009/L-015 직검)
- `pnpm vitest run`: 4/4 · `ci:typecheck` 0 err · `ci:lint` clean · `ci:coverage` floor **66/75/66/66 PASS** (functions 66.25 — 얇은 margin)

Refs #402 Phase 4

🗿 MoAI <email@mo.ai.kr>