### PR TITLE
test(coverage): ra/templates + locale — app/api 0% 라우트 완결 (#402 Phase 4)

### DIFF
--- a/app/api/locale/__tests__/route.exec.test.ts
+++ b/app/api/locale/__tests__/route.exec.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET /api/locale (cookie-based locale switch).
+// @MX:SPEC SPEC-REGULA-I18N-001
+
+import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+
+const { GET } = await import('@/app/api/locale/route');
+
+function getReq(query: string): NextRequest {
+  return new NextRequest(`http://localhost/api/locale?${query}`);
+}
+
+describe('GET /api/locale (cookie-based locale switch)', () => {
+  it('returns 307 with en locale cookie + redirect to returnTo', async () => {
+    const res = await GET(getReq('locale=en&returnTo=/dashboard'));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe('http://localhost/dashboard');
+    const cookie = res.headers.get('Set-Cookie') ?? '';
+    expect(cookie).toContain('regula-locale=en');
+    expect(cookie).toContain('SameSite=Lax');
+  });
+
+  it('defaults to ko for a non-en locale param', async () => {
+    const res = await GET(getReq('locale=ja&returnTo=/'));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Set-Cookie')).toContain('regula-locale=ko');
+  });
+
+  it('sanitizes a non-relative returnTo to /', async () => {
+    const res = await GET(getReq('locale=en&returnTo=http://evil.example'));
+    expect(res.headers.get('Location')).toBe('http://localhost/');
+  });
+
+  it('defaults returnTo to / when absent', async () => {
+    const res = await GET(getReq('locale=en'));
+    expect(res.headers.get('Location')).toBe('http://localhost/');
+  });
+});

--- a/app/api/ra/templates/__tests__/route.exec.test.ts
+++ b/app/api/ra/templates/__tests__/route.exec.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Execution tests for GET /api/ra/templates (SPEC-REGULA-ENTERPRISE-001).
+// @MX:SPEC SPEC-REGULA-ENTERPRISE-001 (REQ-ENTERPRISE-019)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let rows: unknown[] = [];
+
+vi.mock('@/lib/auth/with-permission', () => ({
+  withPermission: vi.fn(
+    (
+      _action: string,
+      handler: (req: Request, ctx: unknown, session: unknown) => Promise<Response>,
+    ) =>
+      (req: Request, ctx: unknown) =>
+        handler(req, ctx, {
+          user: { id: 'user-001', role: 'ra-member', organizationId: 'org-001' },
+        }),
+  ),
+}));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.orderBy = () => chain;
+  // Intentional thenable: `await` on the chain resolves to rows.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(rows);
+  return { db: { select: () => chain } };
+});
+
+const { GET } = await import('@/app/api/ra/templates/route');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rows = [];
+});
+
+describe('GET /api/ra/templates (REQ-ENTERPRISE-019)', () => {
+  it('returns 200 with the template list', async () => {
+    rows = [{ id: 't1' }, { id: 't2' }];
+    const res = await GET(new Request('http://localhost/api/ra/templates'), {});
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.templates).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 (#402). 마지막 2개 0% 라우트 — ra/templates(GET list), locale(cookie switch + returnTo sanitization). ★이것으로 app/api의 모든 0% route (>=20L) 커버 완료. floor 66/75/66/66 PASS (vitest 5/5 · typecheck 0 · lint clean · coverage). Refs #402 Phase 4. 🗿 MoAI <email@mo.ai.kr>