### PR TITLE
test(coverage): workflow events SSE 3종 (indication-impact/submission-drafter/audit-response) (#402 Phase 4)

### DIFF
--- a/app/api/ra/workflows/audit-response/[runId]/events/__tests__/route.exec.test.ts
+++ b/app/api/ra/workflows/audit-response/[runId]/events/__tests__/route.exec.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET .../audit-response/[runId]/events (SPEC-REGULA-WORKFLOWS-LLM-002).
+// @MX:SPEC SPEC-REGULA-WORKFLOWS-LLM-002 (AC-04 / REQ-WFLLM-002 / M4)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const buildEventsResponse = vi.fn(
+  async (
+    _runId: string,
+    _userId: string,
+    _orgId: string,
+    opts: { wireInput: (input: unknown) => unknown },
+  ) => {
+    opts.wireInput({ deficiency: 'x' });
+    return new Response(null, { status: 200 });
+  },
+);
+const wireAuditResponseInput = vi.fn((input: unknown) => ({ wired: input }));
+const executeAuditResponseStep = vi.fn();
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, { user: { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' } }),
+  ),
+}));
+vi.mock('@/lib/workflows/_shared/events-route', () => ({ buildEventsResponse }));
+vi.mock('@/lib/workflows/_shared/input-wiring', () => ({ wireAuditResponseInput }));
+vi.mock('@/lib/workflows/audit-response/executor', () => ({
+  executeStep: executeAuditResponseStep,
+}));
+
+const { GET } = await import('@/app/api/ra/workflows/audit-response/[runId]/events/route');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET .../audit-response/[runId]/events', () => {
+  it('delegates to buildEventsResponse with workflowType audit_response and wires input', async () => {
+    const res = await GET(new Request('http://localhost/events'), { params: { runId: 'r-1' } });
+    expect(res.status).toBe(200);
+    expect(buildEventsResponse).toHaveBeenCalledWith(
+      'r-1',
+      'user-001',
+      'org-001',
+      expect.objectContaining({ workflowType: 'audit_response' }),
+    );
+    expect(wireAuditResponseInput).toHaveBeenCalledWith(
+      expect.objectContaining({ cerResults: null }),
+    );
+  });
+});

--- a/app/api/ra/workflows/indication-impact/[runId]/events/__tests__/route.exec.test.ts
+++ b/app/api/ra/workflows/indication-impact/[runId]/events/__tests__/route.exec.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET .../indication-impact/[runId]/events (SPEC-REGULA-WORKFLOWS-LLM-002).
+// @MX:SPEC SPEC-REGULA-WORKFLOWS-LLM-002 (AC-04 / REQ-WFLLM-002 / M4)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const buildEventsResponse = vi.fn(
+  // Invoke opts.wireInput so the route's arrow closure is covered.
+  async (
+    _runId: string,
+    _userId: string,
+    _orgId: string,
+    opts: { wireInput: (input: unknown) => unknown },
+  ) => {
+    opts.wireInput({ indication: 'x' });
+    return new Response(null, { status: 200 });
+  },
+);
+const wireIndicationImpactInput = vi.fn((input: unknown) => ({ wired: input }));
+const executeIndicationImpactStep = vi.fn();
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, { user: { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' } }),
+  ),
+}));
+vi.mock('@/lib/workflows/_shared/events-route', () => ({ buildEventsResponse }));
+vi.mock('@/lib/workflows/_shared/input-wiring', () => ({ wireIndicationImpactInput }));
+vi.mock('@/lib/workflows/indication-impact/executor', () => ({
+  executeStep: executeIndicationImpactStep,
+}));
+
+const { GET } = await import('@/app/api/ra/workflows/indication-impact/[runId]/events/route');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET .../indication-impact/[runId]/events', () => {
+  it('delegates to buildEventsResponse with workflowType indication_impact and wires input', async () => {
+    const res = await GET(new Request('http://localhost/events'), { params: { runId: 'r-1' } });
+    expect(res.status).toBe(200);
+    expect(buildEventsResponse).toHaveBeenCalledWith(
+      'r-1',
+      'user-001',
+      'org-001',
+      expect.objectContaining({ workflowType: 'indication_impact' }),
+    );
+    // The wireInput arrow was invoked → wireIndicationImpactInput called with pccpResults:null.
+    expect(wireIndicationImpactInput).toHaveBeenCalledWith(
+      expect.objectContaining({ pccpResults: null }),
+    );
+  });
+});

--- a/app/api/ra/workflows/submission-drafter/[runId]/events/__tests__/route.exec.test.ts
+++ b/app/api/ra/workflows/submission-drafter/[runId]/events/__tests__/route.exec.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET .../submission-drafter/[runId]/events (SPEC-REGULA-WORKFLOWS-LLM-002).
+// @MX:SPEC SPEC-REGULA-WORKFLOWS-LLM-002 (AC-04 / REQ-WFLLM-002 / M4)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const buildEventsResponse = vi.fn(
+  async (
+    _runId: string,
+    _userId: string,
+    _orgId: string,
+    opts: { wireInput: (input: unknown) => unknown },
+  ) => {
+    opts.wireInput({ device: 'x' });
+    return new Response(null, { status: 200 });
+  },
+);
+const wireSubmissionDrafterInput = vi.fn((input: unknown) => ({ wired: input }));
+const executeSubmissionDrafterStep = vi.fn();
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, { user: { id: 'user-001', role: 'ra-lead', organizationId: 'org-001' } }),
+  ),
+}));
+vi.mock('@/lib/workflows/_shared/events-route', () => ({ buildEventsResponse }));
+vi.mock('@/lib/workflows/_shared/input-wiring', () => ({ wireSubmissionDrafterInput }));
+vi.mock('@/lib/workflows/submission-drafter/executor', () => ({
+  executeStep: executeSubmissionDrafterStep,
+}));
+
+const { GET } = await import('@/app/api/ra/workflows/submission-drafter/[runId]/events/route');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET .../submission-drafter/[runId]/events', () => {
+  it('delegates to buildEventsResponse with workflowType submission_drafter and wires input', async () => {
+    const res = await GET(new Request('http://localhost/events'), { params: { runId: 'r-1' } });
+    expect(res.status).toBe(200);
+    expect(buildEventsResponse).toHaveBeenCalledWith(
+      'r-1',
+      'user-001',
+      'org-001',
+      expect.objectContaining({ workflowType: 'submission_drafter' }),
+    );
+    expect(wireSubmissionDrafterInput).toHaveBeenCalledWith(
+      expect.objectContaining({ predicateResults: null }),
+    );
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 (#402). 3개 workflow SSE events 라우트 — 테스트 부재 → 실행형 테스트. buildEventsResponse 위임 + wireInput 화살표 커버. 전 분기 커버, floor 66/75/66/66 PASS (vitest 3/3 · typecheck 0 · lint clean · coverage 67.52 · full suite 5501 passed). Refs #402 Phase 4. 🗿 MoAI <email@mo.ai.kr>