### PR TITLE
docs(v3): #531 SPEC-V3-RESTRUCTURE-001 kernel-only 재스코프 v1.1.0

### DIFF
--- a/.moai/specs/SPEC-V3-RESTRUCTURE-001/spec.md
+++ b/.moai/specs/SPEC-V3-RESTRUCTURE-001/spec.md
@@ -1,13 +1,13 @@
 ---
 id: SPEC-V3-RESTRUCTURE-001
-version: 1.0.0
+version: 1.1.0
 status: planned
 phase: restructure
 priority: High
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-21
 author: manager-spec
-issue_number: 35
+issue_number: 531
 depends_on:
   - SPEC-REGULA-PHI-REMOVAL-001 (PHI 제거 완료 후 아카이브 잔여 도메인 정리)
 supersedes: []
@@ -17,17 +17,18 @@ labels:
   - component/schema
   - component/structure
   - type/restructure
-  - type/archive
+  - type/kernel
   - domain/architecture
 ---
 
-# SPEC-V3-RESTRUCTURE-001 — v3 구조 정리 (Phase A+B: 아카이브 잔여 14도메인 + lib/kernel/ 추출 + schema.ts 분할)
+# SPEC-V3-RESTRUCTURE-001 — v3 구조 정리 (Phase B: lib/kernel/ 추출 + schema.ts 분할 — kernel-only 재스코프, Phase A 8도메인 아카이브 완료)
 
 ## HISTORY
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 1.0.0 | 2026-07-02 | manager-spec | 초기 작성. Phase C-2 완료(4도메인 아카이브) 후 잔여 14도메인 + kernel 추출 + schema 분할을 다룸. 마스터 계획 `docs/proposals/v3-architecture-revamp-plan-2026-07-02.md` 기반. |
+| 1.1.0 | 2026-07-21 | manager-spec (rescope, #531) | kernel-only 재스코프. Phase A(#530) 8도메인 아카이브 완료로 잔여 아카이브 태스크 제거. 수치 직검 정정(baseline 4815→5450, codemod 178→289, FK 261→274, migration 106→125, pgTable 86→94, schema 3232→3531). drizzle 선례 거짓 정정(신규 배선). |
 
 ---
 
@@ -35,81 +36,60 @@ labels:
 
 ### 1.1 배경 (Background)
 
-Regula v3 아키텍처 개편의 **Phase A(아카이브 잔여) + Phase B(kernel 추출 + schema 분할)** 를 다룬다. Phase C-2에서 0-의존성 4도메인(clinical-investigation, cyberdevice, labeling, change-control, 106 files)이 이미 `archive/qms-pms/`로 이동 완료되었다. 본 SPEC은 **잔여 14도메인**의 아카이브를 완료하고, 공유 인프라(db/auth/audit)를 `lib/kernel/`로 추출하며, 단일 `schema.ts`(3,232줄, 86 pgTable)를 다중 파일로 분할한다.
+Regula v3 아키텍처 개편 중 **Phase B(kernel 추출 + schema 분할)** 만을 다룬다. **Phase A(아카이브)는 #530/PR #534로 종료**되었다: 8도메인(change-control, clinical-investigation, cyberdevice, dhf, esubmit, labeling, samd, workflows)이 `archive/qms-pms/`로 이동 완료되었고 `.archive-manifest.json`(domain_count=8, total_files=148)이 생성되었으며 회귀 테스트는 green(5450 passed, 0 failed, 68 skipped)이다.
 
-마스터 계획은 이를 계층 2.5(kernel/domain/archive 3-tier)로 정의하며, Drizzle 다중 스키마 파일 glob 로드(`schema-docingest.ts` 선례 검증됨)로 전환한다.
+본 SPEC은 공유 인프라(db/auth/audit)를 `lib/kernel/`로 추출하고, 단일 `schema.ts`(3,531줄, 94 pgTable)를 다중 파일로 분할한다. 마스터 계획은 이를 계층 2.5(kernel/domain/archive 3-tier)로 정의한다.
 
-### 1.2 Phase A 대상 — 잔여 14 도메인 (직접 검증, 2026-07-02)
+**Drizzle 다중 스키마 파일 glob 로드(신규 배선 — 현재 `drizzle.config.ts`는 단일 `'./lib/db/schema.ts'` 참조, `schema-docingest.ts` 미배선, 선례 아님).** Phase B에서 이를 array 형태로 신규 전환한다.
 
-**SHRINK 2종** (필요 파일은 KEEP 도메인으로 이동, 나머지 아카이브):
+### 1.2 Phase A 상태 — 완료 (#530/PR #534, 8도메인)
 
-1. **`lib/rlhf/` (17 files)**: `applyRlhfReranking` in `lib/rlhf/retrieval-hook.ts` → `lib/ai/`로 이동. `lib/ai/merge.ts:7`가 이 함수를 import하여 RAG 결과 재랭킹에 사용. 나머지 16 files 아카이브.
-2. **`lib/knowledge-gap/` (13 files)**: `markGapResolved`/`replayGapTest` in `lib/knowledge-gap/replay.ts` → `lib/radar/`로 이동. `lib/radar/delta-sync/gap-replay.ts:14`가 이 함수들을 import하여 delta-sync 후 gap 재테스트에 사용. 나머지 12 files 아카이브.
+**Phase A 완료(#530/PR #534)**: 8도메인 아카이브 — change-control, clinical-investigation, cyberdevice, dhf, esubmit, labeling, samd, workflows. `.archive-manifest.json` 갱신(domain_count=8, total_files=148). 회귀 baseline 5450 passed, 0 failed, 68 skipped (live run 2026-07-21).
 
-**고의존성 8종** (stub 교체 / import 제거 / KEEP 유지 도메인별 판단):
+**잔여 QMS 인접 도메인은 #519 오케스트레이터 판정상 KEEP 재분류**되어 본 SPEC 범위에서 제외된다. `ls lib/` 직검(2026-07-21)으로 라이브 보존 확인:
+- `lib/rlhf/`, `lib/knowledge-gap/`, `lib/risk/`, `lib/pccp/`, `lib/traceability/`, `lib/knowledge-promo/`, `lib/model-governance/`, `lib/standards/`, `lib/project-memory/`, `lib/corpus-license/` — 전부 LIVE (KEEP)
+- `lib/classification/`, `lib/classify/`, `lib/domains/`, `lib/ai/`, `lib/radar/`, `lib/ingest/` 등 — v3 활성 도메인 (KEEP)
 
-| 도메인 | lib files | app routes | SPEC | 비고 |
-|---|---|---|---|---|
-| `lib/risk/` | 11 | 13 | SPEC-REGULA-RISK-001 | cross-import 0종 (독립) — 저의존성과 동일하게 바로 이동 가능 |
-| `lib/traceability/` | 17 | 11 | SPEC-REGULA-TRACEABILITY-001 | cross-import 1종 (lib/predicate → lib/traceability 0건, 역방향 traceability→predicate) |
-| `lib/corpus-license/` | 10 | 3 | SPEC-REGULA-CORPUS-LICENSE-001 | cross-import 1종 |
-| `lib/pccp/` | 14 | 6 | SPEC-REGULA-PCCP-001 | cross-import 1종 |
-| `lib/knowledge-promo/` | 5 | 4 | SPEC-REGULA-KNOWLEDGE-PROMO-001 | RETIRE (audit/db/observability만 참조 — 공유 인프라) |
-| `lib/model-governance/` | 13 | 6 | SPEC-REGULA-MODEL-GOVERNANCE-001 | cross-import 0종 (독립) |
-| `lib/standards/` | 12 | 7 | SPEC-REGULA-STANDARDS-001 | cross-import 1종 |
-| `lib/project-memory/` | 4 | 5 | SPEC-REGULA-PROJECT-MEMORY-001 | cross-import 2종 |
+**pccp는 #521에 따라 규제 제출물(QMS 아님)로 라이브 보존**된다(아카이브 등재 삭제). 잔여 도메인 처분은 별도 거버넌스 결정이며, 본 kernel-only 재스코프에서는 다루지 않는다.
 
-**저의존성 4종** (0-의존성과 동일하게 바로 이동):
-
-| 도메인 | lib files | app routes | SPEC | 비고 |
-|---|---|---|---|---|
-| `lib/dhf/` | 1 | 11 | (SPEC 없음) | QMS 핵심 |
-| `lib/pms/` | 1 | 0 | SPEC-REGULA-PMS-001 | 라우트는 workflows 사용 |
-| `lib/samd/` | 1 | 7 | (SPEC 없음) | QMS 보조 |
-| `lib/esubmit/` | 1 | 9 | (SPEC 없음) | stub, UI 0 |
-
-**잔여 14도메인 총계 (직접 검증)**: lib 120 files + app 90 files = **210 files**. SPEC 11개 (dhf/samd/esubmit은 SPEC 없음).
+> **주의**: 본 SPEC v1.0.0의 "잔여 14도메인 아카이브 + SHRINK(rlhf/knowledge-gap)" 계획은 Phase A의 8도메인 완료와 잔여 도메인 KEEP 재판정으로 무효화되었다. 본 v1.1.0에서는 kernel 추출(Phase B)만 다룬다.
 
 ### 1.3 Phase B 대상 — kernel 추출 + schema 분할
 
 **lib/kernel/ 추출** (공유 인프라 경계 확립):
 
-| 현재 위치 | 이동 위치 | 참조 파일 수 | 역할 |
+| 현재 위치 | 이동 위치 | 참조 파일 수 (직검 2026-07-21) | 역할 |
 |---|---|---|---|
-| `lib/db/` | `lib/kernel/db/` | 173 | DB 클라이언트, schema-kernel |
-| `lib/auth/` | `lib/kernel/auth/` | 178 | Auth.js v5, RBAC |
-| `lib/audit/` | `lib/kernel/audit/` | 116 | writeAudit, append-only |
-| `lib/ratelimit/` | `lib/kernel/ratelimit/` | — | KV ratelimiter |
-| `lib/storage/` | `lib/kernel/storage/` | — | Object storage |
-| `lib/schemas/` | `lib/kernel/schemas/` | — | Zod 공유 스키마 |
+| `lib/db/` | `lib/kernel/db/` | 174 | DB 클라이언트, schema-kernel |
+| `lib/auth/` | `lib/kernel/auth/` | 181 | Auth.js v5, RBAC |
+| `lib/audit/` | `lib/kernel/audit/` | 119 | writeAudit, append-only |
+| `lib/ratelimit/` | `lib/kernel/ratelimit/` | 0 | KV ratelimiter (kernel re-export만 유지, codemod 비대상) |
+| `lib/storage/` | `lib/kernel/storage/` | 0 | Object storage (kernel re-export만 유지, codemod 비대상) |
+| `lib/schemas/` | `lib/kernel/schemas/` | 4 | Zod 공유 스키마 (codemod 대상 포함) |
 
-**schema.ts 분할** (Drizzle 다중 스키마 파일 — `schema-docingest.ts` 선례):
+**schema.ts 분할** (Drizzle 다중 스키마 파일 — 신규 전환, 선례 아님):
 
-| 파일 | 내용 | 테이블 수 (예상) |
+| 파일 | 내용 | 테이블 수 (직검) |
 |---|---|---|
-| `lib/kernel/db/schema-kernel.ts` | users, audit_log, audit_verify_history, sessions | ~5 |
-| `lib/db/schema.ts` (레거시) | KEEP 도메인 + 아카이브 도메인 테이블 (감소 상태 유지, `@deprecated` 주석) | ~81 |
+| `lib/kernel/db/schema-kernel.ts` | kernel 테이블 — 직검 식별된 export: `users`(L668), `auditLogs`(L1285, table `audit_logs`), `sessions`(L1537). `verificationTokens`(L1567)은 kernel 후보(run phase에서 확정). 명목 ~3-4 테이블. | 3-4 |
+| `lib/db/schema.ts` (레거시) | KEEP 도메인 + 아카이브 도메인 테이블 (감소 상태 유지, `@deprecated` 주석 — Phase A 미적용 상태) | ~90 |
 
-> **주의**: 본 SPEC에서는 kernel 테이블 분할(Phase B-1)만 수행. per-domain schema 분할(ai/ks/inbox/impact/registry)은 Phase C 신규 도메인 구현 시 개별 SPEC에서 처리. `drizzle.config.ts`의 glob 로드 확장만 본 SPEC 범위.
+> **주의**: 본 SPEC v1.0.0의 "kernel 테이블 ~5개(users, audit_log, audit_verify_history, sessions)" 추정치는 직검 결과 정정된다. `audit_verify_history` 테이블은 존재하지 않으며, 가장 가까운 것은 `verificationTokens`(L1567)이다. kernel 테이블 확정 집합과 수는 run phase B2에서 사전 grep으로 최종 확정한다. 본 SPEC에서는 kernel 테이블 분할(Phase B-2)만 수행한다. per-domain schema 분할(ai/ks/inbox/impact/registry)은 Phase C 신규 도메인 구현 시 개별 SPEC에서 처리. `drizzle.config.ts`의 glob 로드 확장만 본 SPEC 범위.
 
 ### 1.4 규제·정책 근거 (Policy Anchor)
 
-- **Charter [지양-3] QMS 대체 금지**: 14도메인 중 다수가 QMS 운영 기능(risk, traceability, pccp, dhf, pms, samd, esubmit, standards). Regula는 RA 문서 분석 AI지 QMS 운영 시스템이 아니므로 아카이브가 정책 정합.
-- **Charter [지양-5] SaaS 외판 금지**: corpus-license, knowledge-promo는 SaaS 경계 도메인. 내부 6-8명 팀 범위 밖.
-- **데이터 안전성**: 아카이브는 코드/라우트 이동만. DB 테이블, RLS 정책, audit enum은 migration 제자리 유지로 보존.
+- **Charter [지양-3] QMS 대체 금지**: Phase A에서 8개 QMS/PLM 도메인 아카이브 완료. 잔여 도메인(risk, traceability, pccp, rlhf, knowledge-gap 등)은 #519 KEEP 재판정으로 라이브 보존.
+- **Charter [지양-5] SaaS 외판 금지**: kernel 추출은 내부 인프라 경계 확립이며 SaaS 경계 확장 아님.
+- **데이터 안전성**: migration은 제자리 유지. DB 테이블, RLS 정책, audit enum은 migration 제자리 유지로 보존.
 
 ### 1.5 본 SPEC의 범위 (In Scope)
 
-- 잔여 14도메인 lib 120 files + app 90 files → `archive/qms-pms/` 이동
-- SHRINK: rlhf `retrieval-hook.ts`의 `applyRlhfReranking` → `lib/ai/`로, knowledge-gap `replay.ts`의 `markGapResolved`/`replayGapTest` → `lib/radar/`로 이동
-- 크로스 임포트 처리: stub 교체 / import 제거 / KEEP 유지 도메인별 판단
-- lib/kernel/ 디렉토리 생성, db/auth/audit/ratelimit/storage/schemas 이동
-- lib/kernel/index.ts 공개 API (re-export 레이어, 새 추상층 금지)
-- schema.ts에서 kernel 테이블(users, audit_log 등 ~5개) 발췌 → schema-kernel.ts
-- drizzle.config.ts glob 로드 확장 (schema.ts + schema-kernel.ts)
-- 아카이브 도메인 테이블에 `@deprecated` 주석 (Phase C-2 누락 보완)
-- codemod 스크립트로 import 경로 일괄 변경 (`@/lib/db` → `@/lib/kernel/db` 등)
-- .archive-manifest.json 갱신 (Phase C-2 4도메인 + 본 SPEC 14도메인 = 총 18도메인)
+- lib/kernel/ 디렉토리 생성, db/auth/audit/ratelimit/storage/schemas 이동 (git mv)
+- lib/kernel/index.ts 공개 API (re-export 레이어, 새 추상층 금지 — REQ-V3R-004)
+- schema.ts에서 kernel 테이블(`users`, `auditLogs`, `sessions`, + `verificationTokens` 후보) 발췌 → schema-kernel.ts
+- drizzle.config.ts glob 로드 확장 (단일 `'./lib/db/schema.ts'` → array: schema-kernel + schema + schema-docingest). **신규 전환(선례 아님)**
+- codemod 스크립트로 import 경로 일괄 변경: `@/lib/db`(174) → `@/lib/kernel/db`, `@/lib/auth`(181) → `@/lib/kernel/auth`, `@/lib/audit`(119) → `@/lib/kernel/audit`, `@/lib/schemas`(4) → `@/lib/kernel/schemas`. **union 289 파일(동적 import 55건 포함, 배럴 re-export 포함 — L-014)**
+- `.archive-manifest.json` 유지 (Phase A #530 완료 상태: 8도메인, total_files=148)
 
 ### 1.6 Out of Scope
 
@@ -118,8 +98,9 @@ Regula v3 아키텍처 개편의 **Phase A(아카이브 잔여) + Phase B(kernel
 - audit_log hash chain 강화 — Phase D, SPEC-V3-AUDIT-CHAIN-001
 - BFF 통합 (lib/api → lib/bff) — Phase E, SPEC-V3-BFF-001
 - per-domain schema 분할 (schema-ai.ts, schema-ks.ts 등) — Phase C에서 도메인별 처리
-- migration 테이블 DROP — **영구 금지** (261 FK 보존)
+- migration 테이블 DROP — **영구 금지** (274 FK 보존)
 - 운영 DB 데이터 삭제 (TRUNCATE 포함) — 별도 purge 작업 시 사용자 승인 필수
+- **Phase A 아카이브 재이동 금지** (#530 완료, 잔여 도메인은 #519 KEEP 재분류 — 본 SPEC은 kernel 추출만)
 
 ---
 
@@ -127,19 +108,19 @@ Regula v3 아키텍처 개편의 **Phase A(아카이브 잔여) + Phase B(kernel
 
 | ID | EARS Statement | Priority |
 |----|----------------|----------|
-| REQ-V3R-001 | **WHEN** 잔여 14도메인 아카이브 이동이 완료되면, **THEN** the system **SHALL** `pnpm typecheck && pnpm lint && pnpm test` 명령이 exit 0으로 통과하고 기준 회귀 테스트(4815 passed) 대비 신규 failure 0건을 유지하여야 한다 | High |
-| REQ-V3R-002 | **WHEN** SHRINK 대상 도메인(rlhf, knowledge-gap) 아카이브 시, **THEN** the system **SHALL** 필요 함수(`applyRlhfReranking`, `markGapResolved`, `replayGapTest`)를 KEEP 도메인(`lib/ai/`, `lib/radar/`)으로 먼저 이동시킨 후 나머지 파일들을 아카이브하여야 한다 (역참조 2건: `lib/ai/merge.ts`, `lib/radar/delta-sync/gap-replay.ts`) | High |
-| REQ-V3R-003 | **WHERE** KEEP 코드가 아카이브 도메인을 import 하는 경우, the system **SHALL** SHRINK(stub 교체 또는 함수 이동) / import 제거 / KEEP 유지 도메인별 판단 전략 중 하나로 100% 처리하여야 한다 (크로스 임포트 잔존 0건) | High |
+| REQ-V3R-001 | **WHEN** kernel 추출 및 schema 분할 완료 후, **THEN** the system **SHALL** `pnpm typecheck && pnpm lint && pnpm test` 명령이 exit 0으로 통과하고 기준 회귀 테스트(5450 passed, 0 failed, 68 skipped — live run 2026-07-21) 대비 신규 failure 0건을 유지하여야 한다 | High |
+| REQ-V3R-002 | **N/A (Phase A 완료로 무효화)**: 원 v1.0.0의 SHRINK 대상(rlhf, knowledge-gap)은 #519 KEEP 재판정으로 라이브 보존됨. `lib/rlhf/`, `lib/knowledge-gap/`은 archive 미이동. 본 SPEC 범위에서 제외. | N/A |
+| REQ-V3R-003 | **N/A (Phase A 완료로 무효화)**: 원 v1.0.0의 크로스 임포트 처리(KEEP→archive)는 잔여 도메인 KEEP 재분류로 대상 없음. Phase A 8도메인은 0-의존성/독립 이동 완료. | N/A |
 | REQ-V3R-004 | **WHILE** lib/kernel/ 추출 진행 중, the system **SHALL** kernel↔domain 순환 의존성이 0건이 되도록 보존하여야 한다 (kernel은 re-export 레이어, 새 추상층/의존성 역전 인터페이스 도입 금지 — TRUST 5 Readable) | High |
-| REQ-V3R-005 | **WHEN** schema.ts 분할 시, **THEN** the system **SHALL** Drizzle FK 관계 261개를 100% 보존하고 `drizzle-kit check`가 통과하여야 한다 (kernel 테이블 분리 시 references는 schema-kernel.ts의 export를 import하여 사용) | High |
-| REQ-V3R-006 | **THE SYSTEM SHALL** migration 디렉토리(106 files)를 제자리에 유지하고 아카이브 도메인 테이블의 DROP migration을 작성하지 않아야 한다 (선형 체인 보존, 261 FK 참조 붕괴 방지) | High |
-| REQ-V3R-007 | **THE SYSTEM SHALL** 아카이브 대상 도메인 테이블(clinical_investigation, risk, traceability, pccp, rlhf, knowledge_gap 등)을 schema.ts에서 삭제하지 않고 `@deprecated` 주석으로 표시하여야 한다 (Phase C-2 4도메인 분 포함 보완) | Medium |
-| REQ-V3R-008 | **WHEN** Phase A(아카이브)가 완료되면, **THEN** the system **SHALL** archive/qms-pms/ 디렉토리에 총 18도메인(Phase C-2 4 + 본 SPEC 14)이 존재하고 .archive-manifest.json이 갱신되어야 한다 | High |
-| REQ-V3R-009 | **WHEN** Phase B(kernel 추출)의 codemod가 실행되면, **THEN** the system **SHALL** 178+ 파일의 `@/lib/db`, `@/lib/auth`, `@/lib/audit` import 경로를 `@/lib/kernel/db`, `@/lib/kernel/auth`, `@/lib/kernel/audit`로 일괄 변경하고 변경 누락 0건을 검증하여야 한다 | High |
-| REQ-V3R-010 | **IF** 아카이브 이동 중 RLS 정책 또는 audit enum 참조가 붕괴되면, **THEN** the system **SHALL** 즉시 중단하고 사용자에게 보고하여야 한다 (완화: migration 제자리 유지로 RLS/enum은 DB에 보존, schema.ts는 `@deprecated` 주석만) | Medium |
-| REQ-V3R-011 | **THE SYSTEM SHALL** 아카이브 순서를 안전 순서(저의존성 4종 → SHRINK 2종 → 고의존성 8종)로 수행하고 각 단계마다 회귀 테스트 게이트(4815+ passed)를 통과하여야 한다 | High |
+| REQ-V3R-005 | **WHEN** schema.ts 분할 시, **THEN** the system **SHALL** Drizzle FK 관계 274개를 100% 보존하고 `drizzle-kit check`가 통과하여야 한다 (kernel 테이블 분리 시 references는 schema-kernel.ts의 export를 import하여 사용) | High |
+| REQ-V3R-006 | **THE SYSTEM SHALL** migration 디렉토리(125 files)를 제자리에 유지하고 아카이브 도메인 테이블의 DROP migration을 작성하지 않아야 한다 (선형 체인 보존, 274 FK 참조 붕괴 방지) | High |
+| REQ-V3R-007 | **THE SYSTEM SHALL** 아카이브 대상 도메인 테이블(change-control, clinical-investigation, cyberdevice, dhf, esubmit, labeling, samd, workflows — 8도메인 분)을 schema.ts에서 삭제하지 않고 `@deprecated` 주석으로 표시하여야 한다 (Phase A #530에서 미적용 상태 — 본 SPEC Phase B에서 보완) | Medium |
+| REQ-V3R-008 | **WHEN** Phase A(아카이브)가 완료되면(선행 #530 완료), **THEN** the system **SHALL** archive/qms-pms/ 디렉토리에 8도메인(Phase A #530)이 존재하고 .archive-manifest.json(domain_count=8, total_files=148)이 유지되어야 한다 | High |
+| REQ-V3R-009 | **WHEN** Phase B(kernel 추출)의 codemod가 실행되면, **THEN** the system **SHALL** 289 파일(union, 동적 import 55건 포함)의 `@/lib/db`, `@/lib/auth`, `@/lib/audit`, `@/lib/schemas` import 경로를 `@/lib/kernel/db`, `@/lib/kernel/auth`, `@/lib/kernel/audit`, `@/lib/kernel/schemas`로 일괄 변경하고 변경 누락 0건을 검증하여야 한다 (L-014: 정적 + 동적 + 배럴 re-export grep) | High |
+| REQ-V3R-010 | **IF** kernel 추출 중 RLS 정책 또는 audit enum 참조가 붕괴되면, **THEN** the system **SHALL** 즉시 중단하고 사용자에게 보고하여야 한다 (완화: migration 제자리 유지로 RLS/enum은 DB에 보존) | Medium |
+| REQ-V3R-011 | **THE SYSTEM SHALL** kernel 추출을 안전 순서(B1 디렉토리 생성 → B2 schema-kernel 발췌 → B3 drizzle config 전환 → B4 kernel/index.ts → B5 codemod)로 수행하고 각 단계마다 회귀 테스트 게이트(5450+ passed)를 통과하여야 한다 | High |
 | REQ-V3R-012 | **WHEN** lib/kernel/index.ts 공개 API 작성 시, **THEN** the system **SHALL** 다음을 re-export 하여야 한다: `db`, `withTenantScope` (db/client), `getSession`, `requireRole`, `withPermission` (auth), `writeAudit`, `verifyHashChain` (audit), `rateLimit` (ratelimit), `uploadAsset` (storage) | Medium |
-| REQ-V3R-013 | **THE SYSTEM SHALL** .archive-manifest.json에 원본 경로, 체크섬, 복원 경로 매핑을 포함하여야 한다 (git mv 기반이므로 복원 용이) | Medium |
+| REQ-V3R-013 | **THE SYSTEM SHALL** .archive-manifest.json에 원본 경로, 체크섬, 복원 경로 매핑을 포함하여야 한다 (Phase A #530에서 생성 완료 — 본 SPEC은 유지만) | Medium |
 | REQ-V3R-014 | **WHEN** `next dev` 구동 중 페이지 로드 시, **THEN** the system **SHALL** 500 에러가 0건이어야 한다 (L-012: next dev 구동 중 pnpm build 금지 — `.next` chunk 충돌) | Medium |
 | REQ-V3R-015 | **IF** migration 체인 꼬임이 감지되면, **THEN** the system **SHALL** 즉시 중단하고 테이블 DROP 전면 금지, TRUNCATE만 허용 원칙을 적용하여야 한다 (L-013: 실DB 직검으로 검증) | Medium |
 
@@ -149,15 +130,15 @@ Regula v3 아키텍처 개편의 **Phase A(아카이브 잔여) + Phase B(kernel
 
 | AC# | Criterion | Verification |
 |-----|-----------|--------------|
-| AC-01 | 잔여 14도메인 아카이브 후 KEEP 코드 `pnpm typecheck && pnpm lint && pnpm test` green (회귀 4815+ 유지, 신규 failure 0) | test runner output |
-| AC-02 | 크로스 임포트 100% 처리: `grep -rn "from.*@/lib/rlhf\|from.*@/lib/knowledge-gap\|from.*@/lib/risk\|from.*@/lib/traceability\|from.*@/lib/corpus-license\|from.*@/lib/pccp\|from.*@/lib/knowledge-promo\|from.*@/lib/model-governance\|from.*@/lib/standards\|from.*@/lib/project-memory\|from.*@/lib/dhf\|from.*@/lib/pms\|from.*@/lib/samd\|from.*@/lib/esubmit" lib/ app/ components/` 결과에서 KEEP 코드 잔존 0건 (archive/ 내부 제외) | grep 게이트 |
+| AC-01 | kernel 추출 후 KEEP 코드 `pnpm typecheck && pnpm lint && pnpm test` green (회귀 5450+ 유지, 신규 failure 0) | test runner output |
+| AC-02 | **N/A (Phase A 완료)**: 원 v1.0.0의 크로스 임포트 grep 게이트는 잔여 도메인 KEEP 재분류로 대상 없음 | N/A |
 | AC-03 | lib/kernel/ 경계 확립: kernel↔domain 순환 의존성 0건 (`@/lib/kernel`이 `@/lib/domains`를 import 0건) | grep 게이트 |
-| AC-04 | schema.ts 분할 후 `pnpm drizzle-kit check` 통과, Drizzle FK 261개 보존 (분할 전후 FK 수 동일) | drizzle-kit check output + FK count 비교 |
-| AC-05 | migration/ 디렉토리 106 files 제자리 유지, 아카이브 도메인 테이블 DROP migration 0건 추가 | `ls migrations/*.sql \| wc -l` = 106 (불변) |
-| AC-06 | archive/qms-pms/ 총 18도메인 완료 (Phase C-2 4 + 본 SPEC 14), .archive-manifest.json 갱신 | `ls archive/qms-pms/lib/ \| wc -l` = 18 |
-| AC-07 | lib/db/schema.ts 아카이브 도메인 테이블에 `@deprecated` 주석 추가 (Phase C-2 4도메인 + 본 SPEC 14도메인 = 18도메인 분) | grep `@deprecated` 주석 |
-| AC-08 | SHRINK 검증: `applyRlhfReranking`이 `lib/ai/` 내부에 존재, `markGapResolved`/`replayGapTest`가 `lib/radar/` 내부에 존재, 원본 lib/rlhf/lib/knowledge-gap은 archive/로 이동 | grep + find |
-| AC-09 | codemod 후 `@/lib/db`, `@/lib/auth`, `@/lib/audit` import 경로가 `@/lib/kernel/*`로 일괄 변경됨 (178+ 파일), 변경 누락 0건 | grep `@/lib/db\|@/lib/auth\|@/lib/audit` 결과에서 kernel 경로 미사용 파일 0건 |
+| AC-04 | schema.ts 분할 후 `pnpm drizzle-kit check` 통과, Drizzle FK 274개 보존 (분할 전후 FK 수 동일) | drizzle-kit check output + FK count 비교 |
+| AC-05 | migration/ 디렉토리 125 files 제자리 유지, 아카이브 도메인 테이블 DROP migration 0건 추가 | `ls migrations/*.sql \| wc -l` = 125 (불변) |
+| AC-06 | archive/qms-pms/ 8도메인(Phase A #530 완료) 유지, .archive-manifest.json(domain_count=8, total_files=148) 존재 | `ls archive/qms-pms/lib/ \| wc -l` = 8 |
+| AC-07 | lib/db/schema.ts 아카이브 도메인 테이블(8도메인 분: change-control, clinical-investigation, cyberdevice, dhf, esubmit, labeling, samd, workflows)에 `@deprecated` 주석 추가 — **Phase A #530에서 미적용(grep `@deprecated` = 0), 본 SPEC Phase B에서 보완 필요** | grep `@deprecated` 주석 (현재 0 → 보완 후 8도메인 분) |
+| AC-08 | **N/A (Phase A 완료, KEEP 재분류)**: 원 v1.0.0의 SHRINK 검증(rlhf→lib/ai, knowledge-gap→lib/radar)은 #519 KEEP 판정으로 수행 안 함. rlhf/knowledge-gap은 라이브 유지. | N/A |
+| AC-09 | codemod 후 `@/lib/db`, `@/lib/auth`, `@/lib/audit`, `@/lib/schemas` import 경로가 `@/lib/kernel/*`로 일괄 변경됨 (289 파일 union, 동적 import 55건 포함), 변경 누락 0건 (정적+동적+배럴 grep) | grep `@/lib/db\|@/lib/auth\|@/lib/audit\|@/lib/schemas` 결과에서 kernel 경로 미사용 파일 0건 |
 | AC-10 | `next dev` 구동 후 주요 페이지(/, /admin, /ra) 로드 시 500 에러 0건 (L-012 준수) | E2E / 수동 확인 |
 | AC-11 | lib/kernel/index.ts가 REQ-V3R-012의 re-export 항목을 모두 포함 | grep kernel/index.ts export 키워드 |
 
@@ -165,60 +146,43 @@ Regula v3 아키텍처 개편의 **Phase A(아카이브 잔여) + Phase B(kernel
 
 ## §4 Technical Approach
 
-### 4.1 Phase A — 아카이브 안전 순서 (최소 regression risk)
+### 4.1 Phase A — 완료 (#530/PR #534)
 
-**원칙**: 저의존성 → SHRINK → 고의존성. 각 단계 독립 commit + regression test 게이트.
+**Phase A 완료(#530/PR #534)**: 8도메인 아카이브 + `.archive-manifest.json`(domain_count=8, total_files=148) 생성 + 회귀 green(5450 passed, 0 failed, 68 skipped). 본 SPEC v1.1.0에서 Phase A 재이동 태스크는 없다.
 
-| Sub-Phase | 작업 | Regression Risk | 검증 |
-|-------|------|-----------------|------|
-| **A1: 저의존성 4종** | dhf, pms, samd, esubmit (lib 4 files, app 27 files) → archive/ | 낮음 (cross-import 0건) | typecheck + test green |
-| **A2: 독립 2종** | risk (cross-import 0), model-governance (cross-import 0) → archive/ | 낮음 | typecheck + test green |
-| **A3: SHRINK 2종** | rlhf: `retrieval-hook.ts`의 `applyRlhfReranking` → `lib/ai/rlhf-adapter.ts`로 이동, 나머지 16 files 아카이브. knowledge-gap: `replay.ts`의 `markGapResolved`/`replayGapTest` → `lib/radar/gap-replay-adapter.ts`로 이동, 나머지 12 files 아카이브 | 중간 (SHRINK 이동 후 import 경로 갱신) | `lib/ai/merge.ts`, `lib/radar/delta-sync/gap-replay.ts` 컴파일 확인 |
-| **A4: 고의존성 6종** | knowledge-promo (RETIRE), traceability, corpus-license, pccp, standards, project-memory → archive/ (각 도메인별 stub/import 제거 판단) | 중간~높음 | 각 도메인별 typecheck 게이트 |
-| **A5: schema @deprecated** | schema.ts의 아카이브 18도메인 테이블에 `@deprecated` 주석 (Phase C-2 4도메인 포함 보완) | 낮음 (주석만) | grep 주석 확인 |
-| **A6: .archive-manifest 갱신** | Phase C-2 4도메인 + 본 SPEC 14도메인 = 18도메인 매니페스트 통합 | 낮음 | manifest 검증 |
+> **잔여 보완**: AC-07(`@deprecated` 주석)은 Phase A에서 미적용 상태(grep `@deprecated` in schema.ts = 0). 본 Phase B 진행 중 schema.ts 분할 시 8도메인 테이블에 `@deprecated` 주석을 보완 추가한다(REQ-V3R-007).
 
 ### 4.2 Phase B — Kernel 추출 + schema 분할
 
 | Sub-Phase | 작업 | Regression Risk | 검증 |
 |-------|------|-----------------|------|
-| **B1: lib/kernel/ 생성** | 디렉토리 생성, db/auth/audit/ratelimit/storage/schemas 이동 (git mv) | 높음 (178+ 파일 import 경로) | codemod 후 typecheck |
-| **B2: schema-kernel.ts 발췌** | schema.ts에서 users, audit_log, audit_verify_history, sessions (~5 테이블) 발췌 → schema-kernel.ts. references는 cross-file import 사용 | 높음 (FK 261개) | `drizzle-kit check` 즉시 검증 |
-| **B3: drizzle.config glob 확장** | `schema: './lib/db/schema.ts'` → `schema: ['./lib/kernel/db/schema-kernel.ts', './lib/db/schema.ts', './lib/db/schema-docingest.ts']` | 낮음 | drizzle-kit generate 확인 |
-| **B4: kernel/index.ts 작성** | REQ-V3R-012 re-export 항목 작성 (thin wrapper, 새 추상층 금지) | 낮음 | typecheck |
-| **B5: codemod import 경로** | `@/lib/db` → `@/lib/kernel/db`, `@/lib/auth` → `@/lib/kernel/auth` 등 178+ 파일 일괄 변경 | 높음 | grep 누락 0건 + test green |
+| **B1: lib/kernel/ 생성** | 디렉토리 생성, db/auth/audit/ratelimit/storage/schemas 이동 (git mv) | 높음 (289 파일 import 경로) | codemod 후 typecheck |
+| **B2: schema-kernel.ts 발췌** | schema.ts에서 kernel 테이블(`users` L668, `auditLogs` L1285, `sessions` L1537, + `verificationTokens` L1567 후보) 발췌 → schema-kernel.ts. references는 cross-file import 사용 | 높음 (FK 274개) | `drizzle-kit check` 즉시 검증 |
+| **B3: drizzle.config glob 확장** | `schema: './lib/db/schema.ts'`(단일) → `schema: ['./lib/kernel/db/schema-kernel.ts', './lib/db/schema.ts', './lib/db/schema-docingest.ts']`(array). **신규 전환(선례 아님 — 현재 schema-docingest.ts 미배선)** | 중간 | drizzle-kit generate --dry 무의도 diff 0 확인 |
+| **B4: kernel/index.ts 작성** | REQ-V3R-012 re-export 항목 작성 (thin wrapper, 새 추상층 금지) | 낮음 | typecheck + grep export |
+| **B5: codemod import 경로** | `@/lib/db` → `@/lib/kernel/db`, `@/lib/auth` → `@/lib/kernel/auth`, `@/lib/audit` → `@/lib/kernel/audit`, `@/lib/schemas` → `@/lib/kernel/schemas` (289 파일 union, 동적 import 55건 + 배럴 re-export 포함) 일괄 변경 | 높음 | 정적+동적+배럴 grep 누락 0건 + test green |
 
-### 4.3 도메인별 처리 전략 매트릭스 (run phase #35용)
+### 4.3 도메인별 처리 전략 — N/A (Phase A 완료)
 
-| 도메인 | 전략 | 크로스 임포트 처리 | 비고 |
-|---|---|---|---|
-| dhf, pms, samd, esubmit | DIRECT ARCHIVE | 없음 (0종) | 저의존성 |
-| risk, model-governance | DIRECT ARCHIVE | 없음 (0종) | 독립 |
-| rlhf | SHRINK | `lib/ai/merge.ts` import → `lib/ai/rlhf-adapter.ts`로 함수 이동 | `applyRlhfReranking` 보존 |
-| knowledge-gap | SHRINK | `lib/radar/delta-sync/gap-replay.ts` import → `lib/radar/gap-replay-adapter.ts`로 함수 이동 | `markGapResolved`/`replayGapTest` 보존 |
-| knowledge-promo | RETIRE | 공유 인프라(audit/db/observability)만 참조 → 바로 아카이브 | 기능 축소 |
-| traceability | STUB/IMPORT 제거 | lib/predicate ↔ lib/traceability (역방향 1종) — stub 또는 import 제거 | 도메인별 판단 |
-| corpus-license | STUB/IMPORT 제거 | lib/pccp ↔ lib/corpus-license 상호참조 — 한쪽 stub | 도메인별 판단 |
-| pccp | STUB/IMPORT 제거 | lib/corpus-license ↔ lib/pccp — corpus-license과 함께 처리 | 도메인별 판단 |
-| standards | STUB/IMPORT 제거 | lib/standards → 다른 도메인 1종 | 도메인별 판단 |
-| project-memory | STUB/IMPORT 제거 | lib/project-memory → 다른 도메인 2종 | 도메인별 판단 |
+본 v1.0.0의 Phase A 도메인 처리 매트릉스(dhf/pms/samd/esubmit DIRECT ARCHIVE, rlhf/knowledge-gap SHRINK, knowledge-promo RETIRE, traceability/corpus-license/pccp/standards/project-memory STUB 등)는 Phase A #530 8도메인 완료 + 잔여 도메인 #519 KEEP 재판정으로 대부분 N/A. 잔여 KEEP 도메인은 별도 거버넌스 결정이 필요하며 본 kernel-only 재스코프 범위 밖이다.
 
 ### 4.4 의존성 (Dependencies)
 
 - **선행**: SPEC-REGULA-PHI-REMOVAL-001 (PHI 제거 완료, Issue #319) — vigilance/capa 정리 후 아카이브 잔여 도메인 정리
-- **독립**: 본 SPEC은 구조 정리이므로 다른 진행 중 SPEC에 의존하지 않음
-- **후속 영향**: Phase C(v3 신규 도메인)가 lib/kernel/ 경계에 의존. Phase D(UI)가 kernel 추출 완료 전제. Phase E(BFF)는 독립적
+- **Phase A 선행 완료**: #530/PR #534 (8도메인 아카이브 + manifest 생성 + 회귀 green)
+- **독립**: 본 SPEC Phase B는 구조 정리이므로 다른 진행 중 SPEC에 의존하지 않음
+- **후속 영향**: Phase C(v3 신규 도메인)가 lib/kernel/ 경계에 의존. Phase D(UI)가 kernel 추출 완료 전제. Phase E(BFF)는 kernel auth/audit 사용(#531 §4.1)
 
 ### 4.5 Regression-Risk Matrix
 
 | 영역 | Risk | 완화 방안 |
 |------|------|-----------|
-| **schema.ts 분할 (FK 261개)** | HIGH — kernel 테이블 분리 시 Drizzle 타입 에러 | `drizzle-kit check` 즉시 검증, 점진적 분리 (kernel 테이블만 먼저, per-domain은 Phase C) |
-| **178+ 파일 import 경로 변경** | HIGH — codemod 누락 시 typecheck 에러 | grep으로 누락 0건 검증, 자동화 스크립트, 단계적 검증 |
-| **SHRINK 함수 이동** | MEDIUM — import 경로 갱신 누락 | `lib/ai/merge.ts`, `lib/radar/delta-sync/gap-replay.ts` 직검 |
-| **RLS 정책 / audit enum 참조** | MEDIUM — 아카이브 후 코드 부재 | migration 제자리 유지, schema.ts `@deprecated` 주석만 |
+| **schema.ts 분할 (FK 274개)** | HIGH — kernel 테이블 분리 시 Drizzle 타입 에러 | `drizzle-kit check` 즉시 검증, 점진적 분리 (kernel 테이블만 먼저, per-domain은 Phase C) |
+| **289 파일 import 경로 변경 (동적 import 55건 + 배럴 포함)** | HIGH — codemod 누락 시 typecheck 에러 | 정적+동적+배럴 grep으로 누락 0건 검증 (L-014), 자동화 스크립트, 단계적 검증 |
+| **drizzle config 신규 배선** | MEDIUM — schema-docingest.ts 편입이 신규 migration diff를 유발할 수 있음 | `drizzle-kit generate --dry`로 무의도 diff 0 확인, 필요시 편입 범위 조정 |
+| **RLS 정책 / audit enum 참조** | MEDIUM — kernel 이동 후 코드 부재 | migration 제자리 유지, schema.ts `@deprecated` 주석만 |
 | **migration 체인 꼬임** | HIGH — 테이블 DROP 시 CASCADE 필요 | 테이블 DROP 전면 금지, TRUNCATE만 (사용자 승인 시) |
-| **next dev 500 에러** | MEDIUM — 라우트 이동 후 chunk 충돌 | L-012: next dev 구동 중 build 금지, 페이지별 로드 테스트 |
+| **next dev 500 에러** | MEDIUM — import 경로 변경 후 chunk 충돌 | L-012: next dev 구동 중 build 금지, 페이지별 로드 테스트 |
 
 ---
 
@@ -232,14 +196,14 @@ Regula v3 아키텍처 개편의 **Phase A(아카이브 잔여) + Phase B(kernel
 
 ## §6 Rollback Plan
 
-### 6.1 코드 Rollback (Phase A — git mv 기반)
+### 6.1 코드 Rollback (Phase A — #530 완료, 본 SPEC에서 재이동 없음)
 
-- 각 sub-phase(A1~A6)를 개별 commit으로 분리 → 부분 rollback 가능
-- `git revert <commit>`로 파일 복구 (git mv이므로 역순 이동 용이)
-- SHRINK 이동 함수 rollback: `lib/ai/rlhf-adapter.ts`, `lib/radar/gap-replay-adapter.ts` 삭제 후 원본 위치로 복원
+- Phase A는 #530/PR #534에서 완료됨. 본 SPEC v1.1.0은 Phase A 태스크를 포함하지 않는다.
+- Phase A rollback이 필요한 경우: `git revert` #530 병합 커밋 (별도 거버넌스 결정 필요).
 
 ### 6.2 Kernel 추출 Rollback (Phase B)
 
+- 각 sub-phase(B1~B5)를 개별 commit으로 분리 → 부분 rollback 가능
 - import 경로 rollback: `@/lib/kernel/db` → `@/lib/db` 역codemod
 - schema-kernel.ts → schema.ts로 병합 (drizzle-kit check 검증)
 - lib/kernel/ 디렉토리 삭제 후 원본 위치로 git mv 역순
@@ -247,41 +211,49 @@ Regula v3 아키텍처 개편의 **Phase A(아카이브 잔여) + Phase B(kernel
 ### 6.3 전체 Rollback 시나리오
 
 1. 이전 main 브랜치로 `git revert` (feature branch 경유)
-2. 회귀 테스트 전체 실행 (4815+ passed 확인)
+2. 회귀 테스트 전체 실행 (5450+ passed 확인)
 3. `drizzle-kit check` + 실DB 스키마 일관성 검증 (L-013)
 
 ---
 
 ## §7 Exclusions (What NOT to Build)
 
-본 SPEC은 구조 정리만 다룬다. 다음은 명시적으로 제외:
+본 SPEC v1.1.0은 kernel 추출(Phase B)만 다룬다. 다음은 명시적으로 제외:
 
 - **v3 신규 도메인 구현 금지**: inbox/triage/consult/registry는 Phase C 개별 SPEC에서 구현
 - **UI 재작성 금지**: components/ 재작성은 Phase D, SPEC-V3-UI-001
 - **audit hash chain 강화 금지**: Phase D, SPEC-V3-AUDIT-CHAIN-001 (본 SPEC은 kernel 이동만)
 - **per-domain schema 분할 금지**: schema-ai.ts, schema-ks.ts 등은 Phase C에서 도메인별 처리 (본 SPEC은 kernel 테이블 분할만)
-- **테이블 DROP migration 금지**: 261 FK 보존, 아카이브 도메인 테이블은 schema.ts에 `@deprecated` 주석만
-- **새 추상층 도입 금지**: kernel은 re-export 레이어 (thin wrapper). 의존성 역전 인터페이스, Interface segregation 도입 안 함 (6-8명 팀에 불필요, TRUST 5 Readable)
+- **테이블 DROP migration 금지**: 274 FK 보존, 아카이브 도메인 테이블은 schema.ts에 `@deprecated` 주석만
+- **Phase A 아카이브 재이동 금지**: #530/PR #534에서 8도메인 아카이브 완료. 잔여 도메인(rlhf, knowledge-gap, risk, traceability, pccp, knowledge-promo, model-governance, standards, project-memory, corpus-license)은 #519 KEEP 재분류 — 본 SPEC에서 이동/SHRINK/RETIRE 금지
+- **새 추상층 도입 금지**: kernel은 re-export 레이어 (thin wrapper). 의존성 역전 인터페이스, Interface segregation 도입 안 함 (TRUST 5 Readable)
 - **의존성 역전 컨테이너 금지**: DI 프레임워크, 데코레이터 기반 주입 등 과잉 추상화 전면 금지
+
+### Out of Scope — Phase A 잔여 도메인 처분
+
+- 잔여 KEEP 도메인(risk, traceability, pccp, rlhf, knowledge-gap, knowledge-promo, model-governance, standards, project-memory, corpus-license)의 아카이브/SHRINK/RETIRE는 본 kernel-only 재스코프 범위 밖. 별도 거버넌스 결정 + 개별 SPEC 필요.
 
 ---
 
 ## §8 Follow-up Issues
 
 - (구현 중 발견 시 등록)
-- 아카이브 18도메인 테이블의 향후 DROP 여부 — 별도 이슈 (사용자 승인 필요, 데이터 보존 정책 확정 후)
+- 아카이브 8도메인 테이블의 향후 DROP 여부 — 별도 이슈 (사용자 승인 필요, 데이터 보존 정책 확정 후)
 - lib/classify vs lib/classification 중복 도메인 병합 — 본 SPEC 범위 밖, 별도 조사 권장
 - per-domain schema 분할 (schema-ai.ts 등) — Phase C에서 도메인별 SPEC 등록
+- kernel 테이블 확정 집합(`verificationTokens` L1567 포함 여부) — run phase B2 사전 grep으로 최종 확정
 
 ---
 
 ## §9 References
 
 - **마스터 계획**: `docs/proposals/v3-architecture-revamp-plan-2026-07-02.md` (676줄)
+- **재개 계획**: `docs/proposals/v3-abe-resumption-plan-2026-07-19.md` §3 (Phase B kernel 추출 상세)
 - **프로젝트 구조**: `.moai/project/structure.md` (v3 3-Tier 정의)
-- **Phase C-2 완료**: `archive/qms-pms/` (4도메인, 106 files)
-- **Charter**: `~/.claude/projects/-home-abyz-lab-work-workspace-github-holee9-ra-med-bot/memory/product-charter.md`
+- **Phase A 완료**: #530/PR #534 — archive/qms-pms/ (8도메인), `.archive-manifest.json` (domain_count=8, total_files=148)
+- **Charter**: `.moai/specs/CHARTER.md` v2.0.0
 - **선례 SPEC**: `.moai/specs/SPEC-REGULA-PHI-REMOVAL-001/spec.md` (대규모 도메인 제거 구조 참조)
-- **schema 분할 선례**: `lib/db/schema-docingest.ts` (Drizzle 다중 파일 검증됨)
-- **Lessons**: L-007(직검), L-010(migration 실DB), L-012(next dev build 금지), L-013(실DB 직검 3중 맹점)
-- **관련 이슈**: #35 (본 SPEC 진행 이슈), #319 (PHI 제거 선행)
+- **schema 분할 상태**: `lib/db/schema.ts` (3,531줄, 94 pgTable). `schema-docingest.ts`는 `drizzle.config.ts`에 **미배선** — 선례 아님, B3에서 array config로 신규 전환
+- **drizzle.config.ts**: `schema: './lib/db/schema.ts'` (단일 파일, L20 — 직검 2026-07-21)
+- **Lessons**: L-007(직검), L-010(migration 실DB), L-012(next dev build 금지), L-013(실DB 직검 3중 맹점), L-014(동적 import·배럴 grep)
+- **관련 이슈**: #35 (본 SPEC 진행 이슈), #319 (PHI 제거 선행), #530 (Phase A 종료 게이트), #531 (Phase B 재개), #519 (잔여 도메인 KEEP 재판정), #521 (pccp 규제 제출물 보존)

--- a/.moai/specs/SPEC-V3-RESTRUCTURE-001/tasks.md
+++ b/.moai/specs/SPEC-V3-RESTRUCTURE-001/tasks.md
@@ -1,86 +1,22 @@
-# Tasks — SPEC-V3-RESTRUCTURE-001
+# Tasks — SPEC-V3-RESTRUCTURE-001 (v1.1.0 kernel-only 재스코프)
 
-> v3 구조 정리 (Phase A: 아카이브 잔여 14도메인 + Phase B: kernel 추출 + schema.ts 분할)
-> 마스터 계획: `docs/proposals/v3-architecture-revamp-plan-2026-07-02.md`
+> v3 구조 정리 (Phase B: kernel 추출 + schema.ts 분할 — Phase A #530 완료)
+> 재개 계획: `docs/proposals/v3-abe-resumption-plan-2026-07-19.md` §3
 
 ---
 
 ## 사전 검증 (Pre-flight Checks)
 
-- [ ] **T0.1** 기준 회귀 테스트 확보: `pnpm test` 실행 → 4815+ passed 기록 (baseline)
-- [ ] **T0.2** 기준 FK 수 확보: `grep -c "REFERENCES" migrations/*.sql` → 261개 기록 (schema 분할 전후 비교용)
-- [ ] **T0.3** Phase C-2 아카이브 상태 확인: `ls archive/qms-pms/lib/` → change-control, clinical-investigation, cyberdevice, labeling (4도메인, 106 files)
+- [ ] **T0.1** 기준 회귀 테스트 확보: `pnpm test` 실행 → **5450 passed, 0 failed, 68 skipped** (5518 total, exit 0, 59.7s — live run 2026-07-21 baseline)
+- [ ] **T0.2** 기준 FK 수 확보: `grep -h REFERENCES migrations/*.sql | wc -l` → **274개** 기록 (schema 분할 전후 비교용). migration count: `ls migrations/*.sql | wc -l` → **125** (불변 확인용)
+- [ ] **T0.3** Phase A 아카이브 상태 확인: `ls archive/qms-pms/lib/` → **8도메인**(change-control, clinical-investigation, cyberdevice, dhf, esubmit, labeling, samd, workflows); `.archive-manifest.json` domain_count=8, total_files=148
 - [ ] **T0.4** 작업 브랜치 생성: `git checkout -b feat/v3-restructure-001`
 
 ---
 
-## Phase A — 아카이브 잔여 14도메인 (안전 순서)
+## Phase A — 완료 (#530/PR #534)
 
-### Sub-Phase A1: 저의존성 4종 아카이브 (Priority High)
-
-- [ ] **T1.1** `lib/dhf/` (1 file) + app/*dhf* (11 files) → `archive/qms-pms/lib/dhf/`, `archive/qms-pms/app/dhf/`로 git mv
-- [ ] **T1.2** `lib/pms/` (1 file) → `archive/qms-pms/lib/pms/`로 git mv (app 라우트 0건)
-- [ ] **T1.3** `lib/samd/` (1 file) + app/*samd* (7 files) → `archive/qms-pms/`로 git mv
-- [ ] **T1.4** `lib/esubmit/` (1 file) + app/*esubmit* (9 files) → `archive/qms-pms/`로 git mv
-- [ ] **T1.5** 회귀 게이트: `pnpm typecheck && pnpm test` → baseline 대비 failure 0건
-- [ ] **T1.6** commit: `chore(archive): A1 저의존성 4도메인 아카이브 (dhf/pms/samd/esubmit)`
-
-### Sub-Phase A2: 독립 2종 아카이브 (Priority High)
-
-- [ ] **T2.1** `lib/risk/` (11 files) + app/*risk* (13 files) → `archive/qms-pms/`로 git mv (cross-import 0종)
-- [ ] **T2.2** `lib/model-governance/` (13 files) + app/*model-governance* (6 files) → `archive/qms-pms/`로 git mv (cross-import 0종)
-- [ ] **T2.3** 회귀 게이트: `pnpm typecheck && pnpm test` → failure 0건
-- [ ] **T2.4** commit: `chore(archive): A2 독립 2도메인 아카이브 (risk/model-governance)`
-
-### Sub-Phase A3: SHRINK 2종 (필요 함수 이동 후 아카이브) (Priority High)
-
-- [ ] **T3.1** **rlhf SHRINK**: `lib/rlhf/retrieval-hook.ts`에서 `applyRlhfReranking` 함수 + 관련 타입 발췌 → `lib/ai/rlhf-adapter.ts` 신규 파일로 이동
-- [ ] **T3.2** `lib/ai/merge.ts:7` import 경로 갱신: `from '@/lib/rlhf/retrieval-hook'` → `from '@/lib/ai/rlhf-adapter'` (또는 상대 경로 `./rlhf-adapter`)
-- [ ] **T3.3** `lib/rlhf/` 나머지 16 files + app/*rlhf* (4 files) → `archive/qms-pms/`로 git mv
-- [ ] **T3.4** **knowledge-gap SHRINK**: `lib/knowledge-gap/replay.ts`에서 `markGapResolved`, `replayGapTest` 함수 + 관련 타입 발췌 → `lib/radar/gap-replay-adapter.ts` 신규 파일로 이동
-- [ ] **T3.5** `lib/radar/delta-sync/gap-replay.ts:14` import 경로 갱신: `from '@/lib/knowledge-gap/replay'` → `from '@/lib/radar/gap-replay-adapter'` (또는 상대 경로)
-- [ ] **T3.6** `lib/knowledge-gap/` 나머지 12 files + app/*knowledge-gap* (4 files) → `archive/qms-pms/`로 git mv
-- [ ] **T3.7** SHRINK 검증: `grep -rn "applyRlhfReranking" lib/ai/` → `lib/ai/rlhf-adapter.ts` 존재, `grep -rn "markGapResolved\|replayGapTest" lib/radar/` → `lib/radar/gap-replay-adapter.ts` 존재
-- [ ] **T3.8** 회귀 게이트: `pnpm typecheck && pnpm test` → failure 0건 (특히 rlhf-reranking 관련 통합 테스트)
-- [ ] **T3.9** commit: `chore(archive): A3 SHRINK 2도메인 아카이브 (rlhf/knowledge-gap) — 함수 이동 포함`
-
-### Sub-Phase A4: 고의존성 6종 아카이브 (Priority High)
-
-> 각 도메인별 크로스 임포트 처리는 run phase #35에서 도메인별 판단. stub 교체 / import 제거 / 기능 축소 중 선택.
-
-- [ ] **T4.1** **knowledge-promo RETIRE**: `lib/knowledge-promo/` (5 files) + app/*knowledge-promo* (4 files) → `archive/qms-pms/`로 git mv (공유 인프라만 참조하므로 바로 이동)
-- [ ] **T4.2** **traceability**: 크로스 임포트 처리(lib/predicate ↔ traceability 1종) → `lib/traceability/` (17 files) + app/*traceability* (11 files) 아카이브
-- [ ] **T4.3** **corpus-license**: 크로스 임포트 처리(pccp 상호참조) → `lib/corpus-license/` (10 files) + app/*corpus-license* (3 files) 아카이브
-- [ ] **T4.4** **pccp**: 크로스 임포트 처리(corpus-license과 함께) → `lib/pccp/` (14 files) + app/*pccp* (6 files) 아카이브
-- [ ] **T4.5** **standards**: 크로스 임포트 처리(1종) → `lib/standards/` (12 files) + app/*standards* (7 files) 아카이브
-- [ ] **T4.6** **project-memory**: 크로스 임포트 처리(2종) → `lib/project-memory/` (4 files) + app/*project-memory* (5 files) 아카이브
-- [ ] **T4.7** 회귀 게이트: `pnpm typecheck && pnpm lint && pnpm test` → failure 0건
-- [ ] **T4.8** commit: `chore(archive): A4 고의존성 6도메인 아카이브 (knowledge-promo/traceability/corpus-license/pccp/standards/project-memory)`
-
-### Sub-Phase A5: schema.ts @deprecated 주석 (Priority Medium)
-
-- [ ] **T5.1** schema.ts에서 아카이브 18도메인 테이블 식별 (Phase C-2 4도메인 + 본 SPEC 14도메인 분)
-- [ ] **T5.2** 각 테이블 정의上方에 `/** @deprecated 아카이브됨 — archive/qms-pms/ 참조, SPEC-V3-RESTRUCTURE-001 */` 주석 추가
-- [ ] **T5.3** 검증: `grep -c "@deprecated.*SPEC-V3-RESTRUCTURE-001" lib/db/schema.ts` → 아카이브 도메인 테이블 수와 일치
-- [ ] **T5.4** 회귀 게이트: `pnpm typecheck` (주석만이므로 영향 0)
-- [ ] **T5.5** commit: `chore(schema): A5 아카이브 18도메인 테이블 @deprecated 주석 (Phase C-2 누락 보완)`
-
-### Sub-Phase A6: .archive-manifest.json 갱신 (Priority Medium)
-
-- [ ] **T6.1** `.archive-manifest.json` 스키마 정의: `{ "version": "1.0", "archived_at": "ISO-8601", "domains": [{ "name": "...", "original_path": "...", "archive_path": "...", "checksum": "...", "spec": "..." }] }`
-- [ ] **T6.2** Phase C-2 4도메인(change-control, clinical-investigation, cyberdevice, labeling) + 본 SPEC 14도메인 = 18도메인 엔트리 작성
-- [ ] **T6.3** 각 도메인별 체크섬 계산 (`sha256sum` 기반) 및 매핑
-- [ ] **T6.4** `archive/qms-pms/README.md` 갱신: 아카이브 사유, 복원 방법, 18도메인 목록
-- [ ] **T6.5** commit: `docs(archive): A6 .archive-manifest.json 18도메인 갱신 + README`
-
-### Sub-Phase A7: Phase A 최종 게이트 (Priority High)
-
-- [ ] **T7.1** `pnpm typecheck` → 0 에러
-- [ ] **T7.2** `pnpm lint` → 0 에러 (lint:hex full, L-008)
-- [ ] **T7.3** `pnpm test` → 4815+ passed (baseline 대비 신규 failure 0)
-- [ ] **T7.4** AC-01, AC-02, AC-06, AC-07, AC-08 검증 통과
-- [ ] **T7.5** `ls archive/qms-pms/lib/ | wc -l` → 18 (Phase C-2 4 + 본 SPEC 14)
-- [ ] **T7.6** commit: `chore(archive): Phase A 완료 — 18도메인 아카이브`
+> Phase A 완료(#530/PR #534) — 8도메인 아카이브 + `.archive-manifest.json` 생성 + 회귀 green(5450 passed). 본 tasks.md에서 Phase A 태스크 제거(kernel-only 재스코프 v1.1.0). 잔여 도메인(rlhf, knowledge-gap, risk, traceability, pccp, knowledge-promo, model-governance, standards, project-memory, corpus-license)은 #519 KEEP 재분류 — 본 SPEC 범위 밖.
 
 ---
 
@@ -90,26 +26,30 @@
 
 - [ ] **T8.1** `mkdir -p lib/kernel/{db,auth,audit,ratelimit,storage,schemas}`
 - [ ] **T8.2** `lib/db/` → `lib/kernel/db/`로 git mv (schema.ts, schema-docingest.ts, client.ts, migrations/ 포함)
-- [ ] **T8.3** `lib/auth/` → `lib/kernel/auth/`로 git mv (178 파일 참조)
-- [ ] **T8.4** `lib/audit/` → `lib/kernel/audit/`로 git mv (116 파일 참조)
-- [ ] **T8.5** `lib/ratelimit/` → `lib/kernel/ratelimit/`로 git mv
-- [ ] **T8.6** `lib/storage/` → `lib/kernel/storage/`로 git mv
-- [ ] **T8.7** `lib/schemas/` → `lib/kernel/schemas/`로 git mv (Zod 공유)
+- [ ] **T8.3** `lib/auth/` → `lib/kernel/auth/`로 git mv (**181 파일 참조** — 직검 2026-07-21)
+- [ ] **T8.4** `lib/audit/` → `lib/kernel/audit/`로 git mv (**119 파일 참조** — 직검 2026-07-21)
+- [ ] **T8.5** `lib/ratelimit/` → `lib/kernel/ratelimit/`로 git mv (직접 import 0건 — kernel re-export만 유지)
+- [ ] **T8.6** `lib/storage/` → `lib/kernel/storage/`로 git mv (직접 import 0건 — kernel re-export만 유지)
+- [ ] **T8.7** `lib/schemas/` → `lib/kernel/schemas/`로 git mv (**4 파일 참조** — Zod 공유, codemod 대상)
 - [ ] **T8.8** commit: `refactor(kernel): B1 공유 인프라 6모듈 → lib/kernel/ 이동`
 
 ### Sub-Phase B2: schema-kernel.ts 발췌 (Priority High)
 
-- [ ] **T9.1** schema.ts에서 kernel 테이블 식별: users, audit_log, audit_verify_history, sessions (~5 테이블, 사전 grep으로 정확한 수 확인)
+> **kernel 테이블 직검 식별 (2026-07-21)**: `users`(L668), `auditLogs`(L1285, table `audit_logs`), `sessions`(L1537). `verificationTokens`(L1567)은 kernel 후보. 원 v1.0.0 추정치 "users, audit_log, audit_verify_history, sessions (~5)" 중 `audit_verify_history`는 **존재하지 않음**(정정). 최종 확정 집합은 사전 grep으로 확인.
+
+- [ ] **T9.1** schema.ts에서 kernel 테이블 식별 (사전 grep): `grep -nE "^export const (users|auditLogs|sessions|verificationTokens)" lib/db/schema.ts` → 직검 identity + 최종 수 확정 (명목 3-4: users, auditLogs, sessions, + verificationTokens 후보)
 - [ ] **T9.2** `lib/kernel/db/schema-kernel.ts` 신규 파일 생성, kernel 테이블 정의 이동
 - [ ] **T9.3** FK references 처리: 다른 도메인 테이블이 kernel 테이블을 참조할 때 `import { users } from '@/lib/kernel/db/schema-kernel'` 사용 (Drizzle 다중 파일 패턴)
 - [ ] **T9.4** schema.ts에서 kernel 테이블 정의 제거 후 schema-kernel.ts에서 import (또는 re-export)
-- [ ] **T9.5** **즉시 검증**: `pnpm drizzle-kit check` → FK 261개 보존 확인 (T0.2 baseline 대비)
+- [ ] **T9.5** **즉시 검증**: `pnpm drizzle-kit check` → **FK 274개** 보존 확인 (T0.2 baseline 대비)
 - [ ] **T9.6** 실패 시 롤백: kernel 테이블을 schema.ts에 잔류시키고 import만 분리 (점진적)
-- [ ] **T9.7** commit: `refactor(schema): B2 kernel 테이블 5개 → schema-kernel.ts 분할 (FK 261 보존)`
+- [ ] **T9.7** commit: `refactor(schema): B2 kernel 테이블 발췌 → schema-kernel.ts 분할 (FK 274 보존)`
 
-### Sub-Phase B3: drizzle.config.ts glob 확장 (Priority Medium)
+### Sub-Phase B3: drizzle.config.ts glob 확장 — 신규 전환 (Priority Medium)
 
-- [ ] **T10.1** `drizzle.config.ts`의 `schema` 필드를 배열로 변경:
+> **정정 (2026-07-21 직검)**: 현재 `drizzle.config.ts` L20은 `schema: './lib/db/schema.ts'` **단일 파일**. `schema-docingest.ts`는 **미배선** — 원 v1.0.0 "선례 검증됨"은 거짓. B3는 array로 **신규 전환**한다.
+
+- [ ] **T10.1** `drizzle.config.ts`의 `schema` 필드를 단일 문자열 → 배열로 변경:
   ```typescript
   schema: [
     './lib/kernel/db/schema-kernel.ts',
@@ -117,9 +57,9 @@
     './lib/db/schema-docingest.ts',
   ],
   ```
-- [ ] **T10.2** `pnpm drizzle-kit generate` 실행 → migration 정상 생성 확인 (신규 migration 0건 — 구조 변경만)
-- [ ] **T10.3** `pnpm drizzle-kit check` → FK 261개 불변 확인
-- [ ] **T10.4** commit: `refactor(drizzle): B3 config glob 확장 — kernel + legacy + docingest`
+- [ ] **T10.2** `pnpm drizzle-kit generate --dry` 실행 → **무의도 diff 0 확인** (schema-docingest.ts 편입이 신규 migration을 유발하지 않는지 검증; 유발 시 편입 범위 조정)
+- [ ] **T10.3** `pnpm drizzle-kit check` → **FK 274개** 불변 확인
+- [ ] **T10.4** commit: `refactor(drizzle): B3 config glob 확장 (신규 전환) — kernel + legacy + docingest`
 
 ### Sub-Phase B4: lib/kernel/index.ts 공개 API (Priority Medium)
 
@@ -131,19 +71,24 @@
   export { rateLimit } from './ratelimit';
   export { uploadAsset } from './storage';
   ```
-- [ ] **T11.2** 새 추상층 도입 금지 검증: kernel은 re-export만, 의존성 역전 인터페이스/클래스 주입 금지 (TRUST 5 Readable)
+- [ ] **T11.2** 새 추상층 도입 금지 검증: kernel은 re-export만, 의존성 역전 인터페이스/클래스 주입 금지 (TRUST 5 Readable — REQ-V3R-004)
 - [ ] **T11.3** commit: `feat(kernel): B4 lib/kernel/index.ts 공개 API (re-export thin wrapper)`
 
 ### Sub-Phase B5: codemod import 경로 일괄 변경 (Priority High)
 
-- [ ] **T12.1** codemod 스크립트 작성: `@/lib/db` → `@/lib/kernel/db`, `@/lib/auth` → `@/lib/kernel/auth`, `@/lib/audit` → `@/lib/kernel/audit`, `@/lib/ratelimit` → `@/lib/kernel/ratelimit`, `@/lib/storage` → `@/lib/kernel/storage`, `@/lib/schemas` → `@/lib/kernel/schemas`
-- [ ] **T12.2** 스크립트 실행: lib/, app/, components/ 내 178+ 파일 일괄 변경
-- [ ] **T12.3** 누락 검증: `grep -rn "from.*@/lib/db['\"]\|from.*@/lib/auth['\"]\|from.*@/lib/audit['\"]" lib/ app/ components/` → 결과 0건 (kernel 경로 미사용 파일 0건)
+> **직검 (2026-07-21)**: union **289 파일**(db 174 · auth 181 · audit 119 · schemas 4, overlap deduped). 동적 import **55건**. ratelimit/storage는 직접 import 0건 → codemod 비대상(kernel re-export만 유지).
+
+- [ ] **T12.1** codemod 스크립트 작성 (대상 4 경로): `@/lib/db` → `@/lib/kernel/db`, `@/lib/auth` → `@/lib/kernel/auth`, `@/lib/audit` → `@/lib/kernel/audit`, `@/lib/schemas` → `@/lib/kernel/schemas`
+- [ ] **T12.2** 스크립트 실행: lib/, app/, components/ 내 **289 파일**(union, 동적 import 55건 포함) 일괄 변경
+- [ ] **T12.3** **누락 0 검증 (L-014: 정적 + 동적 + 배럴 re-export)**:
+  - 정적: `grep -rlE "@/lib/(db|auth|audit|schemas)([/'\"]|$)" lib/ app/ components/ | grep -v '/archive/'` → kernel 미경유 파일 0건
+  - 동적: `grep -rnE "import\(['\"]@/lib/(db|auth|audit|schemas)" lib/ app/` → 동적 import 잔존 0건
+  - 배럴: `lib/index.ts`류 재export 경로 갱신 확인 (`@/lib/db`, `@/lib/auth`, `@/lib/audit`, `@/lib/schemas` export가 `@/lib/kernel/*`을 가리키도록)
 - [ ] **T12.4** `pnpm typecheck` → 0 에러
-- [ ] **T12.5** `pnpm lint` → 0 에러
-- [ ] **T12.6** `pnpm test` → 4815+ passed (baseline 대비 failure 0)
+- [ ] **T12.5** `pnpm lint` → 0 에러 (lint:hex full, L-008)
+- [ ] **T12.6** `pnpm test` → **5450+ passed** (baseline 대비 failure 0)
 - [ ] **T12.7** AC-09 검증 통과
-- [ ] **T12.8** commit: `refactor(codemod): B5 178+ 파일 import 경로 @/lib/kernel/* 일괄 변경`
+- [ ] **T12.8** commit: `refactor(codemod): B5 289 파일(동적 import 포함) import 경로 @/lib/kernel/* 일괄 변경`
 
 ### Sub-Phase B6: 순환 의존성 검증 (Priority High)
 
@@ -153,27 +98,37 @@
 - [ ] **T13.4** AC-10 검증 통과
 - [ ] **T13.5** commit: `test(kernel): B6 순환 의존성 0건 + next dev 페이지 로드 검증`
 
+### Sub-Phase B7: schema @deprecated 보완 (Priority Medium)
+
+> **AC-07 보완**: Phase A #530에서 `@deprecated` 주석 미적용(grep `@deprecated` in schema.ts = 0). 본 Phase B에서 8도메인 아카이브 테이블에 보완 추가.
+
+- [ ] **T14.1** schema.ts에서 아카이브 8도메인 테이블 식별 (change-control, clinical-investigation, cyberdevice, dhf, esubmit, labeling, samd, workflows 분)
+- [ ] **T14.2** 각 테이블 정의上方에 `/** @deprecated 아카이브됨 — archive/qms-pms/ 참조, Phase A #530 */` 주석 추가
+- [ ] **T14.3** 검증: `grep -c "@deprecated.*Phase A #530\|@deprecated.*SPEC-V3-RESTRUCTURE" lib/db/schema.ts` → 아카이브 도메인 테이블 수와 일치
+- [ ] **T14.4** 회귀 게이트: `pnpm typecheck` (주석만이므로 영향 0)
+- [ ] **T14.5** commit: `chore(schema): B7 아카이브 8도메인 테이블 @deprecated 주석 보완 (Phase A #530 누락 보완)`
+
 ---
 
 ## Phase B 최종 게이트 (Priority High)
 
-- [ ] **T14.1** AC-03 (kernel 순환 의존성 0), AC-04 (drizzle-kit check FK 261 보존), AC-05 (migration 106 불변), AC-09 (codemod 누락 0), AC-10 (next dev 500 없음), AC-11 (kernel/index.ts re-export) 전부 통과
-- [ ] **T14.2** `pnpm typecheck && pnpm lint && pnpm test` 전체 green
-- [ ] **T14.3** 실DB 스키마 일관성 검증: `psql regula_test -c "\dt"` → 테이블 수 불변, `\d users` → kernel 테이블 정상 (L-013)
-- [ ] **T14.4** commit: `chore(kernel): Phase B 완료 — kernel 추출 + schema 분할 + codemod`
+- [ ] **T15.1** AC-03 (kernel 순환 의존성 0), AC-04 (drizzle-kit check **FK 274** 보존), AC-05 (migration **125** 불변), AC-07 (@deprecated 8도메인 분 보완), AC-09 (codemod 누락 0 — 정적+동적+배럴), AC-10 (next dev 500 없음), AC-11 (kernel/index.ts re-export) 전부 통과
+- [ ] **T15.2** `pnpm typecheck && pnpm lint && pnpm test` 전체 green (**5450+ passed**)
+- [ ] **T15.3** 실DB 스키마 일관성 검증: `psql regula_test -c "\dt"` → 테이블 수 불변, `\d users` → kernel 테이블 정상 (L-013)
+- [ ] **T15.4** commit: `chore(kernel): Phase B 완료 — kernel 추출 + schema 분할 + codemod`
 
 ---
 
 ## 사후 검증 (Post-flight Checks)
 
-- [ ] **T15.1** archive/qms-pms/lib/ 18도메인 확인 (Phase C-2 4 + 본 SPEC 14)
-- [ ] **T15.2** lib/kernel/ 6모듈(db/auth/audit/ratelimit/storage/schemas) 존재 확인
-- [ ] **T15.3** schema-kernel.ts 존재 + kernel 테이블 ~5개 포함 확인
-- [ ] **T15.4** drizzle.config.ts glob에 3 파일(schema-kernel, schema, schema-docingest) 포함 확인
-- [ ] **T15.5** .archive-manifest.json 18도메인 엔트리 포함 확인
-- [ ] **T15.6** 전체 AC-01 ~ AC-11 검증 통과
-- [ ] **T15.7** `git log --oneline` → Phase A(7 commits) + Phase B(6 commits) 순서 확인
-- [ ] **T15.8** PR 생성: `feat(v3): SPEC-V3-RESTRUCTURE-001 — Phase A+B 구조 정리 완료 (#35)`
+- [ ] **T16.1** archive/qms-pms/lib/ **8도메인**(Phase A #530 완료 상태) 유지 확인 — 재이동 없음
+- [ ] **T16.2** lib/kernel/ 6모듈(db/auth/audit/ratelimit/storage/schemas) 존재 확인
+- [ ] **T16.3** schema-kernel.ts 존재 + kernel 테이블(users, auditLogs, sessions, + verificationTokens) 포함 확인
+- [ ] **T16.4** drizzle.config.ts glob에 3 파일(schema-kernel, schema, schema-docingest) array 포함 확인 (신규 배선)
+- [ ] **T16.5** .archive-manifest.json 8도메인 엔트리 유지 확인 (domain_count=8, total_files=148)
+- [ ] **T16.6** 전체 AC-01 ~ AC-11 검증 통과 (AC-02, AC-08은 N/A — Phase A 완료/KEEP 재분류)
+- [ ] **T16.7** `git log --oneline` → Phase B(7 commits: B1~B7 + 최종 게이트) 순서 확인
+- [ ] **T16.8** PR 생성: `feat(v3): SPEC-V3-RESTRUCTURE-001 — Phase B kernel 추출 완료 (#531)`
 
 ---
 
@@ -181,33 +136,27 @@
 
 | 위험 | 완화 조치 | 검증 시점 |
 |---|---|---|
-| schema.ts 분할 시 FK 261개 깨짐 | `drizzle-kit check` 즉시 검증, 점진적 분리 (kernel만) | T9.5, T10.3 |
-| 178+ 파일 import 경로 변경 누락 | grep 누락 0건, 자동화 스크립트 | T12.3 |
-| RLS 정책 / audit enum 참조 붕괴 | migration 제자리, schema.ts @deprecated 주석만 | T5.x, T10.2 |
+| schema.ts 분할 시 **FK 274개** 깨짐 | `drizzle-kit check` 즉시 검증, 점진적 분리 (kernel만) | T9.5, T10.3 |
+| **289 파일** import 경로 변경 누락 (동적 import 55건 + 배럴 포함) | 정적+동적+배럴 grep 누락 0건 (L-014), 자동화 스크립트 | T12.3 |
+| drizzle config 신규 배선 (schema-docingest.ts 편입) | `drizzle-kit generate --dry` 무의도 diff 0 확인 | T10.2 |
+| RLS 정책 / audit enum 참조 붕괴 | migration 제자리, schema.ts @deprecated 주석만 | T14.x |
 | migration 체인 꼬임 | 테이블 DROP 전면 금지, TRUNCATE만 (사용자 승인 시) | T10.2 |
 | next dev 500 에러 | L-012: build 금지, 페이지별 로드 테스트 | T13.3 |
-| SHRINK 함수 이동 누락 | merge.ts, gap-replay.ts 직검 | T3.7 |
-| 실DB 스키마 불일치 | L-013: psql 직검 | T14.3 |
+| 실DB 스키마 불일치 | L-013: psql 직검 | T15.3 |
+| kernel 테이블 집합 부정확 (`audit_verify_history` 부재) | 사전 grep으로 identity 확정, verificationTokens 포함 여부 판단 | T9.1 |
 
 ---
 
-## run phase #35용 핵심 정보 (도메인별 처리 매트릭스)
+## Phase B 런-페이즈용 핵심 정보 (kernel 추출 안전 순서)
 
-| 도메인 | Sub-Phase | 전략 | 크로스 임포트 | 검증 키 |
-|---|---|---|---|---|
-| dhf | A1 (T1.1) | DIRECT ARCHIVE | 없음 | typecheck + test green |
-| pms | A1 (T1.2) | DIRECT ARCHIVE | 없음 | typecheck green |
-| samd | A1 (T1.3) | DIRECT ARCHIVE | 없음 | typecheck + test green |
-| esubmit | A1 (T1.4) | DIRECT ARCHIVE | 없음 | typecheck + test green |
-| risk | A2 (T2.1) | DIRECT ARCHIVE | 없음 (0종) | typecheck + test green |
-| model-governance | A2 (T2.2) | DIRECT ARCHIVE | 없음 (0종) | typecheck + test green |
-| rlhf | A3 (T3.1-T3.3) | SHRINK | `lib/ai/merge.ts` → `applyRlhfReranking` 이동 | grep `applyRlhfReranking` in lib/ai/ |
-| knowledge-gap | A3 (T3.4-T3.6) | SHRINK | `lib/radar/delta-sync/gap-replay.ts` → 함수 이동 | grep `markGapResolved` in lib/radar/ |
-| knowledge-promo | A4 (T4.1) | RETIRE | 공유 인프라만 | typecheck green |
-| traceability | A4 (T4.2) | STUB/IMPORT 제거 | lib/predicate ↔ traceability (1종) | 도메인별 판단 |
-| corpus-license | A4 (T4.3) | STUB/IMPORT 제거 | pccp 상호참조 (1종) | pccp와 함께 처리 |
-| pccp | A4 (T4.4) | STUB/IMPORT 제거 | corpus-license 상호참조 (1종) | corpus-license와 함께 |
-| standards | A4 (T4.5) | STUB/IMPORT 제거 | 1종 | 도메인별 판단 |
-| project-memory | A4 (T4.6) | STUB/IMPORT 제거 | 2종 | 도메인별 판단 |
+| Sub-Phase | 작업 | 게이트 | Risk |
+|---|---|---|---|
+| B1 | `lib/kernel/` 생성 + db/auth/audit/ratelimit/storage/schemas git mv | typecheck(codemod 후) | High |
+| B2 | schema-kernel.ts 발췌(users/auditLogs/sessions/+verificationTokens) + cross-file FK import | **`drizzle-kit check` 즉시** + FK 수 동일(274) | **최고** |
+| B3 | drizzle.config glob 전환(단일→array, 신규 배선) | `drizzle-kit generate --dry` 무의도 diff 0 | Medium |
+| B4 | kernel/index.ts re-export 작성 | typecheck + `grep` export 항목 존재(AC-11) | Low |
+| B5 | codemod 289 파일(동적 import 55건 + 배럴 포함) import 경로 | 정적+동적+배럴 grep 0건 + `pnpm test` green + AC-03 순환의존 0 | High |
+| B6 | 순환 의존성 0건 + next dev 페이지 로드 500 없음 | grep + next dev 수동 확인 | Medium |
+| B7 | schema @deprecated 보완(Phase A #530 누락분) | grep `@deprecated` 8도메인 분 | Low |
 
-> **도메인별 판단 원칙**: stub 교체(어댑터 no-op) / import 제거(사용 중단) / 기능 축소(SHRINK) 중 해당 도메인의 Charter 정합성과 구현 비용을 고려해 run phase에서 결정. 단, AC-02(KEEP 코드 잔존 import 0건)는 무조건 충족.
+> **kernel 추출 원칙 (REQ-V3R-004)**: kernel은 re-export 레이어(thin wrapper) — 새 추상층, 의존성 역전 인터페이스, DI 컨테이너 전면 금지 (TRUST 5 Readable). 순환 의존성 0건 유지: `grep -rl "@/lib/domains" lib/kernel/` = 0건.


### PR DESCRIPTION
## Summary

Phase B(#531) plan-phase — `SPEC-V3-RESTRUCTURE-001`을 **kernel-only**로 재스코프 (v1.0.0 → v1.1.0). Phase A(#530/PR #534) 8도메인 아카이브 완료로 잔여 아카이브 태스크를 제거하고 Phase B(kernel 추출)만 잔존. **doc-only** (코드 변동 없음).

## Changes (2 files, +176/-255)

- `spec.md` v1.1.0 — §3.6 정정 8건 + 읽기전용 직검 수치 정정
- `tasks.md` — Phase A 서브페이즈 제거(완료 처리), Phase B(B1~B7) 보존 + 수치 갱신

## 정정 내역 (재개 계획서 §3.6 + 읽기전용 직검 실측 2026-07-21)

| 항목 | stale → VERIFIED |
|---|---|
| baseline | 4815 → **5450 passed** (0 failed, 68 skipped) |
| codemod | 178+ → **289 파일** (union; 동적 import 55 + `@/lib/schemas` 4 포함) |
| FK REFERENCES | 261 → **274** |
| migration | 106 → **125** |
| pgTable | 86 → **94** |
| schema.ts | 3232 → **3,531줄** |
| 아카이브 도메인 | 18 → **8** (`.archive-manifest.json` domain_count=8) |
| drizzle.config | "선례 검증됨" → **"신규 전환"** (`schema-docingest.ts` 미배선, 선례 거짓) |
| kernel 테이블 | `audit_verify_history`(허구) → **users / audit_logs / sessions / verificationTokens**(실측 후보) |

★ §3.6 계획서 자체가 놓친 stale 7종(migration/FK/pgTable/schema 줄/codemod union/schemas/동적import)을 **orchestrator 읽기전용 일괄 검증**으로 포착 정정 — verification-claim-integrity (§3.6 수치도 맹신 금지).

## Verification

- **plan-auditor PASS 0.862** (Tier L 임계 0.85 통과, harmonic mean: Clarity 0.85 / Completeness 0.85 / Testability 0.90 / Traceability 0.85)
- 13개 수치 독립 재검 **zero divergence**
- **REQ-V3R-004 보존** (kernel = re-export only, 새 추상층/의존성 역전/DI 금지) — load-bearing Phase B 제약, 원문 + 3곳 재강조
- **B7**(`@deprecated` 보완) 편입 — Phase A #530 미적용(grep `@deprecated`=0)을 Phase B에서 보완. orphan-coverage(REQ-V3R-007) + zero functional risk(주석만) + 단순성(5개 주석에 별도 SPEC은 과잉)
- 판단 4건 해결: A(N/A 수용) / B(B7 유지, 감사·manager-spec 합치) / C(issue_number 35→531, #35 closed·무관) / D(supersedes [] 정확, ARCHIVE/KERNEL-001은 비정식 레이블)

## Next — run-phase (별도 세션 + 후속 PR)

B1(`lib/kernel/` 생성) → B2(schema-kernel.ts 발췌, **최고 risk**: FK 274 보존, `drizzle-kit check` 즉시) → B3(drizzle config array 전환, `--dry` 무의도 diff 0) → B4(kernel/index.ts re-export) → B5(codemod 289파일, 정적+동적+배럴 누락 0) → B6(순환의존 0) → B7(@deprecated 보완). 각 서브페이즈 게이트: typecheck/lint/test green + 실DB 직검(L-013). Implementation Kickoff Approval 게이트 통과 상태.

감시 권고(선택, 차순위): D1 frontmatter canonical화(`labels`→`tags` 등, v1.0.0 기존 드리프트) · `tier: L` 명시 · T9.1 kernel FK-references 카운트 확장 — 본 PR 범위 외(#533 또는 run-phase).

Refs #531 (plan-phase 재스코프 완료; B1~B7 구현은 후속 PR).

🗿 MoAI <email@mo.ai.kr>