### PR TITLE
test(coverage): ra/impact + [assessmentId] 실행형 테스트 (#402 Phase 4)

### DIFF
--- a/app/api/ra/impact/[assessmentId]/__tests__/route.exec.test.ts
+++ b/app/api/ra/impact/[assessmentId]/__tests__/route.exec.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET /api/ra/impact/[assessmentId] (SPEC-REGULA-IMPACT-001).
+// @MX:SPEC SPEC-REGULA-IMPACT-001
+//
+// No prior test existed (0% coverage). Invokes GET with db mocked as a chainable
+// thenable over a per-test select queue (assessment lookup + action items).
+// Covers: 200 with action_items, 404, no-org 400.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+let selectQueue: unknown[][] = [];
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated) {
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        }
+        return handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-member', organizationId },
+        });
+      },
+  ),
+}));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.innerJoin = () => chain;
+  chain.where = () => chain;
+  chain.orderBy = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued select result.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(selectQueue.shift() ?? []);
+  return { db: { select: () => chain } };
+});
+
+const { GET } = await import('@/app/api/ra/impact/[assessmentId]/route');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  selectQueue = [];
+});
+
+describe('GET /api/ra/impact/[assessmentId] (SPEC-REGULA-IMPACT-001)', () => {
+  it('returns 200 with the assessment + action_items', async () => {
+    selectQueue = [
+      [{ id: 'a1', impact_level: 'high' }], // assessment lookup
+      [
+        { id: 'i1', status: 'open' },
+        { id: 'i2', status: 'done' },
+      ], // action items
+    ];
+    const res = await GET(new Request('http://localhost/api/ra/impact/a1'), {
+      params: { assessmentId: 'a1' },
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.assessment.id).toBe('a1');
+    expect(body.assessment.action_items).toHaveLength(2);
+  });
+
+  it('returns 404 Assessment not found when the row is missing', async () => {
+    selectQueue = [[]];
+    const res = await GET(new Request('http://localhost/api/ra/impact/ax'), {
+      params: { assessmentId: 'ax' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 Organization context required when orgId is missing', async () => {
+    organizationId = undefined as unknown as string;
+    const res = await GET(new Request('http://localhost/api/ra/impact/a1'), {
+      params: { assessmentId: 'a1' },
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/ra/impact/__tests__/route.exec.test.ts
+++ b/app/api/ra/impact/__tests__/route.exec.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET /api/ra/impact (SPEC-REGULA-IMPACT-001).
+// @MX:SPEC SPEC-REGULA-IMPACT-001
+//
+// No prior test existed (0% coverage). Invokes GET with db mocked as a chainable
+// thenable over a per-test select queue: the main assessments select, then one
+// action-item select per assessment (Promise.all). Covers: counts mapping + 400.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+let selectQueue: unknown[][] = [];
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated) {
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        }
+        return handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-member', organizationId },
+        });
+      },
+  ),
+}));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.innerJoin = () => chain;
+  chain.where = () => chain;
+  chain.orderBy = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued select result.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(selectQueue.shift() ?? []);
+  return { db: { select: () => chain } };
+});
+
+const { GET } = await import('@/app/api/ra/impact/route');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  selectQueue = [];
+});
+
+describe('GET /api/ra/impact (SPEC-REGULA-IMPACT-001)', () => {
+  it('returns 200 with assessments + open/total action-item counts', async () => {
+    selectQueue = [
+      [{ id: 'a1' }, { id: 'a2' }], // main assessments select
+      [
+        { id: 'i1', status: 'open' },
+        { id: 'i2', status: 'open' },
+        { id: 'i3', status: 'done' },
+      ], // a1 items
+      [{ id: 'i4', status: 'done' }], // a2 items
+    ];
+    const res = await GET(new Request('http://localhost/api/ra/impact'), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.assessments).toHaveLength(2);
+    expect(body.assessments[0]).toMatchObject({ action_items_total: 3, action_items_open: 2 });
+    expect(body.assessments[1]).toMatchObject({ action_items_total: 1, action_items_open: 0 });
+  });
+
+  it('returns 400 Organization context required when orgId is missing', async () => {
+    organizationId = undefined as unknown as string;
+    const res = await GET(new Request('http://localhost/api/ra/impact'), {});
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 4 BLOCK-4 (#402). `ra/impact` (GET list) + `ra/impact/[assessmentId]` (GET detail) — 테스트 부재로 실행 0% → **실행형 테스트 추가**.

## Coverage (lcov, main 기준)
| file | before | after |
|---|---|---|
| ra/impact/route.ts | 0% | 전 분기 커버 (59L) |
| ra/impact/[assessmentId]/route.ts | 0% | 전 분기 커버 (69L) |
| **All files** | 67.36% | **67.51%** (+0.15) |

## Branches (SPEC-REGULA-IMPACT-001)
- list: assessments + per-row **action-item open/total counts** (Promise.all 매핑), no-org 400
- detail: assessment + action_items, 404, no-org 400

db join 체인을 chainable thenable + selectQueue로 모델링 (list는 main select + per-row N select).

## Gates (L-009/L-015 직검)
- `pnpm vitest run`: 5/5 · `ci:typecheck` 0 err · `ci:lint` clean · `ci:coverage` floor **66/75/66/66 PASS**

Refs #402 Phase 4

🗿 MoAI <email@mo.ai.kr>