### PR TITLE
test(coverage): model-governance/change-request + [id]/eval 실행형 테스트 (#402 Phase 4)

### DIFF
--- a/app/api/model-governance/change-request/[id]/eval/__tests__/route.exec.test.ts
+++ b/app/api/model-governance/change-request/[id]/eval/__tests__/route.exec.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for POST /api/model-governance/change-request/[id]/eval (SPEC-REGULA-MODEL-GOVERNANCE-001).
+// @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (REQ-MODELGOV-010/011)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+
+const assertChangeRequestAccess = vi.fn(
+  async (): Promise<{ id: string } | null> => ({ id: 'cr-1' }),
+);
+const recordEvalResult = vi.fn();
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated) {
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        }
+        return handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-lead', organizationId },
+        });
+      },
+  ),
+}));
+
+vi.mock('@/lib/model-governance/access', () => ({ assertChangeRequestAccess }));
+vi.mock('@/lib/model-governance/change-workflow', () => ({ recordEvalResult }));
+
+const { POST } = await import('@/app/api/model-governance/change-request/[id]/eval/route');
+
+function postReq(body: unknown): Request {
+  return new Request('http://localhost/api/model-governance/change-request/cr-1/eval', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  assertChangeRequestAccess.mockResolvedValue({ id: 'cr-1' });
+  recordEvalResult.mockResolvedValue({ passed: true, score: 0.92, threshold: 0.85, reason: '' });
+});
+
+describe('POST /api/model-governance/change-request/[id]/eval (REQ-MODELGOV-010/011)', () => {
+  it('returns 200 with evalStatus passed when the gate passes', async () => {
+    const res = await POST(postReq({ evalResultJson: { pass: 10 } }), {
+      params: { id: 'cr-1' },
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ evalStatus: 'passed', score: 0.92, threshold: 0.85 });
+  });
+
+  it('returns 200 with evalStatus failed when the gate fails', async () => {
+    recordEvalResult.mockResolvedValueOnce({
+      passed: false,
+      score: 0.4,
+      threshold: 0.85,
+      reason: 'below_threshold',
+    });
+    const res = await POST(postReq({ evalResultJson: { pass: 2 } }), {
+      params: { id: 'cr-1' },
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.evalStatus).toBe('failed');
+    expect(body.reason).toBe('below_threshold');
+  });
+
+  it('returns 404 Change request not found on IDOR miss', async () => {
+    assertChangeRequestAccess.mockResolvedValueOnce(null);
+    const res = await POST(postReq({ evalResultJson: {} }), { params: { id: 'cr-x' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 Missing change request id when id is absent', async () => {
+    const res = await POST(postReq({ evalResultJson: {} }), { params: {} });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 Invalid input when evalResultJson is missing', async () => {
+    const res = await POST(postReq({ evalRunId: 'er-1' }), { params: { id: 'cr-1' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 when organizationId is missing', async () => {
+    organizationId = undefined as unknown as string;
+    const res = await POST(postReq({ evalResultJson: {} }), { params: { id: 'cr-1' } });
+    expect(res.status).toBe(403);
+  });
+});

--- a/app/api/model-governance/change-request/__tests__/route.exec.test.ts
+++ b/app/api/model-governance/change-request/__tests__/route.exec.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for /api/model-governance/change-request (SPEC-REGULA-MODEL-GOVERNANCE-001).
+// @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (REQ-MODELGOV-004/005)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+let rows: unknown[] = [];
+
+const assertPromptAccess = vi.fn(async (): Promise<boolean> => true);
+const assertModelPinAccess = vi.fn(async (): Promise<boolean> => true);
+const createChangeRequest = vi.fn();
+const safeParse = vi.fn();
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated) {
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        }
+        return handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-lead', organizationId },
+        });
+      },
+  ),
+}));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  // Intentional thenable: `await` on the chain resolves to rows.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(rows);
+  const dbs = { select: () => chain };
+  return {
+    withTenantScope: vi.fn(async (_orgId: string, fn: (dbs: unknown) => unknown) => fn(dbs)),
+  };
+});
+
+vi.mock('@/lib/model-governance/access', () => ({
+  assertPromptAccess,
+  assertModelPinAccess,
+}));
+vi.mock('@/lib/model-governance/change-workflow', () => ({ createChangeRequest }));
+vi.mock('@/lib/model-governance/types', () => ({
+  createChangeRequestInputSchema: { safeParse },
+}));
+
+const { POST, GET } = await import('@/app/api/model-governance/change-request/route');
+
+function postReq(body: unknown): Request {
+  return new Request('http://localhost/api/model-governance/change-request', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+const validInput = { promptId: 'p-1', modelPinId: 'mp-1', evalRunId: 'er-1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  rows = [];
+  assertPromptAccess.mockResolvedValue(true);
+  assertModelPinAccess.mockResolvedValue(true);
+  createChangeRequest.mockResolvedValue({ id: 'cr-1', status: 'pending_eval' });
+  safeParse.mockReturnValue({ success: true, data: validInput });
+});
+
+describe('POST /api/model-governance/change-request (REQ-MODELGOV-004/005)', () => {
+  it('returns 201 with the created change request', async () => {
+    const res = await POST(postReq(validInput), {});
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.changeRequest.id).toBe('cr-1');
+  });
+
+  it('returns 404 Prompt not found on IDOR miss', async () => {
+    assertPromptAccess.mockResolvedValueOnce(false);
+    const res = await POST(postReq(validInput), {});
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('Prompt not found');
+  });
+
+  it('returns 404 Model pin not found on IDOR miss', async () => {
+    assertModelPinAccess.mockResolvedValueOnce(false);
+    const res = await POST(postReq(validInput), {});
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('Model pin not found');
+  });
+
+  it('returns 500 when createChangeRequest throws', async () => {
+    createChangeRequest.mockRejectedValueOnce(new Error('tx'));
+    const res = await POST(postReq(validInput), {});
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 400 Invalid input when the schema rejects', async () => {
+    safeParse.mockReturnValueOnce({ success: false, error: { flatten: () => ({}) } });
+    const res = await POST(postReq(validInput), {});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 when organizationId is missing', async () => {
+    organizationId = undefined as unknown as string;
+    const res = await POST(postReq(validInput), {});
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /api/model-governance/change-request', () => {
+  it('returns 200 with the org-scoped change requests', async () => {
+    rows = [{ id: 'cr-1' }, { id: 'cr-2' }];
+    const res = await GET(new Request('http://localhost/api/model-governance/change-request'), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.changeRequests).toHaveLength(2);
+  });
+
+  it('returns 403 when organizationId is missing', async () => {
+    organizationId = undefined as unknown as string;
+    const res = await GET(new Request('http://localhost/api/model-governance/change-request'), {});
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 4 BLOCK-4 (#402). model-governance `change-request` (POST/GET) + `change-request/[id]/eval` (POST) — 테스트 부재로 실행 0% → **실행형 테스트 추가**.

## Coverage (lcov, main 기준)
| file | before | after |
|---|---|---|
| change-request/route.ts | 0% | 전 분기 커버 (64L) |
| change-request/[id]/eval/route.ts | 0% | 전 분기 커버 (69L) |
| **All files** | 67.36% | **67.52%** (+0.16) |

## Branches (SPEC-REGULA-MODEL-GOVERNANCE-001, REQ-MODELGOV-004/005/010/011)
- POST: 201, **Prompt/ModelPin IDOR 404×2**, createChangeRequest 에러 500, invalid 400, no-org 403
- GET: org-scoped list, no-org 403
- [id]/eval POST: evalStatus **passed/failed 게이트** (score/threshold/reason), IDOR 404, missing-id 400, invalid 400, no-org 403

## Gates (L-009/L-015 직검)
- `pnpm vitest run`: 14/14 · `ci:typecheck` 0 err · `ci:lint` clean · `ci:coverage` floor **66/75/66/66 PASS**

Refs #402 Phase 4

🗿 MoAI <email@mo.ai.kr>