### PR TITLE
test(coverage): knowledge-promo/search + admin/users/[id] + checklists items (#402 Phase 4)

### DIFF
--- a/app/api/admin/users/[id]/__tests__/route.exec.test.ts
+++ b/app/api/admin/users/[id]/__tests__/route.exec.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for PATCH /api/admin/users/[id] (SPEC-REGULA-ENTERPRISE-001).
+// @MX:SPEC SPEC-REGULA-ENTERPRISE-001
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+
+type AuditInput = {
+  actor_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  meta_json?: Record<string, unknown>;
+};
+
+const writeAudit = vi.fn(async (_input: AuditInput) => {});
+const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/audit', () => ({ writeAudit }));
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated)
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        return handler(req, ctx, { user: { id: 'admin-1', role: 'admin', organizationId } });
+      },
+  ),
+}));
+vi.mock('@/lib/db/client', () => ({
+  db: {
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({ update: () => ({ set: () => ({ where: txUpdateWhere }) }) }),
+    ),
+  },
+}));
+
+const { PATCH } = await import('@/app/api/admin/users/[id]/route');
+
+function patchReq(body: unknown): Request {
+  return new Request('http://localhost/api/admin/users/u-1', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+});
+
+describe('PATCH /api/admin/users/[id]', () => {
+  it('returns 200 + profile.update audit (admin) on a valid status', async () => {
+    const res = await PATCH(patchReq({ status: 'active' }), { params: { id: 'u-1' } });
+    expect(res.status).toBe(200);
+    expect(txUpdateWhere).toHaveBeenCalled();
+    const audits = writeAudit.mock.calls.map((c) => (c as unknown[])[0] as AuditInput);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.meta_json).toMatchObject({ status: 'active', admin: true });
+  });
+
+  it('returns 400 on an invalid status enum', async () => {
+    const res = await PATCH(patchReq({ status: 'banned' }), { params: { id: 'u-1' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when id is absent', async () => {
+    const res = await PATCH(patchReq({ status: 'active' }), { params: {} });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/knowledge-promo/search/__tests__/route.exec.test.ts
+++ b/app/api/knowledge-promo/search/__tests__/route.exec.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET /api/knowledge-promo/search (SPEC-REGULA-KNOWLEDGE-PROMO-001).
+// @MX:SPEC SPEC-REGULA-KNOWLEDGE-PROMO-001 (REQ-001/002/003, AC-01)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+
+const searchOrgConversations = vi.fn();
+const searchPromotedSemantic = vi.fn();
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated)
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        return handler(req, ctx, { user: { id: 'user-001', role: 'ra-member', organizationId } });
+      },
+  ),
+}));
+vi.mock('@/lib/knowledge-promo/semantic-search', () => ({
+  searchOrgConversations,
+  searchPromotedSemantic,
+}));
+
+const { GET } = await import('@/app/api/knowledge-promo/search/route');
+
+function getReq(query: string): Request {
+  return new Request(`http://localhost/api/knowledge-promo/search?${query}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  searchOrgConversations.mockResolvedValue([{ id: 'c1' }]);
+  searchPromotedSemantic.mockResolvedValue([{ id: 'p1' }]);
+});
+
+describe('GET /api/knowledge-promo/search (REQ-001/002/003, AC-01)', () => {
+  it('returns 200 fulltext mode (default) via searchOrgConversations', async () => {
+    const res = await GET(getReq('q=510k'), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ mode: 'fulltext' });
+    expect(body.conversations).toHaveLength(1);
+    expect(body.promoted).toEqual([]);
+    expect(searchOrgConversations).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: 'org-001', query: '510k' }),
+    );
+  });
+
+  it('returns 200 semantic mode via searchPromotedSemantic', async () => {
+    const res = await GET(getReq('q=510k&mode=semantic'), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ mode: 'semantic' });
+    expect(body.promoted).toHaveLength(1);
+    expect(body.conversations).toEqual([]);
+    expect(searchPromotedSemantic).toHaveBeenCalled();
+  });
+
+  it('returns 400 invalid_mode for an unknown mode', async () => {
+    const res = await GET(getReq('q=x&mode=hybrid'), {});
+    expect(res.status).toBe(400);
+  });
+
+  it('clamps limit to the 1–50 range', async () => {
+    await GET(getReq('q=x&limit=999'), {});
+    expect(searchOrgConversations).toHaveBeenCalledWith(expect.objectContaining({ limit: 50 }));
+  });
+
+  it('returns 403 no_org_context when orgId is missing', async () => {
+    organizationId = undefined as unknown as string;
+    const res = await GET(getReq('q=x'), {});
+    expect(res.status).toBe(403);
+  });
+});

--- a/app/api/ra/checklists/[id]/items/[itemId]/__tests__/route.exec.test.ts
+++ b/app/api/ra/checklists/[id]/items/[itemId]/__tests__/route.exec.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for PATCH /api/ra/checklists/[id]/items/[itemId] (SPEC-INTEGRATION-001).
+// @MX:SPEC SPEC-INTEGRATION-001, Issue #170
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+
+type AuditInput = {
+  actor_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  meta_json?: Record<string, unknown>;
+};
+
+class HybridRaClientError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'HybridRaClientError';
+    this.statusCode = statusCode;
+  }
+}
+
+const writeAudit = vi.fn(async (_input: AuditInput) => {});
+const hybridFetch = vi.fn();
+
+vi.mock('@/lib/audit', () => ({ writeAudit }));
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated)
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        return handler(req, ctx, { user: { id: 'user-001', role: 'ra-lead', organizationId } });
+      },
+  ),
+}));
+vi.mock('@/lib/api/hybrid-ra-client', () => ({
+  createHybridRaFetch: vi.fn(() => hybridFetch),
+  HybridRaClientError,
+}));
+
+const { PATCH } = await import('@/app/api/ra/checklists/[id]/items/[itemId]/route');
+
+function patchReq(body: unknown): Request {
+  return new Request('http://localhost/api/ra/checklists/cl-1/items/it-1', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  hybridFetch.mockResolvedValue({ json: async () => ({ ok: true }) });
+});
+
+describe('PATCH /api/ra/checklists/[id]/items/[itemId] (BFF proxy + audit)', () => {
+  it('returns 200 + checklist.toggle audit (sorted updatedFields) on success', async () => {
+    const res = await PATCH(patchReq({ checked: true, note: 'x' }), {
+      params: { id: 'cl-1', itemId: 'it-1' },
+    });
+    expect(res.status).toBe(200);
+    const audits = writeAudit.mock.calls.map((c) => (c as unknown[])[0] as AuditInput);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.meta_json).toMatchObject({
+      checklistId: 'cl-1',
+      updatedFields: ['checked', 'note'],
+    });
+  });
+
+  it('passes HybridRaClientError status + message through', async () => {
+    hybridFetch.mockRejectedValueOnce(new HybridRaClientError('upstream unavailable', 502));
+    const res = await PATCH(patchReq({ checked: true }), {
+      params: { id: 'cl-1', itemId: 'it-1' },
+    });
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toBe('upstream unavailable');
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 (#402). 3 라우트 — knowledge-promo/search(fulltext/semantic + limit clamp), admin/users/[id](status PATCH + audit), ra/checklists/[id]/items/[itemId](BFF proxy + checklist.toggle audit). 전 분기 커버, floor 66/75/66/66 PASS (vitest 10/10 · typecheck 0 · lint clean · coverage 67.52). Refs #402 Phase 4. 🗿 MoAI <email@mo.ai.kr>