### PR TITLE
test(coverage): lib/cer/meddev-stages + lib/qa/contrast-check 단위 테스트 (#402 Phase 4)

### DIFF
--- a/lib/cer/__tests__/meddev-stages.test.ts
+++ b/lib/cer/__tests__/meddev-stages.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Unit tests for lib/cer/meddev-stages (SPEC-REGULA-CER-001).
+// @MX:SPEC SPEC-REGULA-CER-001 (REQ-CER-001~011)
+
+import { describe, expect, it } from 'vitest';
+import { CER_STAGES, type CerStageId, getStage, isLastStage } from '../meddev-stages';
+
+describe('meddev-stages (SPEC-REGULA-CER-001)', () => {
+  it('exposes the 10-stage canonical CER outline in order', () => {
+    expect(CER_STAGES).toHaveLength(10);
+    expect(CER_STAGES.map((s) => s.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('getStage returns the matching stage for a valid id', () => {
+    const s1 = getStage(1);
+    expect(s1.id).toBe(1);
+    expect(typeof s1.title).toBe('string');
+    expect(getStage(10).id).toBe(10);
+  });
+
+  it('getStage throws on an unknown id', () => {
+    expect(() => getStage(99 as CerStageId)).toThrow(/Unknown CER stage id/);
+  });
+
+  it('isLastStage is true only for stage 10', () => {
+    expect(isLastStage(10)).toBe(true);
+    expect(isLastStage(1)).toBe(false);
+  });
+});

--- a/lib/qa/__tests__/contrast-check.test.ts
+++ b/lib/qa/__tests__/contrast-check.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Unit tests for lib/qa/contrast-check pure functions (SPEC-REGULA-VALIDATION-002).
+// @MX:SPEC SPEC-REGULA-VALIDATION-002 (#368, REQ-ENTERPRISE-048)
+//
+// Tests the pure WCAG math/parsing helpers. runContrastCheck (fs-based) is
+// covered by the CI integration test; not exercised here.
+
+import { describe, expect, it } from 'vitest';
+import {
+  channelLuminance,
+  contrastRatio,
+  extractHexValue,
+  relativeLuminance,
+} from '../contrast-check';
+
+describe('contrast-check pure helpers (SPEC-REGULA-VALIDATION-002)', () => {
+  it('channelLuminance returns 0 for black and 1 for white', () => {
+    expect(channelLuminance(0)).toBeCloseTo(0, 5);
+    expect(channelLuminance(255)).toBeCloseTo(1, 5);
+  });
+
+  it('relativeLuminance is 0 for #000000 and 1 for #ffffff (with or without #)', () => {
+    expect(relativeLuminance('#000000')).toBeCloseTo(0, 5);
+    expect(relativeLuminance('ffffff')).toBeCloseTo(1, 5);
+    expect(relativeLuminance('#ffffff')).toBeCloseTo(1, 5);
+  });
+
+  it('contrastRatio is 21 for black/white and 1 for identical colors', () => {
+    expect(contrastRatio('#ffffff', '#000000')).toBeCloseTo(21, 0);
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 0);
+    expect(contrastRatio('#abcdef', '#abcdef')).toBeCloseTo(1, 5);
+  });
+
+  it('extractHexValue resolves a direct hex and returns null for var()/no-match', () => {
+    expect(extractHexValue('--color-brand-500: #2563eb', '--color-brand-500')).toBe('#2563eb');
+    expect(extractHexValue('--color-x: var(--other)', '--color-x')).toBeNull();
+    expect(extractHexValue('no token here', '--color-missing')).toBeNull();
+  });
+
+  it('a known AA-pass pair exceeds 4.5', () => {
+    // brand-800 (~dark) on brand-50 (~light) — high contrast.
+    expect(contrastRatio('#1e3a5f', '#f0f7ff')).toBeGreaterThan(4.5);
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 (#402). 2개 pure lib — meddev-stages(getStage/isLastStage/CER_STAGES), contrast-check(WCAG luminance/contrastRatio/extractHexValue). 모킹 불필요 pure 함수 전 분기. floor 66/75/66/66 PASS (vitest 9/9 · typecheck 0 · lint clean · coverage 67.59). Refs #402 Phase 4. 🗿 MoAI <email@mo.ai.kr>