### PR TITLE
test(coverage): auth/signup + auth/change-password 실행형 테스트 (#402 Phase 4)

### DIFF
--- a/app/api/auth/change-password/__tests__/route.exec.test.ts
+++ b/app/api/auth/change-password/__tests__/route.exec.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for PATCH /api/auth/change-password (SPEC-REGULA-AUTH-001).
+// @MX:SPEC SPEC-REGULA-AUTH-001
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let session: { user: { id: string } } | null = { user: { id: 'u-1' } };
+let userQueue: unknown[][] = [];
+
+type AuditInput = {
+  actor_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  meta_json?: Record<string, unknown>;
+};
+
+const writeAudit = vi.fn(async (_input: AuditInput) => {});
+const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/audit', () => ({ writeAudit }));
+vi.mock('@/lib/auth', () => ({ auth: vi.fn(async () => session) }));
+vi.mock('bcryptjs', () => ({ default: { hash: vi.fn(async () => 'hashed') } }));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued user row.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(userQueue.shift() ?? []);
+  return {
+    db: {
+      select: () => chain,
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ update: () => ({ set: () => ({ where: txUpdateWhere }) }) }),
+      ),
+    },
+  };
+});
+
+const { PATCH } = await import('@/app/api/auth/change-password/route');
+
+function patchReq(body: unknown): Request {
+  return new Request('http://localhost/api/auth/change-password', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  session = { user: { id: 'u-1' } };
+  userQueue = [];
+});
+
+describe('PATCH /api/auth/change-password (SPEC-REGULA-AUTH-001)', () => {
+  it('returns 200 + profile.update audit (mustChangePasswordCleared) on success', async () => {
+    userQueue = [[{ id: 'u-1', mustChangePassword: true }]];
+    const res = await PATCH(patchReq({ password: 'newpassword1' }));
+    expect(res.status).toBe(200);
+    expect(txUpdateWhere).toHaveBeenCalled();
+    const audits = writeAudit.mock.calls.map((c) => (c as unknown[])[0] as AuditInput);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.meta_json).toMatchObject({
+      passwordChanged: true,
+      mustChangePasswordCleared: true,
+    });
+  });
+
+  it('returns 401 when there is no session', async () => {
+    session = null;
+    const res = await PATCH(patchReq({ password: 'newpassword1' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when the user is not found', async () => {
+    userQueue = [[]];
+    const res = await PATCH(patchReq({ password: 'newpassword1' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 on a too-short password', async () => {
+    const res = await PATCH(patchReq({ password: 'short' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/auth/signup/__tests__/route.exec.test.ts
+++ b/app/api/auth/signup/__tests__/route.exec.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for POST /api/auth/signup (OWASP A01:2021 deferred-role signup).
+// @MX:SPEC SPEC-REGULA-AUTH-001
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let existingQueue: unknown[][] = [];
+
+type AuditInput = {
+  actor_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  meta_json?: Record<string, unknown>;
+};
+
+const writeAudit = vi.fn(async (_input: AuditInput) => {});
+const txInsertReturning = vi.fn().mockResolvedValue([{ id: 'u-1' }]);
+
+vi.mock('@/lib/audit', () => ({ writeAudit }));
+vi.mock('bcryptjs', () => ({ default: { hash: vi.fn(async () => 'hashed') } }));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued existing-user result.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(existingQueue.shift() ?? []);
+  return {
+    db: {
+      select: () => chain,
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ insert: () => ({ values: () => ({ returning: txInsertReturning }) }) }),
+      ),
+    },
+  };
+});
+
+const { POST } = await import('@/app/api/auth/signup/route');
+
+function postReq(body: unknown): Request {
+  return new Request('http://localhost/api/auth/signup', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = { name: 'Regula User', email: 'reg@example.com', password: 'securepass1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  existingQueue = [];
+  txInsertReturning.mockResolvedValue([{ id: 'u-1' }]);
+});
+
+describe('POST /api/auth/signup (OWASP A01:2021 deferred role)', () => {
+  it('returns 201 + profile.update audit (actor_id null, source signup) on success', async () => {
+    existingQueue = [[]];
+    const res = await POST(postReq(validBody));
+    expect(res.status).toBe(201);
+    const audits = writeAudit.mock.calls.map((c) => (c as unknown[])[0] as AuditInput);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      actor_id: null,
+      action: 'profile.update',
+      resource_type: 'user',
+    });
+    expect(audits[0]?.meta_json).toMatchObject({ status: 'pending', source: 'signup' });
+  });
+
+  it('returns 409 when the email is already in use', async () => {
+    existingQueue = [[{ id: 'u-x' }]];
+    const res = await POST(postReq(validBody));
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 400 on an invalid email', async () => {
+    const res = await POST(postReq({ ...validBody, email: 'not-an-email' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 on a too-short password', async () => {
+    const res = await POST(postReq({ ...validBody, password: 'short' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when the insert returns no row', async () => {
+    existingQueue = [[]];
+    txInsertReturning.mockResolvedValue([]);
+    const res = await POST(postReq(validBody));
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 (#402). auth/signup (POST public, deferred-role OWASP A01) + auth/change-password (PATCH) — 테스트 부재로 실행 0% → 실행형 테스트. signup(409/400/500/audit actor null) + change-password(401/404/400/audit) 분기 커버. 전 분기 커버, floor 66/75/66/66 PASS (vitest 9/9 · typecheck 0 · lint clean · coverage 67.51/76.4/66.4/67.51). bcrypt/db/auth mock. Refs #402 Phase 4. 🗿 MoAI <email@mo.ai.kr>