### PR TITLE
test(coverage): lib/corpus-license/access + lib/model-governance/access (#402 Phase 4)

### DIFF
--- a/lib/corpus-license/__tests__/access.test.ts
+++ b/lib/corpus-license/__tests__/access.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Unit tests for lib/corpus-license/access (SPEC-REGULA-CORPUS-LICENSE-001).
+// @MX:SPEC SPEC-REGULA-CORPUS-LICENSE-001 (REQ-CORPUSLIC-012)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let selectQueue: unknown[][] = [];
+
+const auditCorpusAccessDenied = vi.fn(async () => {});
+
+vi.mock('@/lib/corpus-license/audit', () => ({ auditCorpusAccessDenied }));
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued select result.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(selectQueue.shift() ?? []);
+  return { db: { select: () => chain } };
+});
+
+const { assertSourceInOrg, assertSourceLicenseInOrg } = await import('../access');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectQueue = [];
+});
+
+describe('assertSourceLicenseInOrg (REQ-CORPUSLIC-012)', () => {
+  it('returns {id, sourceId} on an in-org match', async () => {
+    selectQueue = [[{ id: 'lic-1', sourceId: 'src-1', orgId: 'org-1' }]];
+    expect(
+      await assertSourceLicenseInOrg({ sourceLicenseId: 'lic-1', orgId: 'org-1', userId: 'u-1' }),
+    ).toEqual({
+      id: 'lic-1',
+      sourceId: 'src-1',
+    });
+    expect(auditCorpusAccessDenied).not.toHaveBeenCalled();
+  });
+
+  it('returns null on a missing row (no audit)', async () => {
+    selectQueue = [[]];
+    expect(
+      await assertSourceLicenseInOrg({ sourceLicenseId: 'x', orgId: 'org-1', userId: 'u-1' }),
+    ).toBeNull();
+    expect(auditCorpusAccessDenied).not.toHaveBeenCalled();
+  });
+
+  it('returns null + audits on a cross-org mismatch', async () => {
+    selectQueue = [[{ id: 'lic-1', sourceId: 'src-1', orgId: 'org-B' }]];
+    expect(
+      await assertSourceLicenseInOrg({ sourceLicenseId: 'lic-1', orgId: 'org-A', userId: 'u-1' }),
+    ).toBeNull();
+    expect(auditCorpusAccessDenied).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'source_license_cross_org' }),
+    );
+  });
+});
+
+describe('assertSourceInOrg', () => {
+  it('returns true on an in-org match', async () => {
+    selectQueue = [[{ id: 'src-1', orgId: 'org-1' }]];
+    expect(await assertSourceInOrg({ sourceId: 'src-1', orgId: 'org-1', userId: 'u-1' })).toBe(
+      true,
+    );
+  });
+
+  it('returns false on a missing source (no audit)', async () => {
+    selectQueue = [[]];
+    expect(await assertSourceInOrg({ sourceId: 'x', orgId: 'org-1', userId: 'u-1' })).toBe(false);
+  });
+
+  it('returns false + audits on a cross-org mismatch', async () => {
+    selectQueue = [[{ id: 'src-1', orgId: 'org-B' }]];
+    expect(await assertSourceInOrg({ sourceId: 'src-1', orgId: 'org-A', userId: 'u-1' })).toBe(
+      false,
+    );
+    expect(auditCorpusAccessDenied).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'source_cross_org' }),
+    );
+  });
+});

--- a/lib/model-governance/__tests__/access.test.ts
+++ b/lib/model-governance/__tests__/access.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+// @MX:NOTE [AUTO] Unit tests for lib/model-governance/access (SPEC-REGULA-MODEL-GOVERNANCE-001).
+// @MX:SPEC SPEC-REGULA-MODEL-GOVERNANCE-001 (Issue 71)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let selectQueue: unknown[][] = [];
+
+vi.mock('@/lib/db/client', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.limit = () => chain;
+  // Intentional thenable: `await` on the chain pops the next queued select result.
+  // biome-ignore lint/suspicious/noThenProperty: deliberate chainable thenable for the db mock
+  chain.then = (resolve: (v: unknown) => void) => resolve(selectQueue.shift() ?? []);
+  return { db: { select: () => chain } };
+});
+
+const { assertChangeRequestAccess, assertModelPinAccess, assertPromptAccess } = await import(
+  '../access'
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectQueue = [];
+});
+
+describe('assertPromptAccess', () => {
+  it('returns true when the prompt row exists in-org', async () => {
+    selectQueue = [[{ id: 'p-1' }]];
+    expect(await assertPromptAccess('p-1', 'org-1')).toBe(true);
+  });
+
+  it('returns false when the row is missing', async () => {
+    selectQueue = [[]];
+    expect(await assertPromptAccess('px', 'org-1')).toBe(false);
+  });
+});
+
+describe('assertModelPinAccess', () => {
+  it('returns true / false based on row presence', async () => {
+    selectQueue = [[{ id: 'mp-1' }]];
+    expect(await assertModelPinAccess('mp-1', 'org-1')).toBe(true);
+    selectQueue = [[]];
+    expect(await assertModelPinAccess('mx', 'org-1')).toBe(false);
+  });
+});
+
+describe('assertChangeRequestAccess', () => {
+  it('returns the row on success', async () => {
+    selectQueue = [
+      [
+        {
+          id: 'cr-1',
+          promptId: 'p-1',
+          modelPinId: 'mp-1',
+          evalStatus: 'passed',
+          approvalStatus: 'approved',
+        },
+      ],
+    ];
+    const row = await assertChangeRequestAccess('cr-1', 'org-1');
+    expect(row).toMatchObject({ id: 'cr-1', evalStatus: 'passed' });
+  });
+
+  it('returns null on a missing / cross-org row', async () => {
+    selectQueue = [[]];
+    expect(await assertChangeRequestAccess('cx', 'org-1')).toBeNull();
+  });
+});


### PR DESCRIPTION
Phase 4 BLOCK-4 (#402). 2개 IDOR access 가드 lib — corpus-license/access(sourceLicense/source + cross-org audit), model-governance/access(prompt/modelPin/changeRequest). 전 분기 커버, floor 66/75/66/66 PASS (vitest 11/11 · typecheck 0 · lint clean · coverage). Refs #402 Phase 4. 🗿 MoAI <email@mo.ai.kr>