### PR TITLE
test(coverage): model-gov/rollback + checklists/generate + admin/radar/health (#402 Phase 4)

### DIFF
--- a/app/api/admin/radar/health/__tests__/route.exec.test.ts
+++ b/app/api/admin/radar/health/__tests__/route.exec.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET /api/admin/radar/health (SPEC-REGULA-RADAR-001).
+// @MX:SPEC SPEC-REGULA-RADAR-001
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+let selectQueue: unknown[][] = [];
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated)
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        return handler(req, ctx, { user: { id: 'admin-1', role: 'admin', organizationId } });
+      },
+  ),
+}));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.orderBy = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued select result.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(selectQueue.shift() ?? []);
+  return { db: { select: () => chain } };
+});
+
+const { GET } = await import('@/app/api/admin/radar/health/route');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  selectQueue = [];
+});
+
+describe('GET /api/admin/radar/health (SPEC-REGULA-RADAR-001)', () => {
+  it('returns 200 ok with last crawler run + 24h update count', async () => {
+    selectQueue = [
+      [{ crawlerName: 'fda', startedAt: 'ts', status: 'ok' }], // last run
+      [{ count: '5' }], // count(*) — pg returns numeric as string
+    ];
+    const res = await GET(new Request('http://localhost/api/admin/radar/health'), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('ok');
+    expect(body.last_crawler_run).toMatchObject({ crawlerName: 'fda' });
+    expect(body.updates_last_24h).toBe(5);
+  });
+
+  it('returns 200 with null last_crawler_run when no runs exist', async () => {
+    selectQueue = [[], [{ count: '0' }]];
+    const res = await GET(new Request('http://localhost/api/admin/radar/health'), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.last_crawler_run).toBeNull();
+    expect(body.updates_last_24h).toBe(0);
+  });
+});

--- a/app/api/model-governance/rollback/__tests__/route.exec.test.ts
+++ b/app/api/model-governance/rollback/__tests__/route.exec.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for POST /api/model-governance/rollback (SPEC-REGULA-MODEL-GOVERNANCE-001).
+// @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (REQ-MODELGOV-006, AC-03)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+
+class RollbackError extends Error {
+  reason: string;
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'RollbackError';
+    this.reason = reason;
+  }
+}
+
+const rollbackCombination = vi.fn();
+const safeParse = vi.fn();
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated)
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        return handler(req, ctx, { user: { id: 'user-001', role: 'ra-lead', organizationId } });
+      },
+  ),
+}));
+vi.mock('@/lib/model-governance/rollback', () => ({ rollbackCombination, RollbackError }));
+vi.mock('@/lib/model-governance/types', () => ({ rollbackInputSchema: { safeParse } }));
+
+const { POST } = await import('@/app/api/model-governance/rollback/route');
+
+function postReq(body: unknown): Request {
+  return new Request('http://localhost/api/model-governance/rollback', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  rollbackCombination.mockResolvedValue({ fromId: 'c-2', toId: 'c-1' });
+  safeParse.mockReturnValue({ success: true, data: { toCombinationId: 'c-1' } });
+});
+
+describe('POST /api/model-governance/rollback (REQ-MODELGOV-006, AC-03)', () => {
+  it('returns 200 with from/to ids on success', async () => {
+    const res = await POST(postReq({ toCombinationId: 'c-1' }), {});
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ fromId: 'c-2', toId: 'c-1' });
+  });
+
+  it('returns 404 when the rollback target is not found', async () => {
+    rollbackCombination.mockRejectedValueOnce(new RollbackError('combination_not_found'));
+    const res = await POST(postReq({ toCombinationId: 'cx' }), {});
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 on a non-not-found RollbackError', async () => {
+    rollbackCombination.mockRejectedValueOnce(new RollbackError('no_previous_version'));
+    const res = await POST(postReq({ toCombinationId: 'c-1' }), {});
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 500 on a generic rollback error', async () => {
+    rollbackCombination.mockRejectedValueOnce(new Error('tx aborted'));
+    const res = await POST(postReq({ toCombinationId: 'c-1' }), {});
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 400 Invalid input when the schema rejects', async () => {
+    safeParse.mockReturnValueOnce({ success: false, error: { flatten: () => ({}) } });
+    const res = await POST(postReq({}), {});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 when organizationId is missing', async () => {
+    organizationId = undefined as unknown as string;
+    const res = await POST(postReq({ toCombinationId: 'c-1' }), {});
+    expect(res.status).toBe(403);
+  });
+});

--- a/app/api/ra/checklists/generate/__tests__/route.exec.test.ts
+++ b/app/api/ra/checklists/generate/__tests__/route.exec.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for POST /api/ra/checklists/generate (SPEC-INTEGRATION-001).
+// @MX:SPEC SPEC-INTEGRATION-001, Issue #170
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authenticated = true;
+let organizationId = 'org-001';
+
+type AuditInput = {
+  actor_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  meta_json?: Record<string, unknown>;
+};
+
+class HybridRaClientError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'HybridRaClientError';
+    this.statusCode = statusCode;
+  }
+}
+
+const writeAudit = vi.fn(async (_input: AuditInput) => {});
+const hybridFetch = vi.fn();
+
+vi.mock('@/lib/audit', () => ({ writeAudit }));
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) => {
+        if (!authenticated)
+          return Promise.resolve(Response.json({ error: 'Unauthorized' }, { status: 401 }));
+        return handler(req, ctx, { user: { id: 'user-001', role: 'ra-lead', organizationId } });
+      },
+  ),
+}));
+vi.mock('@/lib/api/hybrid-ra-client', () => ({
+  createHybridRaFetch: vi.fn(() => hybridFetch),
+  HybridRaClientError,
+}));
+
+const { POST } = await import('@/app/api/ra/checklists/generate/route');
+
+function postReq(body: unknown): Request {
+  return new Request('http://localhost/api/ra/checklists/generate', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authenticated = true;
+  organizationId = 'org-001';
+  hybridFetch.mockResolvedValue({ json: async () => ({ id: 'cl-1' }) });
+});
+
+describe('POST /api/ra/checklists/generate (BFF proxy + audit)', () => {
+  it('returns 201 + workflow.start audit (resource_id from projectId) on success', async () => {
+    const res = await POST(postReq({ projectId: 'proj-9', deviceClass: 'II' }), {});
+    expect(res.status).toBe(201);
+    const audits = writeAudit.mock.calls.map((c) => (c as unknown[])[0] as AuditInput);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.resource_id).toBe('proj-9');
+    expect(audits[0]?.meta_json?.requestFields).toEqual(['deviceClass', 'projectId']);
+  });
+
+  it('uses a fallback resource_id when projectId is absent', async () => {
+    await POST(postReq({ deviceClass: 'II' }), {});
+    const audits = writeAudit.mock.calls.map((c) => (c as unknown[])[0] as AuditInput);
+    expect(audits[0]?.resource_id).toBe('checklist.generate');
+  });
+
+  it('passes HybridRaClientError status + message through', async () => {
+    hybridFetch.mockRejectedValueOnce(new HybridRaClientError('upstream unavailable', 502));
+    const res = await POST(postReq({ projectId: 'p' }), {});
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toBe('upstream unavailable');
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 (#402). 3 라우트 — model-gov/rollback(RollbackError not_found→404/409/500), checklists/generate(BFF proxy+audit), admin/radar/health(last run+24h count). 전 분기 커버, floor 66/75/66/66 PASS (vitest 11/11 · typecheck 0 · lint clean · coverage 67.49). Refs #402 Phase 4. 🗿 MoAI <email@mo.ai.kr>